### PR TITLE
LRC-206: add new download link

### DIFF
--- a/content/develop/data-types/timeseries/quickstart.md
+++ b/content/develop/data-types/timeseries/quickstart.md
@@ -36,7 +36,7 @@ docker run -p 6379:6379 -it --rm redis/redis-stack-server
 
 ### Download and running binaries
 
-First download the pre-compiled version from the [Redis download center](https://app.redislabs.com/#/rlec-downloads).
+First download the pre-compiled version from the [Redis download center](https://redis.io/downloads).
 
 Next, run Redis with RedisTimeSeries:
 


### PR DESCRIPTION
Replace the download-related link with the new downloads link. N.B. the new download link is not yet available, so you'll get 404s if you click on it.

https://staging.learn.redis.com/docs/staging/LRC-206/develop/data-types/timeseries/quickstart/

@cmilesb @andy-stark-redis @kaitlynmichael @rrelledge