### PR TITLE
Fix TS.ALTER syntax

### DIFF
--- a/content/commands/ts.alter/index.md
+++ b/content/commands/ts.alter/index.md
@@ -65,7 +65,7 @@ stack_path: docs/data-types/timeseries
 summary: Update the retention, chunk size, duplicate policy, and labels of an existing
   time series
 syntax: 'TS.ALTER key [RETENTION retentionPeriod] [CHUNK_SIZE size] [DUPLICATE_POLICY
-  policy] [LABELS [{label value}...]] '
+  policy] [LABELS {label value}...] '
 syntax_fmt: "TS.ALTER key [RETENTION\_retentionPeriod] [CHUNK_SIZE\_size] [DUPLICATE_POLICY\_\
   <BLOCK | FIRST | LAST | MIN | MAX | SUM>] [LABELS\_label value [label value ...]]"
 syntax_str: "[RETENTION\_retentionPeriod] [CHUNK_SIZE\_size] [DUPLICATE_POLICY\_<BLOCK\


### PR DESCRIPTION
LABELS argument itself is optional. But label-value pairs under it are not.

TS.ALTER should have same syntax as [TS.CREATE](https://github.com/redis/docs/blob/edda9a5364a2a4998c16cdb7de327fe7ac9307f7/content/commands/ts.create/index.md?plain=1#L77) and [TS.ADD](https://github.com/redis/docs/blob/edda9a5364a2a4998c16cdb7de327fe7ac9307f7/content/commands/ts.add/index.md?plain=1#L81). My suggestion here for TS.ALTER reflects the current syntax in both the other mentioned commands.