### PR TITLE
RS: Add step to prepare and format flash to Auto Tiering quick start

### DIFF
--- a/content/operate/rs/databases/auto-tiering/quickstart.md
+++ b/content/operate/rs/databases/auto-tiering/quickstart.md
@@ -54,6 +54,22 @@ Docker container on Windows, MacOS, and Linux.
 docker run -d --cap-add sys_resource --name rp -p 8443:8443 -p 12000:12000 redislabs/redis:latest
 ```
 
+## Prepare and format flash memory
+
+After you [install Redis Enterprise Software](#install-redis-enterprise-software), use the `prepare_flash` script to prepare and format flash memory:
+
+```sh
+sudo /opt/redislabs/sbin/prepare_flash.sh
+```
+
+This script finds unformatted disks and mounts them as RAID partitions in `/var/opt/redislabs/flash`.
+
+To verify the disk configuration, run:
+
+```sh
+sudo lsblk
+```
+
 ## Set up a cluster and enable Auto Tiering
 
 1. Direct your browser to `https://localhost:8443/new` on the host machine to


### PR DESCRIPTION
DOC-593

The missing quick  start step was originally included in the [Auto Tiering installation](https://redis.io/docs/staging/DOC-593/operate/rs/installing-upgrading/install/install-on-linux/#auto-tiering-installation) section of the general Redis Enterprise Software installation instructions.