### PR TITLE
RC: Fix GB/MB typo

### DIFF
--- a/content/operate/rc/databases/configuration/high-availability.md
+++ b/content/operate/rc/databases/configuration/high-availability.md
@@ -44,7 +44,7 @@ Replication can affect performance as traffic increases to synchronize all copie
 
 For both Redis Cloud Essentials and Redis Cloud Pro, replication doubles the dataset size you need for your database. 
 
-For Redis Cloud Essentials, the size of the plan you choose includes replication. Therefore, if you choose replication, the dataset size you can use is half of the stated plan size. For example, if you choose a 1GB plan, Redis allocates 512 GB for the memory limit, and the other 512 MB for Replication.
+For Redis Cloud Essentials, the size of the plan you choose includes replication. Therefore, if you choose replication, the dataset size you can use is half of the stated plan size. For example, if you choose a 1GB plan, Redis allocates 512 MB for the dataset size, and the other 512 MB for replication.
 
 For Redis Cloud Pro, you also need to double the amount of memory needed if you choose replication.
 


### PR DESCRIPTION
From issue #174 
Staging link: https://redis.io/docs/staging/174-high-availability-and-replication/operate/rc/databases/configuration/high-availability/#dataset-size