### PR TITLE
remove nav arrows and padding

### DIFF
--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -9,7 +9,10 @@
     <li class="my-2">
       <a class="pl-6 flex {{ if $isActive }} active text-redis-ink-900 {{ else }} text-redis-pen-700 hover:text-redis-pen-600 {{ end }}" href="{{.RelPermalink}}">
         {{ if gt (len $childPages) 0 }}
-            <span class="pr-3">→</span>
+          {{ if or $isActive $isActivePath -}}
+            <span class="pr-0"></span>
+          {{ else -}}
+            <span class="pr-0"></span>
           {{ end -}}
         {{ end -}}
         <span>{{.LinkTitle}}</span>

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -10,9 +10,9 @@
       <a class="pl-6 flex {{ if $isActive }} active text-redis-ink-900 {{ else }} text-redis-pen-700 hover:text-redis-pen-600 {{ end }}" href="{{.RelPermalink}}">
         {{ if gt (len $childPages) 0 }}
           {{ if or $isActive $isActivePath -}}
-            <span class="pr-3">↓</span>
+            <span class="pr-3"></span>
           {{ else -}}
-            <span class="pr-3">→</span>
+            <span class="pr-3"></span>
           {{ end -}}
         {{ end -}}
         <span>{{.LinkTitle}}</span>

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -9,10 +9,7 @@
     <li class="my-2">
       <a class="pl-6 flex {{ if $isActive }} active text-redis-ink-900 {{ else }} text-redis-pen-700 hover:text-redis-pen-600 {{ end }}" href="{{.RelPermalink}}">
         {{ if gt (len $childPages) 0 }}
-          {{ if or $isActive $isActivePath -}}
-            <span class="pr-3"></span>
-          {{ else -}}
-            <span class="pr-3"></span>
+            <span class="pr-3">→</span>
           {{ end -}}
         {{ end -}}
         <span>{{.LinkTitle}}</span>


### PR DESCRIPTION
DOC-3699
https://redis.io/docs/staging/nav-arrows/operate/rc/cloud-integrations/

This removes the arrows and padding around them which makes the nesting really confusing in the doc nav menu.