### PR TITLE
Do not generate a preview link for deleted files

### DIFF
--- a/.github/workflows/autocomment.yaml
+++ b/.github/workflows/autocomment.yaml
@@ -46,7 +46,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             $FILES_URL \
-              | jq -r --arg prefix $BRANCH_NAME/ '.[] | select(.filename | test("content\/.+\\.md")) | ($prefix + .filename)' \
+              | jq -r --arg prefix $BRANCH_NAME/ '.[] | select(((.filename | test("content\/.+\\.md")) and .status != "removed")) | ($prefix + .filename)' \
               | sed -E -e 's|(^[^/]+/)([^/]+/)|\1|' -e 's|^|https://redis.io/docs/staging/|' -e 's|(_?index)?\.md||' \
               | uniq \
               | xargs \


### PR DESCRIPTION
Currently the bot generates a link even for deleted files, such as `https://redis.io/docs/staging/DOC-3785-ext-client-libs/develop/connect/clients/go` in https://github.com/redis/docs/pull/228

