### PR TITLE
DOC-3942 fixed archive link and text

### DIFF
--- a/content/integrate/redis-data-integration/rdi-archive.md
+++ b/content/integrate/redis-data-integration/rdi-archive.md
@@ -10,4 +10,7 @@ linkTitle: Archive
 weight: 999
 ---
 
-Previous versions of Redis Data Integration documentation are available on the [Redis Data Integration documentation archive](https://docs.redis.com/latest/rdi/). 
+RDI is now in general availability but you can still access an
+[archived version of the docs for the preview version](https://docs.redis.com/rdi-preview/rdi/)
+if you need to refer to them. Note that these docs will not be updated and
+information in the current docs supersedes the content of the preview docs.


### PR DESCRIPTION
Updated the RDI archive page to point to the correct link on the redis.com site (which is still available for now).