### PR TITLE
Remove/replace H1 elements in article body

### DIFF
--- a/content/commands/expire/index.md
+++ b/content/commands/expire/index.md
@@ -177,9 +177,9 @@ recorded.
 This pattern is easily modified to use counters using [`INCR`]({{< relref "/commands/incr" >}}) instead of lists
 using [`RPUSH`]({{< relref "/commands/rpush" >}}).
 
-# Appendix: Redis expires
+## Appendix: Redis expires
 
-## Keys with an expire
+### Keys with an expire
 
 Normally Redis keys are created without an associated time to live.
 The key will simply live forever, unless it is removed by the user in an
@@ -193,14 +193,14 @@ specified amount of time elapsed.
 The key time to live can be updated or entirely removed using the `EXPIRE` and
 [`PERSIST`]({{< relref "/commands/persist" >}}) command (or other strictly related commands).
 
-## Expire accuracy
+### Expire accuracy
 
 In Redis 2.4 the expire might not be pin-point accurate, and it could be between
 zero to one seconds out.
 
 Since Redis 2.6 the expire error is from 0 to 1 milliseconds.
 
-## Expires and persistence
+### Expires and persistence
 
 Keys expiring information is stored as absolute Unix timestamps (in milliseconds
 in case of Redis version 2.6 or greater).
@@ -216,7 +216,7 @@ you set a key with a time to live of 1000 seconds, and then set your computer
 time 2000 seconds in the future, the key will be expired immediately, instead of
 lasting for 1000 seconds.
 
-## How Redis expires keys
+### How Redis expires keys
 
 Redis keys are expired in two ways: a passive way and an active way.
 
@@ -229,7 +229,7 @@ These keys should be expired anyway, so periodically, Redis tests a few keys at
 random amongst the set of keys with an expiration.
 All the keys that are already expired are deleted from the keyspace.
 
-## How expires are handled in the replication link and AOF file
+### How expires are handled in the replication link and AOF file
 
 In order to obtain a correct behavior without sacrificing consistency, when a
 key expires, a [`DEL`]({{< relref "/commands/del" >}}) operation is synthesized in both the AOF file and gains all

--- a/content/develop/data-types/json/developer.md
+++ b/content/develop/data-types/json/developer.md
@@ -9,15 +9,11 @@ categories:
 - oss
 - kubernetes
 - clients
-description: 'Notes on debugging, testing and documentation
-
-  '
+description: 'Notes on JSON debugging, testing and documentation.'
 linkTitle: Developer notes
 title: Developer notes
 weight: 7
 ---
-
-# Developing Redis JSON
 
 Developing Redis JSON involves setting up the development environment (which can be either Linux-based or macOS-based), building RedisJSON (the Redis module providing JSON), running tests and benchmarks, and debugging both the JSON module and its tests.
 

--- a/content/develop/data-types/probabilistic/bloom-filter.md
+++ b/content/develop/data-types/probabilistic/bloom-filter.md
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 - clients
 description: Bloom filters are a probabilistic data structure that checks for presence
-  of an element in a set.
+  of an element in a set
 linkTitle: Bloom filter
 stack: true
 title: Bloom filter

--- a/content/develop/data-types/probabilistic/bloom-filter.md
+++ b/content/develop/data-types/probabilistic/bloom-filter.md
@@ -10,15 +10,12 @@ categories:
 - kubernetes
 - clients
 description: Bloom filters are a probabilistic data structure that checks for presence
-  of an element in a set
+  of an element in a set.
 linkTitle: Bloom filter
 stack: true
 title: Bloom filter
 weight: 10
 ---
-
-
-# Bloom Filter
 
 A Bloom filter is a probabilistic data structure in Redis Stack that enables you to check if an element is present in a set using a very small memory space of a fixed size.
 

--- a/content/develop/data-types/probabilistic/count-min-sketch.md
+++ b/content/develop/data-types/probabilistic/count-min-sketch.md
@@ -17,8 +17,6 @@ title: Count-min sketch
 weight: 60
 ---
 
-# Count-min sketch
-
 Count-Min Sketch is a probabilistic data structure in Redis Stack that can be used to estimate the frequency of events/elements in a stream of data.
 
 It uses a sub-linear space at the expense of over-counting some events due to collisions. It consumes a stream of events/elements and keeps estimated counters of their frequency.
