### PR TITLE
Update REST API password documentation 

### DIFF
--- a/content/operate/rs/references/rest-api/objects/user.md
+++ b/content/operate/rs/references/rest-api/objects/user.md
@@ -23,7 +23,7 @@ An API object that represents a Redis Enterprise user.
 | email | string | User's email (pattern matching only ASCII characters) |
 | email_alerts | boolean (default:&nbsp;true) | Activate email alerts for a user |
 | name | string | User's name (pattern does not allow non-ASCII and special characters &,\<,>,") |
-| password | string | User's password. Note that it could also be an already hashed value, in which case the `password_hash_method` parameter is also provided. |
+| password | string | User's password. If the `password_hash_method` below is set to `1`, the password should be hashed using sha256. The format before hashing is `username:clustername:password`| 
 | password_hash_method | '1' | Used when password is passed pre-hashed to specify the hashing method |
 | password_issue_date | string | The date in which the password was set (read-only) |
 | role | 'admin'<br />'cluster_member'<br />'cluster_viewer'<br />'db_member'<br /> **'db_viewer'** <br />'none' | User's [role]({{< relref "/operate/rs/references/rest-api/permissions#roles" >}}) |

--- a/content/operate/rs/references/rest-api/objects/user.md
+++ b/content/operate/rs/references/rest-api/objects/user.md
@@ -23,7 +23,7 @@ An API object that represents a Redis Enterprise user.
 | email | string | User's email (pattern matching only ASCII characters) |
 | email_alerts | boolean (default:&nbsp;true) | Activate email alerts for a user |
 | name | string | User's name (pattern does not allow non-ASCII and special characters &,\<,>,") |
-| password | string | User's password. If the `password_hash_method` below is set to `1`, the password should be hashed using sha256. The format before hashing is `username:clustername:password`| 
+| password | string | User's password. If `password_hash_method` is set to `1`, the password should be hashed using SHA-256. The format before hashing is `username:clustername:password`. | 
 | password_hash_method | '1' | Used when password is passed pre-hashed to specify the hashing method |
 | password_issue_date | string | The date in which the password was set (read-only) |
 | role | 'admin'<br />'cluster_member'<br />'cluster_viewer'<br />'db_member'<br /> **'db_viewer'** <br />'none' | User's [role]({{< relref "/operate/rs/references/rest-api/permissions#roles" >}}) |


### PR DESCRIPTION
The current documentation doesn't explain how to hash a password when creating or updating a user. This is a lot to put in a small space, so a shorter explanation might be better.