### PR TITLE
DEV: fix dev list page link squish bug

### DIFF
--- a/content/develop/connect/insight/_index.md
+++ b/content/develop/connect/insight/_index.md
@@ -10,6 +10,7 @@ categories:
 - kubernetes
 - clients
 description: Visualize and optimize Redis data
+hideListLinks: true
 linkTitle: Redis Insight
 stack: true
 title: Redis Insight

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -39,7 +39,11 @@
           <nav>
             {{ range .CurrentSection.Pages }}
               <a href="{{ .RelPermalink }}"{{ with .Params.manualLinkTitle }} title="{{ . }}"{{ end }}{{ with .Params.manualLinkTarget }} target="{{ . }}"{{ if eq . "_blank" }} rel="noopener"{{ end }}{{ end }}>{{- .Title -}}</a>
-              <p>{{ .Description | markdownify }}</p>
+              {{ if .Description }}
+                <p>{{ .Description | markdownify }}</p>
+              {{ else }}
+                <br /><br />
+              {{ end }}
             {{ end }}
           </nav>
         {{ end }}


### PR DESCRIPTION
While reading the Redis Insight page, I noticed that the list page links at the bottom of the page were squished together on a single line. This PR applies the same patch that was made to the Operate and Integrate list view layouts.