### PR TITLE
Doc 3831 client page fixes

### DIFF
--- a/content/develop/connect/_index.md
+++ b/content/develop/connect/_index.md
@@ -40,7 +40,7 @@ It's easy to connect your application to a Redis database. The official client l
 - [C#/.NET]({{< relref "/develop/connect/clients/dotnet" >}})
 - [Node.js]({{< relref "/develop/connect/clients/nodejs" >}})
 - [Java]({{< relref "/develop/connect/clients/java" >}})
-- [Go]({{< relref "/develop/connect/clients/java" >}})
+- [Go]({{< relref "/develop/connect/clients/go" >}})
 
 <!--You can find a complete list of all client libraries, including the community-maintained ones, on the [clients page](/resources/clients/).-->
 

--- a/content/develop/connect/_index.md
+++ b/content/develop/connect/_index.md
@@ -36,11 +36,11 @@ The [Redis command line interface]({{< relref "/develop/connect/cli" >}}) (also 
 
 It's easy to connect your application to a Redis database. The official client libraries cover the following languages:
 
-* [C#/.NET]({{< relref "/develop/connect/clients/dotnet" >}})
-* [Go]({{< relref "/develop/connect/clients/go" >}})
-* [Java]({{< relref "/develop/connect/clients/java" >}})
-* [Node.js]({{< relref "/develop/connect/clients/nodejs" >}})
-* [Python]({{< relref "/develop/connect/clients/python" >}})
+- [Python]({{< relref "/develop/connect/clients/python" >}})
+- [C#/.NET]({{< relref "/develop/connect/clients/dotnet" >}})
+- [Node.js]({{< relref "/develop/connect/clients/nodejs" >}})
+- [Java]({{< relref "/develop/connect/clients/java" >}})
+- [Go]({{< relref "/develop/connect/clients/java" >}})
 
 <!--You can find a complete list of all client libraries, including the community-maintained ones, on the [clients page](/resources/clients/).-->
 

--- a/content/develop/connect/cli.md
+++ b/content/develop/connect/cli.md
@@ -9,9 +9,7 @@ categories:
 - oss
 - kubernetes
 - clients
-description: 'Overview of redis-cli, the Redis command line interface
-
-  '
+description: 'Overview of redis-cli, the Redis command line interface'
 linkTitle: CLI
 title: Redis CLI
 weight: 1

--- a/content/develop/connect/clients/_index.md
+++ b/content/develop/connect/clients/_index.md
@@ -22,7 +22,7 @@ for five main languages:
 - [C#/.NET]({{< relref "/develop/connect/clients/dotnet" >}})
 - [Node.js]({{< relref "/develop/connect/clients/nodejs" >}})
 - [Java]({{< relref "/develop/connect/clients/java" >}})
-- [Go]({{< relref "/develop/connect/clients/java" >}})
+- [Go]({{< relref "/develop/connect/clients/go" >}})
 
 We also provide several higher-level
 [object mapping (OM)]({{< relref "/develop/connect/clients/om-clients" >}})

--- a/content/develop/connect/clients/_index.md
+++ b/content/develop/connect/clients/_index.md
@@ -16,22 +16,19 @@ weight: 45
 ---
 
 Use the Redis client libraries to connect to Redis servers from
-your own code. We support and document client libraries
-for four main languages:
-[Python]({{< relref "/develop/connect/clients/python" >}}),
-[C#/.NET]({{< relref "/develop/connect/clients/dotnet" >}}),
-[Node.js]({{< relref "/develop/connect/clients/nodejs" >}}),
-and [Java]({{< relref "/develop/connect/clients/java" >}}).
-We also provide higher-level
+your own code. We support client libraries
+for five main languages:
+- [Python]({{< relref "/develop/connect/clients/python" >}})
+- [C#/.NET]({{< relref "/develop/connect/clients/dotnet" >}})
+- [Node.js]({{< relref "/develop/connect/clients/nodejs" >}})
+- [Java]({{< relref "/develop/connect/clients/java" >}})
+- [Go]({{< relref "/develop/connect/clients/java" >}})
+
+We also provide several higher-level
 [object mapping (OM)]({{< relref "/develop/connect/clients/om-clients" >}})
-for these languages.
-
-We also develop libraries for the following languages but with limited
-support and documentation on external sites:
-
-- [Go](https://redis.uptrace.dev/guide/)
-- [Ruby](https://github.com/redis/redis-rb)
-- [C](https://github.com/redis/hiredis)
+libraries and there are several
+[community-supported clients]({{< relref "/develop/connect/clients/comm-supp-clients" >}})
+for other languages.
 
 You will need access to a Redis server to use these libraries.
 You can experiment with a local installation of Redis Stack

--- a/content/develop/connect/clients/comm-supp-clients.md
+++ b/content/develop/connect/clients/comm-supp-clients.md
@@ -1,0 +1,25 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Connect to a Redis database with other languages
+linkTitle: Community-supported clients
+title: Community-supported clients
+weight: 7
+---
+
+The table below lists the recommended client libraries for languages that
+are not supported by Redis directly.
+
+| Language | Client name | Github | Docs |
+| :-- | :-- | :-- | :-- |
+| C | hiredis | https://github.com/redis/hiredis | |
+| PHP | predis | https://github.com/predis/predis | https://github.com/predis/predis/wiki |
+| Ruby | redis-rb | https://github.com/redis/redis-rb | https://rubydoc.info/gems/redis |

--- a/content/develop/connect/clients/go.md
+++ b/content/develop/connect/clients/go.md
@@ -1,0 +1,180 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Connect your Go application to a Redis database
+linkTitle: Go
+title: Go guide
+weight: 5
+---
+
+Install Redis and the Redis client, then connect your Go application to a Redis database. 
+
+## go-redis
+
+[go-redis](https://github.com/redis/go-redis) provides Go clients for various flavors of Redis and a type-safe API for each Redis command.
+
+### Install
+
+`go-redis` supports last two Go versions and only works with Go modules. 
+So, first, you need to initialize a Go module:
+
+```
+go mod init github.com/my/repo
+```
+
+To install go-redis/v9:
+
+```
+go get github.com/redis/go-redis/v9
+```
+
+### Connect
+
+To connect to a Redis server:
+
+```go
+import (
+	"context"
+	"fmt"
+	"github.com/redis/go-redis/v9"
+)
+
+func main() {
+    client := redis.NewClient(&redis.Options{
+        Addr:	  "localhost:6379",
+        Password: "", // no password set
+        DB:		  0,  // use default DB
+    })
+}
+```
+
+Another way to connect is using a connection string.
+
+```go
+opt, err := redis.ParseURL("redis://<user>:<pass>@localhost:6379/<db>")
+if err != nil {
+	panic(err)
+}
+
+client := redis.NewClient(opt)
+```
+
+Store and retrieve a simple string.
+
+```go
+ctx := context.Background()
+
+err := client.Set(ctx, "foo", "bar", 0).Err()
+if err != nil {
+    panic(err)
+}
+
+val, err := client.Get(ctx, "foo").Result()
+if err != nil {
+    panic(err)
+}
+fmt.Println("foo", val)
+```
+
+Store and retrieve a map.
+
+```go
+session := map[string]string{"name": "John", "surname": "Smith", "company": "Redis", "age": "29"}
+for k, v := range session {
+    err := client.HSet(ctx, "user-session:123", k, v).Err()
+    if err != nil {
+        panic(err)
+    }
+}
+
+userSession := client.HGetAll(ctx, "user-session:123").Val()
+fmt.Println(userSession)
+ ```
+
+#### Connect to a Redis cluster
+
+To connect to a Redis cluster, use `NewClusterClient`. 
+
+```go
+client := redis.NewClusterClient(&redis.ClusterOptions{
+    Addrs: []string{":16379", ":16380", ":16381", ":16382", ":16383", ":16384"},
+
+    // To route commands by latency or randomly, enable one of the following.
+    //RouteByLatency: true,
+    //RouteRandomly: true,
+})
+```
+
+#### Connect to your production Redis with TLS
+
+When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
+
+Establish a secure connection with your Redis database using this snippet.
+
+```go
+// Load client cert
+cert, err := tls.LoadX509KeyPair("redis_user.crt", "redis_user_private.key")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Load CA cert
+caCert, err := os.ReadFile("redis_ca.pem")
+if err != nil {
+    log.Fatal(err)
+}
+caCertPool := x509.NewCertPool()
+caCertPool.AppendCertsFromPEM(caCert)
+
+client := redis.NewClient(&redis.Options{
+    Addr:     "my-redis.cloud.redislabs.com:6379",
+    Username: "default", // use your Redis user. More info https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/
+    Password: "secret", // use your Redis password
+    TLSConfig: &tls.Config{
+        MinVersion:   tls.VersionTLS12,
+        Certificates: []tls.Certificate{cert},
+        RootCAs:      caCertPool,
+    },
+})
+
+//send SET command
+err = client.Set(ctx, "foo", "bar", 0).Err()
+if err != nil {
+    panic(err)
+}
+
+//send GET command and print the value
+val, err := client.Get(ctx, "foo").Result()
+if err != nil {
+    panic(err)
+}
+fmt.Println("foo", val)
+```
+
+
+#### dial tcp: i/o timeout
+
+You get a `dial tcp: i/o timeout` error when `go-redis` can't connect to the Redis Server, for example, when the server is down or the port is protected by a firewall. To check if Redis Server is listening on the port, run telnet command on the host where the `go-redis` client is running.
+
+```go
+telnet localhost 6379
+Trying 127.0.0.1...
+telnet: Unable to connect to remote host: Connection refused
+```
+
+If you use Docker, Istio, or any other service mesh/sidecar, make sure the app starts after the container is fully available, for example, by configuring healthchecks with Docker and holdApplicationUntilProxyStarts with Istio. 
+For more information, see [Healthcheck](https://docs.docker.com/engine/reference/run/#healthcheck).
+
+### Learn more
+
+* [Documentation](https://redis.uptrace.dev/guide/)
+* [GitHub](https://github.com/redis/go-redis)
+ 

--- a/content/operate/rs/databases/connect/supported-clients-browsers.md
+++ b/content/operate/rs/databases/connect/supported-clients-browsers.md
@@ -28,11 +28,12 @@ Note: You cannot use client libraries to configure Redis Enterprise Software.  I
 
 We recommend the following clients when using a [discovery service]({{< relref "/operate/rs/databases/durability-ha/discovery-service.md" >}}) based on the Redis Sentinel API:
 
-- [redis-py]({{< relref "/develop/connect/clients/python" >}}) (Python Redis client)
-- [Hiredis](https://github.com/redis/hiredis) (C Redis client)
-- [Jedis]({{< relref "/develop/connect/clients/java/" >}}) (Java Redis client)
-- [NRedisStack]({{< relref "/develop/connect/clients/dotnet" >}}) (.Net Redis client)
-- [go-redis]({{< relref "/develop/connect/clients/go" >}}) (Go Redis client)
+- [redis-py]({{< relref "/develop/connect/clients/python" >}}) (Python client)
+- [NRedisStack]({{< relref "/develop/connect/clients/dotnet" >}}) (.NET client)
+- [Jedis]({{< relref "/develop/connect/clients/java/jedis" >}}) (synchronous Java client)
+- [Lettuce]({{< relref "/develop/connect/clients/java/lettuce" >}}) (asynchronous Java client)
+- [go-redis]({{< relref "/develop/connect/clients/go" >}}) (Go client)
+- [Hiredis](https://github.com/redis/hiredis) (C client)
 
 If you need to use another client, you can use [Sentinel Tunnel](https://github.com/RedisLabs/sentinel_tunnel)
 to discover the current Redis master with Sentinel and create a TCP tunnel between a local port on the client and the master.


### PR DESCRIPTION
Reinstated the Go page, moved the minor clients list to its own page, and added a link to Lettuce from the Enterprise supported clients page.