### PR TITLE
expiration fixes

### DIFF
--- a/content/commands/ft.search/index.md
+++ b/content/commands/ft.search/index.md
@@ -496,7 +496,7 @@ FT.SEARCH returns an array reply, where the first element is an integer reply of
 {{% alert title="Notes" color="warning" %}}
  
 - If `NOCONTENT` is given, an array is returned where the first element is the total number of results, and the rest of the members are document ids.
-- If a key expires during the query, an attempt to load the key's value will return a null array. The key is still counted in the total number of results
+- If a relevant key expires while a query is running, an attempt to load the key's value will return a null array. However, the key is still counted in the total number of results.
 
 {{% /alert %}}
 

--- a/content/commands/ft.search/index.md
+++ b/content/commands/ft.search/index.md
@@ -496,7 +496,7 @@ FT.SEARCH returns an array reply, where the first element is an integer reply of
 {{% alert title="Notes" color="warning" %}}
  
 - If `NOCONTENT` is given, an array is returned where the first element is the total number of results, and the rest of the members are document ids.
-- If a hash expires after the query process starts, the hash is counted in the total number of results, but the key name and content return as null.
+- If a key expires during the query, an attempt to load the key's value will return a null array. The key is still counted in the total number of results
 
 {{% /alert %}}
 


### PR DESCRIPTION
align the messaging (FT.AGGREGATE and FT.SEARCH) and make it more clear when a key expires during a query execution, what should be the expected behaviour. So the key name it's still return, but the value should be nil