### PR TITLE
LRC-324 Add canonicals to prod layout

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,6 +11,7 @@
     {{ if and hugo.IsProduction -}}
       <meta name="robots" content="index, follow">
       <meta name="google-site-verification" content="suIo51jDr2z6o48kiD53RKtRvp-JgZ-njy8SWMdrkMo">
+      <link rel="canonical" href="{{ .Permalink | safeURL }}" />
     {{ else -}}
       <meta name="robots" content="noindex, nofollow">
     {{ end -}}


### PR DESCRIPTION
LRC-324

I tested this locally by temporarily adding the same `link rel="canonical"` tag to the production environment check's `else` statement. When I viewed the page source on different sections of the site, I did see the expected `href` generated for each canonical link in the HTML head.