### PR TITLE
OP: remove more 404s related to RedisGears

### DIFF
--- a/content/develop/connect/insight/release-notes/v2.0.md
+++ b/content/develop/connect/insight/release-notes/v2.0.md
@@ -176,7 +176,7 @@ RedisInsight-preview 2.0 can be installed along with the current GA (1.11) versi
 - Workbench:
   - Advanced command-line interface that lets you run commands against your Redis server 
   - Workbench editor allows comments, multi-line formatting and multi-command execution
-  - Intelligent Redis command auto-complete and syntax highlighting with support for [RediSearch](https://oss.redis.com/redisearch/), [RedisJSON](https://oss.redis.com/redisjson/), [RedisGraph](https://oss.redis.com/redisgraph/), [RedisTimeSeries](https://oss.redis.com/redistimeseries/), [RedisGears](https://oss.redis.com/redisgears/), [RedisAI](https://oss.redis.com/redisai/), [RedisBloom](https://oss.redis.com/redisbloom/)
+  - Intelligent Redis command auto-complete and syntax highlighting with support for [RediSearch](https://oss.redis.com/redisearch/), [RedisJSON](https://oss.redis.com/redisjson/), [RedisGraph](https://oss.redis.com/redisgraph/), [RedisTimeSeries](https://oss.redis.com/redistimeseries/), [RedisGears]({{< relref "/operate/oss_and_stack/stack-with-enterprise/deprecated-features/triggers-and-functions" >}}), [RedisAI](https://oss.redis.com/redisai/), [RedisBloom](https://oss.redis.com/redisbloom/)
   - Allows rendering custom data visualization per Redis command using externally developed plugins
 - Browser:
   - Browse, filter and visualize key-value Redis data structures

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/_index.md
@@ -28,8 +28,6 @@ If you're running Redis Community Edition, you'll also need to [install the Redi
 
 To get started with RedisGears, see the quick start tutorial for [Python]({{< relref "/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/quickstart" >}}) or [Java]({{< relref "/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/quickstart" >}}).
 
-To learn more about the RedisGears API and understand how it works under the hood, see the [RedisGears docs](https://oss.redislabs.com/redisgears/).
-
 ## Write-behind caching patterns
 
 Redis users typically implement caching by using the look-aside pattern. However, with RedisGears, you can implement write-behind caching strategies as well.
@@ -38,5 +36,4 @@ Redis publishes RedisGears recipes to support write-behind. You can learn how to
 
 ## More info
 
-- [RedisGears introduction](https://oss.redis.com/redisgears/intro.html)
 - [RedisGears source](https://github.com/RedisGears/RedisGears)

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/classes/gearsbuilder/config-get.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/classes/gearsbuilder/config-get.md
@@ -14,7 +14,7 @@ weight: 50
 public static java.lang.String configGet​(java.lang.String key)
 ```
 
-Gets the value of a RedisGears [configuration setting](https://oss.redis.com/redisgears/configuration.html).
+Gets the value of a RedisGears [configuration setting]({{< relref "/operate/oss_and_stack/stack-with-enterprise/deprecated-features/triggers-and-functions/Configuration" >}}).
 
 {{<note>}}
 You can set configuration values when you load the module or use the [`RG.CONFIGSET`](https://oss.redislabs.com/redisgears/commands.html#rgconfigset) command.

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/classes/readers/commandoverrider.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/classes/readers/commandoverrider.md
@@ -17,7 +17,7 @@ The `CommandOverrider` allows you to override and customize Redis commands.
 1. Run `RG.JEXECUTE` to register your code.
 
 {{<note>}}
-If you register code that uses `CommandOverrider`, its `reader` value is `"CommandReader"` when you run the [`RG.DUMPREGISTRATIONS`](http://oss.redis.com/redisgears/commands.html#rgdumpregistrations) command, not `"CommandOverrider"`.
+If you register code that uses `CommandOverrider`, its `reader` value is `"CommandReader"` when you run the `RG.DUMPREGISTRATIONS` command, not `"CommandOverrider"`.
 {{</note>}}
 
 ## Parameters

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/commands/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/commands/_index.md
@@ -18,8 +18,6 @@ Use a Redis client like `redis-cli` to send commands to the RedisGears JVM plugi
 
 {{<table-children columnNames="Command,Description" columnSources="LinkTitle,Description" enableLinks="LinkTitle">}}
 
-See the general [RedisGears commands](https://oss.redis.com/redisgears/commands.html) page for more commands.
-
 {{<note>}}
 Ignore any commands that start with `RG.PY` while using the JVM plugin. The `RG.PY` commands are for the Python plugin.
 {{</note>}}

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/recipes/write-behind.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/recipes/write-behind.md
@@ -145,7 +145,7 @@ The following XML maps Redis hashes, which represent students, to a MySQL table:
 ```
 ## Commands
 
-Run rghibernate commands with [`RG.TRIGGER`](http://oss.redis.com/redisgears/commands.html#rgtrigger):
+Run rghibernate commands with `RG.TRIGGER`:
 
 ```sh
 redis-cli RG.TRIGGER SYNC.<COMMAND>

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/_index.md
@@ -23,5 +23,4 @@ Once you have written your code, upload it to a node on your Redis Enterprise cl
 ## More info
 
 - [RedisGears Python quick start]({{< relref "/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/quickstart" >}})
-- [RedisGears Python operations](http://oss.redis.com/redisgears/operations.html)
 - [RedisGears recipes]({{< relref "/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/recipes" >}})

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/quickstart.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/quickstart.md
@@ -139,4 +139,4 @@ redis.cloud:6379> GET age:maximum
 
 ## Next steps
 
-You should now have a basic idea of how to run RedisGears functions for batch and event processing. But there's a lot more to RedisGears than this. To better understand it, see the [RedisGears tutorial](https://oss.redis.com/redisgears/intro.html). If you're interested in write-behind caching, see our [write-behind caching]({{< relref "/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/recipes/write-behind" >}}) overview.
+You should now have a basic idea of how to run RedisGears functions for batch and event processing. If you're interested in write-behind caching, see our [write-behind caching]({{< relref "/operate/oss_and_stack/stack-with-enterprise/gears-v1/python/recipes/write-behind" >}}) overview.

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/register-events.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/register-events.md
@@ -12,7 +12,7 @@ toc: 'true'
 weight: 80
 ---
 
-You can register RedisGears functions to [run when certain events occur](https://oss.redis.com/redisgears/intro.html#event-processing) in a Redis database.
+You can register RedisGears functions to run when certain events occur in a Redis database.
 
 ## Register on events
 
@@ -29,12 +29,6 @@ To register RedisGears functions to run on an event, your code needs to:
     - The `KeysReader` object for Java.
 
 For more information and examples of event registration, see:
-
-- Python references:
-
-    - [`KeysReader`](https://oss.redis.com/redisgears/readers.html#keysreader)
-
-    - [`GearsBuilder.register()`](https://oss.redis.com/redisgears/functions.html#register)
 
 - Java references:
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisgears/redisgears-1.0-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisgears/redisgears-1.0-release-notes.md
@@ -71,7 +71,7 @@ Details:
 
     - [#594](https://github.com/RedisGears/RedisGears/pull/594) Added RedisGears info section to Redis info command
 
-    - [#587](https://github.com/RedisGears/RedisGears/pull/587) `inorder` option for the [command reader](https://oss.redis.com/redisgears/1.0/readers.html#commandreader)
+    - [#587](https://github.com/RedisGears/RedisGears/pull/587) `inorder` option for the command reader
     
     - [#592](https://github.com/RedisGears/RedisGears/pull/592), [#586](https://github.com/RedisGears/RedisGears/pull/586) Background executions will now appear on Redis slowlog, available in Redis 6.2 and above.
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisgears/redisgears-1.2-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisgears/redisgears-1.2-release-notes.md
@@ -47,8 +47,8 @@ Details:
 - Bug fixes:
 
     - [#792](https://github.com/RedisGears/RedisGears/issues/792), [#798](https://github.com/RedisGears/RedisGears/pull/798) Execution was triggered infinitely when trimming is turned off.
-    - [#791](https://github.com/RedisGears/RedisGears/issues/791), [#796](https://github.com/RedisGears/RedisGears/pull/796) Stop triggering executions during [pause](https://oss.redis.com/redisgears/commands.html#rgpauseregistrations) even on failure.
-    - [#794](https://github.com/RedisGears/RedisGears/pull/794), [#797](https://github.com/RedisGears/RedisGears/pull/797) Use [`PythonInstallationDir`](https://oss.redis.com/redisgears/configuration.html#pythoninstallationdir) configuration to find the virtual environment location on Redis Enterprise. (MOD-1734)
+    - [#791](https://github.com/RedisGears/RedisGears/issues/791), [#796](https://github.com/RedisGears/RedisGears/pull/796) Stop triggering executions during pause even on failure.
+    - [#794](https://github.com/RedisGears/RedisGears/pull/794), [#797](https://github.com/RedisGears/RedisGears/pull/797) Use `PythonInstallationDir` configuration to find the virtual environment location on Redis Enterprise. (MOD-1734)
 
 ## v1.2.4 (May 2022)
 
@@ -61,11 +61,11 @@ Details:
 - Improvements:
 
     - [#772](https://github.com/RedisGears/RedisGears/pull/772) Added the ability to upgrade a dependency at runtime with `FORCE_REQUIREMENTS_REINSTALLATION` on `RG.PYEXECUTE`.
-    - [#765](https://github.com/RedisGears/RedisGears/pull/765) Allow deactivating [override Python allocators](https://oss.redis.com/redisgears/configuration.html#overridepythonallocators) for performance improvements.
+    - [#765](https://github.com/RedisGears/RedisGears/pull/765) Allow deactivating override Python allocators for performance improvements.
 
 - Bug fixes:
 
-    - [#761](https://github.com/RedisGears/RedisGears/issues/761), [#760](https://github.com/RedisGears/RedisGears/issues/760), [#778](https://github.com/RedisGears/RedisGears/pull/778) [`StreamReader`](https://oss.redis.com/redisgears/readers.html#streamreader) fixes to pause and unregister stream processing.
+    - [#761](https://github.com/RedisGears/RedisGears/issues/761), [#760](https://github.com/RedisGears/RedisGears/issues/760), [#778](https://github.com/RedisGears/RedisGears/pull/778) `StreamReader` fixes to pause and unregister stream processing.
 
 ## v1.2.3 (April 2022)
 
@@ -101,23 +101,23 @@ Full documentation for JVM support can be found on the [Redis documentation webs
 
 RedisGears provides support for Python coroutines. Each step of your gears function can now be a Python coroutine that will take the execution to the background or will wait for some event to happen. Refer to the following links for more information:
 
-- [Async Await Support](https://oss.redis.com/redisgears/1.2/intro.html#async-await-support)
-- [Async Await Advanced Topics](https://oss.redis.com/redisgears/1.2/async_await_advance_topics.html)
+- Async Await Support
+- Async Await Advanced Topics
 
 #### Override commands API
 
-You can override Redis vanilla commands with a function. For more information, refer to the RedisGears [command hooks](https://oss.redis.com/redisgears/1.2/commands_hook.html) documentation.
+You can override Redis vanilla commands with a function. For more information, refer to the RedisGears command hooks documentation.
 
 #### Key miss event for read-through pattern
 
 Requested by many users, RedisGears 1.2 allows you to register functions on key miss event. One use case for this is to implement a read-through caching pattern. For more information about this topic, refer to the following links:
 
-- [Key Miss Event](https://oss.redis.com/redisgears/1.2/miss_event.html) in the RedisGears documentation.
+- Key Miss Event in the RedisGears documentation.
 - [rghibernate](https://github.com/RedisGears/rghibernate) recipe that leverages the key miss event to implement read-through from external databases.
 
 #### Better visibility and analyzing tools
 
-We improved the experience during the development phase by enabling better debugging and troubleshooting. There is still room for improvement but RedisGears 1.2 makes the first steps toward a simpler API that is easier to use. This new version allows you to name your code and upgrade it with a single Redis command. For more information, refer to the [upgrade section](https://oss.redis.com/redisgears/1.2/intro.html#code-upgrades) of the RedisGears introduction documentation.
+We improved the experience during the development phase by enabling better debugging and troubleshooting. There is still room for improvement but RedisGears 1.2 makes the first steps toward a simpler API that is easier to use. This new version allows you to name your code and upgrade it with a single Redis command. For more information, refer to the upgrade section of the RedisGears introduction documentation.
 
 RedisGears now tracks the following new statistics to better analyze your registrations:
 
@@ -130,16 +130,16 @@ For streams, RedisGears also tracks the following data:
 - `lastEstimatedLagMS` - gives the last batch lag (the time difference between the first batch entry in the stream and the time the entire batch finished processing)
 - `avgEstimatedLagMS` - average of the `lastEstimatedLagMS` field.
 
-The [`RG.DUMPREGISTRATIONS`](https://oss.redis.com/redisgears/1.2/commands.html#rgdumpregistrations) command exposes these new statistics.
+The `RG.DUMPREGISTRATIONS` command exposes these new statistics.
 
 RedisGears 1.2 also adds support for a Python profiler, specifically [`cProfile`](https://docs.python.org/3.7/library/profile.html#module-cProfile). For more information, refer to the documentation for the following commands:
 
-- [`RG.PYPROFILE STATS`](https://oss.redis.com/redisgears/1.2/commands.html#rgpyprofile-stats)
-- [`RG.PYPROFILE RESET`](https://oss.redis.com/redisgears/1.2/commands.html#rgpyprofile-reset)
+- `RG.PYPROFILE STATS`
+- `RG.PYPROFILE RESET`
 
 #### RedisAI integration
 
-Although RedisAI integration was already supported in v1.0, RedisGears 1.2 adds official support for all capabilities in [RedisAI v1.2](https://oss.redis.com/redisgears/1.2/redisai.html). The API was extended to support [RedisAI DAG](https://oss.redis.com/redisai/commands/#aidagexecute) and was combined with the new async await API to achieve the best performance possible.
+Although RedisAI integration was already supported in v1.0, RedisGears 1.2 adds official support for all capabilities in RedisAI v1.2. The API was extended to support RedisAI DAG and was combined with the new async await API to achieve the best performance possible.
 
 ### Details
 


### PR DESCRIPTION
Here, I'm removing a bunch of bad links related to long deleted RedisGears v1 content (former redis.io). In some cases, particularly the Gears v1.2 release notes, I removed links, but left the link text. In other cases, I removed entire sentences.