### PR TITLE
DOC-3640: fix commands links to persistence page

### DIFF
--- a/content/commands/bgrewriteaof/index.md
+++ b/content/commands/bgrewriteaof/index.md
@@ -29,11 +29,9 @@ syntax_fmt: BGREWRITEAOF
 syntax_str: ''
 title: BGREWRITEAOF
 ---
-Instruct Redis to start an [Append Only File][tpaof] rewrite process.
+Instruct Redis to start an [Append Only File]({{< relref "/operate/oss_and_stack/management/persistence" >}}#append-only-file) rewrite process.
 The rewrite will create a small optimized version of the current Append Only
 File.
-
-[tpaof]: /operate/oss_and_stack/management/persistence#append-only-file
 
 If `BGREWRITEAOF` fails, no data gets lost as the old AOF will be untouched.
 
@@ -50,7 +48,4 @@ Specifically:
 Since Redis 2.4 the AOF rewrite is automatically triggered by Redis, however the
 `BGREWRITEAOF` command can be used to trigger a rewrite at any time.
 
-Please refer to the [persistence documentation][tp] for detailed information.
-
-[tp]: /operate/oss_and_stack/management/persistence
-
+Please refer to the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.

--- a/content/commands/bgrewriteaof/index.md
+++ b/content/commands/bgrewriteaof/index.md
@@ -48,4 +48,4 @@ Specifically:
 Since Redis 2.4 the AOF rewrite is automatically triggered by Redis, however the
 `BGREWRITEAOF` command can be used to trigger a rewrite at any time.
 
-Please refer to the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.
+See the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.

--- a/content/commands/bgsave/index.md
+++ b/content/commands/bgsave/index.md
@@ -56,7 +56,4 @@ opportunity.
 A client may be able to check if the operation succeeded using the [`LASTSAVE`]({{< relref "/commands/lastsave" >}})
 command.
 
-Please refer to the [persistence documentation][tp] for detailed information.
-
-[tp]: /operate/oss_and_stack/management/persistence
-
+Please refer to the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.

--- a/content/commands/bgsave/index.md
+++ b/content/commands/bgsave/index.md
@@ -56,4 +56,4 @@ opportunity.
 A client may be able to check if the operation succeeded using the [`LASTSAVE`]({{< relref "/commands/lastsave" >}})
 command.
 
-Please refer to the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.
+See the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.

--- a/content/commands/config-set/index.md
+++ b/content/commands/config-set/index.md
@@ -71,9 +71,7 @@ above is to the latest development version.
 It is possible to switch persistence from RDB snapshotting to append-only file
 (and the other way around) using the `CONFIG SET` command.
 For more information about how to do that please check the [persistence
-page][tp].
-
-[tp]: /operate/oss_and_stack/management/persistence
+page]({{< relref "/operate/oss_and_stack/management/persistence" >}}).
 
 In general what you should know is that setting the `appendonly` parameter to
 `yes` will start a background process to save the initial append-only file

--- a/content/commands/config-set/index.md
+++ b/content/commands/config-set/index.md
@@ -70,8 +70,7 @@ above is to the latest development version.
 
 It is possible to switch persistence from RDB snapshotting to append-only file
 (and the other way around) using the `CONFIG SET` command.
-For more information about how to do that please check the [persistence
-page]({{< relref "/operate/oss_and_stack/management/persistence" >}}).
+See the [persistence page]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for more information.
 
 In general what you should know is that setting the `appendonly` parameter to
 `yes` will start a background process to save the initial append-only file

--- a/content/commands/save/index.md
+++ b/content/commands/save/index.md
@@ -41,4 +41,4 @@ However in case of issues preventing Redis to create the background saving child
 (for instance errors in the fork(2) system call), the `SAVE` command can be a
 good last resort to perform the dump of the latest dataset.
 
-Please refer to the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.
+See the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.

--- a/content/commands/save/index.md
+++ b/content/commands/save/index.md
@@ -41,6 +41,4 @@ However in case of issues preventing Redis to create the background saving child
 (for instance errors in the fork(2) system call), the `SAVE` command can be a
 good last resort to perform the dump of the latest dataset.
 
-Please refer to the [persistence documentation][tp] for detailed information.
-
-[tp]: /operate/oss_and_stack/management/persistence
+Please refer to the [persistence documentation]({{< relref "/operate/oss_and_stack/management/persistence" >}}) for detailed information.


### PR DESCRIPTION
Ticket: [DOC-3640](https://redislabs.atlassian.net/browse/DOC-3640)
Staging links:

https://redis.io/docs/staging/DOC-3640/commands/bgsave/
https://redis.io/docs/staging/DOC-3640/commands/bgrewriteaof/
https://redis.io/docs/staging/DOC-3640/commands/save/
https://redis.io/docs/staging/DOC-3640/commands/config-set/

While I did modify the links a bit, I'm not 100% this will work correctly on the main site. There may be some mischievous redirects at play.
