### PR TITLE
add explanation of double quotes for TAG special chars

### DIFF
--- a/content/develop/interact/search-and-query/query/exact-match.md
+++ b/content/develop/interact/search-and-query/query/exact-match.md
@@ -45,8 +45,6 @@ or
 FT.SEARCH index "@field==value" DIALECT 5
 ```
 
-See [DIALECT 5]({{< relref "/develop/interact/search-and-query/advanced-concepts/dialects" >}}#dialect-5) for more information.
-
 As described in the [article about range queries]({{< relref "/develop/interact/search-and-query/query/range" >}}), you can also use the `FILTER` argument:
 
 ```
@@ -96,15 +94,13 @@ This short example shows you how to query for new bicycles:
 FT.SEARCH idx:bicycle "@condition:{new}"
 ```
 
-The following characters must be escaped to be used in an exact match query involving tags:
+Exact matching of tags that include special characters can be accomplished by using double quotes and [DIALECT 2]({{< relref "/develop/interact/search-and-query/advanced-concepts/dialects" >}}#dialect-2).  Example below:
+```
+JSON.SET key:1 $ '{"email": "test@redis.com"}'
+FT.CREATE idx ON JSON PREFIX 1 key: SCHEMA $.email AS email TAG
 
-`$` - used to define a variable such as `$params`.
-
-`{}` - used to define `TAG` query attributes.
-
-`\` - used to indicate that the succeeding character should be handled as literal.
-
-`|` - used for the logical OR operator.
+FT.SEARCH idx '@email:{"test@redis.com"}' DIALECT 2
+```
 
 ## Full-text field
 

--- a/content/develop/interact/search-and-query/query/exact-match.md
+++ b/content/develop/interact/search-and-query/query/exact-match.md
@@ -94,7 +94,7 @@ This short example shows you how to query for new bicycles:
 FT.SEARCH idx:bicycle "@condition:{new}"
 ```
 
-Exact matching of tags that include special characters can be accomplished by using double quotes and [DIALECT 2]({{< relref "/develop/interact/search-and-query/advanced-concepts/dialects" >}}#dialect-2).  Example below:
+Use double quotes and [DIALECT 2]({{< relref "/develop/interact/search-and-query/advanced-concepts/dialects" >}}#dialect-2) for exact match queries involving tags that contain special characters. Here's an example:
 ```
 JSON.SET key:1 $ '{"email": "test@redis.com"}'
 FT.CREATE idx ON JSON PREFIX 1 key: SCHEMA $.email AS email TAG


### PR DESCRIPTION
Removed reference to DIALECT 5 and added example of new feature for exact matching of TAG with special chars.