### PR TITLE
Fix pipelining example code

### DIFF
--- a/content/develop/use/pipelining/index.md
+++ b/content/develop/use/pipelining/index.md
@@ -126,9 +126,9 @@ end
 
 def with_pipelining
   r = Redis.new
-  r.pipelined do
+  r.pipelined do |rp|
     10_000.times do
-      r.ping
+      rp.ping
     end
   end
 end


### PR DESCRIPTION
Maybe I'm missing something, but provided code example doesn't work as advertised, redis client is not magically turning itself to pipelined version, and benchmark proves it.

verified with gem redis 5.2.0 and redis-client 0.22.1