### PR TITLE
DOC-3809 fixed headings on client lib pages

### DIFF
--- a/content/develop/connect/clients/dotnet.md
+++ b/content/develop/connect/clients/dotnet.md
@@ -15,22 +15,21 @@ title: C#/.NET guide
 weight: 2
 ---
 
-Install Redis and the Redis client, then connect your .NET application to a Redis database. 
+[NRedisStack](https://github.com/redis/NRedisStack) is the .NET client for Redis.
+The sections below explain how to install `NRedisStack` and connect your application
+to a Redis database.
 
-## NRedisStack
+`NRedisStack` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
-[NRedisStack](https://github.com/redis/NRedisStack) is a .NET client for Redis.
-`NredisStack` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
-
-### Install
+## Install
 
 Using the `dotnet` CLI, run:
 
-```
+```bash
 dotnet add package NRedisStack
 ```
 
-### Connect
+## Connect
 
 Connect to localhost on port 6379.
 
@@ -81,7 +80,7 @@ IJsonCommands json = db.JSON();
 ITimeSeriesCommands ts = db.TS();
 ```
 
-#### Connect to a Redis cluster
+### Connect to a Redis cluster
 
 To connect to a Redis cluster, you just need to specify one or all cluster endpoints in the client configuration:
 
@@ -103,7 +102,7 @@ db.StringSet("foo", "bar");
 Console.WriteLine(db.StringGet("foo")); // prints bar
 ```
 
-#### Connect to your production Redis with TLS
+### Connect to your production Redis with TLS
 
 When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
 
@@ -166,7 +165,7 @@ conn.StringSet("foo", "bar");
 Console.WriteLine(conn.StringGet("foo"));   
 ```
 
-### Example: Indexing and querying JSON documents
+## Example: Indexing and querying JSON documents
 
 This example shows how to convert Redis search results to JSON format using `NRedisStack`.
 
@@ -274,7 +273,7 @@ for (var i=0; i<result.TotalResults; i++)
 // Tel Aviv - 2
 ```
 
-### Learn more
+## Learn more
 
 * [GitHub](https://github.com/redis/NRedisStack)
  

--- a/content/develop/connect/clients/java/jedis.md
+++ b/content/develop/connect/clients/java/jedis.md
@@ -15,13 +15,15 @@ title: Jedis guide
 weight: 1
 ---
 
-Install Redis and the Redis client, then connect your Java application to a Redis database. 
+[Jedis](https://github.com/redis/jedis) is the *synchronous* Java client for Redis.
+Use [Lettuce]({{< relref "/develop/connect/clients/java/lettuce" >}}) if you need
+an *asynchronous* Java client.
+The sections below explain how to install `Jedis` and connect your application
+to a Redis database.
 
-## Jedis
+`Jedis` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
-[Jedis](https://github.com/redis/jedis) is a Java client for Redis designed for performance and ease of use.
-
-### Install
+## Install
 
 To include `Jedis` as a dependency in your application, edit the dependency file, as follows.
 
@@ -52,7 +54,7 @@ To include `Jedis` as a dependency in your application, edit the dependency file
 
 * Build from [source](https://github.com/redis/jedis)
 
-### Connect
+## Connect
 
 For many applications, it's best to use a connection pool. You can instantiate and use a `Jedis` connection pool like so:
 
@@ -96,7 +98,7 @@ jedis.set("foo", "bar");
 System.out.println(jedis.get("foo")); // prints "bar"
 ```
 
-#### Connect to a Redis cluster
+### Connect to a Redis cluster
 
 To connect to a Redis cluster, use `JedisCluster`. 
 
@@ -112,7 +114,7 @@ jedisClusterNodes.add(new HostAndPort("127.0.0.1", 7380));
 JedisCluster jedis = new JedisCluster(jedisClusterNodes);
 ```
 
-#### Connect to your production Redis with TLS
+### Connect to your production Redis with TLS
 
 When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
 
@@ -194,9 +196,13 @@ public class Main {
 }
 ```
 
-### Production usage
+## Production usage
 
-### Configuring Connection pool
+The following sections explain how to handle situations that may occur
+in your production environment.
+
+### Configuring a connection pool
+
 As mentioned in the previous section, use `JedisPool` or `JedisPooled` to create a connection pool.
 `JedisPooled`, added in Jedis version 4.0.0, provides capabilities similar to `JedisPool` but with a more straightforward API.
 A connection pool holds a specified number of connections, creates more connections when necessary, and terminates them when they are no longer needed.
@@ -244,7 +250,7 @@ poolConfig.setTimeBetweenEvictionRuns(Duration.ofSeconds(1));
 JedisPooled jedis = new JedisPooled(poolConfig, "localhost", 6379);
 ```
 
-### Timeout
+### Timeouts
 
 To set a timeout for a connection, use the `JedisPooled` or `JedisPool` constructor with the `timeout` parameter, or use `JedisClientConfig` with the `socketTimeout` and `connectionTimeout` parameters:
 
@@ -261,6 +267,7 @@ JedisPooled jedisWithTimeout = new JedisPooled(hostAndPort,
 ```
 
 ### Exception handling
+
 The Jedis Exception Hierarchy is rooted on `JedisException`, which implements `RuntimeException`, and are therefore all unchecked exceptions.
 
 ```
@@ -279,7 +286,8 @@ JedisException
 └── InvalidURIException
 ```
 
-#### General Exceptions
+#### General exceptions
+
 In general, Jedis can throw the following exceptions while executing commands:
 
 - `JedisConnectionException` - when the connection to Redis is lost or closed unexpectedly. Configure failover to handle this exception automatically with Resilience4J and the built-in Jedis failover mechanism.  
@@ -300,7 +308,7 @@ Conditions when `JedisException` can be thrown:
 
 All the Jedis exceptions are runtime exceptions and in most cases irrecoverable, so in general bubble up to the API capturing the error message.
 
-## DNS cache and Redis
+### DNS cache and Redis
 
 When you connect to a Redis with multiple endpoints, such as [Redis Enterprise Active-Active](https://redis.com/redis-enterprise/technology/active-active-geo-distribution/), it's recommended to disable the JVM's DNS cache to load-balance requests across multiple endpoints.
 
@@ -310,7 +318,7 @@ java.security.Security.setProperty("networkaddress.cache.ttl","0");
 java.security.Security.setProperty("networkaddress.cache.negative.ttl", "0");
 ```
 
-### Learn more
+## Learn more
 
 * [Jedis API reference](https://www.javadoc.io/doc/redis.clients/jedis/latest/index.html)
 * [Failover with Jedis](https://github.com/redis/jedis/blob/master/docs/failover.md)

--- a/content/develop/connect/clients/java/lettuce.md
+++ b/content/develop/connect/clients/java/lettuce.md
@@ -15,11 +15,13 @@ title: Lettuce guide
 weight: 2
 ---
 
-Install Redis and the Redis client, then connect your Lettuce application to a Redis database.
+[Lettuce](https://github.com/redis/lettuce/tree/main/src/main) is the *asynchronous* Java client for Redis.
+Use [Jedis]({{< relref "/develop/connect/clients/java/jedis" >}}) if you need
+a *synchronous* Java client.
+The sections below explain how to install `Lettuce` and connect your application
+to a Redis database.
 
-## Lettuce
-
-Lettuce offers a powerful and efficient way to interact with Redis through its asynchronous and reactive APIs. By leveraging these capabilities, you can build high-performance, scalable Java applications that make optimal use of Redis's capabilities.
+`Lettuce` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
 ## Install
 
@@ -171,8 +173,6 @@ RedisURI redisUri = RedisURI.Builder.redis("localhost")
 RedisClient client = RedisClient.create(redisUri);
 ```
 
-
-
 ## Connection Management in Lettuce
 
 Lettuce uses `ClientResources` for efficient management of shared resources like event loop groups and thread pools.
@@ -182,7 +182,6 @@ A typical approach with Lettuce is to create a single `RedisClient` instance and
 These connections are multiplexed; that is, multiple commands can be run concurrently over a single or a small set of connections, making explicit pooling less critical.
 
 Lettuce provides pool config to be used with Lettuce asynchronous connection methods.
-
 
 ```java
 package org.example;

--- a/content/develop/connect/clients/nodejs.md
+++ b/content/develop/connect/clients/nodejs.md
@@ -15,22 +15,21 @@ title: Node.js guide
 weight: 3
 ---
 
-Install Redis and the Redis client, then connect your Node.js application to a Redis database. 
+[node-redis](https://github.com/redis/node-redis) is the Redis client for Node.js.
+The sections below explain how to install `node-redis` and connect your application
+to a Redis database.
 
-## node-redis
-
-[node-redis](https://github.com/redis/node-redis) is a modern, high-performance Redis client for Node.js.
 `node-redis` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
-### Install
+## Install
 
 To install node-redis, run:
 
-```
+```bash
 npm install redis
 ```
 
-### Connect
+## Connect
 
 Connect to localhost on port 6379. 
 
@@ -82,7 +81,7 @@ createClient({
 ```
 To check if the client is connected and ready to send commands, use `client.isReady`, which returns a Boolean. `client.isOpen` is also available. This returns `true` when the client's underlying socket is open, and `false` when it isn't (for example, when the client is still connecting or reconnecting after a network error).
 
-#### Connect to a Redis cluster
+### Connect to a Redis cluster
 
 To connect to a Redis cluster, use `createCluster`.
 
@@ -112,7 +111,7 @@ console.log(value); // returns 'bar'
 await cluster.quit();
 ```
 
-#### Connect to your production Redis with TLS
+### Connect to your production Redis with TLS
 
 When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
 
@@ -143,15 +142,18 @@ await client.disconnect();
 
 You can also use discrete parameters and UNIX sockets. Details can be found in the [client configuration guide](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md).
 
-### Production usage
+## Production usage
 
-#### Handling errors
+The following sections explain how to handle situations that may occur
+in your production environment.
+
+### Handling errors
+
 Node-Redis provides [multiple events to handle various scenarios](https://github.com/redis/node-redis?tab=readme-ov-file#events), among which the most critical is the `error` event.
 
 This event is triggered whenever an error occurs within the client.
 
 It is crucial to listen for error events.
-
 
 If a client does not register at least one error listener and an error occurs, the system will throw that error, potentially causing the Node.js process to exit unexpectedly.
 See [the EventEmitter docs](https://nodejs.org/api/events.html#events_error_events) for more details.
@@ -166,8 +168,7 @@ client.on('error', error => {
 });
 ```
 
-
-#### Handling reconnections
+### Handling reconnections
 
 If network issues or other problems unexpectedly close the socket, the client will reject all commands already sent, since the server might have already executed them.
 The rest of the pending commands will remain queued in memory until a new socket is established.
@@ -200,7 +201,7 @@ After approximately two minutes, the client logs an error message and terminates
 2. Use a numerical value to set a fixed delay in milliseconds.
 3. Use `false` to disable reconnection attempts. This option should only be used for testing purposes.
 
-#### Timeout
+### Timeouts
 
 To set a timeout for a connection, use the `connectTimeout` option:
 ```typescript
@@ -211,7 +212,7 @@ const client = createClient({
 client.on('error', error => console.error('Redis client error:', error));
 ```
 
-### Learn more
+## Learn more
 
 * [Node-Redis Configuration Options](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md)
 * [Redis commands](https://redis.js.org/#node-redis-usage-redis-commands)

--- a/content/develop/connect/clients/python.md
+++ b/content/develop/connect/clients/python.md
@@ -15,15 +15,13 @@ title: Python guide
 weight: 1
 ---
 
-Install Redis and the Redis client, then connect your Python application to a Redis database. 
-
-## redis-py
-
-Get started with the [redis-py](https://github.com/redis/redis-py) client for Redis. 
+[redis-py](https://github.com/redis/redis-py) is the Python client for Redis. 
+The sections below explain how to install `redis-py` and connect your application
+to a Redis database.
 
 `redis-py` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
-### Install
+## Install
 
 To install `redis-py`, enter:
 
@@ -41,7 +39,7 @@ The Python `distutils` packaging scheme is no longer part of Python 3.12 and gre
 pip install redis[hiredis]
 ```
 
-### Connect
+## Connect
 
 Connect to localhost on port 6379, set a value in Redis, and retrieve it. All responses are returned as bytes in Python. To receive decoded strings, set `decode_responses=True`. For more connection options, see [these examples](https://redis.readthedocs.io/en/stable/examples.html).
 
@@ -73,7 +71,7 @@ r.hgetall('user-session:123')
 # {'surname': 'Smith', 'name': 'John', 'company': 'Redis', 'age': '29'}
 ```
 
-#### Connect to a Redis cluster
+### Connect to a Redis cluster
 
 To connect to a Redis cluster, use `RedisCluster`.
 
@@ -93,7 +91,7 @@ rc.get('foo')
 ```
 For more information, see [redis-py Clustering](https://redis-py.readthedocs.io/en/stable/clustering.html).
 
-#### Connect to your production Redis with TLS
+### Connect to your production Redis with TLS
 
 When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
 
@@ -117,7 +115,7 @@ r.get('foo')
 ```
 For more information, see [redis-py TLS examples](https://redis-py.readthedocs.io/en/stable/examples/ssl_connection_examples.html).
 
-### Example: Indexing and querying JSON documents
+## Example: Indexing and querying JSON documents
 
 Make sure that you have Redis Stack and `redis-py` installed. Import dependencies:
 
@@ -217,7 +215,7 @@ print(rs.aggregate(req).rows)
 # [[b'city', b'Tel Aviv', b'count', b'2'], [b'city', b'London', b'count', b'1']]
 ```
 
-### Learn more
+## Learn more
 
 * [Command reference](https://redis-py.readthedocs.io/en/stable/commands.html)
 * [Tutorials](https://redis.readthedocs.io/en/stable/examples.html)


### PR DESCRIPTION
The headings were a bit badly organised in the client library pages (eg, it gave the impression of missing content in some places). These pages will be changed quite a lot in the near future but it seems worthwhile to make them clearer while we're waiting for the new versions.