### PR TITLE
Doc 3596

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -118,7 +118,7 @@
           "ButtonLabel" "Read more"
           "LinksLeftTitle" "Featured content"
           "LinksLeft" (slice
-              (dict "Text" "From Fixed to Flexible" "URL" "./operate/rc/subscriptions/upgrade-essentials-pro/")
+              (dict "Text" "Upgrade database from Essentials to Pro" "URL" "./operate/rc/subscriptions/upgrade-essentials-pro/")
               (dict "Text" "Redis Cloud REST API" "URL" "./operate/rc/api/")
               (dict "Text" "Prometheus and Grafana with Redis Cloud" "URL" "./integrate/prometheus-with-redis-cloud/")
               )


### PR DESCRIPTION
fix link targets for Essentials to Pro and Prometheus and changed link title for essentials to pro

Preview:
https://staging.learn.redis.com/docs/staging/DOC-3596/
