### PR TITLE
DEV: flesh out FT.INFO page

### DIFF
--- a/content/commands/ft.info/index.md
+++ b/content/commands/ft.info/index.md
@@ -29,129 +29,227 @@ syntax_str: ''
 title: FT.INFO
 ---
 
-Return information and statistics on the index
+Returns information and statistics about a given index.
 
 [Examples](#examples)
 
 ## Required arguments
 
-<details open>
-<summary><code>index</code></summary>
+`index`
+<br />
+is the name of the given index. You must first create the index using [`FT.CREATE`]({{< baseurl >}}/commands/ft.create/).
 
-is full-text index name. You must first create the index using [`FT.CREATE`]({{< baseurl >}}/commands/ft.create/).
-</details>
+## RESP reply
 
-## Return
+`FT.INFO` returns an array reply with pairs of keys and values.
 
-FT.INFO returns an array reply with pairs of keys and values.
+## Returned values
 
-Returned values include:
+### General
 
-- `index_definition`: reflection of [`FT.CREATE`]({{< baseurl >}}/commands/ft.create/) command parameters.
-- `fields`: index schema - field names, types, and attributes.
-- Number of documents.
-- Number of distinct terms.
-- Average bytes per record.
-- Size and capacity of the index buffers.
-- Indexing state and percentage as well as failures:
-  - `indexing`: whether of not the index is being scanned in the background.
-  - `percent_indexed`: progress of background indexing (1 if complete).
-  - `hash_indexing_failures`: number of failures due to operations not compatible with index schema.
+| Return field name | Definition |
+|:---               |:---        |
+| `index_name` | The index name that was defined when index was created. |
+| `index_options` | The index options selected during `FT.CREATE` such as `FILTER {filter}`, `LANGUAGE {default_lang}`, etc. |
+| `index_definition` | Includes `key_type`, hash or JSON; `prefixes`, if any; and `default_score`. |
+| `attributes` | The index schema field names, types, and attributes. |
+| `num_docs` | The number of documents. |
+| `max_doc_id` | The maximum document ID. |
+| `num_terms` | The number of distinct terms. |
+| `num_records` | The total number of records. |
 
-Optional statistics include:
+### Various size statistics
 
-* `garbage collector` for all options other than NOGC.
-* `cursors` if a cursor exists for the index.
-* `stopword lists` if a custom stopword list is used.
+| Statistic | Definition |
+|:---       |:---        |
+| `inverted_sz_mb` | The memory used by the inverted index, which is the core data structure used for searching in RediSearch. The size is given in megabytes. |
+| `vector_index_sz_mb` | The memory used by the vector index, which stores any vectors associated with each document. |
+| `total_inverted_index_blocks` | The total number of blocks in the inverted index. |
+| `offset_vectors_sz_mb` | The memory used by the offset vectors, which store positional information for terms in documents. |
+| `doc_table_size_mb` | The memory used by the document table, which contains metadata about each document in the index. |
+| `sortable_values_size_mb` | The memory used by sortable values, which are values associated with documents and used for sorting purposes. |
+| `key_table_size_mb` | The memory used by the key table, which stores the mapping between document IDs and Redis keys. |
+| `geoshapes_sz_mb` | The memory used by GEO-related fields. |
+| `records_per_doc_avg` | The average number of records (including deletions) per document. |
+| `bytes_per_record_avg` | The average size of each record in bytes. |
+| `offsets_per_term_avg` | The average number of offsets (position information) per term. |
+| `offset_bits_per_record_avg` | The average number of bits used for offsets per record. |
 
-## Examples
+### Indexing-related statistics
+
+| Statistic | Definition |
+|:---       |:---        |
+| `hash_indexing_failures` | The number of failures encountered during indexing. |
+| `total_indexing_time` | The total time is taken for indexing in seconds. |
+| `indexing` | Indicates whether the index is currently being indexed. |
+| `percent_indexed` | The percentage of the index that has been successfully indexed. |
+| `number_of_uses` | The number of times the index has been used. |
+| `cleaning` | DWD need def'n |
+
+### Garbage collection statistics
+
+| Statistic | Definition |
+|:---       |:---        |
+| `bytes_collected` | The number of bytes collected during garbage collection. |
+| `total_ms_run` | The total time in milliseconds spent on garbage collection. |
+| `total_cycles` | The total number of garbage collection cycles. |
+| `average_cycle_time_ms` | The average time in milliseconds for each garbage collection cycle. The value `nan` indicates that the average cycle time is not available. |
+| `last_run_time_ms` | The time in milliseconds taken by the last garbage collection run. |
+
+The next two GC-related fields are relevant in scenarios where simultaneous changes occurred in the same memory area by both the parent process and the child process, resulting in the parent discarding these changes.
+
+| Statistic | Definition |
+|:---       |:---        |
+| `gc_numeric_trees_missed` | The number of numeric tree nodes whose changes were discarded due to splitting by the parent process during garbage collection. |
+| `gc_blocks_denied` | The number of blocks whose changes were discarded (skipped) because they were modified by the parent process during the garbage collection. Notably, as inverted index blocks are append-only, only the last block of an inverted index can be skipped. |
+
+### Cursor statistics
+
+| Statistic | Definition |
+|:---       |:---        |
+| `global_idle` | The number of idle cursors in the system. |
+| `global_total` | The total number of cursors in the system. |
+| `index_capacity` | The maximum number of cursors allowed per index. |
+| `index_total` | The total number of cursors open on the index. |
+
+### Other statistics
+
+- Dialect statistics: the number of times the index was searched using each DIALECT, 1 - 4.
+- Index error statistics, including `indexing failures`, `last indexing error`, and `last indexing error key`.
+- Field statistics, including `indexing failures`, `last indexing error`, and `last indexing error key` for each schema field.
+
+## Example
 
 <details open>
 <summary><b>Return statistics about an index</b></summary>
 
 {{< highlight bash >}}
-127.0.0.1:6379> FT.INFO idx
-1) index_name
- 2) wikipedia
+127.0.0.1:6379> ft.info idx:bicycle
+ 1) index_name
+ 2) idx:bicycle
  3) index_options
  4) (empty array)
