### PR TITLE
SDIFF and SUNION return sets in RESP3

### DIFF
--- a/data/resp3_replies.json
+++ b/data/resp3_replies.json
@@ -978,7 +978,7 @@
     "[Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): the SHA1 digest of the script added into the script cache."
   ],
   "SDIFF": [
-    "[Array reply](../../develop/reference/protocol-spec#arrays): a list with the members of the resulting set."
+    "[Set reply](../../develop/reference/protocol-spec#sets): a set with the members of the resulting set."
   ],
   "SDIFFSTORE": [
     "[Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the resulting set."
@@ -1158,7 +1158,7 @@
     "[Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): the substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
   ],
   "SUNION": [
-    "[Array reply](../../develop/reference/protocol-spec#arrays): a list with the members of the resulting set."
+    "[Set reply](../../develop/reference/protocol-spec#sets): a set with the members of the resulting set."
   ],
   "SUNIONSTORE": [
     "[Integer reply](../../develop/reference/protocol-spec#integers): Number of the elements in the resulting set."


### PR DESCRIPTION
The docs for `SINTER` are already correct. I verified this on my local Redis 7.2.5 server.

```
> hello 3
...
3# "proto" => (integer) 3
...
> sadd foo a
(integer) 1
> sadd foo b
(integer) 1
> sadd bar a
(integer) 1
> sinter foo bar
1~ "a"
> sdiff foo bar
1~ "b"
> sunion foo bar
1~ "a"
2~ "b"
```