### PR TITLE
DOC-3749 updated time series client lib list

### DIFF
--- a/content/develop/data-types/timeseries/clients.md
+++ b/content/develop/data-types/timeseries/clients.md
@@ -17,99 +17,12 @@ title: Clients
 weight: 5
 ---
 
-You can use Redis time series with several client libraries, written by the module authors and community members - abstracting the API in different programming languages. 
+The table below shows the client libraries that support Redis time series:
 
-While it is possible and simple to use the raw Redis commands API, in most cases it's more convenient to use a client library abstracting it. 
-
-## Currently available Libraries
-
-Some languages have client libraries that provide support for the time series commands:
-
-| Project | Language | License | Author | Stars |
-| ------- | -------- | ------- | ------ | --- |
-| [Jedis][Jedis-url] | Java | MIT | [Redis][Jedis-author] |  [![Jedis-stars]][Jedis-url] |
-| [JRedisTimeSeries][JRedisTimeSeries-url] | Java | BSD-3 | [RedisLabs][JRedisTimeSeries-author] |  [![JRedisTimeSeries-stars]][JRedisTimeSeries-url] |
-| [redis-modules-java][redis-modules-java-url] | Java | Apache-2 | [dengliming][redis-modules-java-author] | [![redis-modules-java-stars]][redis-modules-java-url] |
-| [redistimeseries-go][redistimeseries-go-url] | Go | Apache-2 | [RedisLabs][redistimeseries-go-author] |  [![redistimeseries-go-stars]][redistimeseries-go-url]  |
-| [rueidis][rueidis-url] | Go | Apache-2 | [Rueian][rueidis-author] |  [![rueidis-stars]][rueidis-url]  |
-| [redis-py][redis-py-url] ([examples][redis-py-example-url])| Python | MIT | [RedisLabs][redis-py-author] | [![redis-py-stars]][redis-py-url] |
-| [NRedisTimeSeries][NRedisTimeSeries-url] | .NET | BSD-3 | [RedisLabs][NRedisTimeSeries-author] |  [![NRedisTimeSeries-stars]][NRedisTimeSeries-url] |
-| [phpRedisTimeSeries][phpRedisTimeSeries-url] | PHP | MIT | [Alessandro Balasco][phpRedisTimeSeries-author] |  [![phpRedisTimeSeries-stars]][phpRedisTimeSeries-url] |
-| [node-redis][node-redis-url] | JavaScript | MIT | [Redis][node-redis-author] | [![node-redis-stars]][node-redis-url] |
-| [redis-time-series][redis-time-series-url] | JavaScript | MIT | [Rafa Campoy][redis-time-series-author] | [![redis-time-series-stars]][redis-time-series-url] |
-| [redistimeseries-js][redistimeseries-js-url] | JavaScript | MIT | [Milos Nikolovski][redistimeseries-js-author] | [![redistimeseries-js-stars]][redistimeseries-js-url] |
-| [redis-modules-sdk][redis-modules-sdk-url] | Typescript | BSD-3-Clause | [Dani Tseitlin][redis-modules-sdk-author] |[![redis-modules-sdk-stars]][redis-modules-sdk-url]| 
-| [redis_ts][redis_ts-url] | Rust | BSD-3 | [Thomas Profelt][redis_ts-author] | [![redis_ts-stars]][redis_ts-url] |
-| [rustis][rustis-url] | Rust | MIT | [Dahomey Technologies][rustis-author] | [![rustis-stars]][rustis-url] |
-| [redistimeseries][redistimeseries-url] | Ruby | MIT | [Eaden McKee][redistimeseries-author] | [![redistimeseries-stars]][redistimeseries-url] |
-| [redis-time-series][redis-time-series-rb-url] | Ruby | MIT | [Matt Duszynski][redis-time-series-rb-author] | [![redis-time-series-rb-stars]][redis-time-series-rb-url] |
-
-[Jedis-url]: https://github.com/redis/jedis/
-[Jedis-author]: https://redis.com
-[Jedis-stars]: https://img.shields.io/github/stars/redis/jedis.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[JRedisTimeSeries-url]: https://github.com/RedisTimeSeries/JRedisTimeSeries/
-[JRedisTimeSeries-author]: https://redislabs.com
-[JRedisTimeSeries-stars]: https://img.shields.io/github/stars/RedisTimeSeries/JRedisTimeSeries.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[NRedisTimeSeries-url]: https://github.com/RedisTimeSeries/NRedisTimeSeries
-[NRedisTimeSeries-author]: https://redislabs.com
-[NRedisTimeSeries-stars]: https://img.shields.io/github/stars/RedisTimeSeries/NRedisTimeSeries.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-
-[redis-modules-java-url]: https://github.com/dengliming/redis-modules-java
-[redis-modules-java-author]: https://github.com/dengliming
-[redis-modules-java-stars]: https://img.shields.io/github/stars/dengliming/redis-modules-java.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redistimeseries-go-url]: https://github.com/RedisTimeSeries/redistimeseries-go/
-[redistimeseries-go-author]: https://redislabs.com
-[redistimeseries-go-stars]: https://img.shields.io/github/stars/RedisTimeSeries/redistimeseries-go.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[rueidis-url]: https://github.com/rueian/rueidis
-[rueidis-author]: https://github.com/rueian
-[rueidis-stars]: https://img.shields.io/github/stars/rueian/rueidis.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redis-py-url]: https://github.com/redis/redis-py/
-[redis-py-example-url]: https://github.com/redis/redis-py/blob/master/tests/test_timeseries.py
-[redis-py-author]: https://redislabs.com
-[redis-py-stars]: https://img.shields.io/github/stars/redis/redis-py.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[NRedisTimeSeries-url]: https://github.com/RedisTimeSeries/NRedisTimeSeries/
-[NRedisTimeSeries-author]: https://redislabs.com
-[NRedisTimeSeries-stars]: https://img.shields.io/github/stars/RedisTimeSeries/NRedisTimeSeries.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[phpRedisTimeSeries-url]: https://github.com/palicao/phpRedisTimeSeries
-[phpRedisTimeSeries-author]: https://github.com/palicao
-[phpRedisTimeSeries-stars]: https://img.shields.io/github/stars/palicao/phpRedisTimeSeries.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[node-redis-url]: https://github.com/redis/node-redis
-[node-redis-author]: https://redis.com
-[node-redis-stars]: https://img.shields.io/github/stars/redis/node-redis.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redis-time-series-url]: https://github.com/averias/redis-time-series
-[redis-time-series-author]: https://github.com/averias
-[redis-time-series-stars]: https://img.shields.io/github/stars/averias/redis-time-series.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redistimeseries-js-url]: https://github.com/nikolovskimilos/redistimeseries-js
-[redistimeseries-js-author]: https://github.com/nikolovskimilos
-[redistimeseries-js-stars]: https://img.shields.io/github/stars/nikolovskimilos/redistimeseries-js.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redis-modules-sdk-url]: https://github.com/danitseitlin/redis-modules-sdk
-[redis-modules-sdk-author]: https://github.com/danitseitlin
-[redis-modules-sdk-stars]: https://img.shields.io/github/stars/danitseitlin/redis-modules-sdk.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redis_ts-url]: https://github.com/tompro/redis_ts
-[redis_ts-author]: https://github.com/tompro
-[redis_ts-stars]: https://img.shields.io/github/stars/tompro/redis_ts.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redistimeseries-url]: https://github.com/eadz/redistimeseries
-[redistimeseries-author]: https://github.com/eadz
-[redistimeseries-stars]: https://img.shields.io/github/stars/eadz/redistimeseries.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[redis-time-series-rb-url]: https://github.com/dzunk/redis-time-series
-[redis-time-series-rb-author]: https://github.com/dzunk
-[redis-time-series-rb-stars]: https://img.shields.io/github/stars/dzunk/redis-time-series.svg?style=social&amp;label=Star&amp;maxAge=2592000
-
-[rustis-url]: https://github.com/dahomey-technologies/rustis
-[rustis-author]: https://github.com/dahomey-technologies
-[rustis-stars]: https://img.shields.io/github/stars/dahomey-technologies/rustis.svg?style=social&amp;label=Star&amp;maxAge=2592000
+| Language | Client |
+| :-- | :-- |
+| Python | [redis-py]({{< relref "/develop/connect/clients/python" >}}) |
+| JavaScript | [node-redis]({{< relref "/develop/connect/clients/nodejs" >}}) |
+| Java | [Jedis]({{< relref "/develop/connect/clients/java/jedis" >}}) |
+| C#/.NET | [NRedisStack]({{< relref "/develop/connect/clients/dotnet" >}}) |
+| Go | [redistimeseries-go](https://github.com/RedisTimeSeries/redistimeseries-go/)


### PR DESCRIPTION
[DOC-3749](https://redislabs.atlassian.net/browse/DOC-3749) refers to several issues in this page that seems to have carried over some details from the recently-replaced docs site (and some over-complicated Markdown). The page is possibly worth keeping for now because the features for Go are in a separate library, not the usual Go client, so this should be noted somewhere.

[DOC-3749]: https://redislabs.atlassian.net/browse/DOC-3749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