### PR TITLE
Doc 3909 improve tag query syntax docs

### DIFF
--- a/content/develop/interact/search-and-query/advanced-concepts/escaping.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/escaping.md
@@ -29,7 +29,9 @@ for each document. Finding a match like this is much more efficient than pattern
 the whole text and also lets you use
 [stemming]({{< relref "/develop/interact/search-and-query/advanced-concepts/stemming" >}}) and
 [stop words]({{< relref "/develop/interact/search-and-query/advanced-concepts/stopwords" >}})
-to improve the search even further.
+to improve the search even further. See this article about
+[Tokenization](https://queryunderstanding.com/tokenization-c8cdd6aef7ff)
+for a general introduction to the concepts.
 
 Redis Stack uses a very simple tokenizer for documents and a slightly more sophisticated tokenizer for queries. Both allow a degree of control over string escaping and tokenization. 
 

--- a/content/develop/interact/search-and-query/advanced-concepts/escaping.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/escaping.md
@@ -17,7 +17,7 @@ weight: 4
 
 Full-text search works by comparing words, URLs, numbers, and other elements of the query
 against the text in the searchable fields of each document. However,
-It would be very inefficient to compare the entire text of the query against the
+it would be very inefficient to compare the entire text of the query against the
 entire text of each field over and over again, so the search system doesn't do this.
 Instead, it splits the document text into short, significant sections
 called *tokens* during the indexing process and stores the tokens as part of the document's

--- a/content/develop/interact/search-and-query/advanced-concepts/escaping.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/escaping.md
@@ -15,13 +15,32 @@ title: Tokenization
 weight: 4
 ---
 
-# Controlling text tokenization and escaping
+Full-text search works by comparing words, URLs, numbers, and other elements of the query
+against the text in the searchable fields of each document. However,
+It would be very inefficient to compare the entire text of the query against the
+entire text of each field over and over again, so the search system doesn't do this.
+Instead, it splits the document text into short, significant sections
+called *tokens* during the indexing process and stores the tokens as part of the document's
+index data.
+
+During a search, the query system also tokenizes the
+query text and then simply compares the tokens from the query against the tokens stored
+for each document. Finding a match like this is much more efficient than pattern-matching on
+the whole text and also lets you use
+[stemming]({{< relref "/develop/interact/search-and-query/advanced-concepts/stemming" >}}) and
+[stop words]({{< relref "/develop/interact/search-and-query/advanced-concepts/stopwords" >}})
+to improve the search even further.
 
 Redis Stack uses a very simple tokenizer for documents and a slightly more sophisticated tokenizer for queries. Both allow a degree of control over string escaping and tokenization. 
 
-Note: There is a different mechanism for tokenizing text and tag fields, this document refers only to text fields. For tag fields please refer to the [tag fields]({{< relref "/develop/interact/search-and-query/advanced-concepts/tags" >}}) documentation. 
+The sections below describe the rules for tokenizing text fields and queries.
+Note that
+[Tag fields]({{< relref "/develop/interact/search-and-query/advanced-concepts/tags" >}}) 
+are essentially text fields but they use a simpler form of tokenization, as described
+separately in the
+[Tokenization rules for tag fields](#tokenization-rules-for-tag-fields) section.
 
-## The rules of text field tokenization
+## Tokenization rules for text fields
 
 1. All punctuation marks and whitespace (besides underscores) separate the document and queries into tokens. For example, any character of `,.<>{}[]"':;!@#$%^&*()-+=~` will break the text into terms, so the text `foo-bar.baz...bag` will be tokenized into `[foo, bar, baz, bag]`
 
@@ -34,3 +53,23 @@ Note: There is a different mechanism for tokenizing text and tag fields, this do
 5. Latin characters are converted to lowercase. 
 
 6. A backslash before the first digit will tokenize it as a term. This will translate the `-` sign as NOT, which otherwise would make the number negative. Add a backslash before `.` if you are searching for a float. For example, `-20 -> {-20} vs -\20 -> {NOT{20}}`.
+
+## Tokenization rules for tag fields
+
+[Tag fields]({{< relref "/develop/interact/search-and-query/advanced-concepts/tags" >}}) interpret
+a text field as a list of *tags* delimited by a
+[separator]({{< relref "/develop/interact/search-and-query/advanced-concepts/tags#creating-a-tag-field" >}})
+character (which is a comma "," by
+default). The tokenizer simply splits the text wherever it finds the separator and so most
+punctuation marks and whitespace are valid characters within each tag token. The only
+changes that the tokenizer makes to the tags are:
+
+-   Trimming whitespace at the start and end of the tag. Other whitespace in the tag text is left intact.
+-   Converting Latin alphabet characters to lowercase. You can override this by adding the
+    [`CASESENSITIVE`]({{< relref "/develop/interact/search-and-query/basic-constructs/field-and-type-options#tag-fields" >}}) option in the indexing schema for the tag field.
+
+This means that when you define a tag field, you don't need to escape any characters, except
+in the unusual case where you want leading or trailing spaces to be part of the tag text.
+However, you do need to escape certain characters in a *query* against a tag field. See
+[Query syntax]({{< relref "/develop/interact/search-and-query/advanced-concepts/query_syntax#tag-filters" >}})
+for more information about this.

--- a/content/develop/interact/search-and-query/advanced-concepts/query_syntax.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/query_syntax.md
@@ -112,7 +112,10 @@ If a field in the schema is defined as NUMERIC, it is possible to use the FILTER
 
 ## Tag filters
 
-As of v0.91, you can use a special field type called _tag field_, with simpler tokenization and encoding in the index. You can't access the values in these fields using a general fieldless search. Instead, you use special syntax:
+As of v0.91, you can use a special field type called a
+[_tag field_]({{< relref "/develop/interact/search-and-query/advanced-concepts/tags" >}}), with simpler
+[tokenization]({{< relref "/develop/interact/search-and-query/advanced-concepts/escaping#tokenization-rules-for-tag-fields" >}})
+and encoding in the index. You can't access the values in these fields using a general fieldless search. Instead, you use special syntax:
 
 ```
 @field:{ tag | tag | ...}
@@ -127,7 +130,7 @@ Example:
 Tags can have multiple words or include other punctuation marks other than the field's separator (`,` by default). The following characters in tags should be escaped with a backslash (`\`): `$`, `{`, `}`, `\`, and `|`.
 
 {{% alert title="Note" color="warning" %}}
-Before RediSearch 2.6, it was also recommended to escape spaces. The reason was that, if a multiword tag included stopwords, a syntax error was returned. So tags, like "to be or not to be" needed be escaped as "to\ be\ or\ not\ to\ be". For good measure, you also could escape all spaces within tags. Starting with RediSearch 2.6, using `DIALECT 2` or greater you can use spaces in a `tag` query, even with stopwords.
+Before RediSearch 2.4, it was also recommended to escape spaces. The reason was that, if a multiword tag included stopwords, a syntax error was returned. So tags, like "to be or not to be" needed be escaped as "to\ be\ or\ not\ to\ be". For good measure, you also could escape all spaces within tags. Starting with RediSearch 2.4, using [`DIALECT 2`]({{< relref "/develop/interact/search-and-query/advanced-concepts/dialects#dialect-2" >}}) or greater you can use spaces in a `tag` query, even with stopwords.
 {{% /alert %}}
 
 Notice that multiple tags in the same clause create a union of documents containing either tags. To create an intersection of documents containing all tags, you should repeat the tag filter several times. For example:

--- a/content/develop/interact/search-and-query/advanced-concepts/tags.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/tags.md
@@ -15,23 +15,30 @@ title: Tags
 weight: 6
 ---
 
-# Tag fields
+Tag fields are similar to full-text fields but they interpret the text as a simple
+list of *tags* delimited by a
+[separator](#creating-a-tag-field) character (which is a comma "," by default).
+This limitation means that tag fields can use simpler
+[tokenization]({{< relref "/develop/interact/search-and-query/advanced-concepts/escaping" >}})
+and encoding in the index, which is more efficient than full-text indexing.
 
-Tag fields are similar to full-text fields but use simpler tokenization and encoding in the index. The values in these fields cannot be accessed by general field-less search and can be used only with a special syntax.
+The values in tag fields cannot be accessed by general field-less search and can be used only with a special syntax.
 
 The main differences between tag and full-text fields are:
 
-1. Stemming is not performed on tag indexes.
+1.  [Tokenization]({{< relref "/develop/interact/search-and-query/advanced-concepts/escaping#tokenization-rules-for-tag-fields" >}})
+    is very simple for tags.
 
-2. The tokenization is simpler: the user can determine a separator (defaults to a comma) for multiple tags. Whitespace trimming is only done at the end of tags. Thus, tags can contain spaces, punctuation marks, accents, etc.
+1.  Stemming is not performed on tag indexes.
 
-3. The only two transformations performed are lower-casing (for latin languages only as of now) and whitespace trimming. Lower-case transformation can be disabled by passing `CASESENSITIVE`.
+1.  Tags cannot be found from a general full-text search. If a document has a field called "tags"
+    with the values "foo" and "bar", searching for foo or bar without a special tag modifier (see below) will not return this document.
 
-4. Tags cannot be found from a general full-text search. If a document has a field called "tags" with the values "foo" and "bar", searching for foo or bar without a special tag modifier (see below) will not return this document.
+1.  The index is much simpler and more compressed: frequencies or offset vectors of field flags
+    are not stored. The index contains only document IDs encoded as deltas. This means that an entry in
+    a tag index is usually one or two bytes long. This makes them very memory-efficient and fast.
 
-5. The index is much simpler and more compressed: frequencies or offset vectors of field flags are not stored. The index contains only document IDs encoded as deltas. This means that an entry in a tag index is usually one or two bytes long. This makes them very memory efficient and fast.
-
-6. It's possible to create up to 1024 tag fields per index.
+1.  You can create up to 1024 tag fields per index.
 
 ## Creating a tag field
 
@@ -110,9 +117,14 @@ But the next query will return all people who have visited all three cities:
 FT.SEARCH myIndex "@cities:{ New York } @cities:{Los Angeles} @cities:{ Barcelona }"
 ```
 
-## Including punctuation in tags
+## Including punctuation and spaces in tags
 
-A tag can include punctuation other than the field's separator. You do not need to escape punctuation when using the [`HSET`]({{< relref "/commands/hset" >}}) command to add the value to a Redis Hash.
+A tag field can contain any punctuation characters except for the field separator.
+You can use punctuation without escaping when you *define* a tag field,
+but you typically need to escape certain characters when you *query* the field
+because the query syntax itself uses the same characters.
+(See [Query syntax]({{< relref "/develop/interact/search-and-query/advanced-concepts/query_syntax#tag-filters" >}})
+for the full set of characters that require escaping.)
 
 For example, given the following index:
 
@@ -126,35 +138,21 @@ You can add tags that contain punctuation like this:
 HSET test:1 tags "Andrew's Top 5,Justin's Top 5"
 ```
 
-However, when you query for tags that contain punctuation, you must escape that punctuation with a backslash character (`\`). This is the case with most languages and also redis-cli.
-
-For example, querying for the tag `Andrew's Top 5` in the redis-cli looks like this:
+However, when you query for those tags, you must escape the punctuation characters
+with a backslash (`\`). So, querying for the tag `Andrew's Top 5` in
+[`redis-cli`]({{< relref "/develop/connect/cli" >}}) looks like this:
 
 ```
 FT.SEARCH punctuation "@tags:{ Andrew\\'s Top 5 }"
 ```
 
-## Tags that contain multiple words
+(Note that you need the double backslash here because the terminal app itself
+uses the backslash as an escape character.
+Programming languages commonly use this convention also.)
 
-As the examples in this document show, a single tag can include multiple words. It is recommended that you escape spaces when querying, though doing so is not required.
-
-You escape spaces the same way that you escape punctuation: by preceding the space with a backslash character (or two backslashes, depending on the programming language and environment).
-
-Thus, you would escape the tag "to be or not to be" like so when querying in the redis-cli:
-
-```
-FT.SEARCH idx "@tags:{ to\\ be\\ or\\ not\\ to\\ be }"
-```
-
-You should escape spaces because if a tag includes multiple words and some of them are stop words like "to" or "be," a query that includes these words without escaping spaces will create a syntax error.
-
-You can see what that looks like in the following example:
-
-```
-127.0.0.1:6379> FT.SEARCH idx "@tags:{ to be or not to be }"
-(error) Syntax error at offset 27 near be
-```
-
-Note: stop words are words that are so common that a search engine ignores them. To learn more, see [stop words]({{< relref "/develop/interact/search-and-query/advanced-concepts/stopwords" >}}).
-
-Given the potential for syntax errors,it is recommended that you escape all spaces within tag queries.
+You can include spaces in a tag filter without escaping *unless* you are
+using a version of RediSearch earlier than v2.4 or you are using
+[query dialect 1]({{< relref "/develop/interact/search-and-query/advanced-concepts/dialects#dialect-1" >}}).
+See
+[Query syntax]({{< relref "/develop/interact/search-and-query/advanced-concepts/query_syntax#tag-filters" >}})
+for a full explanation.


### PR DESCRIPTION
[DOC-3909](https://redislabs.atlassian.net/browse/DOC-3909) mentions several confusing bits of text about tag fields and the situations where you need to escape characters when using them. This PR addresses these issues.

[DOC-3909]: https://redislabs.atlassian.net/browse/DOC-3909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