### PR TITLE
DOC-3830 fixed links to Jedis/Lettuce

### DIFF
--- a/content/operate/rs/references/client_references/_index.md
+++ b/content/operate/rs/references/client_references/_index.md
@@ -20,7 +20,7 @@ To connect to Redis instances from within your application, use a Redis client l
 |----------|-------------|
 | .Net | [NRedisStack]({{< relref "/develop/connect/clients/dotnet" >}}) |
 | Go | [go-redis]({{< relref "/develop/connect/clients/go" >}}) |
-| Java | [Jedis]({{< relref "/develop/connect/clients/java/" >}}) |
+| Java | [Jedis]({{< relref "/develop/connect/clients/java/jedis" >}}) (Synchronous) and [Lettuce]({{< relref "/develop/connect/clients/java/lettuce" >}}) (Asynchronous) |
 | Node.js | [node-redis]({{< relref "/develop/connect/clients/nodejs" >}}) |
 | Python | [redis-py]({{< relref "/develop/connect/clients/python" >}}) |
 


### PR DESCRIPTION
Fixes one of the issues in [DOC-3830](https://redislabs.atlassian.net/browse/DOC-3830) (separate Jedis/Lettuce links). The other issue (reinstate Go links) was already fixed separately.

[DOC-3830]: https://redislabs.atlassian.net/browse/DOC-3830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