### PR TITLE
fix: commands pages take up full width available

### DIFF
--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -16,7 +16,7 @@
   {{ $basePath := .Scratch.Get "path" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav-collapsed.html" . }}
-    <div class="py-12 md:px-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:px-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
       <section class="prose w-full py-12"> 
         <h1>Commands</h1>

--- a/layouts/commands/single.html
+++ b/layouts/commands/single.html
@@ -8,7 +8,7 @@
   {{ $component := cond $isModule .Params.module "Redis" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav.html" . }}
-    <div class="py-12 md:pl-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:pl-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
       <section class="prose w-full py-12">
         <h1 class="command-name">


### PR DESCRIPTION
Fixes #351. The `<section>` for the commands pages already has the `w-full` class but the containing div did not, meaning the central content of each page would not take up the full width available. This commit fixes this issue by adding the `w-full` class to the containing div.

These changes were tested to function on Firefox on Linux and Chrome on macOS, with additional verification that the pages looked the same on Safari on iOS and Chrome on Android.