@@ -83,7 +81,7 @@ threshold = error * total_count = 0.001 * 2M = 2000
 This threshold seems to be sitting comfortably between the 2 average counts 500 and 8000 so the initial chosen error rate should be working well for this case.
 
 
-# Sizing
+## Sizing
 
 Even though the Count-Min sketch is similar to Bloom filter in many ways, its sizing is considerably more complex. The initialisation command receives only two sizing parameters, but you have to understand them thoroughly if you want to have a usable sketch.
 

--- a/content/develop/data-types/probabilistic/cuckoo-filter.md
+++ b/content/develop/data-types/probabilistic/cuckoo-filter.md
@@ -17,8 +17,6 @@ title: Cuckoo filter
 weight: 20
 ---
 
-# Cuckoo Filters
-
 A Cuckoo filter, just like a Bloom filter, is a probabilistic data structure in Redis Stack that enables you to check if an element is present in a set in a very fast and space efficient way, while also allowing for deletions and showing better performance than Bloom in some scenarios.
 
 While the Bloom filter is a bit array with flipped bits at positions decided by the hash function, a Cuckoo filter is an array of buckets, storing fingerprints of the values in one of the buckets at positions decided by the two hash functions. A membership query for item `x` searches the possible buckets for the fingerprint of `x`, and returns true if an identical fingerprint is found. A cuckoo filter's fingerprint size will directly determine the false positive rate.

--- a/content/develop/interact/search-and-query/administration/design.md
+++ b/content/develop/interact/search-and-query/administration/design.md
@@ -17,8 +17,6 @@ title: Internal design
 weight: 1
 ---
 
-# Internal design
-
 Redis Stack implements inverted indexes on top of Redis, but unlike previous implementations of Redis inverted indexes, it uses a custom data encoding that allows more memory and CPU efficient searches, and more advanced search features.
 
 This document details some of the design choices and how these features are implemented.

--- a/content/develop/interact/search-and-query/administration/extensions.md
+++ b/content/develop/interact/search-and-query/administration/extensions.md
@@ -11,11 +11,9 @@ categories:
 - clients
 description: Details about extensions for query expanders and scoring functions
 linkTitle: Extensions
-title: Extensions
+title: Extend existing search and query features
 weight: 9
 ---
-
-# Extending the existing search and query features
 
 RediSearch supports an extension mechanism, much like Redis supports modules. The API is very minimal at the moment, and it does not yet support dynamic loading of extensions on a running server. Instead, extensions must be written in C (or a language that has an interface with C) and compiled into dynamic libraries that can be loaded at start up.
 

--- a/content/develop/interact/search-and-query/administration/gc.md
+++ b/content/develop/interact/search-and-query/administration/gc.md
@@ -15,9 +15,7 @@ title: Garbage collection
 weight: 2
 ---
 
-# Garbage collection (GC) in RediSearch
-
-## The need for GC
+## The need for garbage collection
 
 * When documents are deleted by the user, Redis only marks them as deleted in the global document table rather than deleting them outright. This is done for efficiency. Depending on the length of a document, deletion can be a long operation.
 * This means that it is no longer the case that an internal numeric id is assigned to a deleted document. When the index is traversed, a check is made for deletion.

--- a/content/develop/interact/search-and-query/administration/overview.md
+++ b/content/develop/interact/search-and-query/administration/overview.md
@@ -9,15 +9,11 @@ categories:
 - oss
 - kubernetes
 - clients
-description: 'Technical details of the internal design of RediSearch
-
-  '
+description: 'Technical overview of the search and query features of Redis Stack.'
 linkTitle: Technical overview
 title: Technical overview
 weight: 1
 ---
-
-# Technical overview of the search and query features of Redis Stack
 
 ## Abstract
 
@@ -59,7 +55,7 @@ All of this is done while taking advantage of Redis's robust architecture and in
 
 ---
 
-# Indexing documents
+## Indexing documents
 
 Redis Stack needs to know how to index documents in order to search effectively. A document may have several fields, each with its own weight. For example, a title is usually more important than the text itself. The engine can also use numeric or geographical fields for filtering. Hence, the first step is to create the index definition, which tells Redis Stack how to treat the documents that will be added. For example, to define an index of products, indexing their title, description, brand, and price fields, the index creation would look like:
 
