### PR TITLE
DOC-1103 added links from client pages to OM pages

### DIFF
--- a/content/develop/connect/clients/dotnet.md
+++ b/content/develop/connect/clients/dotnet.md
@@ -21,6 +21,10 @@ to a Redis database.
 
 `NRedisStack` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
+You can also access Redis with an object-mapping client interface. See
+[Redis OM for .NET]({{< relref "/integrate/redisom-for-net" >}})
+for more information.
+
 ## Install
 
 Using the `dotnet` CLI, run:

--- a/content/develop/connect/clients/java/_index.md
+++ b/content/develop/connect/clients/java/_index.md
@@ -9,6 +9,7 @@ categories:
 - oss
 - kubernetes
 - clients
+hideListLinks: true
 description: Connect your application to a Redis database using Java and try an example
 linkTitle: Java
 title: Connect with Redis Java clients
@@ -17,5 +18,10 @@ weight: 4
 
 You have two choices of Java clients that you can use with Redis:
 
-- Jedis, for synchronous applications.
-- Lettuce, for asynchronous and reactive applications.
+-   [Jedis]({{< relref "/develop/connect/clients/java/jedis" >}}), for synchronous applications.
+-   [Lettuce]({{< relref "/develop/connect/clients/java/lettuce" >}}),
+    for asynchronous and reactive applications.
+
+You can also access Redis with an object-mapping client interface. See
+[RedisOM for Java]({{< relref "/integrate/redisom-for-java" >}})
+for more information.

--- a/content/develop/connect/clients/nodejs.md
+++ b/content/develop/connect/clients/nodejs.md
@@ -21,6 +21,10 @@ to a Redis database.
 
 `node-redis` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
+You can also access Redis with an object-mapping client interface. See
+[RedisOM for Node.js]({{< relref "/integrate/redisom-for-node-js" >}})
+for more information.
+
 ## Install
 
 To install node-redis, run:

--- a/content/develop/connect/clients/python.md
+++ b/content/develop/connect/clients/python.md
@@ -21,6 +21,10 @@ to a Redis database.
 
 `redis-py` requires a running Redis or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) server. See [Getting started]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis installation instructions.
 
+You can also access Redis with an object-mapping client interface. See
+[RedisOM for Python]({{< relref "/integrate/redisom-for-python" >}})
+for more information.
+
 ## Install
 
 To install `redis-py`, enter:


### PR DESCRIPTION
[DOC-1103](https://redislabs.atlassian.net/browse/DOC-1103)
The only part of the JIRA issue still relevant is the links from the ordinary client pages to the OM pages. It only asks for Node.js but it makes sense to have similar links for the other clients too.

[DOC-1103]: https://redislabs.atlassian.net/browse/DOC-1103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