### PR TITLE
LRC-283: update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 gitpython
 pytoml==0.1.21
-PyYAML==6.0
+PyYAML==6.0.1
 railroad-diagrams==1.1.1
 requests==2.27.1
 semver==2.13.0


### PR DESCRIPTION
Fix requirements.txt so that it works with recent versions of Python3. Change:

```
3c3
< PyYAML==6.0
---
> PyYAML==6.0.1
```