### PR TITLE
Fix broken link in graph deprecation banner

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/deprecated-features/graph/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/deprecated-features/graph/_index.md
@@ -2,10 +2,9 @@
 Title: Graph
 alwaysopen: false
 bannerChildren: true
-bannerLink: https://redis.com/blog/redisgraph-eol/
 bannerText: Redis, Inc. has announced the end of life of RedisGraph. We will carry
   out the process gradually and in accordance with our commitment to our customers.
-  See [details].
+  See [details](https://redis.io/blog/redisgraph-eol/).
 categories:
 - docs
 - operate


### PR DESCRIPTION
It looks like the old `bannerLink` front matter we sometimes used on the old Enterprise docs site doesn't work on the new site. It's easier to fix this by moving the link directly into the `bannerText` since that seems to work fine. I didn't see `bannerLink` used anywhere else in the current docs, so this one should be the only issue.