@@ -385,7 +381,7 @@ Extensions are compiled into dynamic libraries and loaded into RediSearch on ini
 
 ---
 
-# Scalable distributed search
+## Scalable distributed search
 
 While RediSearch is very fast and memory efficient, if an index is big enough, at some point it will be too slow or consume too much memory. It must then be scaled out and partitioned over several machines, each of which will hold a small part of the complete search index.
 

--- a/content/develop/interact/search-and-query/administration/overview.md
+++ b/content/develop/interact/search-and-query/administration/overview.md
@@ -9,7 +9,7 @@ categories:
 - oss
 - kubernetes
 - clients
-description: 'Technical overview of the search and query features of Redis Stack.'
+description: 'Technical overview of the search and query features of Redis Stack'
 linkTitle: Technical overview
 title: Technical overview
 weight: 1

--- a/content/develop/interact/search-and-query/advanced-concepts/chinese.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/chinese.md
@@ -9,13 +9,11 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Chinese support
+description: Chinese support for searching and querying in Redis Stack
 linkTitle: Chinese
-title: Chinese
+title: Chinese support
 weight: 15
 ---
-
-# Chinese support for searching and querying in Redis Stack
 
 Support for adding documents in Chinese is available starting at version 0.99.0.
 

--- a/content/develop/interact/search-and-query/advanced-concepts/highlight.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/highlight.md
@@ -15,8 +15,6 @@ title: Highlighting
 weight: 7
 ---
 
-# Highlighting API
-
 Redis Stack uses advanced algorithms for highlighting and summarizing, which enable only the relevant portions of a document to appear in response to a search query. This feature allows users to immediately understand the relevance of a document to their search criteria, typically highlighting the matching terms in bold text.
 
 ## Command syntax

--- a/content/develop/interact/search-and-query/advanced-concepts/phonetic_matching.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/phonetic_matching.md
@@ -9,13 +9,11 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Phonetic matching
+description: Details about phonetic matching capabilities
 linkTitle: Phonetic
-title: Phonetic
+title: Phonetic matching
 weight: 14
 ---
-
-# Phonetic matching
 
 Phonetic matching, for example "Jon" vs. "John", allows searching for terms based on their pronunciation. This capability can be a useful tool when searching for names of people.
 

--- a/content/develop/interact/search-and-query/advanced-concepts/scoring.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/scoring.md
@@ -11,11 +11,9 @@ categories:
 - clients
 description: Full-text scoring functions
 linkTitle: Scoring
-title: Scoring
+title: Scoring documents
 weight: 8
 ---
-
-# Scoring documents
 
 When searching, documents are scored based on their relevance to the query. The score is a floating point number between 0.0 and 1.0, where 1.0 is the highest score. The score is returned as part of the search results and can be used to sort the results.
 

--- a/content/develop/interact/search-and-query/advanced-concepts/sorting.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/sorting.md
@@ -11,11 +11,9 @@ categories:
 - clients
 description: Support for sorting query results
 linkTitle: Sorting
-title: Sorting
+title: Sorting by indexed fields
 weight: 5
 ---
-
-# Sorting by indexed fields
 
 As of RediSearch 0.15, you can bypass the scoring function mechanism and order search results by the value of different document attributes (fields) directly, even if the sorting field is not used by the query. For example, you can search for first name and sort by last name.
 

--- a/content/develop/interact/search-and-query/advanced-concepts/spellcheck.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/spellcheck.md
@@ -15,8 +15,6 @@ title: Spellchecking
 weight: 13
 ---
 
-# Query spelling correction
-
 Query spelling correction provides suggestions for misspelled search terms. For example, the term 'reids' may be a misspelled version of 'redis'.
 
 In such cases, and as of v1.4, RediSearch can be used for generating alternatives to misspelled query terms. A misspelled term is a full text term (i.e., a word) that is:

--- a/content/develop/interact/search-and-query/advanced-concepts/stemming.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/stemming.md
@@ -15,8 +15,6 @@ title: Stemming
 weight: 10
 ---
 
