### PR TITLE
Add RC category to specific RS pages

### DIFF
--- a/content/operate/rc/databases/configuration/clustering.md
+++ b/content/operate/rc/databases/configuration/clustering.md
@@ -88,7 +88,7 @@ are supported, with the following limitations:
 
 ## Manage the hashing policy
 
-Redis defaults to the [standard hashing policy]({{< relref "/operate/rs/databases/durability-ha/clustering#standard-hashing-policy" >}}). 
+Redis defaults to the [standard hashing policy](#standard-hashing-policy). 
 The clustering configuration of a Redis Cloud instance can be changed. 
 However, hashing policy changes delete existing data 
 (FLUSHDB) before they're applied. 
@@ -183,7 +183,7 @@ Here are some general guidelines:
 
 - [Advanced capabilities]({{< relref "/operate/rc/databases/configuration/advanced-capabilities" >}}) also consume memory. For search databases, consider index size when you size your database.
 
-Memory limits in Redis Cloud are subject to the same considerations as Redis Enterprise Software; to learn more, see [Database memory limits]({{< relref "/operate/rs/databases/memory-performance/memory-limit.md" >}}).
+Memory limits in Redis Cloud are subject to the same considerations as Redis Enterprise Software; to learn more, see [Database memory limits]({{< relref "/operate/rs/databases/memory-performance/memory-limit" >}}).
 
 ## Throughput
 

--- a/content/operate/rc/databases/create-database/create-pro-database-new.md
+++ b/content/operate/rc/databases/create-database/create-pro-database-new.md
@@ -106,7 +106,7 @@ By default, you're shown basic settings, which include:
 | **Throughput** | Identifies maximum throughput for the database, which is specified in terms of operations per second (**Ops/sec**). See [Throughput]({{< relref "/operate/rc/databases/configuration/clustering#throughput" >}}) for more information. |
 | **Dataset size (GB)** | The amount of data for your dataset. Specify small sizes as decimals of 1.0&nbsp;GB; example: `0.1` GB (minimum). We calculate the total memory limit for you based on the other settings you choose for your database. |
 | **High Availability** | Indicates whether a replica copy of the database is maintained in case the primary database becomes unavailable.  (Warning: Doubles memory consumption). See [High Availability]({{< relref "/operate/rc/databases/configuration/high-availability" >}}).  |
-| **Data Persistence** | Defines the data persistence policy, if any. See [Database persistence]({{< relref "/operate/rs/databases/configure/database-persistence.md" >}}). |
+| **Data Persistence** | Defines the data persistence policy, if any. See [Data persistence]({{< relref "/operate/rc/databases/configuration/data-persistence.md" >}}). |
 
 Select **More options** to specify values for the following settings.
 

--- a/content/operate/rc/databases/view-edit-database.md
+++ b/content/operate/rc/databases/view-edit-database.md
@@ -73,7 +73,7 @@ The **Scalability** section is primarily for Redis Cloud Pro plans. Redis Cloud 
 | **Hashing policy**    | Defines the [hashing policy]({{< relref "/operate/rc/databases/configuration/clustering#manage-the-hashing-policy" >}}).  |
 | **OSS Cluster API**       | Enables the [Cluster API]({{< relref "/operate/rc/databases/create-database#oss-cluster-api" >}}) for a database.<br/><br/>When this option is enabled, you cannot define a custom hashing policy.|
 
-To learn more about these settings and when to use them, see [Database clustering]({{< relref "/operate/rs/databases/durability-ha/clustering.md" >}}).
+To learn more about these settings and when to use them, see [Database clustering]({{< relref "/operate/rc/databases/configuration/clustering" >}}).
 
 ### Durability section
 

--- a/content/operate/rs/clusters/optimize/oss-cluster-api.md
+++ b/content/operate/rs/clusters/optimize/oss-cluster-api.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Use the Redis Cluster API to improve performance and keep applications current with cluster topology changes.
 linktitle: "Redis Cluster API"
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/_index.md
+++ b/content/operate/rs/databases/active-active/develop/_index.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: General information to keep in mind while developing applications for
   an Active-Active database.
 hideListLinks: true

--- a/content/operate/rs/databases/active-active/develop/app-failover-active-active.md
+++ b/content/operate/rs/databases/active-active/develop/app-failover-active-active.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: How to failover your application to connect to a remote replica.
 linkTitle: App failover
 weight: 99

--- a/content/operate/rs/databases/active-active/develop/data-types/_index.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/_index.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Introduction to differences in data types between standalone and Active-Active
   Redis databases.
 hideListLinks: true

--- a/content/operate/rs/databases/active-active/develop/data-types/hashes.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/hashes.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using hashes with an Active-Active database.
 linkTitle: Hashes
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/data-types/hyperloglog.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/hyperloglog.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using hyperloglog with an Active-Active database.
 linkTitle: HyperLogLog
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/data-types/json.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/json.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using JSON with an Active-Active database.
 linkTitle: JSON
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/data-types/lists.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/lists.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using list with an Active-Active database.
 linkTitle: Lists
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/data-types/sets.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/sets.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using sets with an Active-Active database.
 linkTitle: Sets
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/data-types/sorted-sets.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/sorted-sets.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using sorted sets with an Active-Active database.
 linkTitle: Sorted sets
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/data-types/streams.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/streams.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using streams with an Active-Active database.
 linkTitle: Streams
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/data-types/strings.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/strings.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Information about using strings and bitfields with an Active-Active database.
 linkTitle: Strings and bitfields
 weight: $weight

--- a/content/operate/rs/databases/active-active/develop/develop-for-aa.md
+++ b/content/operate/rs/databases/active-active/develop/develop-for-aa.md
@@ -4,6 +4,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Overview of how developing applications differs for Active-Active databases
   from standalone Redis databases.
 linkTitle: Develop for Active-Active

--- a/content/operate/rs/databases/auto-tiering/_index.md
+++ b/content/operate/rs/databases/auto-tiering/_index.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Auto Tiering enables your data to span both RAM and dedicated flash memory.
 hideListLinks: true
 linktitle: Auto Tiering

--- a/content/operate/rs/databases/memory-performance/memory-limit.md
+++ b/content/operate/rs/databases/memory-performance/memory-limit.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: When you set a database's memory limit, you define the maximum size the
   database can reach.
 linkTitle: Memory limits

--- a/content/operate/rs/references/cli-utilities/redis-cli/_index.md
+++ b/content/operate/rs/references/cli-utilities/redis-cli/_index.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Run Redis commands.
 hideListLinks: true
 linkTitle: redis-cli (run Redis commands)

--- a/content/operate/rs/references/compatibility/_index.md
+++ b/content/operate/rs/references/compatibility/_index.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Redis Enterprise compatibility with Redis Community Edition.
 hideListLinks: true
 linkTitle: Redis Community Edition compatibility

--- a/content/operate/rs/references/compatibility/commands/_index.md
+++ b/content/operate/rs/references/compatibility/commands/_index.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Redis Community Edition commands compatible with Redis Enterprise.
 hideListLinks: true
 linkTitle: Commands

--- a/content/operate/rs/references/compatibility/commands/cluster.md
+++ b/content/operate/rs/references/compatibility/commands/cluster.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Cluster management commands compatible with Redis Enterprise.
 linkTitle: Cluster management
 weight: 10

--- a/content/operate/rs/references/compatibility/commands/connection.md
+++ b/content/operate/rs/references/compatibility/commands/connection.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Connection management commands compatibility.
 linkTitle: Connection management
 weight: 10

--- a/content/operate/rs/references/compatibility/commands/data-types.md
+++ b/content/operate/rs/references/compatibility/commands/data-types.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Data type commands compatibility (bitmaps, geospatial indices, hashes,
   HyperLogLogs, lists, sets, sorted sets, streams, strings).
 linkTitle: Data types

--- a/content/operate/rs/references/compatibility/commands/generic.md
+++ b/content/operate/rs/references/compatibility/commands/generic.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Generic key commands compatible with Redis Enterprise.
 linkTitle: Keys (generic)
 weight: 10

--- a/content/operate/rs/references/compatibility/commands/pub-sub.md
+++ b/content/operate/rs/references/compatibility/commands/pub-sub.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Pub/sub commands compatibility.
 linkTitle: Pub/sub
 weight: 10

--- a/content/operate/rs/references/compatibility/commands/scripting.md
+++ b/content/operate/rs/references/compatibility/commands/scripting.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Scripting and function commands compatibility.
 linkTitle: Scripting
 weight: 10

--- a/content/operate/rs/references/compatibility/commands/server.md
+++ b/content/operate/rs/references/compatibility/commands/server.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Server management commands compatibility.
 linkTitle: Server management
 toc: 'true'

--- a/content/operate/rs/references/compatibility/commands/transactions.md
+++ b/content/operate/rs/references/compatibility/commands/transactions.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Transaction commands compatibility.
 linkTitle: Transactions
 weight: 10

--- a/content/operate/rs/references/compatibility/config-settings.md
+++ b/content/operate/rs/references/compatibility/config-settings.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Redis Community Edition configuration settings supported by Redis Enterprise.
 linkTitle: Configuration settings
 weight: 50

--- a/content/operate/rs/references/metrics/_index.md
+++ b/content/operate/rs/references/metrics/_index.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: Documents the metrics that are tracked with Redis Enterprise Software.
 hideListLinks: true
 linkTitle: Metrics

--- a/content/operate/rs/references/metrics/database-operations.md
+++ b/content/operate/rs/references/metrics/database-operations.md
@@ -5,6 +5,7 @@ categories:
 - docs
 - operate
 - rs
+- rc
 description: null
 linkTitle: Database operations
 weight: $weight


### PR DESCRIPTION
I went through and added the "rc" category to RS pages that link from RC docs. 

If there's anything else you think might work, @rrelledge - let me know.