### PR TITLE
DOC-2606 added info about JSON array slice defaults

### DIFF
--- a/content/develop/data-types/json/path.md
+++ b/content/develop/data-types/json/path.md
@@ -52,7 +52,7 @@ The following JSONPath syntax table was adapted from Goessner's [path syntax com
 | * | Wildcard, returns all elements. |
 | [] | Subscript operator, accesses an array element. |
 | [,] | Union, selects multiple elements. |
-| [start\:end\:step] | Array slice where *start*, *end*, and *step* are index values. You can omit values from the slice (for example, `[3:]`, `[:8:2]`) to use the default values: *start* defaults to the first index, *end* defaults to the last index and *step* defaults to 1. Use `[*]` or `[:]` to select all elements. |
+| [start\:end\:step] | Array slice where *start*, *end*, and *step* are index values. You can omit values from the slice (for example, `[3:]`, `[:8:2]`) to use the default values: *start* defaults to the first index, *end* defaults to the last index, and *step* defaults to `1`. Use `[*]` or `[:]` to select all elements. |
 | ?() | Filters a JSON object or array. Supports comparison operators <nobr>(`==`, `!=`, `<`, `<=`, `>`, `>=`, `=~`)</nobr>, logical operators <nobr>(`&&`, `\|\|`)</nobr>, and parenthesis <nobr>(`(`, `)`)</nobr>. |
 | () | Script expression. |
 | @ | The current element, used in filter or script expressions. |

--- a/content/develop/data-types/json/path.md
+++ b/content/develop/data-types/json/path.md
@@ -52,7 +52,7 @@ The following JSONPath syntax table was adapted from Goessner's [path syntax com
 | * | Wildcard, returns all elements. |
 | [] | Subscript operator, accesses an array element. |
 | [,] | Union, selects multiple elements. |
-| [start\:end\:step] | Array slice where start, end, and step are indexes. |
+| [start\:end\:step] | Array slice where *start*, *end*, and *step* are index values. You can omit values from the slice (for example, `[3:]`, `[:8:2]`) to use the default values: *start* defaults to the first index, *end* defaults to the last index and *step* defaults to 1. Use `[*]` or `[:]` to select all elements. |
 | ?() | Filters a JSON object or array. Supports comparison operators <nobr>(`==`, `!=`, `<`, `<=`, `>`, `>=`, `=~`)</nobr>, logical operators <nobr>(`&&`, `\|\|`)</nobr>, and parenthesis <nobr>(`(`, `)`)</nobr>. |
 | () | Script expression. |
 | @ | The current element, used in filter or script expressions. |


### PR DESCRIPTION
[DOC-2606](https://redislabs.atlassian.net/browse/DOC-2606)
Default values of start, end, and step for an array slice.

[DOC-2606]: https://redislabs.atlassian.net/browse/DOC-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