-    11) score_field
-    12) __score
-    13) payload_field
-    14) __payload
- 7) fields
- 8) 1) 1) title
-       2) type
-       3) TEXT
-       4) WEIGHT
-       5) "1"
-       6) SORTABLE
-    2) 1) body
-       2) type
-       3) TEXT
-       4) WEIGHT
-       5) "1"
-    3) 1) id
-       2) type
-       3) NUMERIC
-    4) 1) subject location
-       2) type
-       3) GEO
+ 5) index_definition
+ 6) 1) key_type
+    2) JSON
+    3) prefixes
+    4) 1) bicycle:
+    5) default_score
+    6) "1"
+ 7) attributes
+ 8) 1) 1) identifier
+       2) $.pickup_zone
+       3) attribute
+       4) pickup_zone
+       5) type
+       6) GEOSHAPE
+       7) coord_system
+       8) SPHERICAL
+    2) 1) identifier
+       2) $.store_location
+       3) attribute
+       4) store_location
+       5) type
+       6) GEO
+    3) 1) identifier
+       2) $.brand
+       3) attribute
+       4) brand
+       5) type
+       6) TEXT
+       7) WEIGHT
+       8) "1"
+    4) 1) identifier
+       2) $.model
+       3) attribute
+       4) model
+       5) type
+       6) TEXT
+       7) WEIGHT
+       8) "1"
+    5) 1) identifier
+       2) $.description
+       3) attribute
+       4) description
+       5) type
+       6) TEXT
+       7) WEIGHT
+       8) "1"
+    6) 1) identifier
+       2) $.price
+       3) attribute
+       4) price
+       5) type
+       6) NUMERIC
+    7) 1) identifier
+       2) $.condition
+       3) attribute
+       4) condition
+       5) type
+       6) TAG
+       7) SEPARATOR
+       8) ,
  9) num_docs
-10) "0"
+10) "10"
 11) max_doc_id
-12) "345678"
+12) "10"
 13) num_terms
-14) "691356"
+14) "546"
 15) num_records
-16) "0"
+16) "692"
 17) inverted_sz_mb
-18) "0"
+18) "0.003993034362792969"
 19) vector_index_sz_mb
 20) "0"
 21) total_inverted_index_blocks
