### PR TITLE
DOC-3620: add RI RNs to the new site

### DIFF
--- a/content/develop/connect/insight/release-notes/_index.md
+++ b/content/develop/connect/insight/release-notes/_index.md
@@ -1,0 +1,21 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description:
+linkTitle: Release notes
+title: Redis Insight release notes
+weight: 2
+hideListLinks: true
+---
+
+Here are the most recent changes for Redis Insight:
+
+{{< table-children columnNames="Version (Date),Release notes" columnSources="LinkTitle,Title" enableLinks="Title" >}}

--- a/content/develop/connect/insight/release-notes/v.2.14.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.14.0.md
@@ -1,0 +1,23 @@
+---
+Title: RedisInsight v2.14.0, November 2022
+linkTitle: v2.14.0 (Nov 2022)
+date: 2022-11-28 00:00:00 +0000
+description: RedisInsight v2.14.0
+weight: 3
+---
+## 2.14.0 (November 2022)
+This is the General Availability (GA) release of RedisInsight 2.14.
+
+### Highlights
+- Support for [search capabilities](https://redis.io/docs/stack/search/) in Browser: Create secondary index via dedicated form, run queries and full-text search in Browser or Tree views
+- Ability to resize the column width of key values when displaying hashes, lists, and sorted sets
+- Command processing time displayed as part of the result in Workbench
+
+
+### Details
+**Features and improvements**
+- [#1345](https://github.com/RedisInsight/RedisInsight/pull/1345), [#1346](https://github.com/RedisInsight/RedisInsight/pull/1346), [#1376](https://github.com/RedisInsight/RedisInsight/pull/1376) Added support for [search capabilities](https://redis.io/docs/stack/search/) in Browser tool. Create secondary index of your data using a dedicated form. Conveniently run your queries and full-text search against the preselected index and display results in Browser or Tree views. 
+- [#1385](https://github.com/RedisInsight/RedisInsight/pull/1385) Resize the column width of key values when displaying hashes, lists, and sorted sets
+- [#1354](https://github.com/RedisInsight/RedisInsight/pull/1407) Do not scroll to the end of results when double-clicking a command output in CLI
+- [#1347](https://github.com/RedisInsight/RedisInsight/pull/1347) Display command processing time as part of the result in Workbench (time taken to process the command by both RedisInsight backend and Redis)
+- [#1351](https://github.com/RedisInsight/RedisInsight/pull/1351) Display the namespaces section in the Database analysis report when no namespaces were found

--- a/content/develop/connect/insight/release-notes/v.2.16.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.16.0.md
@@ -1,0 +1,27 @@
+---
+Title: RedisInsight v2.16.0, December 2022
+linkTitle: v2.16.0 (Dec 2022)
+date: 2022-12-28 00:00:00 +0000
+description: RedisInsight v2.16.0
+weight: 2
+---
+## 2.16.0 (December 2022)
+This is the General Availability (GA) release of RedisInsight 2.16.
+
+### Highlights
+- Bulk import database connections from a file
+- Navigation enhancements for the Tree view
+- Pre-populated host, port, and database alias in the form when adding a new Redis database
+
+
+### Details
+**Features and improvements**
+- [#1492](https://github.com/RedisInsight/RedisInsight/pull/1492), [#1497](https://github.com/RedisInsight/RedisInsight/pull/1497), [#1500](https://github.com/RedisInsight/RedisInsight/pull/1500), [#1502](https://github.com/RedisInsight/RedisInsight/pull/1502) Migrate your database connections from other Redis GUIs, including RESP.app, with the new feature to bulk import database connections from a file.
+- [#1506](https://github.com/RedisInsight/RedisInsight/pull/1506) Pre-populated host (127.0.0.1), port (6379, or 26379 for [Sentinel](https://redis.io/docs/management/sentinel/) connection type), and database alias in the form when adding a new Redis database
+- [#1473](https://github.com/RedisInsight/RedisInsight/pull/1473) **Browser** view is renamed **List** view to avoid confusion with the Browser tool
+- [#1464](https://github.com/RedisInsight/RedisInsight/pull/1464) Navigation enhancements for the Tree view, covering cases when filters are applied, the list of keys is refreshed or the view is switched to the Tree view
+- [#1481](https://github.com/RedisInsight/RedisInsight/pull/1481), [#1482](https://github.com/RedisInsight/RedisInsight/pull/1482), [#1489](https://github.com/RedisInsight/RedisInsight/pull/1489) Indication of new database connections that have been manually added, auto-discovered or imported, but not opened yet
+- [#1499](https://github.com/RedisInsight/RedisInsight/pull/1499) Display values of [JSON](https://redis.io/docs/stack/json/) keys when [JSON.DEBUG MEMORY](https://redis.io/commands/json.debug-memory/) is not available
+
+**Bugs**
+- [#1514](https://github.com/RedisInsight/RedisInsight/pull/1514) Scan the database even when the [DBSIZE](https://redis.io/commands/dbsize/) returns 0

--- a/content/develop/connect/insight/release-notes/v.2.18.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.18.0.md
@@ -1,0 +1,23 @@
+---
+Title: RedisInsight v2.18.0, January 2023
+linkTitle: v2.18.0 (Jan 2023)
+date: 2023-01-31 00:00:00 +0000
+description: RedisInsight v2.18.0
+weight: 1
+---
+## 2.18.0 (January 2023)
+This is the General Availability (GA) release of RedisInsight 2.18.
+
+### Highlights
+- Support for SSH tunnel to connect to your Redis database
+- Ability to switch between database indexes while connected to your database
+- Recommendations on how to optimize the usage of your database
+
+### Details
+**Features and improvements**
+- [#1567](https://github.com/RedisInsight/RedisInsight/pull/1567), [#1576](https://github.com/RedisInsight/RedisInsight/pull/1576), [#1577](https://github.com/RedisInsight/RedisInsight/pull/1577) Connect to your Redis database via SSH tunnel using a password or private key in PEM format.
+- [#1540](https://github.com/RedisInsight/RedisInsight/pull/1540), [#1608](https://github.com/RedisInsight/RedisInsight/pull/1608) Switch between database indexes while connected to your database in Browser, Workbench, and Database Analysis.
+- [#1457](https://github.com/RedisInsight/RedisInsight/pull/1457), [#1465](https://github.com/RedisInsight/RedisInsight/pull/1465), [#1590](https://github.com/RedisInsight/RedisInsight/pull/1590) Run Database Analysis to generate recommendations on how to save memory and optimize the usage of your database. These recommendations are based on industry standards and Redis best practices. Upvote or downvote recommendations in terms of their usefulness. 
+- [#1598](https://github.com/RedisInsight/RedisInsight/pull/1598) Check and highlight the [JSON](https://redis.io/docs/stack/json/) syntax using new [Monaco Editor](https://microsoft.github.io/monaco-editor/).
+- [#1583](https://github.com/RedisInsight/RedisInsight/pull/1583) Click a pencil icon to make changes to database aliases.
+- [#1579](https://github.com/RedisInsight/RedisInsight/pull/1579) Increase the database password length limitation to 10,000.

--- a/content/develop/connect/insight/release-notes/v.2.20.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.20.0.md
@@ -1,0 +1,35 @@
+---
+Title: RedisInsight v2.20.0, February 2023
+linkTitle: v2.20.0 (Feb 2023)
+date: 2023-02-28 00:00:00 +0000
+description: RedisInsight v2.20.0
+weight: 1
+---
+## 2.20.0 (February 2023)
+This is the General Availability (GA) release of RedisInsight 2.20.
+
+### Highlights
+- Visualizations of [search](https://redis.io/docs/stack/search/) and [graph](https://redis.io/docs/stack/graph/) execution plans in Workbench
+- Guided walkthrough of RedisInsight tools and capabilities for new users
+- Bulk export database connections to a file
+- Upload values of [RedisJSON](https://redis.io/docs/stack/json/) from a file for new keys in Browser
+- Visualizations of [CLIENT LIST](https://redis.io/commands/client-list/) in Workbench
+- See filters previously used in Browser
+
+### Details
+**Features and improvements**
+- [#1629](https://github.com/RedisInsight/RedisInsight/pull/1629), [#1739](https://github.com/RedisInsight/RedisInsight/pull/1739), [#1740](https://github.com/RedisInsight/RedisInsight/pull/1740), [#1781](https://github.com/RedisInsight/RedisInsight/pull/1781) Investigate and optimize your [search](https://redis.io/docs/stack/search/) and [graph](https://redis.io/docs/stack/graph/) queries with new visualizations of execution plans in Workbench. Visualizations are supported for [FT.EXPLAIN](https://redis.io/commands/ft.explain/),[FT.PROFILE](https://redis.io/commands/ft.profile/), [GRAPH.EXPLAIN](https://redis.io/commands/graph.explain/), and [GRAPH.PROFILE](https://redis.io/commands/graph.profile/).
+- [#1698](https://github.com/RedisInsight/RedisInsight/pull/1698) Explore RedisInsight's tools and capabilities with a new walkthrough when you start RedisInsight for the first time.
+- [#1631](https://github.com/RedisInsight/RedisInsight/pull/1631), [#1632](https://github.com/RedisInsight/RedisInsight/pull/1632) Migrate your database connections to another RedisInsight instance by performing a bulk export of database connections to a file.
+- [#1741](https://github.com/RedisInsight/RedisInsight/pull/1741) Upload [RedisJSON](https://redis.io/docs/stack/json/) values from a file for new keys in Browser.
+- [#1653](https://github.com/RedisInsight/RedisInsight/pull/1653) Analyze client connections using new Workbench visualizations for [CLIENT LIST](https://redis.io/commands/client-list/).
+- [#1625](https://github.com/RedisInsight/RedisInsight/pull/1625) Quickly set filters previously used in Browser by selecting them from the list of recently used filters.
+- [#1713](https://github.com/RedisInsight/RedisInsight/pull/1713) See your new Redis keys added in Browser without a need to refresh the list of keys.
+- [#1681](https://github.com/RedisInsight/RedisInsight/pull/1681), [#1692](https://github.com/RedisInsight/RedisInsight/pull/1692), [#1693](https://github.com/RedisInsight/RedisInsight/pull/1693) Avoid the timeout connection errors by configuring the connection timeout for databases added manually via host and port.
+- [#1696](https://github.com/RedisInsight/RedisInsight/pull/1696), [#1703](https://github.com/RedisInsight/RedisInsight/pull/1703) Test the database connection before adding the database.
+- [#1689](https://github.com/RedisInsight/RedisInsight/pull/1689) Update the port of an existing database connection instead of adding a new one.
+- [#1731](https://github.com/RedisInsight/RedisInsight/pull/1731) Use database indexes based on [INFO keyspace](https://redis.io/commands/info/).
+
+**Bugs**
+- [#1678](https://github.com/RedisInsight/RedisInsight/pull/1678) Prevent crashes when SSH is set up on Linux.
+- [#1697](https://github.com/RedisInsight/RedisInsight/pull/1697) Prevent crashes when working with [Redis streams](https://redis.io/docs/data-types/streams) with large IDs.

--- a/content/develop/connect/insight/release-notes/v.2.22.1.md
+++ b/content/develop/connect/insight/release-notes/v.2.22.1.md
@@ -1,0 +1,26 @@
+---
+Title: RedisInsight v2.22.1, March 2023
+linkTitle: v2.22.1 (Mar 2023)
+date: 2023-03-30 00:00:00 +0000
+description: RedisInsight v2.22.1
+weight: 1
+---
+## 2.22.1 (March 2023)
+This is the General Availability (GA) release of RedisInsight 2.22.
+
+### Highlights
+- Share your Redis expertise with your team and the wider community by building custom RedisInsight tutorials. Use our [instructions](https://github.com/RedisInsight/Tutorials) to describe your implementations of Redis for other users to follow and interact with in the context of a connected Redis database
+- Take a quick tour of RedisInsight to discover how it can enhance your development experience when building with Redis or Redis Stack
+- Select from a list of supported decompression formats to view your data in a human-readable format
+
+
+### Details
+**Features and improvements**
+- [#1782](https://github.com/RedisInsight/RedisInsight/pull/1782), [#1813](https://github.com/RedisInsight/RedisInsight/pull/1813) Share your Redis expertise with your team and the wider community by building custom RedisInsight tutorials. The tutorials use markdown and are easy to write. They are an ideal way to describe practical implementations of Redis so users can follow and interact with commands in the context of an already connected Redis database. Check out these [instructions](https://github.com/RedisInsight/Tutorials) to start creating your own tutorials. Let the community discover your content by labeling your GitHub repository with [redis-tutorials](https://github.com/topics/redis-tutorials)
+- [#1834](https://github.com/RedisInsight/RedisInsight/pull/1834) Take a quick tour of RedisInsight to discover how it can enhance your development experience. To start the tour, in the left-side navigation, open the Help Center (above the Settings icon), reset the onboarding and open the Browser page
+- [#1742](https://github.com/RedisInsight/RedisInsight/pull/1742), [#1753](https://github.com/RedisInsight/RedisInsight/pull/1753), [#1755](https://github.com/RedisInsight/RedisInsight/pull/1755), [#1762](https://github.com/RedisInsight/RedisInsight/pull/1762) Configure one of the following data decompression formats when adding a database connection to view your data in a human-readable format: GZIP, LZ4, ZSTD, SNAPPY
+- [#1787](https://github.com/RedisInsight/RedisInsight/pull/1787) Added UX improvements to the search by values of keys feature in Browser: Enable the search box after the index is selected
+
+**Bugs**
+- [#1808](https://github.com/RedisInsight/RedisInsight/pull/1808) Prevent errors when running Docker RedisInsight on Safari Version 16.2
+- [#1835](https://github.com/RedisInsight/RedisInsight/pull/1835) Display total memory and total keys for replicas in Sentinel

--- a/content/develop/connect/insight/release-notes/v.2.24.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.24.0.md
@@ -1,0 +1,30 @@
+---
+Title: RedisInsight v2.24.0, April 2023
+linkTitle: v2.24.0 (Apr 2023)
+date: 2023-04-27 00:00:00 +0000
+description: RedisInsight v2.24
+weight: 1
+---
+## 2.24 (April 2023)
+This is the General Availability (GA) release of RedisInsight 2.24.
+
+### Highlights
+- Bulk data upload: Upload the list of Redis commands from a text file using the new bulk action in the Browser tool. Use the bulk data upload with custom RedisInsight tutorials to quickly load your sample dataset.
+- Support for images in custom tutorials: showcase your Redis expertise with your team and the wider community by building shareable RedisInsight tutorials.
+- JSON formatter support for the [JSON.GET](https://redis.io/commands/json.get/), [JSON.MGET](https://redis.io/commands/json.mget/), and [GET](https://redis.io/commands/get/) command output in Workbench.
+- Added Brotli and PHP GZcompress to the list of supported decompression formats to view your data in a human-readable format. 
+
+### Details
+
+**Features and improvements**
+- [#1930](https://github.com/RedisInsight/RedisInsight/pull/1930), [#1961](https://github.com/RedisInsight/RedisInsight/pull/1961) Upload the list of Redis commands from a text file using the new bulk action in the Browser tool. Use the bulk data upload with custom RedisInsight tutorials to quickly load your sample dataset.
+- [#1936](https://github.com/RedisInsight/RedisInsight/pull/1936), [#1939](https://github.com/RedisInsight/RedisInsight/pull/1939) Added support for images in custom tutorials, available in Workbench. Showcase your Redis expertise with your team and the wider community by building shareable tutorials. Use markdown syntax described in our [instructions](https://github.com/RedisInsight/Tutorials) to build tutorials.
+- [#1946](https://github.com/RedisInsight/RedisInsight/pull/1946) See the output of [JSON.GET](https://redis.io/commands/json.get/), [JSON.MGET](https://redis.io/commands/json.mget/), and [GET](https://redis.io/commands/get/) formatted as JSON in Workbench.
+- [#1876](https://github.com/RedisInsight/RedisInsight/pull/1876) Ability to directly delete a key in the Browser list of keys without having to view its values.
+- [#1889](https://github.com/RedisInsight/RedisInsight/pull/1889), [#1900](https://github.com/RedisInsight/RedisInsight/pull/1900) Added Brotli and PHP GZcompress to the list of supported decompression formats to view your data in a human-readable format. Decompression format is configurable when adding a database connection.
+- [#1886](https://github.com/RedisInsight/RedisInsight/pull/1886) Enhanced command syntax in CLI, Workbench, and Command Helper to align with [command documentation](https://redis.io/commands/).
+- [#1975](https://github.com/RedisInsight/RedisInsight/pull/1975) [Renamed](https://github.com/RedisInsight/RedisInsight/issues/1902) the "Display On System Tray" to "Show in Menu Bar" on macOS.
+
+**Bugs**
+- [#1990](https://github.com/RedisInsight/RedisInsight/pull/1990) Keep the previously specified SNI parameters when a database connection is edited.
+- [#1999](https://github.com/RedisInsight/RedisInsight/pull/1999) Keep the previously set database index when a database connection is edited.

--- a/content/develop/connect/insight/release-notes/v.2.26.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.26.0.md
@@ -1,0 +1,23 @@
+---
+Title: RedisInsight v2.26.0, May 2023
+linkTitle: v2.26.0 (May 2023)
+date: 2023-05-31 00:00:00 +0000
+description: RedisInsight v2.26
+weight: 1
+---
+## 2.26 (May 2023)
+This is the General Availability (GA) release of RedisInsight 2.26.
+
+### Highlights
+- Introducing Insights (Beta): a new right-side panel that displays contextualised database recommendations for optimizing performance and memory usage. The list of recommendations gets updated as you interact with your database. Check out the paired-up tutorials to learn about the recommended feature and vote to provide feedback. This functionality is being rolled out gradually to the user base.
+- Support for bulk data upload in custom tutorials: quickly upload sample datasets from your custom RedisInsight tutorials to share your Redis expertise with your team and the wider community.
+
+### Details
+
+**Features and improvements**
+- [#1847](https://github.com/RedisInsight/RedisInsight/pull/1847), [#1901](https://github.com/RedisInsight/RedisInsight/pull/1901), [#1957](https://github.com/RedisInsight/RedisInsight/pull/1957), [#1972](https://github.com/RedisInsight/RedisInsight/pull/1972) Launching Insights (Beta): a new right-side panel that displays contextualised database recommendations for optimizing performance and memory usage. The list of recommendations gets updated in real-time as you interact with your database taking into account database configuration, user actions and accessed data. Consult the paired-up tutorials to learn more about the recommended feature. This functionality is being rolled out gradually to the user base in order to allow the RedisInsight team to learn and adjust the recommendations. Provide feedback directly in the app or the [GitHub repository](https://github.com/RedisInsight/RedisInsight/issues). 
+- [#2019](https://github.com/RedisInsight/RedisInsight/pull/2019) Quickly upload sample data sets in bulk from your custom RedisInsight tutorials to share your Redis expertise with your team and the wider community. Use a text file with the list of Redis commands and follow our simple [instructions](https://github.com/RedisInsight/Tutorials) to include example data sets in your custom RedisInsight tutorials
+- [#2010](https://github.com/RedisInsight/RedisInsight/pull/2010), [#2012](https://github.com/RedisInsight/RedisInsight/pull/2012), [#2013](https://github.com/RedisInsight/RedisInsight/pull/2013) Optimized the logic when filtering per data type in Browser to avoid unnecessary [TYPE](https://redis.io/commands/type/) commands
+
+**Bugs**
+- [#2014](https://github.com/RedisInsight/RedisInsight/pull/2014) Display the actual command processing time in Workbench when results are grouped

--- a/content/develop/connect/insight/release-notes/v.2.30.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.30.0.md
@@ -1,0 +1,24 @@
+---
+Title: RedisInsight v2.30.0, July 2023
+linkTitle: v2.30.0 (July 2023)
+date: 2023-07-27 00:00:00 +0000
+description: RedisInsight v2.30
+weight: 1
+---
+## 2.30 (July 2023)
+This is the General Availability (GA) release of RedisInsight 2.30.
+
+### Highlights
+Introducing support for [triggers and functions](https://github.com/RedisGears/RedisGears/) that bring application logic closer to your data and give Redis powerful features for event-driven data processing
+
+### Details
+
+**Features and improvements**
+
+[#2247](https://github.com/RedisInsight/RedisInsight/pull/2247), [#2249](https://github.com/RedisInsight/RedisInsight/pull/2249), [#2273](https://github.com/RedisInsight/RedisInsight/pull/2273), [#2279](https://github.com/RedisInsight/RedisInsight/pull/2279) Support for [triggers and functions](https://github.com/RedisGears/RedisGears/) that add the capability to execute server-side functions triggered by events or data operations to:
+ - Speed up applications by running the application logic where the data lives
+ - Eliminate the need to maintain the same code across different applications by moving application functionality inside the Redis database
+ - Maintain consistent data when applications react to any keyspace change
+ - Improve code resiliency by backing up and replicating triggers and functions along with the database
+
+Triggers and functions work with a JavaScript engine, which lets you take advantage of JavaScript’s vast ecosystem of libraries and frameworks and modern, expressive syntax.

--- a/content/develop/connect/insight/release-notes/v.2.32.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.32.0.md
@@ -1,0 +1,25 @@
+---
+Title: RedisInsight v2.32.0, August 2023
+linkTitle: v2.32.0 (August 2023)
+date: 2023-08-31 00:00:00 +0000
+description: RedisInsight v2.32
+weight: 1
+---
+## 2.32 (August 2023)
+This is the General Availability (GA) release of RedisInsight 2.32.
+
+### Highlights
+- Easily provision a free database to use with the RedisInsight interactive tutorials to learn, among others, how to leverage Vector Similarity Search for your AI use cases or discover the power of the native JSON data structure supporting structured querying and full-text search. Take advantage of the in-app social sign-up to [Redis Cloud](https://redis.com/comparisons/oss-vs-enterprise/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_32) to quickly provision a free database with [Redis Stack’s capabilities](https://redis.io/docs/about/about-stack/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_32). Try the [latest 7.2](https://redis.com/blog/introducing-redis-7-2/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_32) release which delivers the new [Triggers and Functions](https://redis.com/blog/introducing-triggers-and-functions/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_32) feature, allowing you to execute server-side functions written in JavaScript that are either triggered by a keyspace change, by a stream entry arrival, or by explicitly calling them, empowering developers to build and maintain real-time applications by moving business logic closer to the data, ensuring a lower latency whilst delivering the best developer experience.
+- Select a custom installation directory on Windows OS for when multi-user access to the app is required.
+
+ 
+### Details
+ 
+**Features and improvements**
+ 
+- [#2270](https://github.com/RedisInsight/RedisInsight/pull/2270), [#2271](https://github.com/RedisInsight/RedisInsight/pull/2271), [#2437](https://github.com/RedisInsight/RedisInsight/pull/2437) Added the ability to quickly provision a free [Redis Cloud](https://redis.com/comparisons/oss-vs-enterprise/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_32) database via in-app social signup (Google or GitHub). Use the database with the RedisInsight interactive tutorials or try the [latest 7.2](https://redis.com/blog/introducing-redis-7-2/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_32) release which delivers the new [Triggers and Functions](https://redis.com/blog/introducing-triggers-and-functions/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_32) feature. To quickly create and automatically add a free Redis Cloud database to RedisInsight, click the "Try Redis Cloud" banner in the list of database connections page and follow the steps.
+- [#2455](https://github.com/RedisInsight/RedisInsight/pull/2455) Select a custom installation directory on Windows OS
+- [#2373](https://github.com/RedisInsight/RedisInsight/pull/2373), [#2387](https://github.com/RedisInsight/RedisInsight/pull/2387) Delete all command results in Workbench at once
+- [#2458](https://github.com/RedisInsight/RedisInsight/pull/2458) Added in-app hints in Browser and Workbench to get started with RedisInsight interactive tutorials
+- [#2422](https://github.com/RedisInsight/RedisInsight/pull/2422) Ignore the empty lines in files when uploading data in bulk
+- [#2470](https://github.com/RedisInsight/RedisInsight/pull/2470) Preset the header containing the engine, the API version and the library name in the JavaScript file when creating a new library within the [Triggers and Functions](https://redis.com/blog/introducing-triggers-and-functions/?utm_source=redisinsight&utm_medium=main&utm_campaign=main) tool

--- a/content/develop/connect/insight/release-notes/v.2.34.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.34.0.md
@@ -1,0 +1,27 @@
+---
+Title: RedisInsight v2.34.0, September 2023
+linkTitle: v2.34.0 (September 2023)
+date: 2023-09-28 00:00:00 +0000
+description: RedisInsight v2.34
+weight: 1
+---
+## 2.34 (September 2023)
+This is the General Availability (GA) release of RedisInsight 2.34.
+
+### Highlights
+- UX improvements to simplify the in-app provisioning and usage of a free [Redis Cloud](https://redis.com/comparisons/oss-vs-enterprise/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_34) database with RedisInsight interactive tutorials. This will allow you to learn easily, among other things, how to leverage the native JSON data structure supporting structured querying and full-text search, including vector similarity search for your AI use cases
+- Ability to refresh the list of [search indexes](https://redis.io/docs/interact/search-and-query/?utm_source=redisinsight&utm_medium=main&utm_campaign=main) displayed in Browser
+- Set the color theme to follow the local system preferences
+
+### Details
+
+**Features and improvements** 
+- [#2585](https://github.com/RedisInsight/RedisInsight/pull/2585) UX improvements to simplify the in-app provisioning and usage of a free [Redis Cloud](https://redis.com/comparisons/oss-vs-enterprise/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_34) database with RedisInsight interactive tutorials. To provision a new database, click the "Try Redis Cloud" banner in the list of database connections page and follow the steps
+- [#2606](https://github.com/RedisInsight/RedisInsight/pull/2606) Ability to refresh the list of [search indexes](https://redis.io/docs/interact/search-and-query/?utm_source=redisinsight&utm_medium=main&utm_campaign=main) displayed in Browser
+- [#2593](https://github.com/RedisInsight/RedisInsight/pull/2593) UX optimizations to improve the back navigation to the list of databases, including for small resolutions
+- [#2599](https://github.com/RedisInsight/RedisInsight/pull/2599) Added an option to set the color theme to follow the local system preferences
+- [#2563](https://github.com/RedisInsight/RedisInsight/pull/2563) Load a new library from the Functions tab within the [Triggers and Functions](https://redis.com/blog/introducing-triggers-and-functions/?utm_source=redisinsight&utm_medium=main&utm_campaign=main) tool
+- [#2496](https://github.com/RedisInsight/RedisInsight/pull/2496) Set milliseconds as a default unit in Slow Log
+
+**Bugs**
+- [#2587](https://github.com/RedisInsight/RedisInsight/pull/2587) Display detailed [errors](https://github.com/RedisInsight/RedisInsight/issues/2562) in transactions run via CLI or Workbench

--- a/content/develop/connect/insight/release-notes/v.2.36.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.36.0.md
@@ -1,0 +1,26 @@
+---
+Title: RedisInsight v2.36.0, October 2023
+linkTitle: v2.36.0 (October 2023)
+date: 2023-10-26 00:00:00 +0000
+description: RedisInsight v2.36
+weight: 1
+---
+## 2.36 (October 2023)
+This is the General Availability (GA) release of RedisInsight 2.36.
+
+### Highlights
+ 
+- Optimizations for efficient handling of big [Redis strings](https://redis.io/docs/data-types/strings/): choose to either view the string value for up to a maximum of 5,000 characters or download the data fully as a file if it exceeds the limit
+- Improved security measurement to no longer display in plain text existing database passwords, SSH passwords, passphrases, and private keys
+ 
+### Details
+ 
+**Features and improvements**
+- [#2685](https://github.com/RedisInsight/RedisInsight/pull/2685), [#2686](https://github.com/RedisInsight/RedisInsight/pull/2686) Added optimizations for working with big [Redis strings](https://redis.io/docs/data-types/strings/). Users can now choose to either view the data up to a maximum of 5,000 characters or download it in a file fully if it exceeds the limit.
+- [#2647](https://github.com/RedisInsight/RedisInsight/pull/2647) Improved security measurement to no longer expose the existing database passwords, SSH passwords, passphrases, and private keys in plain text
+- [#2631](https://github.com/RedisInsight/RedisInsight/pull/2631) Added proactive notification to restart the application when a new version becomes available
+- [#2705](https://github.com/RedisInsight/RedisInsight/pull/2705) Basic support in the [search index](https://redis.io/docs/interact/search-and-query/) creation form (in Browser) to enable [geo polygon](https://redis.io/commands/ft.create/#:~:text=Vector%20Fields.-,GEOSHAPE,-%2D%20Allows%20polygon%20queries) search
+- [#2681](https://github.com/RedisInsight/RedisInsight/pull/2681) Updated the Pickle formatter to [support](https://github.com/RedisInsight/RedisInsight/issues/2260) Pickle protocol 5
+ 
+**Bugs**
+- [#2675](https://github.com/RedisInsight/RedisInsight/pull/2675) Show the "Scan more" control until the cursor returned by the server is 0 to fix [cases](https://github.com/RedisInsight/RedisInsight/issues/2618) when not all keys are displayed.

--- a/content/develop/connect/insight/release-notes/v.2.38.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.38.0.md
@@ -1,0 +1,26 @@
+---
+Title: RedisInsight v2.38.0, November 2023
+linkTitle: v2.38.0 (November 2023)
+date: 2023-11-29 00:00:00 +0000
+description: RedisInsight v2.38
+weight: 1
+---
+## 2.38 (November 2023)
+This is the General Availability (GA) release of RedisInsight 2.38.
+
+### Highlights
+- Major UX improvements and space optimization for a cleaner and more organized Tree view, ensuring easier namespace navigation and faster key browsing. Additionally, in Tree view, you can now sort your Redis key names alphabetically.
+- Renamed the application from RedisInsight v2 to simply RedisInsight
+
+### Details
+
+**Features and improvements**
+
+- [#2706](https://github.com/RedisInsight/RedisInsight/pull/2706), [#2783](https://github.com/RedisInsight/RedisInsight/pull/2783) Major UX improvements and space optimization for a cleaner and more organized Tree view. This includes consolidating the display of namespaces and keys in a dedicated section and omitting namespace information from key names in the list of keys. In addition, the Tree view introduces a new option to alphabetically sort Redis key names.
+- [#2751](https://github.com/RedisInsight/RedisInsight/pull/2751) Renamed the application from RedisInsight v2 to simply RedisInsight
+- [#2799](https://github.com/RedisInsight/RedisInsight/pull/2799) Automatically make three retries to establish or re-establish a database connection if an error occurs
+
+**Bugs**
+- [#2793](https://github.com/RedisInsight/RedisInsight/pull/2793) [Do not require](https://github.com/RedisInsight/RedisInsight/issues/2765) an SSH password or passphrase
+- [#2794](https://github.com/RedisInsight/RedisInsight/pull/2794) Prevent [potential crashes](https://github.com/RedisInsight/RedisInsight/issues/2763) caused by using parentheses in usernames on the Windows operating system
+- [#2797](https://github.com/RedisInsight/RedisInsight/pull/2797) Avoid initiating a bulk deletion or Profiler after the operating system resumes from sleep mode

--- a/content/develop/connect/insight/release-notes/v.2.4.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.4.0.md
@@ -1,0 +1,28 @@
+---
+Title: RedisInsight v2.4.0, June 2022
+linkTitle: v2.4.0 (June 2022)
+date: 2022-06-27 00:00:00 +0000
+description: RedisInsight v2.4.0
+weight: 9
+---
+
+## 2.4.0 (June 2022)
+This is the General Availability (GA) release of RedisInsight 2.4.0
+
+### Headlines:
+- Pub/Sub: Added support for [Redis pub/sub](https://redis.io/docs/manual/pubsub/) enabling subscription to channels and posting messages to channels.
+- Consumer groups: Added support for [streams consumer groups](https://redis.io/docs/manual/data-types/streams/#consumer-groups) enabling provision of different subsets of messages from the same stream to many clients for inspection and processing.
+- Database search: Search the list of databases added to RedisInsight to quickly find the required database.
+
+
+### Details
+**Features and improvements:**
+- [#760](https://github.com/RedisInsight/RedisInsight/pull/760), [#737](https://github.com/RedisInsight/RedisInsight/pull/737), [#773](https://github.com/RedisInsight/RedisInsight/pull/773) Added support for [Redis pub/sub](https://redis.io/docs/manual/pubsub/) enabling subscription to channels and posting messages to channels. Currently does not support sharded channels.
+- [#717](https://github.com/RedisInsight/RedisInsight/pull/717), [#683](https://github.com/RedisInsight/RedisInsight/pull/683), [#684](https://github.com/RedisInsight/RedisInsight/pull/684), [#688](https://github.com/RedisInsight/RedisInsight/pull/688), [#720](https://github.com/RedisInsight/RedisInsight/pull/720), Added support for [streams consumer groups](https://redis.io/docs/manual/data-types/streams/#consumer-groups) to manage different groups and consumers for the same stream, explicit acknowledgment of processed items, ability to inspect the pending items, claiming of unprocessed messages, and coherent history visibility for each single client.
+- [#754](https://github.com/RedisInsight/RedisInsight/pull/754) New **All Relationship** toggle for RedisGraph visualizations in **Workbench**. Enable it to see all relationships between your nodes.
+- [#788](https://github.com/RedisInsight/RedisInsight/pull/788) Quickly search the list of databases added to RedisInsight per database alias, host:port, or the last connection to find the database needed.
+- [#788](https://github.com/RedisInsight/RedisInsight/pull/788) Overview displays the number of keys per the logical database connected if this number is not equal to the total number in the database.
+
+**Bugs Fixed:**
+- [#774](https://github.com/RedisInsight/RedisInsight/pull/774) Fixed cases when not all parameters are received in Overview.
+- [#810](https://github.com/RedisInsight/RedisInsight/pull/810) Display several streams values with the same timestamp.

--- a/content/develop/connect/insight/release-notes/v.2.40.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.40.0.md
@@ -1,0 +1,26 @@
+---
+Title: RedisInsight v2.40.0, December 2023
+linkTitle: v2.40.0 (December 2023)
+date: 2023-12-27 00:00:00 +0000
+description: RedisInsight v2.40
+weight: 1
+---
+## 2.40 (December 2023)
+This is the General Availability (GA) release of RedisInsight 2.40.
+
+### Highlights
+- To simplify in-app provisioning of a free [Redis Cloud](https://redis.com/comparisons/oss-vs-enterprise/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_40) database to use with RedisInsight interactive tutorials, the recommended cloud vendor and region are now preselected 
+- Optimizations when uploading large text files with the list of Redis commands, available under bulk actions in Browser
+
+### Details
+
+**Features and improvements**
+- [#2879](https://github.com/RedisInsight/RedisInsight/pull/2879) UX improvements to simplify in-app provisioning of a free [Redis Cloud](https://redis.com/comparisons/oss-vs-enterprise/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_40) database. Create a new database with a preselected cloud vendor and region by using the recommended sign-up settings. You can manage your database by signing in to the [Redis Cloud console](https://app.redislabs.com/#/databases?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_40)
+- [#2851](https://github.com/RedisInsight/RedisInsight/pull/2851) See plan, cloud vendor, and region details after successfully provisioning your free [Redis Cloud](https://redis.com/comparisons/oss-vs-enterprise/?utm_source=redisinsight&utm_medium=rel_notes&utm_campaign=2_40) database
+- [#2882](https://github.com/RedisInsight/RedisInsight/pull/2882) Optimizations when uploading large text files with the list of Redis commands, available under bulk actions in Browser
+- [#2808](https://github.com/RedisInsight/RedisInsight/pull/2808) Enhanced security measurement to no longer display existing passwords for Redis Sentinel in plain text
+- [#2875](https://github.com/RedisInsight/RedisInsight/pull/2875) Increased performance when resizing the key list and key details in the Tree view, ensuring a smoother user experience
+- [#2866](https://github.com/RedisInsight/RedisInsight/pull/2866) Support for hyphens in [node host names](https://github.com/RedisInsight/RedisInsight/issues/2865)
+
+**Bugs**
+- [#2868](https://github.com/RedisInsight/RedisInsight/pull/2868) Prevent [unintentional data overwrites](https://github.com/RedisInsight/RedisInsight/issues/2791) by disabling both manual and automatic refreshing of key values while editing in the Browser

--- a/content/develop/connect/insight/release-notes/v.2.42.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.42.0.md
@@ -1,0 +1,23 @@
+---
+Title: RedisInsight v2.42.0, January 2024
+linkTitle: v2.42.0 (January 2024)
+date: 2024-01-30 00:00:00 +0000
+description: RedisInsight v2.42
+weight: 1
+---
+## 2.42 (January 2024)
+This is the General Availability (GA) release of RedisInsight 2.42.
+
+### Highlights
+- Introducing a new dedicated developer enablement area! Explore Redis capabilities and learn how to use the native JSON data structure for structured querying and full-text search, including vector similarity search for AI use cases, and more. Browse the tutorials offline or use the in-app provisioning of a free Redis Cloud database to try them interactively.
+- RedisInsight is now available on Docker. Check out our [Docker repository](https://hub.docker.com/repository/docker/redis/redisinsight/general) if that’s your preferred platform. 
+
+
+### Details
+
+**Features and improvements**
+- [#2724](https://github.com/RedisInsight/RedisInsight/pull/2724), [#2752](https://github.com/RedisInsight/RedisInsight/pull/2752), [#2965](https://github.com/RedisInsight/RedisInsight/pull/2965) Introducing a dedicated developer enablement area. Dive into interactive tutorials and level up your Redis game even without a database connected. Start exploring tutorials by clicking on the "Insights" button located in the top-right corner. Because interactive tutorials can alter data in your database, avoid running them in a production environment. For an optimal tutorial experience, create a free [Redis Cloud](https://redis.com/try-free/?utm_source=redisinsight&utm_medium=main&utm_campaign=redisinsight_release_notes) database.
+- [#2972](https://github.com/RedisInsight/RedisInsight/pull/2972), [#2811](https://github.com/RedisInsight/RedisInsight/pull/2811) The long-awaited Docker build is now available. Check out our [Docker repository](https://hub.docker.com/repository/docker/redis/redisinsight/general) if that’s your preferred platform.
+- [#2857](https://github.com/RedisInsight/RedisInsight/pull/2857) Empty Browser and Workbench pages are aligned with the new interactive tutorials.
+- [#2940](https://github.com/RedisInsight/RedisInsight/pull/2940) Recommendations have been renamed to Tips.
+- [#2970](https://github.com/RedisInsight/RedisInsight/pull/2970) A critical vulnerability has been fixed.

--- a/content/develop/connect/insight/release-notes/v.2.44.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.44.0.md
@@ -1,0 +1,24 @@
+---
+Title: RedisInsight v2.44.0, February 2024
+linkTitle: v2.44.0 (February 2024)
+date: 2024-02-29 00:00:00 +0000
+description: RedisInsight v2.44
+weight: 1
+---
+## 2.44 (February 2024)
+This is the General Availability (GA) release of RedisInsight 2.44.
+
+### Highlights
+- Added support for SSH tunneling for clustered databases, unblocking some users who want to migrate from RESP.app to RedisInsight.
+- UX optimizations in the Browser layout to make it easier to leverage [search and query](https://redis.io/docs/interact/search-and-query/?utm_source=redisinsight&utm_medium=main&utm_campaign=redisinsight_release_notes) indexes.
+
+### Details
+
+**Features and improvements**
+- [#2711](https://github.com/RedisInsight/RedisInsight/pull/2711), [#3040](https://github.com/RedisInsight/RedisInsight/pull/3040) Connect to your clustered Redis database via SSH tunnel using a password or private key in PEM format.
+- [#3030](https://github.com/RedisInsight/RedisInsight/pull/3030), [#3070](https://github.com/RedisInsight/RedisInsight/pull/3070) UX optimizations in the Browser layout to enlarge the "Filter by Key" input field in the Browser and optimize the display of long [search and query](https://redis.io/docs/interact/search-and-query/?utm_source=redisinsight&utm_medium=main&utm_campaign=redisinsight_release_notes) indexes.
+- [#3033](https://github.com/RedisInsight/RedisInsight/pull/3033), [#3036](https://github.com/RedisInsight/RedisInsight/pull/3036) Various improvements for custom [tutorials](https://github.com/RedisInsight/Tutorials), including visual highlighting of Redis code blocks and strengthening security measures for bulk data uploads by providing an option to download and preview the list of commands for upload.
+- [#3010](https://github.com/RedisInsight/RedisInsight/pull/3010) Enhancements to prevent authentication errors caused by [certain special characters](https://github.com/RedisInsight/RedisInsight/issues/3019) in database passwords. 
+
+**Bugs**
+- [#3029](https://github.com/RedisInsight/RedisInsight/pull/3029) A fix for cases when autofill [prevents](https://github.com/RedisInsight/RedisInsight/issues/3026) the form to auto-discover Redis Enterprise Cluster database from being submitted.

--- a/content/develop/connect/insight/release-notes/v.2.46.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.46.0.md
@@ -1,0 +1,25 @@
+---
+Title: RedisInsight v2.46.0, March 2024
+linkTitle: v2.46.0 (March 2024)
+date: 2024-03-28 00:00:00 +0000
+description: RedisInsight v2.46
+weight: 1
+---
+## 2.46 (March 2024)
+This is the General Availability (GA) release of RedisInsight 2.46.
+
+### Highlights
+- New formatters for 32-bit and 64-bit vector embeddings for a more human-readable representation in the Browser
+- Cleaner layout on the main page with quick access to JSON and search & query tutorials and Redis Cloud in-app sign-up
+
+
+### Details
+
+**Features and improvements**
+- [#2843](https://github.com/RedisInsight/RedisInsight/pull/2843), [#3185](https://github.com/RedisInsight/RedisInsight/pull/3185) Adding new formatters for 32-bit and 64-bit vector embeddings to visualize them as arrays in Browser for a simpler and more intuitive representation.
+- [#3069](https://github.com/RedisInsight/RedisInsight/pull/3069) UX enhancements in the database list page for an improved user experience, leading to a cleaner layout and easier navigation.
+- [#3151](https://github.com/RedisInsight/RedisInsight/pull/3151) Launch RedisInsight with the previously used window size.
+
+**Bugs**
+- [#3152](https://github.com/RedisInsight/RedisInsight/pull/3152), [#3156](https://github.com/RedisInsight/RedisInsight/pull/3156) A fix to [support the * wildcard](https://github.com/RedisInsight/RedisInsight/issues/3146) in Stream IDs.
+- [#3174](https://github.com/RedisInsight/RedisInsight/pull/3174) Display invalid JSONs as unformatted values when a JSON view is set in Workbench results.

--- a/content/develop/connect/insight/release-notes/v.2.6.0.md
+++ b/content/develop/connect/insight/release-notes/v.2.6.0.md
@@ -1,0 +1,28 @@
+---
+Title: RedisInsight v2.6.0, July 2022
+linkTitle: v2.6.0 (July 2022)
+date: 2022-07-25 00:00:00 +0000
+description: RedisInsight v2.6.0
+weight: 8
+---
+
+## 2.6.0 (July 2022)
+This is the General Availability (GA) release of RedisInsight 2.6.0
+
+### Headlines:
+- Bulk actions: Delete the keys in bulk based on the filters set in Browser or Tree view
+- Multiline support for key values in Browser and Tree View: Click the key value to see it in full
+- [Pipeline](https://redis.io/docs/manual/pipelining/) support in Workbench: Batch Redis commands in Workbench to optimize round-trip times
+- In-app notifications: Receive messages about important changes, updates, or announcements inside the application. Notifications are always available in the Notification center, and can be displayed with or without preview.
+
+### Details
+**Features and improvements:**
+- [#890](https://github.com/RedisInsight/RedisInsight/pull/890), [#883](https://github.com/RedisInsight/RedisInsight/pull/883), [#875](https://github.com/RedisInsight/RedisInsight/pull/875) Delete keys in bulk from your Redis database in Browser and Tree view based on filters you set by key name or data type.
+- [#878](https://github.com/RedisInsight/RedisInsight/pull/878) Multiline support for key values in Browser and Tree View: Select the truncated value to expand the row and see the full value, select again to collapse it.
+- [#837](https://github.com/RedisInsight/RedisInsight/pull/837), [#838](https://github.com/RedisInsight/RedisInsight/pull/838) Added [pipeline](https://redis.io/docs/manual/pipelining/) support for commands run in Workbench to optimize round-trip times. Default number of commands sent in a pipeline is 5, and is configurable in Settings > Advanced. 
+- [#862](https://github.com/RedisInsight/RedisInsight/pull/862), [#840](https://github.com/RedisInsight/RedisInsight/pull/840) Added in-app notifications to inform you about any important changes, updates, or announcements. Notifications are always available in the Notification center, and can be displayed with or without preview.
+- [#830](https://github.com/RedisInsight/RedisInsight/pull/830) To more easily explore and work with stream data, always display stream entry ID and controls to remove the Stream entry regardless of the number of fields.
+- [#928](https://github.com/RedisInsight/RedisInsight/pull/928) Remember the sorting on the list of databases.
+
+**Bugs fixed:**
+- [#932](https://github.com/RedisInsight/RedisInsight/pull/932) Refresh the JSON value in Browser/Tree view.

--- a/content/develop/connect/insight/release-notes/v1.0.0.md
+++ b/content/develop/connect/insight/release-notes/v1.0.0.md
@@ -1,0 +1,11 @@
+---
+Title: RedisInsight v1.0, November 2019
+linkTitle: v1.0 (Nov 2019)
+date: 2019-10-01 03:49:29 +0000
+description: The initial release after Redis acquired RDBTools
+weight: 100
+---
+
+## RedisInsight v1.0.0 release notes (November 2019)
+
+This is the initial release after [Redis acquired RDBTools](https://www.redislabs.com/blog/redisinsight-gui/).

--- a/content/develop/connect/insight/release-notes/v1.1.0.md
+++ b/content/develop/connect/insight/release-notes/v1.1.0.md
@@ -1,0 +1,32 @@
+---
+Title: RedisInsight v1.1, December 2019 
+linkTitle: v1.1 (Dec 2019)
+date: 2019-12-27 03:49:29 +0000
+description: Stability improvements and other fixes
+weight: 99
+---
+## RedisInsight v1.1.0 release notes (December 2019)
+
+### Headlines
+
+- This release improves overall stability and provides fixes for issues found after the previous release.
+
+### Details
+
+- Minor Enhancements:
+    - Core:
+        - Enable mouse wheel support inside the `querycard`.
+    - Browser:
+        - Enable enter key press for adding keys in browser
+    - RediSearch:
+        - Disable HIGHLIGHT markup in JSON view.
+    - Browser:
+        - Improve error message when database is unreachable
+        - Add a reload/refresh button to refresh the value of a key
+        - Enable enter key press for adding keys in browser
+        - Improve error message for unsupported value types
+- Bug Fixes:
+    - RedisGraph:
+        - Fix initial node placement in the view.
+        - Fix initial zoom with respect to the number of nodes in the result.
+    - Other minor fixes.

--- a/content/develop/connect/insight/release-notes/v1.10.0.md
+++ b/content/develop/connect/insight/release-notes/v1.10.0.md
@@ -1,0 +1,72 @@
+---
+Title: RedisInsight v1.10, March 2021
+linkTitle: v1.10 (Mar 2021)
+date: 2021-03-08 00:00:00 +0000
+description: RedisInsight v1.10.0
+weight: 90
+---
+
+## 1.10.1 (April 2021)
+
+This is the maintenance release of RedisInsight 1.10 (v1.10.1)!
+
+### Fixes:
+
+- Core:
+  - Fixed a bug where launching RedisInsight on macOS mojave (10.14.6) would log out the user.
+  - Fixed two major container vulnerability. (CVE-2021-24031, CVE-2021-24032 and CVE-2020-36242)
+  - Select existing installation path on upgrades in Windows.
+- CLI:
+  - Added support for RAW mode (`--raw` in `redis-cli`).
+- Browser:
+  - Fixed a bug where a number in redis string datatype is treated as a JSON .
+  -  RedisJSON - Distinguish between empty and collapsed objects/arrays.
+- Streams:
+  - Added ability to configure auto refresh interval.
+- RedisTimeseries:
+  - Charts now support milliseconds.
+  - Added ability to configure auto refresh interval.
+- RedisGraph:
+  - Properly detect module in Redis Enterprise
+  - Large queries that are truncated in the query card is provided with a tooltip that displays the query on hover.
+  - Properly render boolean data types in the objects.
+- Bulk actions:
+  - Fixed a bug where preview returns duplicate dry run commands.
+
+
+## 1.10.0 (March 2021)
+
+This is the General Availability (GA) Release of RedisInsight 1.10 (v1.10.0)!
+
+### Headlines:
+- Improvements to the way the Browser tool displays "special" strings.
+- UX improvements to the RedisGraph tool.
+- Ability to configure the slowlog threshold from within the Slowlog tool.
+
+### Full Details:
+- Overview:
+    - The connection details of the Redis database are now displayed.
+    - A message is displayed to indicate a cluster with no replicas instead of an empty table.
+    - Fixed a bug where the memory usage chart would display an incorrect graph when the memory usage changes rapidly.
+- Browser:
+    - Pretty-print "special" strings (like JSON, Java serialized object, Python pickle objects, etc.) once the entire value is loaded.
+    - Pretty-print "special" strings (like JSON, Java serialized object, Python pickle objects, etc.) inside container types like Hashes, Sets and Sorted Sets.
+    - Allow sorting the members of a sorted set by score.
+    - Refresh button for the key list.
+    - Delete a key by pressing the "Delete" key.
+    - All keys are now visible by default, i.e, the data type filters are disabled by default.
+    - Fixed bug where switching logical databases did not work correctly sometimes.
+    - Fixed bug where adding a field to a hash with an empty value crashes the UI.
+    - Fixed bug where setting TTL to -1 does not effectively delete the key.
+    - Added tooltip explaining how to use the logical database selector along with a submit button.
+- Streams:
+    - Refresh button for the list of streams.
+- RedisGraph:
+    - Node size is now dependent on the number of direct relationships.
+    - Added support for pasting the full `GRAPH.QUERY` command into the query textbox.
+- RediSearch:
+    - Fixed bug where the application fails to execute queries on indices starting with/enclosed within single-quotes.
+- Bulk Actions:
+    - Improved support for operations on a large number of keys.
+- Slowlog:
+    - Allow configuring the slowlog threshold from within the tool for non-cluster databases.

--- a/content/develop/connect/insight/release-notes/v1.11.0.md
+++ b/content/develop/connect/insight/release-notes/v1.11.0.md
@@ -1,0 +1,49 @@
+---
+Title: RedisInsight v1.11, Oct 2021
+linkTitle: v1.11 (Oct 2021)
+date: 2021-10-17 00:00:00 +0000
+description: RedisInsight v1.11.0
+weight: 89
+---
+
+## 1.11.1 (January 2022)
+
+This is the maintenance release of RedisInsight 1.11 (v1.11.1)!
+
+### Fixes:
+
+- Core:
+  - Fixed a warning about `urllib` version deprecation.
+  - ACL errors are now show in pretty format while in edit database screen.
+  - Fixed unnecessary warning about segment when there's no internet connection.
+- RediSearch:
+  - Fix index tool support for `v2.2.5`.
+- Bulk actions:
+  - Added support for cross-slot bulk action execution.
+  - Fixed a bug where there's a failure when a malformed UTF-8 characters are present in the key.
+- Memory Analysis:
+  - Added support for `quicklist2` data type.
+- Cluster Management:
+  - Generic errors are also displayed in the tool. This is helpful when connected to a vendor provided redis with custom exceptions.
+
+## 1.11.0
+
+This is the General Availability Release of RedisInsight 1.11 (v1.11.0)!
+
+### Headlines:
+- Added beta support for [RedisAI](https://oss.redis.com/redisai/)
+- Fixed the issue with empty fields for Hash objects.
+
+### Full Details:
+- Core:
+  - Fixed a bug where editing cluster returns error.
+  - Fixed broken redis links.
+- Browser
+  - Check Hash value for `emptiness`
+- RedisGraph:
+  - Added support for point datatype.
+  - Fixed a bug where returning relationships without their respective nodes leads to infinite loading
+- RediSearch:
+  - Fixed a bug where a malformed unicode string in redisearch doesn't produce results.
+- RedisTimeseries:
+  - Added support for `TS.REVRANGE` and `TS.MREVRANGE` commands.

--- a/content/develop/connect/insight/release-notes/v1.12.0.md
+++ b/content/develop/connect/insight/release-notes/v1.12.0.md
@@ -1,0 +1,54 @@
+---
+Title: RedisInsight v1.12, May 2022
+linkTitle: v1.12 (May 2022)
+date: 2022-05-24 00:00:00 +0000
+description: RedisInsight v1.12.0
+weight: 11
+---
+
+## 1.12.1 (July 2022)
+
+This is the maintenance release of RedisInsight 1.12 (v1.12.1)!
+
+### Critical Bug Fix:
+- Core:
+  - When you add or remove a Redis Enterprise Software or Redis Cloud database in RedisInsight v1 that has the RediSearch module loaded, all hashes within that database are deleted.
+
+### Fixes:
+- Core:
+  - Added curl command to container.
+  - Fixed container vulnerabilities (CVE-2022-1292, CVE-2022-2068).
+- RediSearch:
+  - Fixed index info to report correct information for RediSearch v2.
+- Profiling:
+  - Added support for profiling module commands.
+  - Added support for viewing information of clients that use IPv6 addresses.
+- RedisGraph:
+  - Added support for `RO_QUERY` only mode. RedisGraph now responds to the `RO_QUERY` command.
+
+## 1.12.0 (May 2022)
+
+This is the General Availability Release of RedisInsight 1.12 (v1.12.0)!
+
+## Headlines:
+- [Authenticate database users](https://docs.redis.com/latest/ri/using-redisinsight/auth-database/): Ask for database username and password
+- Support for `GRAPH.RO_QUERY` command in RedisGraph tool.
+- Support for variable CPU in RedisAI tool.
+
+## Full Details
+
+### Core
+- [Authenticate database users](https://docs.redis.com/latest/ri/using-redisinsight/auth-database/): Ask for database username and password
+  - If enabled, each time a user attempts to open a database previously added to RedisInsight, a form to enter username and password is displayed. This form displays also if a user is idle for a configurable amount of time.
+- Fix major container vulnerabilities.
+- Decrease Docker image size by discarding unnecessary contents.
+- Streams
+  - Fix slowdown and crash while loading large streams data.
+  - Use UTC time for stream id timestamp.
+- Graph
+  - Allow scanning for more keys.
+  - Add support for `GRAPH.RO_QUERY` command.
+- Browser
+  - Fix **Delete key** dialog box that displays when no key is selected.
+- RedisAI
+  - Add support for variable CPU number.

--- a/content/develop/connect/insight/release-notes/v1.13.0.md
+++ b/content/develop/connect/insight/release-notes/v1.13.0.md
@@ -1,0 +1,44 @@
+---
+Title: RedisInsight v1.13, Aug 2022
+linkTitle: v1.13 (Aug 2022)
+date: 2022-08-24 00:00:00 +0000
+description: RedisInsight v1.13.0
+weight: 7
+---
+
+## 1.13.1 (November 2022)
+
+This is the maintenance release of RedisInsight 1.13 (v1.13.1).
+
+### Fixes:
+- Core:
+  - Fixed container vulnerabilities.
+  - Prevented healthcheck API from overloading RedisInsight DB. Earlier, a separate session was created for each healthcheck hit, which overloaded the database with too many session tokens. Now, healtcheck API doesn't create any session tokens.
+  - Get Sentinel host using IP field.
+- Memory Analysis:
+  - Added support for `hashlistpack`, `zsetlistpack`, `quicklist2` and `streamlistpack2`, encoding types.
+
+
+## 1.13.0 (August 2022)
+
+This is the General Availability Release of RedisInsight 1.13 (v1.13.0).
+
+
+## Headlines
+- Subpath Proxy Support
+
+## Details
+
+### Core
+- Subpath Proxy support: RedisInsight can now be proxied behind a subpath
+- Added trusted origins environment variable to set trusted origins
+- Fixed major container vulnerabilities
+- Added proxy notification that displays when such an environment is found
+### RediSearch
+- Fixed index information
+### Profiler
+- Added support for IPv6 clients
+### Memory Analyzer
+- Fixed Lua recommendation
+
+

--- a/content/develop/connect/insight/release-notes/v1.14.0.md
+++ b/content/develop/connect/insight/release-notes/v1.14.0.md
@@ -1,0 +1,26 @@
+---
+Title: RedisInsight v1.14, may 2023
+linkTitle: v1.14 (May 2023)
+date: 2023-05-02 00:00:00 +0000
+description: RedisInsight v1.14.0
+weight: 5
+---
+
+## 1.14.0 (May 2023)
+
+RedisInsight version 1.X was retired on April 30, 2023, and will no longer be supported.
+To continue using the best RedisInsight features and capabilities, download the latest RedisInsight version 2.Y from our [website](https://redis.com/redis-enterprise/redis-insight/) or install it from an app store.
+
+This is the maintenance release of RedisInsight 1.14 (v1.14.0).
+
+## Headlines
+- Export connections to RedisInsight v2.
+
+## Details
+
+### Core
+  - Added support for exporting database connections to easily migrate them to RedisInsight v2 by bulk exporting to a file.
+  - Fixed Prompt verification bug for Sentinel instances.
+
+### Memory analysis
+  - Added support for `setlistpack` and `streamlistpack3` Redis 7 encoding types parsing.

--- a/content/develop/connect/insight/release-notes/v1.2.0.md
+++ b/content/develop/connect/insight/release-notes/v1.2.0.md
@@ -1,0 +1,69 @@
+---
+Title: RedisInsight v1.2, January 2020
+linkTitle: v1.2 (Jan 2020)
+date: 2020-01-27 00:00:00 +0000
+description: TLS Client side authentication support and stability improvements
+weight: 98
+---
+## RedisInsight v1.2.2 release notes
+
+Update urgency: Medium
+
+This is a maintenance release for version 1.2.
+
+### Details
+
+- Bug Fixes:
+    - Core:
+        - This releases fixes the possible __false positive__ malware issues flagged by certain antivirus vendors introduced by [pyinstaller](https://github.com/pyinstaller/pyinstaller/issues/4633) which was reported on [reddit](https://www.reddit.com/r/redis/comments/f1qapz/redisinsight_cotains_malware/).
+
+## RedisInsight v1.2.1 release notes
+
+Update urgency: Medium
+
+This is a maintenance release for version 1.2.
+
+### Details
+
+- Enhancements:
+    - Core:
+        - Upgrade notifications: When you open RedisInsight, a notification is shown if a new version is available.
+    - RediSearch:
+        - Support for [RediSearch 1.6](https://github.com/RediSearch/RediSearch/releases/tag/v1.6.7).
+- Minor Bug Fixes:
+    - RedisTimeSeries:
+        - Time was interpreted as seconds instead of milliseconds as ([Issue 332](https://github.com/RedisTimeSeries/RedisTimeSeries/issues/332))
+
+## RedisInsight v1.2.0 release notes
+
+### Headlines
+
+- This release improves overall stability and provides fixes for issues found after the previous release.
+- Added support for Client side TLS authentication.
+- Resolved bug which caused blank pages at startup.
+
+### Details
+
+- New features:
+    - Core:
+        - Added support for Redis databases that require TLS client authentication (as in Redis Enterprise)
+    - RedisTimeseries:
+        - Initial `auto-updating` functionality when the query's end timestamp is `+`
+- Minor Enhancements:
+    - Core:
+        - Check whether the port is available before starting.
+        - Made `localhost` the default host instead of `0.0.0.0`.
+        - Improved logging during startup.
+    - RedisGraph:
+        - Fixed height of query cards.
+    - RediSearch:
+        - Add support for zero-length and whitespace-only index names.
+- Bug Fixes:
+    - Core:
+        - Moved server to another thread instead of a separate process.
+        In certain situations, the server process was being orphaned after the main process died. This resulted in a several issues, of which the "blank page issue" was the most common. Now that the server process is in a thread instead of a process, the server is not left running when the process exits.
+    - RediSearch:
+        - Fixed several bugs in the display of summarized results in the table view.
+    - Browser:
+        - Better handling of unsupported values - link to other tools that support it or show better error message.
+        - Fixed UI issues when the screen size is varied to provide better responsiveness.

--- a/content/develop/connect/insight/release-notes/v1.3.0.md
+++ b/content/develop/connect/insight/release-notes/v1.3.0.md
@@ -1,0 +1,69 @@
+---
+Title: RedisInsight v1.3, March 2020
+linkTitle: v1.3 (Mar 2020)
+date: 2020-03-30 00:00:00 +0000
+description: Auto-discovery of Redis Cloud databases, visualising paths in RedisGraph
+weight: 97
+---
+
+## RedisInsight v1.3.1 release notes (April 2020)
+
+This is the maintenance release of RedisInsight 1.3 (v1.3.1).
+
+Update urgency: Medium
+
+### Headlines
+
+- Fixed support for connecting to Redis database on TLS-enabled hosts with SNI enforcement.
+
+### Details
+
+- Bug Fixes:
+    - Core:
+        - Fixed support for connecting to Redis database on TLS-enabled hosts with SNI enforcement.
+    - Memory Analysis
+        - Fixed wrong display of table columns in Memory Analyzer view.
+    - Browser
+        - Fixed bug where the TTL on string and RedisJSON keys was being reset on edit.
+    - Configuration:
+        - Fixed freezing/flashing on refreshing configuration.
+    - CLI
+        - Fixed minor visual bug in inline command documentation.
+    - Security
+        - Updated frontend dependencies that had developed security vulnerabilities.
+
+## RedisInsight v1.3.0 release notes (March 2020)
+
+This is the General Availability release of RedisInsight 1.3 (v1.3.0)!
+
+### Headlines
+
+- The Windows installer is now signed with a Microsoft Authenticode certificate.
+- Auto-Discovery of databases for Redis Cloud Pro.
+- Visualising paths in RedisGraph
+
+### Details
+
+- Features:
+    - Security:
+        - The Windows installer now signed with a Microsoft Authenticode certificate
+    - Core:
+        - Auto-Discovery for Redis Cloud Pro: Redis Cloud Pro subscribers can automatically add
+          their cloud databases with just a few clicks
+        - Support for editing the connection details of an added database
+        - Better support for Sentinel-monitored databases with different passwords for the sentinel instance(s) and database
+        - UI improvements to the add database form
+        - Added a button in the top-right menu to reach the online documentation with one click
+    - RedisGraph:
+        - Added support for visualising queries that use [path functions](https://oss.redislabs.com/redisgraph/commands/#path-functions)
+    - Memory Analysis:
+        - Added support for [virtual hosted-style](https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#virtual-hosted-style-access) S3 paths for Offline Analysis
+    - Browser:
+        - Added tooltip to make it easier to view the name of long keys
+
+- Bug Fixes:
+    - Core:
+        - Fixed fonts that were being loaded from the Internet, causing jarring visual changes on slow connections
+    - RedisGraph:
+        - Improved rendering of Array records
+        - Removed `GRAPH.EXPLAIN` calls for now until we have execution plan visualisation

--- a/content/develop/connect/insight/release-notes/v1.4.0.md
+++ b/content/develop/connect/insight/release-notes/v1.4.0.md
@@ -1,0 +1,44 @@
+---
+Title: RedisInsight v1.4, April 2020 
+linkTitle: v1.4 (Apr 2020)
+date: 2020-04-29 00:00:00 +0000
+description: Redis 6 ACLs support, improved CLI and full screen support in Graph, TimeSeries and RedisSearch
+weight: 96
+---
+
+This is the General Availability Release of RedisInsight 1.4 (v1.4.0)!
+
+### Headlines
+
+- Support for Redis 6, Redis Enterprise 6 and ACLs
+- Improve CLI capabilities with removed command restrictions
+- Full screen support in Graph, TimeSeries and RediSearch
+
+### Full details:
+
+- Features
+    - Core:
+        - Added support for Redis 6 + RE6 and authentication using ACL
+        - Added Full screen support for Graph, TimeSeries and RediSearch.  
+        - Improved UI consistency (colors and styles) in Graph and Timeseries
+    - CLI:
+        - Removed the command restrictions, unless a command is specifically blacklisted.
+        - Command responses are displayed in exactly the same way as in `redis-cli`
+    - RedisGraph:
+        - Optimized performances when getting nodes relationships (edges) from user's queries
+    - Stream:
+        - Improved UX when defining the timing range of events to be filtered
+
+- Bug Fixes:
+    - Core:
+        - Fixed issue when connecting to Redis Enterprise with a password using a special character
+    - Stream:
+        - Fixed ability to properly visualize all events
+
+### Known issues
+
+- Core:
+    - Authentication to Redis 6 OSS in cluster mode is not supported yet
+- CLI:
+    - Blocking commands are not supported
+    - Commands which return non-standard streaming responses are not supported: `MONITOR, SUBSCRIBE, PSUBSCRIBE, SYNC, PSYNC, SCRIPT DEBUG`

--- a/content/develop/connect/insight/release-notes/v1.5.0.md
+++ b/content/develop/connect/insight/release-notes/v1.5.0.md
@@ -1,0 +1,39 @@
+---
+Title: RedisInsight v1.5, May 2020 
+linkTitle: v1.5 (May 2020)
+date: 2020-05-12 00:00:00 +0000
+description: New tool for RedisGears, Multi-line query builder and improved suppport of Redis 6 ACLs
+weight: 95
+---
+
+This is the General Availability Release of RedisInsight 1.5 (v1.5.0)!
+
+### Headlines
+
+- Added beta support for [RedisGears module](https://oss.redislabs.com/redisgears/)
+- Added multi-line query editing for RediSearch, RedisGraph and Timeseries
+- Improved support of Redis 6 ACLs
+
+### Full details:
+
+- Features
+    - Core:
+        - Improved support for Redis 6 managing ACL permissions for each different capabilities
+    - Gears:
+        - Beta support for [Redis Gears module](https://oss.redislabs.com/redisgears/)
+            - Explore the latest executed functions and analyze the results or errors
+            - Manage registered functions and get execution summary
+            - Code, build and execute functions
+    - RediSearch:
+        - Multi-line for building queries
+    - RedisGraph:
+        - Multi-line for building queries
+    - Timeseries:
+        - Multi-line for building queries
+
+- Bug Fixes:
+    - Configuration:
+        - Fixed issue not showing the list of modules
+    - Search:
+        - Fixed issue preventing users to see all documents matching a search query
+        - Fixed issue with retrieving the search indexes in case of large database

--- a/content/develop/connect/insight/release-notes/v1.6.0.md
+++ b/content/develop/connect/insight/release-notes/v1.6.0.md
@@ -1,0 +1,133 @@
+---
+Title: RedisInsight v1.6, June 2020 
+linkTitle: v1.6 (June 2020)
+date: 2020-06-10 00:00:00 +0000
+description: Rootless Docker container, Copy keys in Browser and Stream UX improvements
+weight: 94
+---
+
+## 1.6.3 (July 2020)
+
+Maintenance release for RedisInsight 1.6 including bug fixes and enhancements.
+
+### Headlines:
+
+- Mac application is now getting notarized which simplifies the installation process on OS X
+- Fixed the resize of the keys explorer allowing to see long keys
+- Fixed filtering of keys in the browser with the filter capability in the browser
+
+### Full details:
+
+Enhancements and bug fixes
+  - Core:
+    - Mac application is properly signed and notarized on Apple services.
+  - Browser:
+    - Fixed resizing the key explorer allows to see more characters of long keys.
+    - Asynchronous loading of keys in large databases (discovered keys are actionable while search continues).
+    - Improved performance for exact key searches (when search pattern is not using *).
+    - Improved UI showing the progress of scanning the keys in the database.
+    - Fixed filtering the keys by data structures could be  to wrong.
+    - Fixed behavior of EXISTS and TYPE command when those have ACL restrictions.
+    - Fixed behavior when keys matching filters have ACL restrictions.
+    - Improved “Stop Scan” button behavior to respond immediately.
+    - Added visual indicator to show that by default, the browser is filtering out inner keys from modules.
+
+## 1.6.2 (30 June 2020)
+
+Maintenance release for RedisInsight 1.6 including bug fixes and enhancements.
+
+### Headlines:
+
+- Performance improvements to Profiler tool for TLS-enabled databases.
+- Bugfix: Feedback button was not visible.
+
+### Full details:
+
+- Enhancements and bug fixes
+  - Core:
+      - Bugfix: Feedback button was not visible.
+  - Profiler:
+      - The native code implementation of the profiling logic was updated to add full support for TLS connections to Redis.
+  - Graph:
+      - Updated to use a newer version of the Ogma graph visualization library.
+  - Analytics:
+      - Bugfix: Report the OS/platform correctly.
+
+## 1.6.1 (24 June 2020)
+
+Maintenance release for RedisInsight 1.6 including bug fixes and enhancements.
+
+### Headlines:
+
+- Improved support for Redis 6 ACLs with Cluster and Sentinel databases
+- Added support for Redis Cluster in RedisGraph tool
+- UX improvements for RedisGraph tool
+- Enriched captured usage events
+
+### Full details:
+
+- Enhancements and bug fixes
+  - Core:
+    - Improved support for Redis 6 ACLs with Cluster and Sentinel databases
+    - Added events capturing usage of RedisInsight
+  - Graph:
+    - Add support for Redis Cluster
+    - Added option to configure labels to be displayed in graph's nodes (right-click on the node)
+    - Added ability to submit query with 'ctrl + enter' in single line mode
+  - TimeSeries:
+    - Added ability to submit query with 'ctrl + enter' in single line mode
+  - RediSearch:
+    - Added ability to submit query with 'ctrl + enter' in single line mode
+    - Better handling of long index names in index selector dropdown
+    - Fixed bug with pagination on queries with whitespace in the query string
+  - Gears:
+    - Added button to remove an execution from executed functions list
+    - Added option to get rid of the warning message when executing a function 
+    - Fixed error message when it's impossible to visualize the graph
+  - Streams:
+    - Added persistence of user's selected stream columns when switching pages
+
+## 1.6.0 (11 June 2020)
+
+This is the General Availability Release of RedisInsight 1.6!
+
+### Headlines:
+
+- RedisInsight docker container is now rootless being compliant with best practices for containers
+- The Browser gets improved to allow quick copy of keys and resizing of the key explorer
+- Streams is now allowing to sort entries by timestamp, active/unactive live streaming of entries and keep persisted user's selection of fields to save context when switching between streams or other tools of RedisInsight. 
+- New telemetry system allowing to capture tools usage and updated privacy settings
+
+### Full details:
+
+- Features
+  - Core:
+    - Improved docker container by making it rootless
+    - Added visual indicator to show configured user when connecting to Redis 6 using ACLs
+    - Improved navigation to application's settings
+  - Browser:
+    - Added ability to resize the Key explorer panel
+    - Added options to easily copy keys
+    - Added ability to filter out the inner keys
+  - Streams: 
+    - Added persisting selected fields to be displayed to save context when switching to another stream or tool of RedisInsight 
+    - Added ability to sort entries "ascending" or "descending" based on the timestamp
+    - Added ability to active/unactive the live streaming of events 
+    - Updated timestamp font family for consistency
+  - CLI:
+    - Added ACL commands hints and summary info in CLI
+
+- Bug Fixes:
+  - Core:
+    - Fixed issue fetching data from Redis Cloud and replica enabled
+  - Browser:
+    - Fixed issue not shown field named "key" in hash keys
+    - Fixed wrong number of database's keys being displayed
+    - Fixed error when trying to view a Java serialized object
+  - Stream:
+    - Fixed issue with live streaming of entries
+    - Fixed UI when no entries are present in a stream
+  - Bulk Actions:
+    - Fixed responsiveness of the UI
+  - RedisGears:
+    - Fixed focus on editor and display of requirements

--- a/content/develop/connect/insight/release-notes/v1.7.0.md
+++ b/content/develop/connect/insight/release-notes/v1.7.0.md
@@ -1,0 +1,62 @@
+---
+Title: RedisInsight v1.7, September 2020
+linkTitle: v1.7 (Sep 2020)
+date: 2020-09-10 00:00:00 +0000
+description: RediSearch 2.0 support and stability improvements
+weight: 93
+---
+
+## 1.7.1 (October 2020)
+
+Maintenance release for RedisInsight 1.7 including bug fixes and enhancements.
+
+### Headlines:
+
+- Core:
+    - New public health-check API to make monitoring deployments easier.
+    - Display progress information during memory analysis.
+
+### Full details:
+
+Enhancements and bug fixes
+- Core:
+    - Fixed support for TLS in Redis Cluster databases.
+    - Application name is properly capitalized on MacOSX.
+    - Fixed update notifications on Docker - Now links to Docker Hub page and provides instructions for updating.
+- Memory Analysis:
+    - Information about the current stage of analysis is now displayed while the analysis runs.
+    - Fixed issue with running Memory Analysis on MacOSX (related to system OpenSSL libraries).
+- Browser:
+    - Visual improvements to key details view to improve the experience working with long key names.
+- CLI:
+    - Improvements for Redis Cluster databases - Controls to target specific nodes, all nodes, only masters/replicas, etc.
+- Streams:
+    - Fixed consumer groups functionality on Redis Cluster databases.
+- Telemetry:
+    - Report specific modules even when the `MODULE LIST` command is not available.
+
+## 1.7.0 (September 2020)
+
+### Headlines:
+
+- Support for [RediSearch 2.0](https://redislabs.com/blog/introducing-redisearch-2-0/)
+
+### Full Details:
+
+- Core:
+    - Added explanation of the supported subscription types for Redis Cloud database auto-discovery.
+    - Fixed a bug where upgrading from some previous versions would give an error on startup.
+    - Use a non-root group by default for the RedisInsight Docker container.
+- Memory Analysis:
+    - Improved UI for offline analysis via RDB file stored in S3.
+    - Fixed bug where using RDB stored in S3 sub-folder would fail.
+- Browser:
+    - Improved support for searching members of large collections (hashes, sets and sorted sets).
+- Streams:
+    - Improved UX for the handle to resize key selector.
+- RediSearch:
+    - Fixed support for Redis Cloud Essentials databases.
+- RedisGraph:
+    - Fixed an issue where localstorage is filled with unnecessary data.
+- Analytics:
+    - Reporting the subscription type for auto-discovered Redis Cloud databases.

--- a/content/develop/connect/insight/release-notes/v1.8.0.md
+++ b/content/develop/connect/insight/release-notes/v1.8.0.md
@@ -1,0 +1,98 @@
+---
+Title: RedisInsight v1.8, November 2020
+linkTitle: v1.8 (Nov 2020)
+date: 2020-11-11 00:00:00 +0000
+description: RedisInsight v1.8.0
+weight: 92
+---
+
+## 1.8.3 (January 2021)
+
+This is a maintenance release of RedisInsight 1.8 (v1.8.3)!
+
+This fixes the crash on MacOS Big Sur (11.1) for the MacOS package.
+RedisInsight is supported on Mac hardware with Intel chips, but not for Mac hardware with the Apple M1 (ARM) chip.
+
+## 1.8.2 (24 December 2020)
+
+This is the maintenance release of RedisInsight 1.8 (v1.8.2)!
+
+### Fixes:
+
+- Browser:
+    - Improved handling of large strings, lists, hashes, sets and sorted sets.
+    - Better error message when loading a key's value fails.
+    - More robust handling of Java serialized objects - malformed Java serialized objects are now displayed as binary strings.
+    - Increased the default width of the key selector.
+- Memory Analysis:
+    - Fixed crash on databases with modules that store auxiliary module data in the RDB (RediSearch 2, RedisGears, etc.).
+    - Fix integer overflow which results in the size of large keys not being reported properly.
+    - Add Streams statistics to the charts shown in the Memory Analysis Overview tool.
+    - Better error message when online analysis fails due to both the `SYNC` and `DUMP` commands being unavailable.
+
+## 1.8.1 (17 December 2020)
+
+Maintenance release for RedisInsight 1.8 including bug fixes and enhancements.
+
+### Important Note:
+
+We'd love to learn more how you are using RedisInsight. Now we have a user survey in the application, but you can also get to it [here](https://www.surveymonkey.com/r/ZZVR2ZG). 
+
+### Fixes:
+
+- Core:
+    - Fixed placeholder page for modules which was not appearing on desktop packagings of RedisInsight.
+    - Fixed error in handling disconnection to databases on desktop packaging of RedisInsight.
+    - Fixed auto-fill-on-URL-paste when adding Redis databases.
+    - Fixed add database form: scroll to error message if adding a database fails.
+    - Fixed typo in Settings page.
+- CLI:
+    - Fixed on the repeat command option which was not properly cleared when the command was changed.
+
+## 1.8.0 (November 2020)
+
+This is the General Availability Release of RedisInsight 1.8 (v1.8.0)!
+
+### Important Note:
+We'd love to learn more how you are using RedisInsight. We introduce a user survey, you'll see it in the application, but it's happening [here](https://www.surveymonkey.com/r/ZZVR2ZG). 
+
+
+### Headlines:
+
+- Guided experience to get started with RedisInsight, add a database and experiment with modules
+- CLI now supports "help" commands and lets you repeat commands
+- Ability to provide your CA Certificate and skip-verify option for TLS authentications
+- Ability to display RediSearch indices summary
+- Adding a database is getting simpler by auto-filling all database information from the Redis connection URL
+- New environment variables for configuring HOST, PORT and application LOG LEVEL
+- Support for RedisJSON on Redis Cluster
+
+
+### Full Details:
+
+- Core:
+    - New welcome page when no databases are configured
+    - New information pages for each modules, when they are not configured
+    - New environment variables for configuring HOST, PORT and application LOG LEVEL
+    - Ability to add a CA Certificate and skip-verify for TLS authentications
+    - Added auto-filling database details from Redis Connection URL
+- Browser:
+    - Added error message when trying to visualize large keys
+    - Fixed issue when copying key with " character
+- RedisGraph, RediSearch, RedisTimeseries:
+    - Added ability to copy commands with a button click
+- RedisSearch:
+    - Display the selected Index's Summary
+- RedisGraph:
+    - Added ability to persist nodes display choices between queries
+- ReJSON:
+    - Support for RedisJSON on Redis Cluster
+- ClientList:
+    - Sort clients by type
+- CLI:
+    - Added support for the `help` command in CLI
+    - Added ability to repeat commands multiple times with increments
+    - Added the ability to close the Hint window
+    - Added stream command assists
+- Profiler:
+    - Fixed issue with TLS databases

--- a/content/develop/connect/insight/release-notes/v1.9.0.md
+++ b/content/develop/connect/insight/release-notes/v1.9.0.md
@@ -1,0 +1,39 @@
+---
+Title: RedisInsight v1.9, January 2021
+linkTitle: v1.9 (Jan 2021)
+date: 2020-01-15 00:00:00 +0000
+description: RedisInsight v1.9.0
+weight: 91
+---
+
+## 1.9.0 (January 2021)
+
+This is the General Availability Release of RedisInsight 1.9 (v1.9.0)!
+
+### Headlines:
+
+- RedisGraph tools is getting improved with better UX and new interactions capabilities
+- Adding the ability to configure a database, by just using its direct URL to auto fill all required fields
+- CLI is now providing ability to configure your favorite key-bindings between Emacs or Vim
+
+### Full Details:
+
+- Core:
+    - Support for configuration of Redis where the number of databases goes over the default 16.
+    - Ability to add a Redis database using a shareable URL.
+- RedisGraph
+    - UX improvements for large queries: fixed long pause while results are being rendered.
+    - Made various improvements to interactions with the graph visualization:
+    - Selected node's size increased to make it easier to distinguish.
+    - Zoom via mouse wheel.
+    - Double click to zoom in.
+    - Double right-click to zoom out.
+    - Keyboard shortcuts to zoom.
+    - Center on node on fetching direct neighbours.
+    - Halo masking indirect edges on selected node.
+    - Button to reset view: center entire graph.
+    - Button to center on the selected node.
+    - New zoom buttons
+- CLI
+    - Basic navigation key-bindings for Emacs and Vim.
+    - UX improvements: the inputs and other controls are now disabled and a message is shown while the command is executing.

--- a/content/develop/connect/insight/release-notes/v2.0.md
+++ b/content/develop/connect/insight/release-notes/v2.0.md
@@ -1,0 +1,210 @@
+---
+Title: RedisInsight v2.0, Nov 2021
+linkTitle: v2.0 (Nov 2021)
+date: 2021-11-23 00:00:00 +0000
+description: RedisInsight v2.0.2
+weight: 12
+---
+
+## 2.0.6 (April 2022)
+This is the General Availability (GA) release of RedisInsight 2.0.6
+
+### Headlines:
+- SNI support - added SNI support to indicate a hostname in the TLS handshake
+- Save Profiler logs into a file - now you can save and download Profiler logs into a .TXT file
+- Customize delimiters in Tree view - added support for custom delimiters in Tree view
+- Support for node grouping and pulsing in RedisGraph visualizations in Workbench
+
+### Details
+**Features and improvements:**
+- [#548](https://github.com/RedisInsight/RedisInsight/pull/548), [#542](https://github.com/RedisInsight/RedisInsight/pull/542) Added SNI support - use the "Add Database Manually" form to see the new "Use SNI" option under the TLS section to specify the server name and connect to your Redis Database
+- [#521](https://github.com/RedisInsight/RedisInsight/pull/521/files) Added an option to save Profiler logs. Enable saving before starting the Profiler to save the logs into a .TXT file and download it to analyze them outside of the application
+- [#496](https://github.com/RedisInsight/RedisInsight/pull/496) Now you can specify your own delimiters to work with namespaces in the Tree view, default delimiter is colon (':')
+- [#473](https://github.com/RedisInsight/RedisInsight/pull/473) Added a link to GitHub repository of RedisInsight to quickly find and access it - you can see the icon below the "Settings"
+- [#586](https://github.com/RedisInsight/RedisInsight/pull/586) Added support for node grouping and pulsing in the visualisations for RedisGraph in Workbench
+- [#455](https://github.com/RedisInsight/RedisInsight/pull/455) Limited the movement of the special editor with Cypher highlights to Workbench Editor area (to work with it, just type in RedisGraph commands in Workbench)
+- [#462](https://github.com/RedisInsight/RedisInsight/pull/462) Provided additional information about database indexes in the form to add a database using host and port
+- [#489](https://github.com/RedisInsight/RedisInsight/pull/489) Reworked user experience with filters per key type and key name in Browser 
+- [#535](https://github.com/RedisInsight/RedisInsight/pull/535) Added highlights of timestamps and improved text wrapping in Profiler
+
+
+### Bug fixes:
+- [#581](https://github.com/RedisInsight/RedisInsight/pull/581) Fixed the issue with displaying keys in multi-shard databases
+- [#576](https://github.com/RedisInsight/RedisInsight/pull/576) Fixed encoding in Workbench
+
+
+
+## 2.0.5 (March 2022, GA)
+
+This is the General Availability (GA) release of RedisInsight 2.0.
+
+### Headlines
+
+* **Tree view** - A new view of the keys in Browser, which automatically groups keys scanned in your database into folders based on key namespaces. Now you can navigate through and analyze your list of keys quicker by opening only folders with namespaces you want.
+* **Support for Apple M1 (arm64)** - You can download it [here](https://redis.com/redis-enterprise/redis-insight/#insight-form).
+* **Added auto-discovery of local databases** - RedisInsight will automatically find and add your local databases when you open the application for the first time.
+* **A dedicated Editor for Cypher syntax** - Workbench supports autocomplete and highlighting of Cypher syntax for RedisGraph queries. 
+
+### Details
+
+- You can switch to the Tree view in Browser to see all the keys grouped into folders according to their namespaces. Note that we use the colon (:) as a default separator, and it is not customizable yet.
+- Added support for Apple M1 (arm64).
+- Added a mechanism to auto-discover local databases based on the following parameters:
+  - The mechanism only triggers when you open the application for the first time.
+  - The database has standalone connection type.
+  - The database uses the default username and requires no password or TLS certificates.
+- Added new built-in guides in Workbench for additional capabilities.
+- Added tutorials in Workbench for Redis Stack databases that describe common use cases for Redis capabilities.
+- Added a new dedicated Editor to Workbench with support for Cypher syntax autocomplete and highlighting. Use the "Shift+Space" shortcut inside of the quotes for your query to open the dedicated Editor.
+- Show modules uploaded to databases in the list of databases.
+- Added support for returning to the previous command in Workbench Editor. Use arrow up when your cursor is at the beginning of the first row to return to the previous command. Note: there is no support for the reverse direction yet, so use it with caution.
+
+If you installed RedisInsight-preview before, this folder will still exist at the following path:
+* For MacOs: <usersHomeDir>/.redisinsight-preview
+* For Windows: C:/Users/{Username}/.redisinsight-preview
+* For Linux: <usersHomeDir>/.redisinsight-preview
+
+## 2.0.4 (February 2022)
+
+This is the maintenance release of RedisInsight Preview 2.0 (v2.0.4)!
+
+### Headlines
+
+- Fixes to the issues found
+- Profiler
+  - Added RedisInsight Profiler, which uses the MONITOR command to analyze every command sent to the redis instance in real-time.
+- Workbench:
+  - Added support for RedisGears and RedisBloom on the intelligent Redis command auto-complete.
+  - Keep command results previously received in the Workbench.
+  - Support for repeating commands.
+- CLI:
+  - Added support for RedisGears and RedisBloom on the intelligent Redis command auto-complete.
+  - Support for repeating commands.
+- Command Helper:
+  - Added information about RedisGears and RedisBloom Redis commands.
+
+### Details
+
+- Profiler
+  - Added RedisInsight Profiler, which uses the MONITOR command to analyze every command sent to the redis instance in real-time. Note: Running the MONITOR command is dangerous to the performance of your production server, so run it reasonably and remember to stop the Profiler. 
+- Workbench:
+  - Added support for RedisGears and RedisBloom on the intelligent Redis command auto-complete, so the list of similar commands and their arguments are displayed when you start typing any RedisGears or RedisBloom commands.
+  - Keep command results (up to 1MB) previously received in the Workbench, so they are available even after you restart the application. 
+  - Connect Workbench to the database index selected when adding a database.
+  - To repeat any command in Workbench, just enter any integer and then a Redis command with arguments.
+- CLI:
+  - Added support for RedisGears and RedisBloom on the intelligent Redis command auto-complete, so hints with arguments are displayed when you enter any RedisGears or RedisBloom commands
+  - CLI is by default connected to the database index selected when adding a database. Added displaying of the database index connected.
+  - To repeat any command in CLI, just enter any integer and then a Redis command with arguments.
+- Command Helper:
+  - Added information about RedisGears and RedisBloom Redis commands.
+- Core:
+  - Fixed an issue with displaying parameter values in the Overview when no information is received for these parameters.
+
+
+## 2.0.3 (December 2021)
+
+This is the maintenance release of RedisInsight Preview 2.0 (v2.0.3).
+
+### Headlines
+
+- Workbench:
+  - Added indications of commands
+  - New hints with the list of command arguments
+  - Reworked navigation for the built-in guides
+- Help Center:
+  - Added a page with list of supported keyboard shortcuts
+- Core:
+  - Uncoupled Command Helper from CLI
+  - Renamed `ZSET` to Sorted Set
+
+### Details
+
+- Browser:
+  - Changed the format of TTL in the list of keys
+- CLI:
+  - Fixed a bug with `FT.CREATE` command that rendered the window blank
+- Workbench:
+  - Fixed a bug to avoid executing the Redis command one more time when the view of results is changed
+  - Added a new information message when there are no results to display
+  - Added indications of commands (currently, not clickable) in Editor area to point out the lines where commands start
+  - Added new hints in Editor to display the list of command arguments with the following keyboard shortcuts:
+    - Ctrl+Shift+Space for Windows and Linux
+    - ⌘ ⇧ Space for Mac
+  - Added support for remembering the state (expanded or collapsed) for left side panel in Workbench
+  - Reworked navigation for the built-in guides
+  - Changed icons for default and custom plugins
+- Command Helper:
+  - Changed titles of command groups to make them consistent with redis.io
+- Help Center:
+  - Added a page with supported keyboard shortcuts
+- Core:
+  - Reworked logic to open CLI and Command Helper, added an option to open Command Helper without a need to open CLI
+  - Changed fonts and colors across the application to enhance readability
+  - Renamed `ZSET` to Sorted Set
+  - Added description of RedisGears and RedisBloom commands to hints in CLI, Command Helper, and Workbench
+  - Added support for automatic updates to the list of commands and their description in CLI, Command Helper, and Workbench
+
+## 2.0.2 (November 2021)
+
+This is the public preview release of RedisInsight 2.0 (v2.0.2).
+
+RedisInsight 2.0 is a complete product rewrite based on a new tech stack. This version contains a number of must-have and most-used capabilities from previous releases, plus a number of differentiators and delights.
+
+RedisInsight-preview 2.0 can be installed along with the current GA (1.11) version of RedisInsight with no issues.
+
+### Headlines
+
+- Developed using a new tech stack based on Electron, Elastic UI, and Monaco Editor
+- Introducing Workbench - advanced command line interface with intelligent command auto-complete and complex data visualizations
+- Ability to write and render your own data visualizations within Workbench
+- Built-in click-through Redis guides available
+- Support for Light and Dark themes
+- Enhanced user experience with Browser
+
+### Details
+
+- Core:
+  - Enhanced user experience with the list of databases:
+    - View, sort and edit databases added
+    - Multiple deletion of databases
+  - Ability to connect to Redis Standalone, Redis Cluster and Redis Sentinel
+  - Auto discovery of databases managed by Redis Enterprise, Redis Cloud (Flexible), and Redis Sentinel
+  - Support for Redis OSS Cluster API
+  - Support for TLS connection
+  - Works with Microsoft Azure (official support upcoming)
+- Workbench:
+  - Advanced command-line interface that lets you run commands against your Redis server 
+  - Workbench editor allows comments, multi-line formatting and multi-command execution
+  - Intelligent Redis command auto-complete and syntax highlighting with support for [RediSearch](https://oss.redis.com/redisearch/), [RedisJSON](https://oss.redis.com/redisjson/), [RedisGraph](https://oss.redis.com/redisgraph/), [RedisTimeSeries](https://oss.redis.com/redistimeseries/), [RedisGears](https://oss.redis.com/redisgears/), [RedisAI](https://oss.redis.com/redisai/), [RedisBloom](https://oss.redis.com/redisbloom/)
+  - Allows rendering custom data visualization per Redis command using externally developed plugins
+- Browser:
+  - Browse, filter and visualize key-value Redis data structures
+    - Visual cues per data type
+    - Quick view of size and ttl in the main browser view
+    - Ability to filter by pattern and/or data type
+    - Ability to change the number of keys to scan through during filtering
+  - CRUD support for Lists, Hashes, Strings, Sets, Sorted Sets
+    - Search within the data structure (except for Strings)
+  - CRUD support for [RedisJSON](https://oss.redis.com/redisjson/)
+- Database overview:
+  - A number of metrics always on display within the database workspace
+    - Metrics updated every 5 second
+    - CPU, number of keys, commands/sec, network input, network output, total memory, number of connected clients
+  - Enabled modules per Redis server listed
+- CLI:
+  - Command-line interface with enhanced type-ahead command help
+  - Embedded command helper where you can filter and search for Redis commands
+- RediSearch:
+  - Tabular visualizations within Workbench of [RediSearch](https://oss.redis.com/redisearch/) index queries and aggregations (support for FT.INFO, FT.SEARCH and FT.AGGREGATE)
+- Custom plugins:
+  - Ability to build your own visualization plugins to be rendered within Workbench
+  - [Documentation](https://github.com/redisinsight/redisinsight) on how to develop custom plugins and a reference example are provided
+- Built-in guides:
+  - Built-in click-through guides for Redis capabilities
+  - Added a guide on Document Capabilities within Redis
+- User interface (UI):
+  - Light/dark themes available
+  - Colour palette adjusted to the highest level of [Web content accessibility guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/)
+- Data encryption:
+  - Optional ability to encrypt sensitive data such as connection certificates and passwords

--- a/content/develop/connect/insight/release-notes/v2.10.0.md
+++ b/content/develop/connect/insight/release-notes/v2.10.0.md
@@ -1,0 +1,34 @@
+---
+Title: RedisInsight v2.10.0, September 2022
+linkTitle: v2.10.0 (Sept 2022)
+date: 2022-09-29 00:00:00 +0000
+description: RedisInsight v2.10.0
+weight: 5
+---
+## 2.10.0 (September 2022)
+This is the General Availability (GA) release of RedisInsight 2.10.
+
+### Highlights
+- Formatters: Additional support for values of keys with Protobuf, Binary, PHP unserialize (view and edit serialized PHP values as JSON), and Java serialized objects, save formatters selected when viewing other keys
+- New overview for cluster databases displays memory and key allocation as well as database information per shards
+- Configure Workbench to persist the Editor after commands have been run and group the results
+- Complete an optional user survey
+
+### Details
+**Features and improvements**
+- [#1159](https://github.com/RedisInsight/RedisInsight/pull/1159), [#1160](https://github.com/RedisInsight/RedisInsight/pull/1160), [#1068](https://github.com/RedisInsight/RedisInsight/pull/1068), [#1071](https://github.com/RedisInsight/RedisInsight/pull/1071), [#1095](https://github.com/RedisInsight/RedisInsight/pull/1095), [#1097](https://github.com/RedisInsight/RedisInsight/pull/1097), [#1098](https://github.com/RedisInsight/RedisInsight/pull/1098) A dedicated **Analysis Tools** page displays memory and key allocation in cluster databases as well as database information per shards
+- [#1017](https://github.com/RedisInsight/RedisInsight/pull/1017), [#1025](https://github.com/RedisInsight/RedisInsight/pull/1025), [#1029](https://github.com/RedisInsight/RedisInsight/pull/1029), [#1059](https://github.com/RedisInsight/RedisInsight/pull/1059), [#1092](https://github.com/RedisInsight/RedisInsight/pull/1092) Added support for additional data formats in Browser/Tree view, including Protobuf, Binary, Pickle, PHP unserialize (view and edit serialized PHP values as JSON), and Java serialized objects
+- [#1130](https://github.com/RedisInsight/RedisInsight/pull/1130) Save formatters selected when viewing other keys
+- [#1177](https://github.com/RedisInsight/RedisInsight/pull/1177) Add a validation when edited value is not valid in the selected format in Browser/Tree view
+- [#1048](https://github.com/RedisInsight/RedisInsight/pull/1048) Configure Workbench to persist the Editor after commands have been run
+- [#1119](https://github.com/RedisInsight/RedisInsight/pull/1119) Pipeline mode configuration for Workbench moved to Settings > Workbench
+- [#1149](https://github.com/RedisInsight/RedisInsight/pull/1149) Save Workbench space by grouping results 
+- [#1162](https://github.com/RedisInsight/RedisInsight/pull/1162) Complete an optional user survey
+- [#1037](https://github.com/RedisInsight/RedisInsight/pull/1037) Added tooltip to display long fields in [Redis Streams](https://redis.io/docs/data-types/streams/) 
+- [#1202](https://github.com/RedisInsight/RedisInsight/pull/1202) Removed format validations from the admin username in the Redis Enterprise Cluster autodiscovery process
+
+**Bugs**
+- [#1180](https://github.com/RedisInsight/RedisInsight/pull/1180) Fix to display full values for truncated TTL in munutes
+- [#1197](https://github.com/RedisInsight/RedisInsight/pull/1197) Workbench is now available even when encryption failed
+- [#1176](https://github.com/RedisInsight/RedisInsight/pull/1176) Save the refresh value in Browser/Tree view
+- [#1101](https://github.com/RedisInsight/RedisInsight/pull/1101) Fixed an issue when key names are not displayed 

--- a/content/develop/connect/insight/release-notes/v2.12.0.md
+++ b/content/develop/connect/insight/release-notes/v2.12.0.md
@@ -1,0 +1,24 @@
+---
+Title: RedisInsight v2.12.0, October 2022
+linkTitle: v2.12.0 (Oct 2022)
+date: 2022-09-29 00:00:00 +0000
+description: RedisInsight v2.12.0
+weight: 4
+---
+## 2.12.0 (October 2022)
+This is the General Availability (GA) release of RedisInsight 2.12.
+
+### Highlights
+- Database Analysis: Get insights and optimize the usage and performance of your Redis or Redis Stack based on the overview of the memory and data type distribution, big or complicated keys, and namespaces used
+- Faster initial loading of the list of keys in Browser and Tree views
+- Performance optimizations for large results in Workbench
+
+### Details
+**Features and improvements**
+- [#1207](https://github.com/RedisInsight/RedisInsight/pull/1207), [#1222](https://github.com/RedisInsight/RedisInsight/pull/1222), [#1295](https://github.com/RedisInsight/RedisInsight/pull/1295), [#1159](https://github.com/RedisInsight/RedisInsight/pull/1159), [#1231](https://github.com/RedisInsight/RedisInsight/pull/1231), [#1155](https://github.com/RedisInsight/RedisInsight/pull/1155) Get insights and optimize the usage and performance of your Redis or Redis Stack with Database Analysis. Navigate to Analysis Tools and scan up to 10,000 keys in the database to see the summary of memory allocation and the number of keys per Redis data type, memory likely to be freed over time, top 15 key namespaces, and the biggest keys found. You can extrapolate results based on the total number of keys or see the exact results for the number of keys scanned. 
+- [#1280](https://github.com/RedisInsight/RedisInsight/pull/1280) Speed up the initial load of the key list in Browser and Tree views
+- [#1285](https://github.com/RedisInsight/RedisInsight/pull/1285) Support for infinite floating point numbers in sorted sets
+- [#1290](https://github.com/RedisInsight/RedisInsight/pull/1290) Performance optimizations to process large results of Redis commands in Workbench
+
+**Bugs**
+- [#1293](https://github.com/RedisInsight/RedisInsight/pull/1293) Fixed Workbench visualizations in Redis Stack

--- a/content/develop/connect/insight/release-notes/v2.2.0.md
+++ b/content/develop/connect/insight/release-notes/v2.2.0.md
@@ -1,0 +1,28 @@
+---
+Title: RedisInsight v2.2.0, May 2022
+linkTitle: v2.2.0 (May 2022)
+date: 2022-05-26 00:00:00 +0000
+description: RedisInsight v2.2.0
+weight: 10
+---
+
+## 2.2.0 (May 2022)
+This is the General Availability (GA) release of RedisInsight 2.2.0
+
+### Headlines:
+- SlowLog: New tool based on results of the [Slowlog](https://redis.io/commands/slowlog/) command to analyze slow operations in Redis instances
+- Streams: Added support for [Redis Streams](https://redis.io/docs/manual/data-types/streams/)
+- Open the list of keys or key details in full screen
+- Automatically refresh the list of keys and key values with a timer
+
+
+### Details
+**Features and improvements:**
+- [#621](https://github.com/RedisInsight/RedisInsight/pull/621) , [#645](https://github.com/RedisInsight/RedisInsight/pull/645) , [#649](https://github.com/RedisInsight/RedisInsight/pull/649) Added SlowLog, a tool that displays the list of logs captured by the [Slowlog](https://redis.io/commands/slowlog/) command to analyze all commands that exceed a specified runtime, which helps in troubleshooting performance issues. Specify both the runtime and the maximum length of SlowLog (which are server configurations) to configure the list of commands logged and set the auto-refresh interval to automatically update the list of commands displayed.
+- [#597](https://github.com/RedisInsight/RedisInsight/pull/597) , [#598](https://github.com/RedisInsight/RedisInsight/pull/598), [#601](https://github.com/RedisInsight/RedisInsight/pull/601) , [#603](https://github.com/RedisInsight/RedisInsight/pull/603) , [#608](https://github.com/RedisInsight/RedisInsight/pull/608) , [#613](https://github.com/RedisInsight/RedisInsight/pull/613) , [#614](https://github.com/RedisInsight/RedisInsight/pull/614) , [#632](https://github.com/RedisInsight/RedisInsight/pull/632) Support for [Redis Streams](https://redis.io/docs/manual/data-types/streams/), including creation and deletion of Streams, addition and deletion of entries, and filtration of entries per timestamp. [Consumer groups](https://redis.io/docs/manual/data-types/streams/#consumer-groups) will be added in a future release.
+- [#643](https://github.com/RedisInsight/RedisInsight/pull/643) List of keys or key details are supported in full screen mode. To open the key list in full screen, close the key details. To open key details in full screen, use the new **Full Screen** control in key details section.
+- [#633](https://github.com/RedisInsight/RedisInsight/pull/633) Automatically refresh the list of keys and key values with a timer. To do so, enable the **Auto Refresh** mode by clicking the control next to the **Refresh** button and set the refresh rate.
+- [#634](https://github.com/RedisInsight/RedisInsight/pull/634) Removed the max value limitation in the **Database Index** field of the form for adding a new database.
+
+**Bugs Fixed:**
+- [#656](https://github.com/RedisInsight/RedisInsight/pull/656) Binary key names will not trigger errors in databases with enabled OSS Cluster API. Data type, TTL, and size of such keys are displayed in the list of keys in all Redis instances. Key details are currently not available.

--- a/content/develop/connect/insight/release-notes/v2.28.0.md
+++ b/content/develop/connect/insight/release-notes/v2.28.0.md
@@ -1,0 +1,28 @@
+---
+Title: RedisInsight v2.28.0, June 2023
+linkTitle: v2.28.0 (June 2023)
+date: 2023-06-28 00:00:00 +0000
+description: RedisInsight v2.28
+weight: 1
+---
+## 2.28 (June 2023)
+This is the General Availability (GA) release of RedisInsight 2.28.
+
+### Highlights
+- Quickly and conveniently add [Redis Cloud](https://redis.com/redis-enterprise-cloud/overview/) databases that belong to fixed subscriptions using the auto-discovery tool
+- UX optimizations in Browser for an improved experience when performing [full-text search and queries](https://redis.io/docs/stack/search/), filtering, and bulk actions.
+- Support for a monospaced font in [JSON](https://redis.io/docs/stack/json/) key types
+
+### Details
+
+**Features and improvements**
+- [#2198](https://github.com/RedisInsight/RedisInsight/pull/2198), [#2207](https://github.com/RedisInsight/RedisInsight/pull/2207) Automatically discover and add [Redis Cloud](https://redis.com/redis-enterprise-cloud/overview/) databases that belong to fixed subscriptions using the `Redis Cloud` option on the form to auto-discover databases.
+- [#2146](https://github.com/RedisInsight/RedisInsight/pull/2146),[#2161](https://github.com/RedisInsight/RedisInsight/pull/2161) Added UX optimizations in the Browser layout to improve the experience when performing [full-text search and queries](https://redis.io/docs/stack/search/), filtering, and bulk actions.
+- [#2200](https://github.com/RedisInsight/RedisInsight/pull/2200) Changed to a monospaced font in [JSON](https://redis.io/docs/stack/json/) key types, and JSON formatters in Browser and Workbench.
+- [#2204](https://github.com/RedisInsight/RedisInsight/pull/2204) Re-bind default RedisInsight port from 5001 to 5530 to avoid conflicts with other applications
+- [#2120](https://github.com/RedisInsight/RedisInsight/pull/2120) Added the ability to investigate the commands processed by Redis or Redis Stack server without the need to stop Profiler when a new record appears.
+- [#2186](https://github.com/RedisInsight/RedisInsight/pull/2186) Unified the RedisInsight icon with other macOS applications.
+
+
+**Bugs**
+- [#2154](https://github.com/RedisInsight/RedisInsight/pull/2154) Display `(integer) 0` instead of `nil` in [ZRANK](https://redis.io/commands/zrank/) results in Workbench

--- a/content/develop/connect/insight/release-notes/v2.8.0.md
+++ b/content/develop/connect/insight/release-notes/v2.8.0.md
@@ -1,0 +1,27 @@
+---
+Title: RedisInsight v2.8.0, August 2022
+linkTitle: v2.8.0 (Aug 2022)
+date: 2022-08-23 00:00:00 +0000
+description: RedisInsight v2.8.0
+weight: 6
+---
+## 2.8.0 (August 2022)
+This is the General Availability (GA) release of RedisInsight 2.8.0
+
+### Headlines
+- Formatters: See formatted key values in JSON, MessagePack, Hex, Unicode, or ASCII in Browser/Tree view for an improved experience of working with different data formats. 
+- Clone existing database connection or connection details: Clone the database connection you previously added to have the same one, but with a different database index, username, or password.
+- Raw mode in Workbench: Added support for the raw mode in Workbench results
+
+### Details
+**Features and improvements**
+- [#978](https://github.com/RedisInsight/RedisInsight/pull/978), [#959](https://github.com/RedisInsight/RedisInsight/pull/959), [#984](https://github.com/RedisInsight/RedisInsight/pull/984), [#996](https://github.com/RedisInsight/RedisInsight/pull/996), [#992](https://github.com/RedisInsight/RedisInsight/pull/992), [#1030](https://github.com/RedisInsight/RedisInsight/pull/1030) Added support for different data formats in Browser/Tree view, including JSON, MessagePack, Hex, and ASCII. If selected, formatter is applied to the entire key value and is available for any data type supported in Browser/Tree view. If any non-printable characters are detected, data editing is available only in Workbench and CLI to avoid data loss.
+- [#955](https://github.com/RedisInsight/RedisInsight/pull/965) Quickly clone a database connection to have the same one, but with a different database index, username, or password. Open a database connection in the edit mode, request to clone it, and make the changes needed. The original database connection remains the same.
+- [#1012](https://github.com/RedisInsight/RedisInsight/pull/1012) Added support for the raw mode (--raw) in Workbench. Enable it to see the results of commands executed in the raw mode.
+- [#987](https://github.com/RedisInsight/RedisInsight/pull/987) [DBSIZE](https://redis.io/commands/dbsize/) command is no longer required to connect to a database.
+- [#971](https://github.com/RedisInsight/RedisInsight/pull/971) Updated icon for the [RediSearch](https://redis.io/docs/stack/search/) Light module.
+- [#1011](https://github.com/RedisInsight/RedisInsight/pull/1011) Enhanced navigation in the Command Helper allowing you to return to previous actions.
+
+**Bugs fixed**
+- [#1009](https://github.com/RedisInsight/RedisInsight/pull/1009) Fixed an [error]((https://github.com/RedisInsight/RedisInsight/issues/804)) on automatic discovery of Sentinel databases.
+- [#978](https://github.com/RedisInsight/RedisInsight/pull/978) Work with [non-printable characters](https://github.com/RedisInsight/RedisInsight/issues/873). To avoid data loss, when non-printable characters are detected, key and value are editable in Workbench and CLI only.


### PR DESCRIPTION
Ticket: [DOC-3620](https://redislabs.atlassian.net/browse/DOC-3620)
Staging link:  https://redis.io/docs/staging/DOC-3620//develop/connect/insight/release-notes/

The observant amongst you will notice that there's a category under Operate called "Redis Insight". You might think this is the appropriate location for RI RNs. However, these docs are installation instructions and they will be moved under Operate > Redis OSS and Stack at some point.