### PR TITLE
Changed #dataset-size to link to the memory limit section

### DIFF
--- a/content/operate/rc/databases/configuration/clustering.md
+++ b/content/operate/rc/databases/configuration/clustering.md
@@ -165,7 +165,7 @@ their order to suit your application's requirements.
    - **PCRE_ANCHORED:** the pattern is constrained to match only at
         the start of the string which is being searched.
 
-## Memory limit
+## Memory limit {#dataset-size}
 
 The memory limit represents the maximum amount of memory for the database, which includes data values, keys, module data, and overhead for specific features.  High availability features, such as replication and Active-Active,  increase memory consumption.  
 


### PR DESCRIPTION
Found this while reviewing RED-124082 (changing docs links on Cloud).

Staging link: https://redis.io/docs/staging/link-fixes/operate/rc/databases/configuration/clustering#dataset-size