-22) "933290"
+22) "551"
 23) offset_vectors_sz_mb
-24) "0.65932846069335938"
+24) "7.047653198242188e-4"
 25) doc_table_size_mb
-26) "29.893482208251953"
+26) "7.152557373046875e-4"
 27) sortable_values_size_mb
-28) "11.432285308837891"
+28) "0"
 29) key_table_size_mb
-30) "1.239776611328125e-05"
-31) records_per_doc_avg
-32) "-nan"
-33) bytes_per_record_avg
-34) "-nan"
-35) offsets_per_term_avg
-36) "inf"
-37) offset_bits_per_record_avg
-38) "8"
-39) hash_indexing_failures
-40) "0"
-41) indexing
+30) "3.0422210693359375e-4"
+31) geoshapes_sz_mb
+32) "0.00426483154296875"
+33) records_per_doc_avg
+34) "69.19999694824219"
+35) bytes_per_record_avg
+36) "6.0505781173706055"
+37) offsets_per_term_avg
+38) "1.0679190158843994"
+39) offset_bits_per_record_avg
+40) "8"
+41) hash_indexing_failures
 42) "0"
-43) percent_indexed
-44) "1"
-45) number_of_uses
-46) 1
-47) gc_stats
-48)  1) bytes_collected
-     2) "4148136"
+43) total_indexing_time
+44) "4.539999961853027"
+45) indexing
+46) "0"
+47) percent_indexed
+48) "1"
+49) number_of_uses
+50) (integer) 1
+51) cleaning
+52) (integer) 0
+53) gc_stats
+54)  1) bytes_collected
+     2) "0"
      3) total_ms_run
-     4) "14796"
+     4) "0"
      5) total_cycles
-     6) "1"
+     6) "0"
      7) average_cycle_time_ms
-     8) "14796"
+     8) "nan"
      9) last_run_time_ms
-    10) "14796"
+    10) "0"
     11) gc_numeric_trees_missed
     12) "0"
     13) gc_blocks_denied
     14) "0"
-49) cursor_stats
-50) 1) global_idle
+55) cursor_stats
+56) 1) global_idle
     2) (integer) 0
     3) global_total
     4) (integer) 0
@@ -159,10 +257,100 @@ Optional statistics include:
     6) (integer) 128
     7) index_total
     8) (integer) 0
-51) stopwords_list
-52) 1) "tlv"
-    2) "summer"
-    3) "2020"
+57) dialect_stats
+58) 1) dialect_1
+    2) (integer) 0
+    3) dialect_2
+    4) (integer) 0
+    5) dialect_3
+    6) (integer) 0
+    7) dialect_4
+    8) (integer) 0
+59) Index Errors
+60) 1) indexing failures
+    2) (integer) 0
+    3) last indexing error
+    4) N/A
+    5) last indexing error key
+    6) "N/A"
+61) field statistics
+62) 1) 1) identifier
+       2) $.pickup_zone
+       3) attribute
+       4) pickup_zone
+       5) Index Errors
+       6) 1) indexing failures
+          2) (integer) 0
+          3) last indexing error
+          4) N/A
+          5) last indexing error key
+          6) "N/A"
+    2) 1) identifier
+       2) $.store_location
+       3) attribute
+       4) store_location
+       5) Index Errors
+       6) 1) indexing failures
+          2) (integer) 0
+          3) last indexing error
+          4) N/A
+          5) last indexing error key
+          6) "N/A"
+    3) 1) identifier
+       2) $.brand
+       3) attribute
+       4) brand
+       5) Index Errors
+       6) 1) indexing failures
+          2) (integer) 0
+          3) last indexing error
+          4) N/A
+          5) last indexing error key
+          6) "N/A"
+    4) 1) identifier
+       2) $.model
+       3) attribute
+       4) model
+       5) Index Errors
+       6) 1) indexing failures
+          2) (integer) 0
+          3) last indexing error
+          4) N/A
+          5) last indexing error key
+          6) "N/A"
+    5) 1) identifier
+       2) $.description
+       3) attribute
+       4) description
+       5) Index Errors
+       6) 1) indexing failures
+          2) (integer) 0
+          3) last indexing error
+          4) N/A
+          5) last indexing error key
+          6) "N/A"
+    6) 1) identifier
+       2) $.price
+       3) attribute
+       4) price
+       5) Index Errors
+       6) 1) indexing failures
+          2) (integer) 0
+          3) last indexing error
+          4) N/A
+          5) last indexing error key
+          6) "N/A"
+    7) 1) identifier
+       2) $.condition
+       3) attribute
+       4) condition
+       5) Index Errors
+       6) 1) indexing failures
+          2) (integer) 0
+          3) last indexing error
+          4) N/A
+          5) last indexing error key
+          6) "N/A"
 {{< / highlight >}}
 </details>
 
