### PR TITLE
Document lib-name suffix format used by official clients

### DIFF
--- a/content/commands/client-setinfo/index.md
+++ b/content/commands/client-setinfo/index.md
@@ -54,4 +54,10 @@ Currently the supported attributes are:
 
 There is no limit to the length of these attributes. However it is not possible to use spaces, newlines, or other non-printable characters that would violate the format of the [`CLIENT LIST`]({{< relref "/commands/client-list" >}}) reply.
 
+[Official client libraries](https://redis.io/docs/latest/develop/connect/clients/) allow extending `lib-name` with a custom suffix to expose additional information about the client. 
+For example, high-level libraries like [redis-om-spring](https://github.com/redis/redis-om-spring) can report their version. 
+The resulting `lib-name` would be `jedis(redis-om-spring_v1.0.0)`. 
+Brace characters are used to delimit the custom suffix and should be avoided in the suffix itself.
+We recommend using the following format for the custom suffixes for third-party libraries `(?<custom-name>[ -~]+)[ -~]v(?<custom-version>[\d\.]+)` and use `;` to delimit multiple suffixes.
+
 Note that these attributes are **not** cleared by the RESET command.


### PR DESCRIPTION
Moved from https://github.com/redis/redis-doc/pull/2537