### PR TITLE
SITE-WIDE: fix bug that prevented Node.js examples from displaying

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ tagManagerId = "GTM-TKZ6J9R"
 gitHubRepo = "https://github.com/redis/docs"
 
 # Display and sort order for client examples
-clientsExamples = ["Python", "Node", "Java", "Go", "C#"]
+clientsExamples = ["Python", "Node.js", "Java", "Go", "C#"]
 searchService = "/convai/api/search-service"
 ratingsService = "/docusight/api/rate"
 


### PR DESCRIPTION
Fixes redis/node-redis#2780.

This PR fixes a bug in the config.toml file that prevented Node.js TCEs from displaying.