@@ -173,4 +361,3 @@ Optional statistics include:
 ## Related topics
 
 [RediSearch]({{< relref "/develop/interact/search-and-query/" >}})
-

--- a/content/commands/ft.info/index.md
+++ b/content/commands/ft.info/index.md
@@ -82,7 +82,7 @@ is the name of the given index. You must first create the index using [`FT.CREAT
 | `indexing` | Indicates whether the index is currently being generated. |
 | `percent_indexed` | The percentage of the index that has been successfully generated. |
 | `number_of_uses` | The number of times the index has been used. |
-| `cleaning` | DWD need def'n |
+| `cleaning` | The index deletion flag. A value of `1` is an indication that index deletion is in progress. |
 
 ### Garbage collection statistics
 

--- a/content/commands/ft.info/index.md
+++ b/content/commands/ft.info/index.md
@@ -78,9 +78,9 @@ is the name of the given index. You must first create the index using [`FT.CREAT
 | Statistic | Definition |
 |:---       |:---        |
 | `hash_indexing_failures` | The number of failures encountered during indexing. |
-| `total_indexing_time` | The total time is taken for indexing in seconds. |
-| `indexing` | Indicates whether the index is currently being indexed. |
-| `percent_indexed` | The percentage of the index that has been successfully indexed. |
+| `total_indexing_time` | The total time taken for indexing in seconds. |
+| `indexing` | Indicates whether the index is currently being generated. |
+| `percent_indexed` | The percentage of the index that has been successfully generated. |
 | `number_of_uses` | The number of times the index has been used. |
 | `cleaning` | DWD need def'n |
 
@@ -94,7 +94,7 @@ is the name of the given index. You must first create the index using [`FT.CREAT
 | `average_cycle_time_ms` | The average time in milliseconds for each garbage collection cycle. The value `nan` indicates that the average cycle time is not available. |
 | `last_run_time_ms` | The time in milliseconds taken by the last garbage collection run. |
 
-The next two GC-related fields are relevant in scenarios where simultaneous changes occurred in the same memory area by both the parent process and the child process, resulting in the parent discarding these changes.
+The next two GC-related fields are relevant in scenarios where simultaneous changes occurred in the same memory area for both the parent process and the child process, resulting in the parent discarding these changes.
 
 | Statistic | Definition |
 |:---       |:---        |

--- a/content/commands/ft.info/index.md
+++ b/content/commands/ft.info/index.md
@@ -82,7 +82,7 @@ is the name of the given index. You must first create the index using [`FT.CREAT
 | `indexing` | Indicates whether the index is currently being generated. |
 | `percent_indexed` | The percentage of the index that has been successfully generated. |
 | `number_of_uses` | The number of times the index has been used. |
-| `cleaning` | The index deletion flag. A value of `1` is an indication that index deletion is in progress. |
+| `cleaning` | The index deletion flag. A value of `1` indicates index deletion is in progress. |
 
 ### Garbage collection statistics
 

--- a/content/commands/ft.info/index.md
+++ b/content/commands/ft.info/index.md
@@ -31,8 +31,6 @@ title: FT.INFO
 
 Returns information and statistics about a given index.
 
-[Examples](#examples)
-
 ## Required arguments
 
 `index`


### PR DESCRIPTION
Field definitions are [here](https://redislabs.atlassian.net/wiki/spaces/DX/pages/3832414265/FT.INFO+Interpretation+Guide).

@joeywhelan Would it be possible for you to provide a definition for `cleaning`, one of the return values? Right now, I just have a placeholder where its definition should be, "DWD need def'n".