### PR TITLE
LRC-235 Allow embed headers to appear in the on this page ToC

### DIFF
--- a/content/operate/rs/installing-upgrading/install/plan-deployment/supported-platforms.md
+++ b/content/operate/rs/installing-upgrading/install/plan-deployment/supported-platforms.md
@@ -9,5 +9,6 @@ description: Redis Enterprise Software is supported on several operating systems
   cloud environments, and virtual environments.
 linkTitle: Supported platforms
 weight: 30
+tocEmbedHeaders: true
 ---
 {{< embed-md "supported-platforms-embed.md">}}

--- a/content/operate/rs/references/supported-platforms.md
+++ b/content/operate/rs/references/supported-platforms.md
@@ -9,5 +9,6 @@ description: Redis Enterprise Software is supported on several operating systems
   cloud environments, and virtual environments.
 linkTitle: Supported platforms
 weight: 30
+tocEmbedHeaders: true
 ---
 {{<embed-md "supported-platforms-embed.md">}}

--- a/layouts/partials/docs-toc.html
+++ b/layouts/partials/docs-toc.html
@@ -1,9 +1,33 @@
 {{ $this := . }}
+
+<!-- Used to combine current file's headers with embed headers since .TableOfContents doesn't include embed headers -->
+{{ $showEmbedHeaders := .Params.tocEmbedHeaders }}
+{{ $headerRange := .Params.headerRange | default "[1-3]" }}
+<!-- Ignore empty links with + -->
+{{ $headers := findRE ( print "<h" $headerRange ".*?>(.|\n])+?</h" $headerRange ">") .Content }}
+<!-- Must have at least one header to link to -->
+{{ $has_headers := ge (len $headers) 1 }}
+
 {{ with .TableOfContents }}
   <section class="hidden xl:block w-60 h-full shrink-0">
     <div class="w-60 z-40 overflow-auto fixed top-28 h-full max-h-[calc(100vh-15rem)] text-sm">
       {{ partial "meta-links.html" $this }}
-      {{ if gt (len .) 32 }}
+      <!-- Combines current file's headers with embed headers since .TableOfContents doesn't include embed headers. Front matter must include "tocEmbedHeaders: true". -->
+      {{ if and $showEmbedHeaders $has_headers }}
+        <h1 class="font-medium my-3">On this page</h1>
+        <nav class="text-slate-700">
+          <nav id="TableOfContents">
+            <ul>
+              {{ range $i, $header := $headers }}
+                {{ $genAnchor := index (split (index (split $header "id=\"") 1) "\"") 0 }}
+                {{ $anchorID := $genAnchor }}
+                <li><a href="#{{ $anchorID }}">{{ $header | plainify | safeHTML }}</a></li>
+              {{end}}
+            </ul>
+          </nav>
+        </nav>
+      <!-- Use Hugo's .TableOfContents by default -->
+      {{ else if gt (len .) 32 }}
         <h1 class="font-medium my-3">On this page</h1>
         <nav class="text-slate-700">
           {{ . }}


### PR DESCRIPTION
Fixes [LRC-235](https://redislabs.atlassian.net/browse/LRC-235)

We will also need to add `tocEmbedHeaders: true` to the front matter of a few more pages in the future, but those changes will need to wait until the `dmaier-full-sync-test` has been merged into main.