### PR TITLE
Doc 3479 json obtain redis stack

### DIFF
--- a/content/develop/data-types/json/_index.md
+++ b/content/develop/data-types/json/_index.md
@@ -144,125 +144,13 @@ $ redis-cli --raw
 
 ## Enable Redis JSON
 
-Redis JSON is implemented as a module that extends the basic Redis server.
-Redis Stack and Redis Enterprise include this module by default but you can
-also load it dynamically if it isn't already available. The sections below
-the different ways you can access Redis JSON.
-
-### Run with Docker
-
-To run RedisJSON with Docker, use the `redis-stack-server` Docker image:
-
-```sh
-$ docker run -d --name redis-stack-server -p 6379:6379 redis/redis-stack-server:latest
-```
-
-For more information about running Redis Stack in a Docker container, see [Run Redis Stack on Docker]({{< relref "/operate/oss_and_stack/install/install-stack/docker" >}}).
-
-### Download binaries
-
-To download and run the RedisJSON module that provides the JSON data structure from a precompiled binary:
-
-1. Download a precompiled version from the [Redis download center](https://redis.io/downloads).
-
-2. Load the module it in Redis
-
-    ```sh
-    $ redis-server --loadmodule /path/to/module/src/rejson.so
-    ```
-
-### Build from source
-
-To build RedisJSON from the source code:
-
-1. Clone the [repository](https://github.com/RedisJSON/RedisJSON) (make sure you include the `--recursive` option to properly clone submodules):
-
-    ```sh
-    $ git clone --recursive https://github.com/RedisJSON/RedisJSON.git
-    $ cd RedisJSON
-    ```
-
-2. Install dependencies:
-
-    ```sh
-    $ ./sbin/setup
-    ```
-
-3. Build:
-    ```sh
-    $ make build
-    ```
-
-### Load the module to Redis
-
-Requirements:
-
-Generally, it is best to run the latest Redis version.
-
-If your OS has a [Redis 6.x package or later](http://redis.io/downloads), you can install it using the OS package manager.
-
-Otherwise, you can invoke 
-
-```sh
-$ ./deps/readies/bin/getredis
-```
-
-To load the RedisJSON module, use one of the following methods:
-
-* [Makefile recipe](#makefile-recipe)
-* [Configuration file](#configuration-file)
-* [Command-line option](#command-line-option)
-* [MODULE LOAD command]({{< relref "/commands/module-load" >}})
-
-#### Makefile recipe
-
-Run Redis with RedisJSON:
-
-```sh
-$ make run
-```
-
-#### Configuration file
-
-Or you can have Redis load the module during startup by adding the following to your `redis.conf` file:
-
-```
-loadmodule /path/to/module/target/release/librejson.so
-```
-
-On Mac OS, if this module was built as a dynamic library, run:
-
-```
-loadmodule /path/to/module/target/release/librejson.dylib
-```
-
-In the above lines replace `/path/to/module/` with the actual path to the module.
-
-#### Command-line option
-
-You can also have Redis load the module using the following command-line argument syntax:
-
- ```bash
- $ redis-server --loadmodule /path/to/module/librejson.so
- ```
-
-In the above lines replace `/path/to/module/` with the actual path to the module's library.
-
-#### [`MODULE LOAD`]({{< relref "/commands/module-load" >}}) command
-
-You can also use the [`MODULE LOAD`]({{< relref "/commands/module-load" >}}) command to load RedisJSON. Note that [`MODULE LOAD`]({{< relref "/commands/module-load" >}}) is a **dangerous command** and may be blocked/deprecated in the future due to security considerations.
-
-After the module has been loaded successfully, the Redis log should have lines similar to:
-
-```
-...
-9:M 11 Aug 2022 16:24:06.701 * <ReJSON> version: 20009 git sha: d8d4b19 branch: HEAD
-9:M 11 Aug 2022 16:24:06.701 * <ReJSON> Exported RedisJSON_V1 API
-9:M 11 Aug 2022 16:24:06.701 * <ReJSON> Enabled diskless replication
-9:M 11 Aug 2022 16:24:06.701 * <ReJSON> Created new data type 'ReJSON-RL'
-9:M 11 Aug 2022 16:24:06.701 * Module 'ReJSON' loaded from /opt/redis-stack/lib/rejson.so
-...
-```
+Redis JSON is not available by default in the basic Redis server, so you
+should install Redis Stack or Redis Enterprise,
+both of which include JSON and other useful modules.
+See
+[Install Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
+[Install Redis Enterprise]({{< relref "/operate/rs/installing-upgrading/install" >}})
+for full installation instructions.
 
 ## Limitation
 

--- a/content/develop/data-types/probabilistic/_index.md
+++ b/content/develop/data-types/probabilistic/_index.md
@@ -14,3 +14,18 @@ linkTitle: Probabilistic
 title: Probabilistic
 weight: 140
 ---
+
+*Probabilistic data structures* give approximations of statistics such as
+counts, frequencies, and rankings rather than precise values.
+The advantage of using approximations is that they are adequate for
+many common purposes but are much more efficient to calculate. They
+sometimes have other advantages too, such as obfuscating times, locations,
+and other sensitive data.
+
+Probabilistic data structures are not available by default in the basic
+Redis server, so you should install Redis Stack or Redis Enterprise,
+both of which include probabilistic structures and other useful modules.
+See
+[Install Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
+[Install Redis Enterprise]({{< relref "/operate/rs/installing-upgrading/install" >}})
+for full installation instructions.

--- a/content/develop/data-types/timeseries/_index.md
+++ b/content/develop/data-types/timeseries/_index.md
@@ -19,7 +19,15 @@ weight: 150
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/KExRgMb)
 [![Github](https://img.shields.io/static/v1?label=&message=repository&color=5961FF&logo=github)](https://github.com/RedisTimeSeries/RedisTimeSeries/)
 
-Redis Stack (specifically, its RedisTimeSeries module) adds a time series data structure to Redis.
+The *Redis time series* structure lets you store and query timestamped data points.
+
+Redis time series is not available by default in the basic Redis server, so you
+should install Redis Stack or Redis Enterprise,
+both of which include time series and other useful modules.
+See
+[Install Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
+[Install Redis Enterprise]({{< relref "/operate/rs/installing-upgrading/install" >}})
+for full installation instructions.
 
 ## Features
 * High volume inserts, low latency reads

--- a/content/develop/data-types/timeseries/_index.md
+++ b/content/develop/data-types/timeseries/_index.md
@@ -19,7 +19,7 @@ weight: 150
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/KExRgMb)
 [![Github](https://img.shields.io/static/v1?label=&message=repository&color=5961FF&logo=github)](https://github.com/RedisTimeSeries/RedisTimeSeries/)
 
-The *Redis time series* structure lets you store and query timestamped data points.
+The Redis time series structure lets you store and query timestamped data points.
 
 Redis time series is not available by default in the basic Redis server, so you
 should install Redis Stack or Redis Enterprise,

--- a/content/develop/interact/search-and-query/_index.md
+++ b/content/develop/interact/search-and-query/_index.md
@@ -17,7 +17,7 @@ title: Search and query
 weight: 10
 ---
 
-Redis Stack offers an enhanced Redis experience via the following search and query features:
+Redis Search offers an enhanced Redis experience via the following search and query features:
 
 - A rich query language
 - Incremental indexing on JSON and hash documents
@@ -28,7 +28,7 @@ Redis Stack offers an enhanced Redis experience via the following search and que
 
 You can find a complete list of features in the [reference documentation]({{< relref "/develop/interact/search-and-query/advanced-concepts/" >}}).
 
-The search and query features of Redis Stack allow you to use Redis as a:
+The search and query features allow you to use Redis as a:
 
 - Document database
 - Vector database
@@ -40,6 +40,16 @@ Here are the next steps to get you started:
 1. Follow our [quick start guide]({{< relref "/develop/get-started/document-database" >}}) to get some initial hands-on experience.
 2. Learn how to [create an index]({{< relref "/develop/interact/search-and-query/indexing/" >}}).
 3. Learn how to [query your data]({{< relref "/develop/interact/search-and-query/query/" >}}).
+
+## Enable Redis Search
+
+Redis Search is not available by default in the basic Redis server, so you
+should install Redis Stack or Redis Enterprise,
+both of which include Redis Search and other useful modules.
+See
+[Install Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
+[Install Redis Enterprise]({{< relref "/operate/rs/installing-upgrading/install" >}})
+for full installation instructions.
 
 ## License and source code
 


### PR DESCRIPTION
[DOC-3479](https://redislabs.atlassian.net/browse/DOC-3479)
The [current JSON page](https://redis.io/docs/latest/develop/data-types/json/#enable-redis-json) goes into much more detail than the other pages for "optional" modules about how to obtain and install the module. But apparently, the extra info is actually misleading because some people try to jump through hoops installing the module when they probably just wanted to install Redis Stack in the first place.

I've modified the existing pages/sections for JSON and the module features to simply point to the Stack/Enterprise install pages. I've also added some extra description to the probabilistic and time series index pages so that the install info hangs a bit better on the page.

Any other ideas about how to clarify/expand this stuff are more than welcome :-) 


[DOC-3479]: https://redislabs.atlassian.net/browse/DOC-3479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