### PR TITLE
DOC-1993 switched to lowercase for geo units

### DIFF
--- a/content/commands/geodist/index.md
+++ b/content/commands/geodist/index.md
@@ -67,8 +67,8 @@ key_specs:
 linkTitle: GEODIST
 since: 3.2.0
 summary: Returns the distance between two members of a geospatial index.
-syntax_fmt: GEODIST key member1 member2 [M | KM | FT | MI]
-syntax_str: member1 member2 [M | KM | FT | MI]
+syntax_fmt: GEODIST key member1 member2 [m | km | ft | mi]
+syntax_str: member1 member2 [m | km | ft | mi]
 title: GEODIST
 ---
 Return the distance between two members in the geospatial index represented by the sorted set.

--- a/content/commands/georadius/index.md
+++ b/content/commands/georadius/index.md
@@ -166,10 +166,10 @@ replaced_by: '[`GEOSEARCH`]({{< relref "/commands/geosearch" >}}) and [`GEOSEARC
 since: 3.2.0
 summary: Queries a geospatial index for members within a distance from a coordinate,
   optionally stores the result.
-syntax_fmt: "GEORADIUS key longitude latitude radius <M | KM | FT | MI>\n  [WITHCOORD]\
+syntax_fmt: "GEORADIUS key longitude latitude radius <m | km | ft | mi>\n  [WITHCOORD]\
   \ [WITHDIST] [WITHHASH] [COUNT\_count [ANY]] [ASC | DESC]\n  [STORE\_key | STOREDIST\_\
   key]"
-syntax_str: "longitude latitude radius <M | KM | FT | MI> [WITHCOORD] [WITHDIST] [WITHHASH]\
+syntax_str: "longitude latitude radius <m | km | ft | mi> [WITHCOORD] [WITHDIST] [WITHHASH]\
   \ [COUNT\_count [ANY]] [ASC | DESC] [STORE\_key | STOREDIST\_key]"
 title: GEORADIUS
 ---

--- a/content/commands/georadius_ro/index.md
+++ b/content/commands/georadius_ro/index.md
@@ -122,9 +122,9 @@ replaced_by: '[`GEOSEARCH`]({{< relref "/commands/geosearch" >}}) with the `BYRA
 since: 3.2.10
 summary: Returns members from a geospatial index that are within a distance from a
   coordinate.
-syntax_fmt: "GEORADIUS_RO key longitude latitude radius <M | KM | FT | MI>\n  [WITHCOORD]\
+syntax_fmt: "GEORADIUS_RO key longitude latitude radius <m | km | ft | mi>\n  [WITHCOORD]\
   \ [WITHDIST] [WITHHASH] [COUNT\_count [ANY]] [ASC | DESC]"
-syntax_str: "longitude latitude radius <M | KM | FT | MI> [WITHCOORD] [WITHDIST] [WITHHASH]\
+syntax_str: "longitude latitude radius <m | km | ft | mi> [WITHCOORD] [WITHDIST] [WITHHASH]\
   \ [COUNT\_count [ANY]] [ASC | DESC]"
 title: GEORADIUS_RO
 ---

--- a/content/commands/georadiusbymember/index.md
+++ b/content/commands/georadiusbymember/index.md
@@ -160,10 +160,10 @@ replaced_by: '[`GEOSEARCH`]({{< relref "/commands/geosearch" >}}) and [`GEOSEARC
 since: 3.2.0
 summary: Queries a geospatial index for members within a distance from a member, optionally
   stores the result.
-syntax_fmt: "GEORADIUSBYMEMBER key member radius <M | KM | FT | MI> [WITHCOORD]\n\
+syntax_fmt: "GEORADIUSBYMEMBER key member radius <m | km | ft | mi> [WITHCOORD]\n\
   \  [WITHDIST] [WITHHASH] [COUNT\_count [ANY]] [ASC | DESC] [STORE\_key\n  | STOREDIST\_\
   key]"
-syntax_str: "member radius <M | KM | FT | MI> [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT\_\
+syntax_str: "member radius <m | km | ft | mi> [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT\_\
   count [ANY]] [ASC | DESC] [STORE\_key | STOREDIST\_key]"
 title: GEORADIUSBYMEMBER
 ---

