### PR TITLE
Update time series documentation

### DIFF
--- a/content/commands/ts.add/index.md
+++ b/content/commands/ts.add/index.md
@@ -85,10 +85,10 @@ syntax: "TS.ADD key timestamp value \n  [RETENTION retentionPeriod] \n  [ENCODIN
   \ <COMPRESSED|UNCOMPRESSED>] \n  [CHUNK_SIZE size] \n  [DUPLICATE_POLICY policy] \n  [ON_DUPLICATE policy_ovr] \n\
   \  [LABELS [label value ...]]\n"
 syntax_fmt: "TS.ADD key timestamp value [RETENTION\_retentionPeriod]\n  [ENCODING\_\
-  <COMPRESSED | UNCOMPRESSED>] [CHUNK_SIZE\_size]\n  [DUPLICATE_POLICY policy] \n  [ON_DUPLICATE\_<BLOCK | FIRST\
+  <COMPRESSED | UNCOMPRESSED>] [CHUNK_SIZE\_size]\n  [DUPLICATE_POLICY\_policy] \n  [ON_DUPLICATE\_<BLOCK | FIRST\
   \ | LAST | MIN | MAX | SUM>]\n  [LABELS\ [label value ...]]"
 syntax_str: "timestamp value [RETENTION\_retentionPeriod] [ENCODING\_<COMPRESSED\
-  \ | UNCOMPRESSED>] [CHUNK_SIZE\_size] [DUPLICATE_POLICY policy] [ON_DUPLICATE\_<BLOCK | FIRST | LAST | MIN |\
+  \ | UNCOMPRESSED>] [CHUNK_SIZE\_size] [DUPLICATE_POLICY\_policy] [ON_DUPLICATE\_<BLOCK | FIRST | LAST | MIN |\
   \ MAX | SUM>] [LABELS\ [label value ...]]"
 title: TS.ADD
 ---
