### PR TITLE
Menu text

### DIFF
--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Develop
+title: Develop with Redis
 description: Learn how to develop with Redis
 linkTitle: Develop
 ---

--- a/content/integrate/_index.md
+++ b/content/integrate/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Integrations and frameworks
+title: Libraries and tools
 description: 
 linkTitle: Integrate
 ---

--- a/content/operate/_index.md
+++ b/content/operate/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Redis Products
+title: Redis products
 description: Operate any Redis, from Redis Enterprise to Redis Cloud
 linkTitle: Operate
 ---

--- a/content/operate/_index.md
+++ b/content/operate/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Operate
-description: Operate any Redis, from Redis OSS to Redis Cloud
+title: Redis Products
+description: Operate any Redis, from Redis Enterprise to Redis Cloud
 linkTitle: Operate
 ---

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -71,7 +71,7 @@
         </div>
       </nav>
     </div>
-    <div class="lg:px-11 w-full flex flex-col gap-12">
+    <div class="lg:px-11 w-full flex flex-col gap-3">
       <h2 class="text-5xl font-medium" id="operate">Learn</h2>
         {{ partial "docs-section.html" (dict
           "Title" "Develop with Redis"
@@ -124,7 +124,7 @@
           )
         ) }}
       </div>
-      <div class="lg:px-11 w-full flex flex-col gap-12">
+      <div class="lg:px-11 w-full flex flex-col gap-3">
         <h2 class="text-5xl font-medium" id="operate">Explore</h2>
         {{ partial "docs-section.html" (dict
           "Title" "Redis and Stack"

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -71,6 +71,7 @@
         </div>
       </nav>
     </div>
+  <div>
   <h1 class="text-5xl font-medium" id="operate">Learn how to</h1>
     <div class="lg:px-11 w-full flex flex-col gap-24">
         {{ partial "docs-section.html" (dict

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -71,9 +71,8 @@
         </div>
       </nav>
     </div>
-  <div>
-  <h1 class="text-5xl font-medium" id="operate">Learn how to</h1>
     <div class="lg:px-11 w-full flex flex-col gap-24">
+      <h1 class="text-5xl font-medium" id="operate">Learn how to</h1>
         {{ partial "docs-section.html" (dict
           "Title" "Develop with Redis"
           "Description" "Learn how to use the Redis in-memory data store."
@@ -111,7 +110,7 @@
               )
         ) }}
       </div>
-      <div>
+      <div class="lg:px-11 w-full flex flex-col gap-24">
         <h1 class="text-5xl font-medium" id="operate">Explore by product</h1>
         {{ partial "docs-section.html" (dict
           "Title" "Redis OSS and Stack"

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -49,8 +49,8 @@
           <div id="dropdown" class="hidden lg:block border-t border-opacity-50 border-redis-ink-900 text-redis-pen-800">
             <ul class="p-6">
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Libraries, frameworks, and tools</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Redis Cloud, Enterprise, and Insight</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Cloud, Enterprise, and Insight</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600">APIs</a></li>
             </ul>
@@ -61,8 +61,8 @@
         <div class="flex flex-col gap-4">
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a>
-            <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Libraries, frameworks, and tools</a>
-            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Redis Cloud, Enterprise, and Insight</a>
+            <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a>
+            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Cloud, Enterprise, and Insight</a>
           </div>
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
@@ -71,6 +71,7 @@
         </div>
       </nav>
     </div>
+  <h1 class="text-5xl font-medium" id="operate">Learn how to</h1>
     <div class="lg:px-11 w-full flex flex-col gap-24">
         {{ partial "docs-section.html" (dict
           "Title" "Develop with Redis"
@@ -80,9 +81,6 @@
           "LinksLeftTitle" "Featured content"
           "LinksLeft" (slice
             (dict "Text" "Vector search" "URL" "./develop/interact/search-and-query/query/vector-search")
-            )
-          "LinksRightTitle" "Quick starts"
-          "LinksRight" (slice
             (dict "Text" "Data structure store" "URL" "./develop/get-started/data-store/")
             )
           ) }}
@@ -95,10 +93,6 @@
           "LinksLeft" (slice
             (dict "Text" "RedisVL" "URL" "./integrate/redisvl/")
             (dict "Text" "RedisOM for Python" "URL" "./integrate/redisom-for-python")
-            (dict "Text" "RedisOM for Java" "URL" "./integrate/redisom-for-java")
-          )
-          "LinksRightTitle" "Data Integration"
-          "LinksRight" (slice
             (dict "Text" "Ingest" "URL" "./integrate/redis-data-integration/quickstart/ingest-guide/")
             (dict "Text" "Write-behind" "URL" "./integrate/redis-data-integration/quickstart/write-behind-guide/")
           )

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -50,7 +50,7 @@
             <ul class="p-6">
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Redis Products</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Redis products</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600">APIs</a></li>
             </ul>
@@ -62,7 +62,7 @@
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a>
             <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a>
-            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Redis Products</a>
+            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Redis products</a>
           </div>
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -148,6 +148,7 @@
           (dict "Text" "Quick start" "URL" "./operate/rc/rc-quickstart/")
           (dict "Text" "Subscriptions" "URL" "./operate/rc/subscriptions/")
           (dict "Text" "Databases" "URL" "./operate/rc/databases/")
+	  (dict "Text" "Active-Active" "URL" "./operate/rc/databases/create-database/create-active-active-database/")
         )
       ) }}
       {{ partial "docs-section.html" (dict
@@ -160,6 +161,7 @@
             (dict "Text" "Quick start" "URL" "./operate/rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart/")
             (dict "Text" "Clusters" "URL" "./operate/rs/clusters/")
             (dict "Text" "Databases" "URL" "./operate/rs/databases/")
+	    (dict "Text" "Networking" "URL" "./operate/rs/networking/")
           )
         ) }}
         {{ partial "docs-section.html" (dict

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -49,8 +49,8 @@
           <div id="dropdown" class="hidden lg:block border-t border-opacity-50 border-redis-ink-900 text-redis-pen-800">
             <ul class="p-6">
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Integrated libraries, frameworks, and tools</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Operate Redis Cloud, Enterprise, and Insight</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Libraries, frameworks, and tools</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Redis Cloud, Enterprise, and Insight</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600">APIs</a></li>
             </ul>
@@ -61,8 +61,8 @@
         <div class="flex flex-col gap-4">
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a>
-            <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Integrated libraries, frameworks, and tools</a>
-            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Operate Redis Cloud, Enterprise, and Insight</a>
+            <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Libraries, frameworks, and tools</a>
+            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Redis Cloud, Enterprise, and Insight</a>
           </div>
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
@@ -72,10 +72,11 @@
       </nav>
     </div>
     <div class="lg:px-11 w-full flex flex-col gap-24">
-      <div>
         {{ partial "docs-section.html" (dict
           "Title" "Develop with Redis"
           "Description" "Learn how to use the Redis in-memory data store."
+	  "ButtonLink" "./develop"
+          "ButtonLabel" "Learn more"
           "LinksLeftTitle" "Featured content"
           "LinksLeft" (slice
             (dict "Text" "Vector search" "URL" "./develop/interact/search-and-query/query/vector-search")

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -82,13 +82,14 @@
           "LinksLeft" (slice
             (dict "Text" "Vector search" "URL" "./develop/interact/search-and-query/query/vector-search")
             (dict "Text" "Data structure store" "URL" "./develop/get-started/data-store/")
+	    (dict "Text" "Document database" "URL" "./develop/get-started/document-database/")
             )
           ) }}
         {{ partial "docs-section.html" (dict
           "Title" "Libraries and tools"
           "Description" "Learn about libraries and tools available for Redis."
           "ButtonLink" "./integrate"
-          "ButtonLabel" "Browse integrations"
+          "ButtonLabel" "Browse tools"
           "LinksLeftTitle" "Featured libraries"
           "LinksLeft" (slice
             (dict "Text" "RedisVL" "URL" "./integrate/redisvl/")
@@ -102,7 +103,7 @@
           "Description" "Redis Data Integration keeps Redis in sync with the primary database in near real time."
           "ButtonLink" "./integrate/redis-data-integration"
           "ButtonLabel" "Learn more"
-          "LinksLeftTitle" "LEARN MORE ABOUT"
+          "LinksLeftTitle" "LEARN MORE"
           "LinksLeft" (slice
             (dict "Text" "Quick start" "URL" "./integrate/redis-data-integration/quickstart/")
             (dict "Text" "Architecture" "URL" "./integrate/redis-data-integration/architecture/")
@@ -115,7 +116,7 @@
           "Description" "Redis Insight is a cross-platform GUI for Redis, with focus on reducing memory usage and improving application performance."
           "ButtonLink" "./develop/connect/insight/"
           "ButtonLabel" "Learn more"
-          "LinksLeftTitle" "Learn more about"
+          "LinksLeftTitle" "Learn more"
           "LinksLeft" (slice
             (dict "Text" "Install" "URL" "./operate/redisinsight/install/")
             (dict "Text" "User guide" "URL" "./develop/connect/insight/")
@@ -124,13 +125,13 @@
         ) }}
       </div>
       <div class="lg:px-11 w-full flex flex-col gap-24">
-        <h2 class="text-5xl font-medium" id="operate">Explore products</h2>
+        <h2 class="text-5xl font-medium" id="operate">Explore</h2>
         {{ partial "docs-section.html" (dict
           "Title" "Redis and Stack"
           "Description" "Redis Stack extends Redis with modern data models and processing engines to provide a complete developer experience."
           "ButtonLink" "./operate/oss_and_stack/"
           "ButtonLabel" "Read more"
-          "LinksLeftTitle" "Learn more about"
+          "LinksLeftTitle" "Learn more"
           "LinksLeft" (slice
             (dict "Text" "Install" "URL" "./operate/oss_and_stack/install/install-stack/")
             (dict "Text" "Search and query" "URL" "./develop/interact/search-and-query/")
@@ -142,7 +143,7 @@
         "Description" "Database-as-a-service (DBaaS) and the fastest way to deploy Redis Enterprise on Amazon Web Services, Google Cloud, or Microsoft Azure."
         "ButtonLink" "./operate/rc"
         "ButtonLabel" "Read more"
-        "LinksLeftTitle" "Learn more about"
+        "LinksLeftTitle" "Learn more"
         "LinksLeft" (slice
           (dict "Text" "Quick start" "URL" "./operate/rc/rc-quickstart/")
           (dict "Text" "Subscriptions" "URL" "./operate/rc/subscriptions/")
@@ -154,7 +155,7 @@
           "Description" "A self-managed data platform that unlocks the full potential of Redis at enterprise scale."
           "ButtonLink" "./operate/rs"
           "ButtonLabel" "Read more"
-          "LinksLeftTitle" "Learn more about"
+          "LinksLeftTitle" "Learn more"
           "LinksLeft" (slice
             (dict "Text" "Quick start" "URL" "./operate/rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart/")
             (dict "Text" "Clusters" "URL" "./operate/rs/clusters/")
@@ -166,7 +167,7 @@
           "Description" "Redis Enterprise deployed on containerized software platforms and integrated with our partners."
           "ButtonLink" "./operate/kubernetes/"
           "ButtonLabel" "Read more"
-          "LinksLeftTitle" "Learn more about"
+          "LinksLeftTitle" "Learn more"
           "LinksLeft" (slice
             (dict "Text" "Architecture" "URL" "./operate/kubernetes/architecture/")
             (dict "Text" "Deployments" "URL" "./operate/kubernetes/deployment/")

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -48,10 +48,9 @@
           </button>
           <div id="dropdown" class="hidden lg:block border-t border-opacity-50 border-redis-ink-900 text-redis-pen-800">
             <ul class="p-6">
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/get-started'>Get started</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/develop'>Develop</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Integrate</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Operate</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Integrated libraries, frameworks, and tools</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Operate Redis Cloud, Enterprise, and Insight</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600">APIs</a></li>
             </ul>
@@ -60,11 +59,10 @@
       </nav>
       <nav class="hidden lg:block w-full lg:w-64 z-40 h-full leading-7">
         <div class="flex flex-col gap-4">
-          <a class="px-6 py-4 hover:bg-redis-pen-200 border border-redis-ink-900 border-opacity-50 rounded-md" href='{{ .Scratch.Get "path" }}/get-started'>Get started</a>
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
-            <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/develop'>Develop</a>
-            <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Integrate</a>
-            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Operate</a>
+            <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a>
+            <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Integrated libraries, frameworks, and tools</a>
+            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Operate Redis Cloud, Enterprise, and Insight</a>
           </div>
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
@@ -75,23 +73,16 @@
     </div>
     <div class="lg:px-11 w-full flex flex-col gap-24">
       <div>
-        <h1 class="text-5xl font-medium" id="develop">Learn how to</h1>
         {{ partial "docs-section.html" (dict
-          "Title" "Develop"
-          "Description" "Read more about how to use the Redis in-memory data store as a cache, vector database, document database, streaming engine, and message broker."
-          "ButtonLink" "./develop"
-          "ButtonLabel" "Read more"
+          "Title" "Develop with Redis"
+          "Description" "Learn how to use the Redis in-memory data store."
           "LinksLeftTitle" "Featured content"
           "LinksLeft" (slice
             (dict "Text" "Vector search" "URL" "./develop/interact/search-and-query/query/vector-search")
-            (dict "Text" "Query data" "URL" "./develop/interact/search-and-query/query")
-            (dict "Text" "Debug functions" "URL" "./develop/interact/programmability/triggers-and-functions/debugging")
             )
           "LinksRightTitle" "Quick starts"
           "LinksRight" (slice
             (dict "Text" "Data structure store" "URL" "./develop/get-started/data-store/")
-            (dict "Text" "Document database" "URL" "./develop/get-started/document-database/")
-            (dict "Text" "Vector database" "URL" "./develop/get-started/vector-database/")
             )
           ) }}
         {{ partial "docs-section.html" (dict

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -16,9 +16,6 @@
 <main>
   <header class="relative h-96 bg-redis-ink-900 text-white overflow-hidden">
     <div class="absolute w-1/2 h-full top-0 left-1/4">
-      <div class="absolute w-fit -top-10 md:-top-6 -right-80 md:-left-96 scale-75 md:scale-100">
-        {{ partial "icons/redis-cube.html" }}
-      </div>
     </div>
     <div class="relative max-w-[800px] mx-auto px-5 flex flex-col gap-8 md:items-center justify-center h-full z-10">
       <h1 class="text-5xl font-medium">{{ .Title }}</h1>
@@ -72,7 +69,7 @@
       </nav>
     </div>
     <div class="lg:px-11 w-full flex flex-col gap-24">
-      <h1 class="text-5xl font-medium" id="operate">Learn how to</h1>
+      <h1 class="text-5xl font-medium" id="operate">Learn</h1>
         {{ partial "docs-section.html" (dict
           "Title" "Develop with Redis"
           "Description" "Learn how to use the Redis in-memory data store."
@@ -111,7 +108,7 @@
         ) }}
       </div>
       <div class="lg:px-11 w-full flex flex-col gap-24">
-        <h1 class="text-5xl font-medium" id="operate">Explore by product</h1>
+        <h1 class="text-5xl font-medium" id="operate">Explore products</h1>
         {{ partial "docs-section.html" (dict
           "Title" "Redis OSS and Stack"
           "Description" "Redis Stack extends Redis with modern data models and processing engines to provide a complete developer experience."

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -71,7 +71,7 @@
         </div>
       </nav>
     </div>
-    <div class="lg:px-11 w-full flex flex-col gap-24">
+    <div class="lg:px-11 w-full flex flex-col gap-12">
       <h2 class="text-5xl font-medium" id="operate">Learn</h2>
         {{ partial "docs-section.html" (dict
           "Title" "Develop with Redis"
@@ -113,7 +113,7 @@
         ) }}
         {{ partial "docs-section.html" (dict
           "Title" "Redis Insight"
-          "Description" "Redis Insight is a cross-platform GUI for Redis, with focus on reducing memory usage and improving application performance."
+          "Description" "A cross-platform GUI for Redis, with focus on reducing memory usage and improving application performance."
           "ButtonLink" "./develop/connect/insight/"
           "ButtonLabel" "Learn more"
           "LinksLeftTitle" "Learn more"
@@ -124,11 +124,11 @@
           )
         ) }}
       </div>
-      <div class="lg:px-11 w-full flex flex-col gap-24">
+      <div class="lg:px-11 w-full flex flex-col gap-12">
         <h2 class="text-5xl font-medium" id="operate">Explore</h2>
         {{ partial "docs-section.html" (dict
           "Title" "Redis and Stack"
-          "Description" "Redis Stack extends Redis with modern data models and processing engines to provide a complete developer experience."
+          "Description" "Redis Stack extends Redis with modern data models and processing engines."
           "ButtonLink" "./operate/oss_and_stack/"
           "ButtonLabel" "Read more"
           "LinksLeftTitle" "Learn more"
@@ -140,7 +140,7 @@
         ) }}
         {{ partial "docs-section.html" (dict
         "Title" "Redis Cloud"
-        "Description" "Database-as-a-service (DBaaS) and the fastest way to deploy Redis Enterprise on Amazon Web Services, Google Cloud, or Microsoft Azure."
+        "Description" "Deploy Redis Enterprise on Amazon Web Services, Google Cloud, or Microsoft Azure."
         "ButtonLink" "./operate/rc"
         "ButtonLabel" "Read more"
         "LinksLeftTitle" "Learn more"

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -50,7 +50,7 @@
             <ul class="p-6">
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a></li>
-              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Cloud, Enterprise, and Insight</a></li>
+              <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/operate'>Redis Products</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a></li>
               <li><a class="py-2 hover:underline hover:text-redis-pen-600">APIs</a></li>
             </ul>
@@ -62,7 +62,7 @@
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a>
             <a class="px-6 py-4 hover:bg-redis-pen-200 border-y border-redis-ink-900 border-opacity-50" href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a>
-            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Cloud, Enterprise, and Insight</a>
+            <a class="px-6 py-4 rounded-b-md hover:bg-redis-pen-200" href='{{ .Scratch.Get "path" }}/operate'>Redis Products</a>
           </div>
           <div class="flex flex-col border border-redis-ink-900 border-opacity-50 rounded-md">
             <a class="px-6 py-4 rounded-t-md hover:bg-redis-pen-200 text-redis-red-600" href='{{ .Scratch.Get "path" }}/commands'>Commands</a>
@@ -72,7 +72,7 @@
       </nav>
     </div>
     <div class="lg:px-11 w-full flex flex-col gap-24">
-      <h1 class="text-5xl font-medium" id="operate">Learn</h1>
+      <h2 class="text-5xl font-medium" id="operate">Learn</h2>
         {{ partial "docs-section.html" (dict
           "Title" "Develop with Redis"
           "Description" "Learn how to use the Redis in-memory data store."
@@ -85,8 +85,8 @@
             )
           ) }}
         {{ partial "docs-section.html" (dict
-          "Title" "Integrate"
-          "Description" "Read about frameworks and integrations available for Redis."
+          "Title" "Libraries and tools"
+          "Description" "Learn about libraries and tools available for Redis."
           "ButtonLink" "./integrate"
           "ButtonLabel" "Browse integrations"
           "LinksLeftTitle" "Featured libraries"
@@ -98,28 +98,40 @@
           )
         ) }}
         {{ partial "docs-section.html" (dict
-          "Title" "Operate"
-          "Description" "Read about how to install, administer, and monitor Redis OSS, Redis Stack, Redis Enterprise, and Redis Cloud."
-          "ButtonLink" "./operate"
-          "ButtonLabel" "Read more"
-          "LinksLeftTitle" "Featured content"
+          "Title" "Redis Data Integration"
+          "Description" "Redis Data Integration keeps Redis in sync with the primary database in near real time."
+          "ButtonLink" "./integrate/redis-data-integration"
+          "ButtonLabel" "Learn more"
+          "LinksLeftTitle" "LEARN MORE ABOUT"
           "LinksLeft" (slice
-              (dict "Text" "Upgrade database from Essentials to Pro" "URL" "./operate/rc/subscriptions/upgrade-essentials-pro/")
-              (dict "Text" "Redis Cloud REST API" "URL" "./operate/rc/api/")
-              (dict "Text" "Prometheus and Grafana with Redis Cloud" "URL" "./integrate/prometheus-with-redis-cloud/")
-              )
+            (dict "Text" "Quick start" "URL" "./integrate/redis-data-integration/quickstart/")
+            (dict "Text" "Architecture" "URL" "./integrate/redis-data-integration/architecture/")
+            (dict "Text" "Install" "URL" "./integrate/redis-data-integration/installation/")
+            (dict "Text" "Reference" "URL" "./integrate/redis-data-integration/reference/")
+          )
+        ) }}
+        {{ partial "docs-section.html" (dict
+          "Title" "Redis Insight"
+          "Description" "Redis Insight is a cross-platform GUI for Redis, with focus on reducing memory usage and improving application performance."
+          "ButtonLink" "./develop/connect/insight/"
+          "ButtonLabel" "Learn more"
+          "LinksLeftTitle" "Learn more about"
+          "LinksLeft" (slice
+            (dict "Text" "Install" "URL" "./operate/redisinsight/install/")
+            (dict "Text" "User guide" "URL" "./develop/connect/insight/")
+            (dict "Text" "Manage Streams in Redis Insight" "URL" "./develop/connect/insight/tutorials/insight-stream-consumer/")
+          )
         ) }}
       </div>
       <div class="lg:px-11 w-full flex flex-col gap-24">
-        <h1 class="text-5xl font-medium" id="operate">Explore products</h1>
+        <h2 class="text-5xl font-medium" id="operate">Explore products</h2>
         {{ partial "docs-section.html" (dict
-          "Title" "Redis OSS and Stack"
+          "Title" "Redis and Stack"
           "Description" "Redis Stack extends Redis with modern data models and processing engines to provide a complete developer experience."
           "ButtonLink" "./operate/oss_and_stack/"
           "ButtonLabel" "Read more"
           "LinksLeftTitle" "Learn more about"
           "LinksLeft" (slice
-            (dict "Text" "Quick start" "URL" "./develop/get-started/")
             (dict "Text" "Install" "URL" "./operate/oss_and_stack/install/install-stack/")
             (dict "Text" "Search and query" "URL" "./develop/interact/search-and-query/")
             (dict "Text" "JSON" "URL" "./develop/data-types/json/")
@@ -160,31 +172,6 @@
             (dict "Text" "Deployments" "URL" "./operate/kubernetes/deployment/")
             (dict "Text" "Clusters" "URL" "./operate/kubernetes/re-clusters/")
             (dict "Text" "Databases" "URL" "./operate/kubernetes/re-databases/")
-          )
-        ) }}
-        {{ partial "docs-section.html" (dict
-          "Title" "Redis Data Integration"
-          "Description" "Redis Data Integration keeps Redis in sync with the primary database in near real time."
-          "ButtonLink" "./integrate/redis-data-integration"
-          "ButtonLabel" "Read more"
-          "LinksLeftTitle" "LEARN MORE ABOUT"
-          "LinksLeft" (slice
-            (dict "Text" "Quick start" "URL" "./integrate/redis-data-integration/quickstart/")
-            (dict "Text" "Architecture" "URL" "./integrate/redis-data-integration/architecture/")
-            (dict "Text" "Install" "URL" "./integrate/redis-data-integration/installation/")
-            (dict "Text" "Reference" "URL" "./integrate/redis-data-integration/reference/")
-          )
-        ) }}
-        {{ partial "docs-section.html" (dict
-          "Title" "Redis Insight"
-          "Description" "Redis Insight is a cross-platform GUI for Redis, with focus on reducing memory usage and improving application performance."
-          "ButtonLink" "./develop/connect/insight/"
-          "ButtonLabel" "Read more"
-          "LinksLeftTitle" "Learn more about"
-          "LinksLeft" (slice
-            (dict "Text" "Install" "URL" "./operate/redisinsight/install/")
-            (dict "Text" "User guide" "URL" "./develop/connect/insight/")
-            (dict "Text" "Manage Streams in Redis Insight" "URL" "./develop/connect/insight/tutorials/insight-stream-consumer/")
           )
         ) }}
       </div>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -14,8 +14,11 @@
 
 {{ define "main" }}
 <main>
-  <header class="relative h-96 bg-redis-ink-900 text-white overflow-hidden">
+  <header class="relative h-48 bg-redis-ink-900 text-white overflow-hidden">
     <div class="absolute w-1/2 h-full top-0 left-1/4">
+      <div class="absolute w-fit -top-10 md:-top-6 -right-80 md:-left-96 scale-75 md:scale-100">
+        {{ partial "icons/redis-cube.html" }}
+      </div>
     </div>
     <div class="relative max-w-[800px] mx-auto px-5 flex flex-col gap-8 md:items-center justify-center h-full z-10">
       <h1 class="text-5xl font-medium">{{ .Title }}</h1>

--- a/layouts/partials/docs-nav-collapsed.html
+++ b/layouts/partials/docs-nav-collapsed.html
@@ -3,9 +3,9 @@
     {{ $navRoot := cond (eq .Site.Home.Type "docs") .Site.Home .FirstSection -}}
     <div id="sidebar" class="max-h-[calc(100vh-8rem)] border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col">
       {{ if in (slice "Develop" "Integrate" "Operate" "Commands") $navRoot.LinkTitle }}
-        <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Develop" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/develop'>Develop</a>
-        <a class='px-6 py-4 hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Integrate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/integrate'>Integrate</a>
-        <a class='px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Operate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/operate'>Operate</a>
+        <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Develop" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a>
+        <a class='px-6 py-4 hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Integrate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a>
+        <a class='px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Operate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/operate'>Redis products</a>
       {{ else }}
         <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 font-bold' href="{{ $navRoot.RelPermalink }}">{{ $navRoot.LinkTitle }}</a>
         <div class="hidden md:block w-full py-6"></div>

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -42,19 +42,19 @@
     {{ $ulNr := 0 -}}
     {{ $ulShow := 1 -}}
       <div class='min-h-0  border border-opacity-50 border-redis-ink-900 rounded-md flex flex-col {{ if not (in (slice "Develop" "Integrate" "Operate") $navRoot.LinkTitle) }} shrink-0 {{ end }}'>
-        <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Develop" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/develop'>Develop</a>
+        <a class='px-6 py-4 rounded-t-md hover:bg-redis-pen-200 {{ if eq $navRoot.LinkTitle "Develop" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/develop'>Develop with Redis</a>
         {{ if eq $navRoot.LinkTitle "Develop" }}
           <ul class="md:block overflow-y-auto grow pr-6 border-t border-opacity-50 border-redis-ink-900">
             {{ template "li" (dict "page" . "pages" (union $navRoot.Pages $navRoot.Sections).ByWeight) }}
           </ul>
         {{ end }}
-        <a class='px-6 py-4 hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Integrate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/integrate'>Integrate</a>
+        <a class='px-6 py-4 hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Integrate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/integrate'>Libraries and tools</a>
         {{ if eq $navRoot.LinkTitle "Integrate" }}
           <ul class="md:block overflow-y-auto grow pr-6 border-t border-opacity-50 border-redis-ink-900">
             {{ template "li" (dict "page" . "pages" (union $navRoot.Pages $navRoot.Sections).ByWeight) }}
           </ul>
         {{ end }}
-        <a class='px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Operate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/operate'>Operate</a>
+        <a class='px-6 py-4 rounded-b-md hover:bg-redis-pen-200 border-t border-redis-ink-900 border-opacity-50 {{ if eq $navRoot.LinkTitle "Operate" }} font-bold {{ end }}' href='{{ .Scratch.Get "path" }}/operate'>Redis products</a>
         {{ if eq $navRoot.LinkTitle "Operate" }}
           <ul class="md:block overflow-y-auto grow pr-6 border-t border-opacity-50 border-redis-ink-900">
             {{ template "li" (dict "page" . "pages" (union $navRoot.Pages $navRoot.Sections).ByWeight) }}


### PR DESCRIPTION
This PR updates the home page and menu text. On the home page, I reduced the header by half height, removed the orphan Get started category, updated the main three categories to be more meaningful/clear, and got more content above the fold by using a two-column layout. It also changes the other nav menus and index pages to match the new terms. 

https://redis.io/docs/staging/menu-text/