### PR TITLE
DEV: remove outdated key expiration info

### DIFF
--- a/content/commands/expire/index.md
+++ b/content/commands/expire/index.md
@@ -218,30 +218,16 @@ lasting for 1000 seconds.
 
 ## How Redis expires keys
 
-Redis keys are expired in two ways: a passive way, and an active way.
+Redis keys are expired in two ways: a passive way and an active way.
 
-A key is passively expired simply when some client tries to access it, and the
-key is found to be timed out.
+A key is passively expired when a client tries to access it and the
+key is timed out.
 
-Of course this is not enough as there are expired keys that will never be
+However, this is not enough as there are expired keys that will never be
 accessed again.
-These keys should be expired anyway, so periodically Redis tests a few keys at
-random among keys with an expire set.
+These keys should be expired anyway, so periodically, Redis tests a few keys at
+random amongst the set of keys with an expiration.
 All the keys that are already expired are deleted from the keyspace.
-
-Specifically this is what Redis does 10 times per second:
-
-1. Test 20 random keys from the set of keys with an associated expire.
-2. Delete all the keys found expired.
-3. If more than 25% of keys were expired, start again from step 1.
-
-This is a trivial probabilistic algorithm, basically the assumption is that our
-sample is representative of the whole key space, and we continue to expire until
-the percentage of keys that are likely to be expired is under 25%
-
-This means that at any given moment the maximum amount of keys already expired
-that are using memory is at max equal to max amount of write operations per
-second divided by 4.
 
 ## How expires are handled in the replication link and AOF file
 


### PR DESCRIPTION
I removed the outdated description of the expiration algorithm, but I left in place the simpler explanation.