### PR TITLE
DOC-1999 improve argument description

### DIFF
--- a/content/commands/wait/index.md
+++ b/content/commands/wait/index.md
@@ -36,9 +36,11 @@ syntax_fmt: WAIT numreplicas timeout
 syntax_str: timeout
 title: WAIT
 ---
+
 This command blocks the current client until all the previous write commands
-are successfully transferred and acknowledged by at least the specified number
-of replicas. If the timeout, specified in milliseconds, is reached, the command
+are successfully transferred and acknowledged by at least the number
+of replicas you specify in the `numreplicas` argument. If the value
+you specify for the `timeout` argument (in milliseconds) is reached, the command
 returns even if the specified number of replicas were not yet reached.
 
 The command **will always return** the number of replicas that acknowledged


### PR DESCRIPTION
[DOC-1999](https://redislabs.atlassian.net/browse/DOC-1999)
The argument spec under Syntax seems to have been fixed already.

[DOC-1999]: https://redislabs.atlassian.net/browse/DOC-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