### PR TITLE
DOC-3801 update redis_py.json to point to master branch

### DIFF
--- a/data/components/redis_py.json
+++ b/data/components/redis_py.json
@@ -8,7 +8,7 @@
     },
     "examples": {
         "git_uri": "https://github.com/redis/redis-py",
-        "dev_branch": "emb-examples",
+        "dev_branch": "master",
         "path": "doctests",
         "pattern": "*.py"
     }


### PR DESCRIPTION
There is now a doctests folder in the master branch of redis-py, so this updates redis_py.json to point to that. (Not deleting emb-examples yet, btw, until we're sure we don't need it.)