### PR TITLE
Add frontmatter patch for modules-api-ref.md

### DIFF
--- a/content/develop/reference/modules/modules-api-ref-frontmatter.patch
+++ b/content/develop/reference/modules/modules-api-ref-frontmatter.patch
@@ -1,0 +1,23 @@
+--- a/content/develop/reference/modules/modules-api-ref.md
++++ b/content/develop/reference/modules/modules-api-ref.md
+@@ -1,3 +1,20 @@
++---
++categories:
++- docs
++- develop
++- stack
++- oss
++- rs
++- rc
++- oss
++- kubernetes
++- clients
++description: Reference for the Redis Modules API
++linkTitle: API reference
++title: Modules API reference
++weight: 1
++---
++
+ <!-- This file is generated from module.c using
+      redis/redis:utils/generate-module-api-doc.rb -->
+ 


### PR DESCRIPTION
This patch will be used to add frontmatter content to the modules-api-ref.md file generated by redis