### PR TITLE
DOC-3723: suppress hugo serve warnings

### DIFF
--- a/content/develop/get-started/data-store.md
+++ b/content/develop/get-started/data-store.md
@@ -84,9 +84,9 @@ You can get a complete overview of available data types in this documentation si
 
 Each item within Redis has a unique key. All items live within the Redis [keyspace]({{< relref "/develop/use/keyspace" >}}). You can scan the Redis keyspace via the [SCAN command]({{< relref "/commands/scan" >}}). Here is an example that scans for the first 100 keys that have the prefix `bike:`:
 
-{{< clients-example scan_example >}}
+```
 SCAN 0 MATCH "bike:*" COUNT 100
-{{< /clients-example >}}
+```
 
 [SCAN]({{< relref "/commands/scan" >}}) returns a cursor position, allowing you to scan iteratively for the next batch of keys until you reach the cursor value 0.
 

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,0 +1,1 @@
+{{/* suppress warnings */}}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,0 +1,1 @@
+{{/* suppress warnings */}}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,1 @@
+{{/* suppress warnings */}}

--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -119,7 +119,7 @@
       {{ $pages = (where $pages "Type" "!=" "search") }}
       {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
       {{ $pages = (where $pages ".Parent" "!=" nil) }}
-      {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
+      {{/* $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) */}}
       {{ $pages = (where $pages ".Params.hidden" "!=" true) }}
       <div id="commands-grid" class="flex flex-col md:grid grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-4 text-redis-ink-900 mx-auto">
         {{ range $index, $page := $pages }}

--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -119,7 +119,7 @@
       {{ $pages = (where $pages "Type" "!=" "search") }}
       {{ $pages = (where $pages ".Params.hide_summary" "!=" true) }}
       {{ $pages = (where $pages ".Parent" "!=" nil) }}
-      {{/* $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) */}}
+      {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
       {{ $pages = (where $pages ".Params.hidden" "!=" true) }}
       <div id="commands-grid" class="flex flex-col md:grid grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-4 text-redis-ink-900 mx-auto">
         {{ range $index, $page := $pages }}


### PR DESCRIPTION
Ticket: [DOC-3723](https://redislabs.atlassian.net/browse/DOC-3723)

[Staging link](https://redis.io/docs/staging/DOC-3723/)

These changes suppress the warnings normally seen when running `hugo serve` locally. Warnings, in general, annoy me. :)

@rrelledge One of the changes seems innocuous, but if you could take a look and let me know if it's okay. I don't see any difference in produced output. The change is in `layouts/commands/list.html@122`. I'm not sure what that line is doing/accomplishing, but it does generate the following Hugo warning:

`WARN 2024/05/01 10:04:21 .File.UniqueID on zero object. Wrap it in if or with: {{ with .File }}{{ .UniqueID }}{{ end }}`