### PR TITLE
LRC-207: correct BLOCK_SIZE link

### DIFF
--- a/content/develop/interact/search-and-query/basic-constructs/configuration-parameters.md
+++ b/content/develop/interact/search-and-query/basic-constructs/configuration-parameters.md
@@ -548,7 +548,7 @@ $ redis-server --loadmodule ./redisearch.so DEFAULT_DIALECT 2
 
 ### VSS_MAX_RESIZE
 
-The maximum memory resize for vector similarity indexes in bytes. This value will override default memory limits if you need to allow for a large [`BLOCK_SIZE`]({{< baseurl >}}/develop/get-started/vector-database#creation-attributes-per-algorithm).
+The maximum memory resize for vector similarity indexes in bytes. This value will override default memory limits if you need to allow for a large [`BLOCK_SIZE`]({{< baseurl >}}/develop/interact/search-and-query/advanced-concepts/vectors/#creation-attributes-per-algorithm).
 
 #### Default
 


### PR DESCRIPTION
Single link fix. Here's the preview:

https://staging.learn.redis.com/docs/staging/LRC-207/develop/interact/search-and-query/basic-constructs/configuration-parameters/#vss_max_resize

Check the "BLOCK_SIZE" link.

@cmilesb @andy-stark-redis @kaitlynmichael @rrelledge