### PR TITLE
LRC-292: fix broken/incorrect Connect links

### DIFF
--- a/content/develop/connect/_index.md
+++ b/content/develop/connect/_index.md
@@ -42,6 +42,6 @@ It's easy to connect your application to a Redis database. The official client l
 * [Node.js]({{< relref "/develop/connect/clients/nodejs" >}})
 * [Python]({{< relref "/develop/connect/clients/python" >}})
 
-You can find a complete list of all client libraries, including the community-maintained ones, on the [clients page](/resources/clients/).
+<!--You can find a complete list of all client libraries, including the community-maintained ones, on the [clients page](/resources/clients/).-->
 
 <hr/>

--- a/content/develop/connect/clients/_index.md
+++ b/content/develop/connect/clients/_index.md
@@ -19,7 +19,7 @@ Here, you will learn how to connect your application to a Redis database. If you
 
 For more Redis topics, see [Using]({{< relref "/develop/use/" >}}) and [Managing]({{< relref "/operate/oss_and_stack/management/" >}}) Redis.
 
-If you're ready to get started, see the following guides for the official client libraries you can use with Redis. For a complete list of community-driven clients, see [Clients](/resources/clients/).
+<!--If you're ready to get started, see the following guides for the official client libraries you can use with Redis. For a complete list of community-driven clients, see [Clients](/resources/clients/).-->
 
 
 ## High-level client libraries

--- a/content/develop/connect/insight/tutorials/insight-stream-consumer.md
+++ b/content/develop/connect/insight/tutorials/insight-stream-consumer.md
@@ -84,7 +84,7 @@ This example shows how to bring an existing stream into RedisInsight and work wi
 
 1. Install [RedisInsight](https://redis.com/redis-enterprise/redis-insight/?_ga=2.48624486.1318387955.1655817244-1963545967.1655260674#insight-form).
 2. Download and install [Node.js](https://nodejs.org/en/download/) (LTS version).
-3. Install [Redis](/download/). In Docker, check that Redis is running locally on the default port 6379 (with no password set). 
+3. Install [Redis](/operate/oss_and_stack/). In Docker, check that Redis is running locally on the default port 6379 (with no password set). 
 4. Clone the [code repository](https://github.com/redis-developer/introducing-redis-talk) for this example. 
 See the [README](https://github.com/redis-developer/introducing-redis-talk/tree/main/streams) for more information about this example and installation tips.
 5. On your command-line, navigate to the folder containing the code repository and install the Node.js package manager (npm). 


### PR DESCRIPTION
Fix a few broken/incorrect links in the Develop > Connect pages. N.B. in two places, statements containing the invalid links are commented out. This is because the linked content does not exist on the new site.

@cmilesb @dmaier-redislabs @andy-stark-redis @kaitlynmichael @rrelledge 