-# Stemming and Multi-language Support
-
 RediSearch supports stemming - that is adding the base form of a word to the index. This allows the query for "`hiring`" to also return results for "`hire`" and "`hired`", for example.
 
 The current stemming support is based on the Snowball stemmer library, which supports most European languages, as well as Arabic and other. See the "[Supported languages](#supported-languages)" section below. We hope to include more languages soon (if you need a specific language support, please open an issue).

--- a/content/develop/interact/search-and-query/advanced-concepts/stopwords.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/stopwords.md
@@ -15,8 +15,6 @@ title: Stop words
 weight: 1
 ---
 
-# Stop words
-
 Redis Stack has a default list of [stop words](https://en.wikipedia.org/wiki/Stop_words). These are words that are usually so common that they do not add much information to search, but take up a lot of space and CPU time in the index. 
 
 When indexing, stop words are discarded and not indexed. When searching, they are also ignored and treated as if they were not sent to the query processor. This is done when parsing the query. 

--- a/content/develop/interact/search-and-query/advanced-concepts/synonyms.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/synonyms.md
@@ -9,15 +9,11 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Synonym support
+description: Details on synonym support with Redis Stack
 linkTitle: Synonym
-title: Synonym
+title: Synonym support
 weight: 11
 ---
-
-# Synonyms support
-
-## Overview
 
 Redis Stack supports synonyms. That is, searching for synonym words defined by the synonym data structure.
 

--- a/content/develop/interact/search-and-query/deprecated/development.md
+++ b/content/develop/interact/search-and-query/deprecated/development.md
@@ -9,13 +9,11 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Notes on debugging, testing and documentation
+description: Notes on search and query debugging, testing, and documentation
 linkTitle: Developer notes
 title: Developer notes
 weight: 3
 ---
-
-# Developing RediSearch
 
 Developing RediSearch features involves setting up a development environment (which can be either Linux-based or macOS-based), building the module, running tests and benchmarks, and debugging both the module and its tests.
 

--- a/content/develop/interact/search-and-query/deprecated/payloads.md
+++ b/content/develop/interact/search-and-query/deprecated/payloads.md
@@ -11,12 +11,9 @@ categories:
 - clients
 description: Payload support(deprecated)
 linkTitle: Payload
-title: Payload
+title: Document payloads
 weight: 12
 ---
-
-# Document payloads
-
 
 {{% alert title="Warning" color="warning" %}}
 The payload feature is deprecated in 2.0

--- a/content/develop/reference/modules/_index.md
+++ b/content/develop/reference/modules/_index.md
@@ -205,7 +205,7 @@ This allows the module to check if a function exists before using it:
 In recent versions of `redismodule.h`, a convenience macro `RMAPI_FUNC_SUPPORTED(funcname)` is defined.
 Using the macro or just comparing with NULL is a matter of personal preference.
 
-# Passing configuration parameters to Redis modules
+## Passing configuration parameters to Redis modules
 
 When the module is loaded with the [`MODULE LOAD`]({{< relref "/commands/module-load" >}}) command, or using the
 `loadmodule` directive in the `redis.conf` file, the user is able to pass

--- a/content/integrate/redis-data-integration/write-behind/installation/install-redis-gears.md
+++ b/content/integrate/redis-data-integration/write-behind/installation/install-redis-gears.md
@@ -16,8 +16,6 @@ type: integration
 weight: 70
 ---
 
-# RedisGears installation
-
 RDI requires that [RedisGears](https://redis.com/modules/redis-gears) module with the [Python plugin](https://docs.redis.com/latest/modules/redisgears/python/) is installed on the Redis Enterprise cluster.
 
 The Python plugin can be installed explicitly or alongside with the [JVM plugin](https://docs.redis.com/latest/modules/redisgears/jvm/) if the latter is needed on the cluster for other purposes.

--- a/content/integrate/redis-data-integration/write-behind/reference/config-yaml-reference.md
+++ b/content/integrate/redis-data-integration/write-behind/reference/config-yaml-reference.md
@@ -17,7 +17,7 @@ type: integration
 weight: 10
 ---
 
-# Redis Data Integration Configuration File
+## Redis Data Integration Configuration File
 
 **Properties**
 
@@ -28,7 +28,7 @@ weight: 10
 
 <a name="applier"></a>
 
-## applier: Configuration details of Redis Data Integration Applier Gear
+### applier: Configuration details of Redis Data Integration Applier Gear
 
 **Properties**
 
@@ -53,7 +53,7 @@ weight: 10
 **Additional Properties:** not allowed  
 <a name="connections"></a>
 
-## connections: Connections
+### connections: Connections
 
 **Properties (Pattern)**
 

--- a/content/operate/oss_and_stack/management/optimization/benchmarks/index.md
+++ b/content/operate/oss_and_stack/management/optimization/benchmarks/index.md
@@ -325,7 +325,7 @@ the generated log file on a remote filesystem.
 instance using INFO at regular interval to gather statistics is probably fine,
 but MONITOR will impact the measured performance significantly.
 
-# Benchmark results on bare-metal servers across different Redis versions.
+## Benchmark results on bare-metal servers across different Redis versions.
 
 It is critically important that Redis performance is retained or improved seamlessly on every released version. 
 
@@ -357,7 +357,7 @@ Below we present the obtained results, broken by data type.
 ![Sets performance over versions](./performance-sets.png)
 
 ![Sorted sets performance over versions](./performance-sorted-sets.png)
-# Other Redis benchmarking tools
+## Other Redis benchmarking tools
 
 There are several third-party tools that can be used for benchmarking Redis. Refer to each tool's
 documentation for more information about its goals and capabilities.

--- a/content/operate/oss_and_stack/management/optimization/benchmarks/index.md
+++ b/content/operate/oss_and_stack/management/optimization/benchmarks/index.md
@@ -325,7 +325,7 @@ the generated log file on a remote filesystem.
 instance using INFO at regular interval to gather statistics is probably fine,
 but MONITOR will impact the measured performance significantly.
 
-## Benchmark results on bare-metal servers across different Redis versions.
+## Benchmark results on bare-metal servers across different Redis versions
 
 It is critically important that Redis performance is retained or improved seamlessly on every released version. 
 

--- a/content/operate/oss_and_stack/reference/internals/rdd.md
+++ b/content/operate/oss_and_stack/reference/internals/rdd.md
@@ -12,16 +12,16 @@ weight: 2
 
 **Note: this document was written by the creator of Redis, Salvatore Sanfilippo, early in the development of Redis (c. 2013), as part of a series of design drafts. This is preserved for historical interest.**
 
-# Redis Design Draft 2 -- RDB version 7 info fields
+## Redis Design Draft 2 -- RDB version 7 info fields
 
 * Author: Salvatore Sanfilippo `antirez@gmail.com`
 * GitHub issue [#1048](https://github.com/redis/redis/issues/1048)
 
-## History of revisions
+### History of revisions
 
 1.0, 10 April 2013 - Initial draft.
 
-## Overview
+### Overview
 
 The Redis RDB format lacks a simple way to add info fields to an RDB file
 without causing a backward compatibility issue even if the added meta data
@@ -47,7 +47,7 @@ However currently the info fields are designed to only hold additional
 information that are not useful to load the dataset, but can better specify
 how the RDB file was created.
 
-## Info fields representation
+### Info fields representation
 
 The RDB format 6 has the following layout:
 
@@ -81,24 +81,24 @@ ordering.
 The special identifier 0 means that there are no other info fields, and that
 the remaining of the RDB file contains the key-value pairs.
 
-## Handling of info fields
+### Handling of info fields
 
 A program can simply skip every info field it does not understand, as long
 as the RDB version matches the one that it is capable to load.
 
-## Specification of info fields IDs and content.
+### Specification of info fields IDs and content.
 
-### Info field 0 -- End of info fields
+#### Info field 0 -- End of info fields
 
 This just means there are no longer info fields to process.
 
-### Info field 1 -- Creation date
+#### Info field 1 -- Creation date
 
 This field represents the unix time at which the RDB file was created.
 The format of the unix time is a 64 bit little endian integer representing
 seconds since 1th January 1970.
 
-### Info field 2 -- Redis version
+#### Info field 2 -- Redis version
 
 This field represents a null-terminated string containing the Redis version
 that generated the file, as displayed in the Redis version INFO field.

--- a/content/operate/oss_and_stack/stack-with-enterprise/deprecated-features/triggers-and-functions/Configuration.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/deprecated-features/triggers-and-functions/Configuration.md
@@ -37,9 +37,9 @@ Example:
 OK
 ```
 
-# Configurations
+## Configurations
 
-## execution-threads
+### execution-threads
 
 The `execution-threads` configuration option controls the number of background threads that run JS code. **Note that libraries are considered single threaded**. This configuration allows Redis to parallelize the invocation of multiple libraries.
 
@@ -63,7 +63,7 @@ _Runtime Configurability_
 
 No
 
-## library-fatal-failure-policy
+### library-fatal-failure-policy
 
 The `library-fatal-failure-policy` configuration option controls how to handle a fatal error. A fatal error is consider one of the following:
 
@@ -88,7 +88,7 @@ _Runtime Configurability_
 
 Yes
 
-## v8-maxmemory
+### v8-maxmemory
 
 The `v8-maxmemory` configuration option controls the maximum amount of memory used by all V8 libraries. Exceeding this limit is considered a fatal error and will be handled base on the [library-fatal-failure-policy](#library-fatal-failure-policy) configuration value.
 
@@ -112,7 +112,7 @@ _Runtime Configurability_
 
 No
 
-## v8-library-initial-memory-usage
+### v8-library-initial-memory-usage
 
 The `v8-library-initial-memory-usage` configuration option controls the initial memory given to a single V8 library. This value can not be greater then [`v8-library-initial-memory-limit`](#v8-library-initial-memory-limit) or [v8-maxmemory](#v8-maxmemory).
 
@@ -136,7 +136,7 @@ _Runtime Configurability_
 
 No
 
-## v8-library-initial-memory-limit
+### v8-library-initial-memory-limit
 
 The `v8-library-initial-memory-limit` configuration option controls the initial memory limit on a single V8 library. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
 
@@ -160,7 +160,7 @@ _Runtime Configurability_
 
 No
 
-## v8-library-memory-usage-delta
+### v8-library-memory-usage-delta
 
 The `v8-library-memory-usage-delta` configuration option controls the delta by which we will increase the V8 library memory limit once the limit reached. This value can not be greater then [v8-maxmemory](#v8-maxmemory).
 
@@ -184,7 +184,7 @@ _Runtime Configurability_
 
 No
 
-## lock-redis-timeout
+### lock-redis-timeout
 
 The `lock-redis-timeout` configuration option controls the maximum amount of time (in MS) a library can lock Redis. Exceeding this limit is considered a fatal error and will be handled based on the [library-fatal-failure-policy](#library-fatal-failure-policy) configuration value. This
 configuration only affects library loading at runtime with `TFUNCTION LOAD`.
@@ -212,14 +212,14 @@ _Runtime Configurability_
 
 Yes
 
-### Side effects
+#### Side effects
 
 When setting `lock-redis-timeout`, if the new value is higher than the
 `db-loading-lock-redis-timeout`, the `db-loading-lock-redis-timeout` is also updated to
 this value.
 
 
-## db-loading-lock-redis-timeout
+### db-loading-lock-redis-timeout
 
 This timeout configuration is used for setting the upper time limit
 (in milliseconds) for the library loading from RDB.
@@ -245,12 +245,12 @@ _Runtime Configurability_
 
 Yes
 
-### Notes
+#### Notes
 
 The value cannot be lower than the value of `lock-redis-timeout`.
 
 
-## remote-task-default-timeout
+### remote-task-default-timeout
 
 The `remote-task-default-timeout` configuration option controls the timeout when waiting for a remote task to finish. If the timeout is reached an error will result.
 
@@ -274,7 +274,7 @@ _Runtime Configurability_
 
 Yes
 
-## error-verbosity
+### error-verbosity
 
 The `error-verbosity` configuration option controls the verbosity of error messages that will be provided by triggers and functions. The higher the value the more verbose the error messages will be (for example, including stack traces and extra information for better analysis and debugging).
 

--- a/content/operate/redisinsight/proxy.md
+++ b/content/operate/redisinsight/proxy.md
@@ -4,10 +4,9 @@ categories:
 - operate
 - redisinsight
 linkTitle: Proxy settings
-title: Redis Insight proxy
+title: Subpath proxy
 weight: 7
 ---
-# Subpath proxy
 
 {{<note>}}
 Subpath proxy is available only on the Docker version.


### PR DESCRIPTION
DOC-3962

H1 elements that are not the article's title break our search and copilot. I went in and got as many as I could find. 