### PR TITLE
Revert "Update nav to put Commands and APIs at the top of menu on all pages"

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -48,27 +48,27 @@
           </button>
           <div id="dropdown" class="hidden lg:block border-t border-opacity-50 border-redis-ink-900 text-redis-pen-800">
             <ul class="p-6">
-	      <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600">APIs</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/get-started'>Get started</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/develop'>Develop</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Integrate</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Operate</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600">APIs</a></li>
             </ul>
           </div>
         </div>
       </nav>
       <nav class="hidden lg:block w-full lg:w-64 z-40 h-full leading-7">
         <div class="flex flex-col gap-4">
-	<div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
-            <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
-            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/apis'>APIs</a>
-          </div>
           <a class="px-6 py-4 hover:bg-redis-pen-200 border border-redis-ink-900 border-opacity-50 rounded-md" href='{{ .Scratch.Get "path" }}/get-started'>Get started</a>
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/develop'>Develop</a>
             <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Integrate</a>
             <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Operate</a>
+          </div>
+          <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
+            <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
+            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/apis'>APIs</a>
           </div>
         </div>
       </nav>

--- a/layouts/partials/docs-nav-collapsed.html
+++ b/layouts/partials/docs-nav-collapsed.html
@@ -1,16 +1,6 @@
 <div class="md:block w-full md:w-96 h-fit md:h-full shrink-0 text-base font-mono font-normal py-6">
   <nav class="w-full md:w-96 z-40 bg-white md:fixed md:pt-6 h-fit md:h-full max-h-[calc(100vh-7rem)] leading-7">
     {{ $navRoot := cond (eq .Site.Home.Type "docs") .Site.Home .FirstSection -}}
-    {{ if in (slice "Commands" "Integrate") $navRoot.LinkTitle }}
-    <div id="sidebar" class="max-h-[calc(100vh-8rem)] border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col mt-4">
-      <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600 {{ if eq $navRoot.LinkTitle "Commands" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
-      <a class='px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "APIs" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/apis'>APIs</a>
-    </div>
-    <div id="sidebar" class="max-h-[calc(100vh-8rem)] border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col mt-4">
-      <a class='px-6 py-4 rounded-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Get started" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/get-started'>Get started</a>
-    </div>
-    {{ end }}
-    <div style="height: 20px;"></div> <!-- This is the spacer -->
     <div id="sidebar" class="max-h-[calc(100vh-8rem)] border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col">
       {{ if in (slice "Develop" "Integrate" "Operate" "Commands") $navRoot.LinkTitle }}
         <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Develop" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/develop'>Develop</a>
@@ -19,7 +9,12 @@
       {{ else }}
         <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 font-bold' href="{{ $navRoot.RelPermalink }}">{{ $navRoot.LinkTitle }}</a>
         <div class="hidden md:block w-full py-6"></div>
+      {{ end }}       
     </div>
-      {{ end }}      
+    {{ if in (slice "Commands" "Integrate") $navRoot.LinkTitle }}
+    <div id="sidebar-cmd" class="max-h-[calc(100vh-8rem)] border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col mt-4">
+      <a class='px-6 py-4 hover:bg-redis-pen-200 text-redis-red-600 {{ if eq $navRoot.LinkTitle "Commands" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
+    </div>
+    {{ end }}
   </nav>
 </div>

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -41,28 +41,6 @@
     {{ $navRoot := cond (eq .Site.Home.Type "docs") .Site.Home .FirstSection -}}
     {{ $ulNr := 0 -}}
     {{ $ulShow := 1 -}}
-       <div class='min-h-0 border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col {{ if not (eq $navRoot.LinkTitle "Commands") }} shrink-0 {{ end }}'>
-        <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600 {{ if eq $navRoot.LinkTitle "Commands" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
-        {{ if eq $navRoot.LinkTitle "Commands" }}
-          <ul class="md:block overflow-y-auto grow pr-6 border-t border-opacity-50 border-redis-ink-900">
-            {{ template "li" (dict "page" . "pages" (union $navRoot.Pages $navRoot.Sections).ByWeight) }}
-          </ul>
-        {{ end }}
-        <a class='px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "APIs" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/apis'>APIs</a>
-        {{ if eq $navRoot.LinkTitle "APIs" }}
-          <ul class="md:block overflow-y-auto grow pr-6">
-            {{ template "li" (dict "page" . "pages" (union $navRoot.Pages $navRoot.Sections).ByWeight) }}
-          </ul>
-        {{ end }}
-       </div>
-        <div class='min-h-0 border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col {{ if not (eq $navRoot.LinkTitle "Get started") }} shrink-0 {{ end }}'>
-        <a class='px-6 py-4 rounded-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Get started" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/get-started'>Get started</a>
-        {{ if eq $navRoot.LinkTitle "Get started" }}
-          <ul class="md:block overflow-y-auto grow pr-6">
-            {{ template "li" (dict "page" . "pages" (union $navRoot.Pages $navRoot.Sections).ByWeight) }}
-          </ul>
-        {{ end }}
-        </div>  
       <div class='min-h-0  border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col {{ if not (in (slice "Develop" "Integrate" "Operate") $navRoot.LinkTitle) }} shrink-0 {{ end }}'>
         <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Develop" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/develop'>Develop</a>
         {{ if eq $navRoot.LinkTitle "Develop" }}
@@ -83,6 +61,13 @@
           </ul>
         {{ end }}
       </div>
+      <div class='min-h-0 border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col {{ if not (eq $navRoot.LinkTitle "Commands") }} shrink-0 {{ end }}'>
+        <a class='px-6 py-4 hover:bg-redis-pen-200 text-redis-red-600 {{ if eq $navRoot.LinkTitle "Commands" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
+        {{ if eq $navRoot.LinkTitle "Commands" }}
+          <ul class="md:block overflow-y-auto grow pr-6 border-t border-opacity-50 border-redis-ink-900">
+            {{ template "li" (dict "page" . "pages" (union $navRoot.Pages $navRoot.Sections).ByWeight) }}
+          </ul>
+        {{ end }}
       </div>
   </div>
   </nav>


### PR DESCRIPTION
Reverts redis/docs#168

The nav menu changes to re-order the sections and make them consistent are making browsing more difficult.

https://redis.io/docs/staging/revert-168-update-nav/