### PR TITLE
Provide additional information for setting timeout settings when configuring the Lettuce driver

### DIFF
--- a/content/develop/connect/clients/java/lettuce.md
+++ b/content/develop/connect/clients/java/lettuce.md
@@ -178,8 +178,59 @@ RedisClient client = RedisClient.create(redisUri);
 Lettuce uses `ClientResources` for efficient management of shared resources like event loop groups and thread pools.
 For connection pooling, Lettuce leverages `RedisClient` or `RedisClusterClient`, which can handle multiple concurrent connections efficiently.
 
+### Timouts
+There is a multitude of timeouts to different operations in Lettuce, such as command execution, SSL handshake, Sentinel discovery, etc.
+Unless configured otherwise, Lettuce uses a global timeout of 60 seconds. You can set the timeout for each operation individually.
+
+{{% alert title="Tip" color="warning" %}}
+Choosing the right timeout is crucial for your application's performance and stability and is specific to each environment.
+It is not necessary to configure timeouts unless you are having issues with the default values. 
+In some cases the defaults are based on environment specific settings (such as the operating system settings), in other cases they are built-in the Lettuce driver. 
+For more details on setting specific timeouts, see the [Lettuce reference guide](https://lettuce.io/core/release/reference/index.html).
+{{% /alert  %}}
+
+Below is a example of setting a typical socket-level timeouts. The `TCP_USER_TIMEOUT` is useful for scenarios where the server stops responding without acknowledging the last request, while the `KEEPALIVE` settings are good for detecting dead connections while there is no traffic between the client and the server.
+
+```java
+RedisURI redisURI = RedisURI.Builder
+        .redis("localhost")
+        // set the global default from the default 60 seconds to 30 seconds
+        .withTimeout(Duration.ofSeconds(30)) 
+        .build();
+
+try (RedisClient client = RedisClient.create(redisURI)) {
+    // or set specific timeouts for things such as the TCP_USER_TIMEOUT and TCP_KEEPALIVE
+
+    // A good general rule of thumb is to follow the rule
+    // TCP_USER_TIMEOUT = TCP_KEEP_IDLE+TCP_KEEPINTVL * TCP_KEEPCNT
+    // in this case, 20 = 5 + 5 * 3
+
+    SocketOptions.TcpUserTimeoutOptions tcpUserTimeout = SocketOptions.TcpUserTimeoutOptions.builder()
+            .tcpUserTimeout(Duration.ofSeconds(20))
+            .enable().build();
+
+    SocketOptions.KeepAliveOptions keepAliveOptions = SocketOptions.KeepAliveOptions.builder()
+            .interval(Duration.ofSeconds(5))
+            .idle(Duration.ofSeconds(5))
+            .count(3).enable().build();
+
+    SocketOptions socketOptions = SocketOptions.builder()
+            .tcpUserTimeout(tcpUserTimeout)
+            .keepAlive(keepAliveOptions)
+            .build();
+
+    client.setOptions(ClientOptions.builder()
+            .socketOptions(socketOptions)
+            .build());
+
+    StatefulRedisConnection<String, String> connection = client.connect();
+    System.out.println(connection.sync().ping());
+}
+```
+
+### Connection pooling
 A typical approach with Lettuce is to create a single `RedisClient` instance and reuse it to establish connections to your Redis server(s).
-These connections are multiplexed; that is, multiple commands can be run concurrently over a single or a small set of connections, making explicit pooling less critical.
+These connections are multiplexed; that is, multiple commands can be run concurrently over a single or a small set of connections, making explicit pooling less practical.
 
 Lettuce provides pool config to be used with Lettuce asynchronous connection methods.
 

--- a/content/develop/connect/clients/java/lettuce.md
+++ b/content/develop/connect/clients/java/lettuce.md
@@ -179,8 +179,7 @@ Lettuce uses `ClientResources` for efficient management of shared resources like
 For connection pooling, Lettuce leverages `RedisClient` or `RedisClusterClient`, which can handle multiple concurrent connections efficiently.
 
 ### Timouts
-There is a multitude of timeouts to different operations in Lettuce, such as command execution, SSL handshake, Sentinel discovery, etc.
-Unless configured otherwise, Lettuce uses a global timeout of 60 seconds. You can set the timeout for each operation individually.
+Lettuce provides timeouts for many operations, such as command execution, SSL handshake, and Sentinel discovery. By default, Lettuce uses a global timeout value of 60 seconds for these operations, but you can override the global timeout value with individual timeout values for each operation.
 
 {{% alert title="Tip" color="warning" %}}
 Choosing the right timeout is crucial for your application's performance and stability and is specific to each environment.

--- a/content/develop/connect/clients/java/lettuce.md
+++ b/content/develop/connect/clients/java/lettuce.md
@@ -188,7 +188,7 @@ In some cases, the defaults are based on environment-specific settings (e.g., op
 For more details on setting specific timeouts, see the [Lettuce reference guide](https://lettuce.io/core/release/reference/index.html).
 {{% /alert  %}}
 
-Below is a example of setting a typical socket-level timeouts. The `TCP_USER_TIMEOUT` is useful for scenarios where the server stops responding without acknowledging the last request, while the `KEEPALIVE` settings are good for detecting dead connections while there is no traffic between the client and the server.
+Below is an example of setting socket-level timeouts. The `TCP_USER_TIMEOUT` setting is useful for scenarios where the server stops responding without acknowledging the last request, while the `KEEPALIVE` setting is good for detecting dead connections where there is no traffic between the client and the server.
 
 ```java
 RedisURI redisURI = RedisURI.Builder

--- a/content/develop/connect/clients/java/lettuce.md
+++ b/content/develop/connect/clients/java/lettuce.md
@@ -182,9 +182,9 @@ For connection pooling, Lettuce leverages `RedisClient` or `RedisClusterClient`,
 Lettuce provides timeouts for many operations, such as command execution, SSL handshake, and Sentinel discovery. By default, Lettuce uses a global timeout value of 60 seconds for these operations, but you can override the global timeout value with individual timeout values for each operation.
 
 {{% alert title="Tip" color="warning" %}}
-Choosing the right timeout is crucial for your application's performance and stability and is specific to each environment.
-It is not necessary to configure timeouts unless you are having issues with the default values. 
-In some cases the defaults are based on environment specific settings (such as the operating system settings), in other cases they are built-in the Lettuce driver. 
+Choosing suitable timeout values is crucial for your application's performance and stability and is specific to each environment.
+Configuring timeouts is only necessary if you have issues with the default values. 
+In some cases, the defaults are based on environment-specific settings (e.g., operating system settings), while in other cases, they are built into the Lettuce driver. 
 For more details on setting specific timeouts, see the [Lettuce reference guide](https://lettuce.io/core/release/reference/index.html).
 {{% /alert  %}}
 


### PR DESCRIPTION
Added a section to the documentation of the Lettuce driver that specifically deals with timeouts.
The example given is of setting a socket timeouts that a few of our clients have requested recently to deal with connectivity issues. To give examples about all the timeouts would have perhaps been too verbose and some of them are very specific.