@@ -135,7 +135,7 @@ The following arguments are optional because they can be set by [`TS.CREATE`]({{
 
 <details open><summary><code>RETENTION retentionPeriod</code></summary> 
  
- is maximum retention period, compared to the maximum existing timestamp, in milliseconds.
+is maximum retention period, compared to the maximum existing timestamp, in milliseconds.
 
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `RETENTION` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
@@ -147,12 +147,16 @@ specifies the series sample's encoding format.
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
-<details open><summary><code>CHUNK_SIZE size</code></summary> is memory size, in bytes, allocated for each data chunk.
+<details open><summary><code>CHUNK_SIZE size</code></summary>
+  
+is memory size, in bytes, allocated for each data chunk.
 
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `CHUNK_SIZE` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
 <details open><summary><code>DUPLICATE_POLICY policy</code></summary>
+
+is policy for handling insertion ([`TS.ADD`]({{< baseurl >}}/commands/ts.add/) and [`TS.MADD`]({{< baseurl >}}/commands/ts.madd/)) of multiple samples with identical timestamps.
 
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `DUPLICATE_POLICY` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>

--- a/content/commands/ts.add/index.md
+++ b/content/commands/ts.add/index.md
@@ -142,7 +142,7 @@ Use it only if you are creating a new time series. It is ignored if you are addi
     
 <details open><summary><code>ENCODING enc</code></summary> 
 
-specifies the series sample's encoding format.
+specifies the series sample encoding format.
 
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>

--- a/content/commands/ts.add/index.md
+++ b/content/commands/ts.add/index.md
@@ -186,7 +186,7 @@ Use it only if you are creating a new time series. It is ignored if you are addi
 
 <note><b>Notes:</b>
 - You can use this command to create a new time series and add data to it in a single command.
-  `RETENTION`, `ENCODING`, `CHUNK_SIZE`, and `LABELS` are used only when creating a new time series, and ignored when adding samples to an existing time series.
+  `RETENTION`, `ENCODING`, `CHUNK_SIZE`, `DUPLICATE_POLICY`, and `LABELS` are used only when creating a new time series, and ignored when adding samples to an existing time series.
 - Setting `RETENTION` and `LABELS` introduces additional time complexity.
 </note>
 

--- a/content/commands/ts.add/index.md
+++ b/content/commands/ts.add/index.md
@@ -46,6 +46,10 @@ arguments:
     type: pure-token
   name: policy
   optional: true
+  token: DUPLICATE_POLICY
+  type: oneof
+- name: policy_ovr
+  optional: true
   token: ON_DUPLICATE
   type: oneof
 - arguments:
@@ -78,13 +82,13 @@ since: 1.0.0
 stack_path: docs/data-types/timeseries
 summary: Append a sample to a time series
 syntax: "TS.ADD key timestamp value \n  [RETENTION retentionPeriod] \n  [ENCODING\
-  \ <COMPRESSED|UNCOMPRESSED>] \n  [CHUNK_SIZE size] \n  [ON_DUPLICATE policy] \n\
+  \ <COMPRESSED|UNCOMPRESSED>] \n  [CHUNK_SIZE size] \n  [DUPLICATE_POLICY policy] \n  [ON_DUPLICATE policy_ovr] \n\
   \  [LABELS [label value ...]]\n"
 syntax_fmt: "TS.ADD key timestamp value [RETENTION\_retentionPeriod]\n  [ENCODING\_\
-  <COMPRESSED | UNCOMPRESSED>] [CHUNK_SIZE\_size]\n  [ON_DUPLICATE\_<BLOCK | FIRST\
+  <COMPRESSED | UNCOMPRESSED>] [CHUNK_SIZE\_size]\n  [DUPLICATE_POLICY policy] \n  [ON_DUPLICATE\_<BLOCK | FIRST\
   \ | LAST | MIN | MAX | SUM>]\n  [LABELS\ [label value ...]]"
 syntax_str: "timestamp value [RETENTION\_retentionPeriod] [ENCODING\_<COMPRESSED\
-  \ | UNCOMPRESSED>] [CHUNK_SIZE\_size] [ON_DUPLICATE\_<BLOCK | FIRST | LAST | MIN |\
+  \ | UNCOMPRESSED>] [CHUNK_SIZE\_size] [DUPLICATE_POLICY policy] [ON_DUPLICATE\_<BLOCK | FIRST | LAST | MIN |\
   \ MAX | SUM>] [LABELS\ [label value ...]]"
 title: TS.ADD
 ---
@@ -148,12 +152,17 @@ Use it only if you are creating a new time series. It is ignored if you are addi
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `CHUNK_SIZE` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
-<details open><summary><code>ON_DUPLICATE policy</code></summary> 
+<details open><summary><code>DUPLICATE_POLICY policy</code></summary>
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `DUPLICATE_POLICY` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+</details>
+
+<details open><summary><code>ON_DUPLICATE policy_ovr</code></summary> 
 
 is overwrite key and database configuration for [DUPLICATE_POLICY]({{< baseurl >}}/develop/data-types/timeseries/configuration#duplicate_policy), the policy for handling samples with identical timestamps.
 This override is effective only for this single command and does not set the time series duplication policy (which can be set with [`TS.ALTER`]({{< baseurl >}}/commands/ts.alter/)).
 
-`policy` can be one of the following values:
+`policy_ovr` can be one of the following values:
   - `BLOCK`: ignore any newly reported value and reply with an error
   - `FIRST`: ignore any newly reported value
   - `LAST`: override with the newly reported value

--- a/content/commands/ts.decrby/index.md
+++ b/content/commands/ts.decrby/index.md
@@ -119,7 +119,7 @@ Use it only if you are creating a new time series. It is ignored if you are addi
 
 <details open><summary><code>ENCODING enc</code></summary> 
 
-specifies the series sample's encoding format.
+specifies the series sample encoding format.
 
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>

--- a/content/commands/ts.decrby/index.md
+++ b/content/commands/ts.decrby/index.md
@@ -147,7 +147,7 @@ Use it only if you are creating a new time series. It is ignored if you are addi
 
 <note><b>Notes</b>
 
- - You can use this command to add data to a nonexisting time series in a single command. This is why `RETENTION`, `ENCODING`,  `CHUNK_SIZE`, and `LABELS` are optional arguments.
+ - You can use this command to add data to a nonexisting time series in a single command. This is why `RETENTION`, `ENCODING`,  `CHUNK_SIZE`, `DUPLICATE_POLICY`, and `LABELS` are optional arguments.
  - When specified and the key doesn't exist, a new time series is created. Setting the `RETENTION` and `LABELS` introduces additional time complexity.
 </note>
 

--- a/content/commands/ts.decrby/index.md
+++ b/content/commands/ts.decrby/index.md
@@ -12,14 +12,25 @@ arguments:
   optional: true
   token: RETENTION
   type: integer
-- name: uncompressed
+- arguments:
+  - name: uncompressed
+    token: UNCOMPRESSED
+    type: pure-token
+  - name: compressed
+    token: COMPRESSED
+    type: pure-token
+  name: enc
   optional: true
-  token: UNCOMPRESSED
-  type: pure-token
+  token: ENCODING
+  type: oneof
 - name: size
   optional: true
   token: CHUNK_SIZE
   type: integer
+- name: policy
+  optional: true
+  token: DUPLICATE_POLICY
+  type: oneof
 - arguments:
   - name: label
     type: string
@@ -54,11 +65,11 @@ summary: Decrease the value of the sample with the maximum existing timestamp, o
   create a new sample with a value equal to the value of the sample with the maximum
   existing timestamp with a given decrement
 syntax: "TS.DECRBY key subtrahend \n  [TIMESTAMP timestamp] \n  [RETENTION retentionPeriod]\
-  \ \n  [UNCOMPRESSED] \n  [CHUNK_SIZE size] \n  [LABELS [label value ...]]\n"
+  \ \n  [ENCODING <COMPRESSED|UNCOMPRESSED>] \n  [CHUNK_SIZE size] \n  [DUPLICATE_POLICY policy] \n  [LABELS [label value ...]]\n"
 syntax_fmt: "TS.DECRBY key value [TIMESTAMP\_timestamp]\n  [RETENTION\_retentionPeriod]\
-  \ [UNCOMPRESSED] [CHUNK_SIZE\_size]\n  [LABELS\_[label value ...]]"
-syntax_str: "value [TIMESTAMP\_timestamp] [RETENTION\_retentionPeriod] [UNCOMPRESSED]\
-  \ [CHUNK_SIZE\_size] [LABELS\_[label value ...]]"
+  \ [ENCODING\_<COMPRESSED|UNCOMPRESSED>] [CHUNK_SIZE\_size]\n [DUPLICATE_POLICY\_policy] [LABELS\_[label value ...]]"
+syntax_str: "value [TIMESTAMP\_timestamp] [RETENTION\_retentionPeriod] [ENCODING\_<COMPRESSED|UNCOMPRESSED>]\
+  \ [CHUNK_SIZE\_size] [DUPLICATE_POLICY\_policy] [LABELS\_[label value ...]]"
 title: TS.DECRBY
 ---
 
@@ -101,30 +112,43 @@ When not specified, the timestamp is set to the Unix time of the server's clock.
 
 <details open><summary><code>RETENTION retentionPeriod</code></summmary> 
 
-is maximum retention period, compared to the maximum existing timestamp, in milliseconds. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `RETENTION` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+is maximum retention period, compared to the maximum existing timestamp, in milliseconds.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `RETENTION` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
-<details open><summary><code>UNCOMPRESSED</code></summary>
+<details open><summary><code>ENCODING enc</code></summary> 
 
-changes data storage from compressed (default) to uncompressed. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+specifies the series sample's encoding format.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
 <details open><summary><code>CHUNK_SIZE size</code></summary> 
 
-is memory size, in bytes, allocated for each data chunk. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `CHUNK_SIZE` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+is memory size, in bytes, allocated for each data chunk.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `CHUNK_SIZE` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+</details>
+
+<details open><summary><code>DUPLICATE_POLICY policy</code></summary>
+
+is policy for handling insertion ([`TS.ADD`]({{< baseurl >}}/commands/ts.add/) and [`TS.MADD`]({{< baseurl >}}/commands/ts.madd/)) of multiple samples with identical timestamps.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `DUPLICATE_POLICY` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
 <details open><summary><code>LABELS [{label value}...]</code></summary> 
 
-is set of label-value pairs that represent metadata labels of the key and serve as a secondary index. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `LABELS` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+is set of label-value pairs that represent metadata labels of the key and serve as a secondary index.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `LABELS` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
 <note><b>Notes</b>
 
- - You can use this command to add data to a nonexisting time series in a single command.
-  This is why `RETENTION`, `UNCOMPRESSED`,  `CHUNK_SIZE`, and `LABELS` are optional arguments.
- - When specified and the key doesn't exist, a new time series is created.
-  Setting the `RETENTION` and `LABELS` introduces additional time complexity.
+ - You can use this command to add data to a nonexisting time series in a single command. This is why `RETENTION`, `ENCODING`,  `CHUNK_SIZE`, and `LABELS` are optional arguments.
+ - When specified and the key doesn't exist, a new time series is created. Setting the `RETENTION` and `LABELS` introduces additional time complexity.
 </note>
 
 ## Return value

--- a/content/commands/ts.incrby/index.md
+++ b/content/commands/ts.incrby/index.md
@@ -119,7 +119,7 @@ Use it only if you are creating a new time series. It is ignored if you are addi
 
 <details open><summary><code>ENCODING enc</code></summary> 
 
-specifies the series sample's encoding format.
+specifies the series sample encoding format.
 
 Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>

--- a/content/commands/ts.incrby/index.md
+++ b/content/commands/ts.incrby/index.md
@@ -146,7 +146,7 @@ Use it only if you are creating a new time series. It is ignored if you are addi
 </details>
 
 <note><b>Notes</b>
-- You can use this command to add data to a nonexisting time series in a single command. This is why `RETENTION`, `ENCODING`,  `CHUNK_SIZE`, and `LABELS` are optional arguments.
+- You can use this command to add data to a nonexisting time series in a single command. This is why `RETENTION`, `ENCODING`,  `CHUNK_SIZE`, `DUPLICATE_POLICY`, and `LABELS` are optional arguments.
 - When specified and the key doesn't exist, a new time series is created. Setting the `RETENTION` and `LABELS` introduces additional time complexity.
 </note>
 

--- a/content/commands/ts.incrby/index.md
+++ b/content/commands/ts.incrby/index.md
@@ -12,14 +12,25 @@ arguments:
   optional: true
   token: RETENTION
   type: integer
-- name: uncompressed
+- arguments:
+  - name: uncompressed
+    token: UNCOMPRESSED
+    type: pure-token
+  - name: compressed
+    token: COMPRESSED
+    type: pure-token
+  name: enc
   optional: true
-  token: UNCOMPRESSED
-  type: pure-token
+  token: ENCODING
+  type: oneof
 - name: size
   optional: true
   token: CHUNK_SIZE
   type: integer
+- name: policy
+  optional: true
+  token: DUPLICATE_POLICY
+  type: oneof
 - arguments:
   - name: label
     type: string
@@ -54,11 +65,11 @@ summary: Increase the value of the sample with the maximum existing timestamp, o
   create a new sample with a value equal to the value of the sample with the maximum
   existing timestamp with a given increment
 syntax: "TS.INCRBY key addend \n  [TIMESTAMP timestamp] \n  [RETENTION retentionPeriod]\
-  \ \n  [UNCOMPRESSED] \n  [CHUNK_SIZE size] \n  [LABELS [label value ...]]\n"
+  \ \n  [ENCODING <COMPRESSED|UNCOMPRESSED>] \n  [CHUNK_SIZE size] \n  [DUPLICATE_POLICY policy] \n  [LABELS [label value ...]]\n"
 syntax_fmt: "TS.INCRBY key value [TIMESTAMP\_timestamp]\n  [RETENTION\_retentionPeriod]\
-  \ [UNCOMPRESSED] [CHUNK_SIZE\_size]\n  [LABELS\_[label value ...]]"
-syntax_str: "value [TIMESTAMP\_timestamp] [RETENTION\_retentionPeriod] [UNCOMPRESSED]\
-  \ [CHUNK_SIZE\_size] [LABELS\_[label value ...]]"
+  \ [ENCODING\_<COMPRESSED|UNCOMPRESSED>] [CHUNK_SIZE\_size]\n [DUPLICATE_POLICY\_policy] [LABELS\_[label value ...]]"
+syntax_str: "value [TIMESTAMP\_timestamp] [RETENTION\_retentionPeriod] [ENCODING\_<COMPRESSED|UNCOMPRESSED>]\
+  \ [CHUNK_SIZE\_size] [DUPLICATE_POLICY\_policy] [LABELS\_[label value ...]]"
 title: TS.INCRBY
 ---
 
@@ -101,27 +112,41 @@ When not specified, the timestamp is set to the Unix time of the server's clock.
 
 <details open><summary><code>RETENTION retentionPeriod</code></summmary> 
 
-is maximum retention period, compared to the maximum existing timestamp, in milliseconds. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `RETENTION` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+is maximum retention period, compared to the maximum existing timestamp, in milliseconds.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `RETENTION` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
- 
-<details open><summary><code>UNCOMPRESSED</code></summary>
+<details open><summary><code>ENCODING enc</code></summary> 
 
-changes data storage from compressed (default) to uncompressed. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+specifies the series sample's encoding format.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `ENCODING` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
 <details open><summary><code>CHUNK_SIZE size</code></summary> 
 
-is memory size, in bytes, allocated for each data chunk. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `CHUNK_SIZE` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+is memory size, in bytes, allocated for each data chunk.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `CHUNK_SIZE` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+</details>
+
+<details open><summary><code>DUPLICATE_POLICY policy</code></summary>
+
+is policy for handling insertion ([`TS.ADD`]({{< baseurl >}}/commands/ts.add/) and [`TS.MADD`]({{< baseurl >}}/commands/ts.madd/)) of multiple samples with identical timestamps.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `DUPLICATE_POLICY` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
 <details open><summary><code>LABELS [{label value}...]</code></summary> 
 
-is set of label-value pairs that represent metadata labels of the key and serve as a secondary index. Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `LABELS` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
+is set of label-value pairs that represent metadata labels of the key and serve as a secondary index.
+
+Use it only if you are creating a new time series. It is ignored if you are adding samples to an existing time series. See `LABELS` in [`TS.CREATE`]({{< baseurl >}}/commands/ts.create/).
 </details>
 
 <note><b>Notes</b>
-- You can use this command to add data to a nonexisting time series in a single command. This is why `RETENTION`, `UNCOMPRESSED`,  `CHUNK_SIZE`, and `LABELS` are optional arguments.
+- You can use this command to add data to a nonexisting time series in a single command. This is why `RETENTION`, `ENCODING`,  `CHUNK_SIZE`, and `LABELS` are optional arguments.
 - When specified and the key doesn't exist, a new time series is created. Setting the `RETENTION` and `LABELS` introduces additional time complexity.
 </note>
 


### PR DESCRIPTION
DUPLICATE_POLICY is accepted by TS.ADD , TS.DECRBY and TS.INCRBY.

For TS.CREATE and TS.ADD, we documented ENCODING config. For TS.INCRBY and TS.DECRBY, we documented UNCOMPRESSED config which is a legacy config and was deprecated. We replaced it with ENCODING and did not update the documentation.