### PR TITLE
Add tocEmbedHeaders to front matter to fix missing embed headers in 'on this page' ToC

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/json/active-active.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/json/active-active.md
@@ -8,6 +8,7 @@ categories:
 description: JSON support and conflict resolution rules for Active-Active databases.
 linkTitle: Active-Active databases
 weight: 50
+tocEmbedHeaders: true
 ---
 
 RedisJSON v2.2 adds support for JSON in [Active-Active Redis Enterprise databases]({{< relref "/operate/rs/databases/active-active" >}}).

--- a/content/operate/rc/compatibility.md
+++ b/content/operate/rc/compatibility.md
@@ -8,6 +8,7 @@ categories:
 description: Redis Cloud compatibility with open source Redis.
 linkTitle: Open source compatibility
 weight: 90
+tocEmbedHeaders: true
 ---
 
 Both [Redis Enterprise Software]({{< relref "/operate/rs" >}}) and Redis Cloud are compatible with open source

--- a/content/operate/rs/databases/active-active/develop/data-types/json.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/json.md
@@ -8,6 +8,7 @@ categories:
 description: Information about using JSON with an Active-Active database.
 linkTitle: JSON
 weight: $weight
+tocEmbedHeaders: true
 ---
 Active-Active databases support JSON data structures.
 

--- a/content/operate/rs/installing-upgrading/install/plan-deployment/supported-platforms.md
+++ b/content/operate/rs/installing-upgrading/install/plan-deployment/supported-platforms.md
@@ -9,5 +9,6 @@ description: Redis Enterprise Software is supported on several operating systems
   cloud environments, and virtual environments.
 linkTitle: Supported platforms
 weight: 30
+tocEmbedHeaders: true
 ---
 {{< embed-md "supported-platforms-embed.md">}}

--- a/content/operate/rs/references/compatibility/_index.md
+++ b/content/operate/rs/references/compatibility/_index.md
@@ -9,6 +9,7 @@ description: Redis Enterprise compatibility with open source Redis.
 hideListLinks: true
 linkTitle: Open source compatibility
 weight: $weight
+tocEmbedHeaders: true
 ---
 Both Redis Enterprise Software and [Redis Cloud]({{< relref "/operate/rc" >}}) are compatible with open source
 Redis (OSS Redis). 

--- a/content/operate/rs/references/supported-platforms.md
+++ b/content/operate/rs/references/supported-platforms.md
@@ -9,5 +9,6 @@ description: Redis Enterprise Software is supported on several operating systems
   cloud environments, and virtual environments.
 linkTitle: Supported platforms
 weight: 30
+tocEmbedHeaders: true
 ---
 {{<embed-md "supported-platforms-embed.md">}}


### PR DESCRIPTION
LRC-235

Staged previews:
- [Supported platforms reference](https://staging.learn.redis.com/docs/staging/LRC-235-front-matter/operate/rs/references/supported-platforms/)
- [Supported platforms under install](https://staging.learn.redis.com/docs/staging/LRC-235-front-matter/operate/rs/installing-upgrading/install/plan-deployment/supported-platforms/)
- [Redis Enterprise Software compatibility with OSS](https://staging.learn.redis.com/docs/staging/LRC-235-front-matter/operate/rs/references/compatibility/)
- [Redis Cloud compatibility with OSS](https://staging.learn.redis.com/docs/staging/LRC-235-front-matter/operate/rc/compatibility/)
- [Develop for Active-Active > Data types > JSON](https://staging.learn.redis.com/docs/staging/LRC-235-front-matter/operate/rs/databases/active-active/develop/data-types/json/)
- [Store JSON in Active-Active databases](https://staging.learn.redis.com/docs/staging/LRC-235-front-matter/operate/oss_and_stack/stack-with-enterprise/json/active-active/)