### PR TITLE
Update `distributed_locks.md`: add new Ruby Implementation for Distributed Locks

### DIFF
--- a/content/develop/use/patterns/distributed-locks.md
+++ b/content/develop/use/patterns/distributed-locks.md
@@ -38,6 +38,7 @@ Before describing the algorithm, here are a few links to implementations
 already available that can be used for reference.
 
 * [Redlock-rb](https://github.com/antirez/redlock-rb) (Ruby implementation). There is also a [fork of Redlock-rb](https://github.com/leandromoreira/redlock-rb) that adds a gem for easy distribution.
+* [RedisQueuedLocks](https://github.com/0exp/redis_queued_locks) (Ruby implementation).
 * [Redlock-py](https://github.com/SPSCommerce/redlock-py) (Python implementation).
 * [Pottery](https://github.com/brainix/pottery#redlock) (Python implementation).
 * [Aioredlock](https://github.com/joanvila/aioredlock) (Asyncio Python implementation).


### PR DESCRIPTION
Update `distributed_locks.md`: add new Ruby Implementation for Distributed Locks
---
Added new ruby implementation of Redis Distributed Locks `redis_queued_locks` to the Implementations list.
The new implementation realizes "lock request queues" feature.
Repository: https://github.com/0exp/redis_queued_locks

(This PR is a clone of the PR to the old docs: https://github.com/redis/redis-doc/pull/2706)