--- a/content/commands/georadiusbymember_ro/index.md
+++ b/content/commands/georadiusbymember_ro/index.md
@@ -115,9 +115,9 @@ replaced_by: '[`GEOSEARCH`]({{< relref "/commands/geosearch" >}}) with the `BYRA
 since: 3.2.10
 summary: Returns members from a geospatial index that are within a distance from a
   member.
-syntax_fmt: "GEORADIUSBYMEMBER_RO key member radius <M | KM | FT | MI>\n  [WITHCOORD]\
+syntax_fmt: "GEORADIUSBYMEMBER_RO key member radius <m | km | ft | mi>\n  [WITHCOORD]\
   \ [WITHDIST] [WITHHASH] [COUNT\_count [ANY]] [ASC | DESC]"
-syntax_str: "member radius <M | KM | FT | MI> [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT\_\
+syntax_str: "member radius <m | km | ft | mi> [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT\_\
   count [ANY]] [ASC | DESC]"
 title: GEORADIUSBYMEMBER_RO
 ---

--- a/content/commands/geosearch/index.md
+++ b/content/commands/geosearch/index.md
@@ -162,10 +162,10 @@ linkTitle: GEOSEARCH
 since: 6.2.0
 summary: Queries a geospatial index for members inside an area of a box or a circle.
 syntax_fmt: "GEOSEARCH key <FROMMEMBER\_member | FROMLONLAT\_longitude latitude>\n\
-  \  <BYRADIUS\_radius <M | KM | FT | MI> | BYBOX\_width height <M | KM |\n  FT |\
-  \ MI>> [ASC | DESC] [COUNT\_count [ANY]] [WITHCOORD] [WITHDIST]\n  [WITHHASH]"
+  \  <BYRADIUS\_radius <m | km | ft | mi> | BYBOX\_width height <m | km |\n  ft |\
+  \ mi>> [ASC | DESC] [COUNT\_count [ANY]] [WITHCOORD] [WITHDIST]\n  [WITHHASH]"
 syntax_str: "<FROMMEMBER\_member | FROMLONLAT\_longitude latitude> <BYRADIUS\_radius\
-  \ <M | KM | FT | MI> | BYBOX\_width height <M | KM | FT | MI>> [ASC | DESC] [COUNT\_\
+  \ <m | km | ft | mi> | BYBOX\_width height <m | km | ft | mi>> [ASC | DESC] [COUNT\_\
   count [ANY]] [WITHCOORD] [WITHDIST] [WITHHASH]"
 title: GEOSEARCH
 ---

--- a/content/commands/geosearchstore/index.md
+++ b/content/commands/geosearchstore/index.md
@@ -171,10 +171,10 @@ since: 6.2.0
 summary: Queries a geospatial index for members inside an area of a box or a circle,
   optionally stores the result.
 syntax_fmt: "GEOSEARCHSTORE destination source <FROMMEMBER\_member |\n  FROMLONLAT\_\
-  longitude latitude> <BYRADIUS\_radius <M | KM | FT | MI>\n  | BYBOX\_width height\
-  \ <M | KM | FT | MI>> [ASC | DESC] [COUNT\_count\n  [ANY]] [STOREDIST]"
+  longitude latitude> <BYRADIUS\_radius <m | km | ft | mi>\n  | BYBOX\_width height\
+  \ <m | km | ft | mi>> [ASC | DESC] [COUNT\_count\n  [ANY]] [STOREDIST]"
 syntax_str: "source <FROMMEMBER\_member | FROMLONLAT\_longitude latitude> <BYRADIUS\_\
-  radius <M | KM | FT | MI> | BYBOX\_width height <M | KM | FT | MI>> [ASC | DESC]\
+  radius <m | km | ft | mi> | BYBOX\_width height <m | km | ft | mi>> [ASC | DESC]\
   \ [COUNT\_count [ANY]] [STOREDIST]"
 title: GEOSEARCHSTORE
 ---


### PR DESCRIPTION
[DOC-1993](https://redislabs.atlassian.net/browse/DOC-1993)
Some of these commands say in the history that they now support uppercase units but it seemed reasonable to change the syntax docs to keep things consistent.

Also, I assume that the M, KM, etc, in the `token` metadata doesn't need to change just to update the Syntax section?

[DOC-1993]: https://redislabs.atlassian.net/browse/DOC-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