### PR TITLE
OP: fix a few Hugo warnings

### DIFF
--- a/content/operate/rc/resilient-apps.md
+++ b/content/operate/rc/resilient-apps.md
@@ -74,9 +74,9 @@ Depending on the client, you may be recommended to turn off the DNS cache entire
 
 ### Use the WAIT and WAITAOF commands
 
-The [WAIT]({{< relref "/commands/wait/" >}}) and [WAITAOF]({{< relref "/commands/waitaof/" >}}) commands block the current client until all previous write commands are persisted between replicas. With these commands, your application guarantees that acknowledged writes are recorded between replicas. 
+The [WAIT]({{< relref "/commands/wait" >}}) and [WAITAOF]({{< relref "/commands/waitaof" >}}) commands block the current client until all previous write commands are persisted between replicas. With these commands, your application guarantees that acknowledged writes are recorded between replicas. 
 
-For more info, see [Use the WAIT command for strong consistency]({{< relref "/operate/rs/clusters/optimize/wait/" >}}).
+For more info, see [Use the WAIT command for strong consistency]({{< relref "/operate/rs/clusters/optimize/wait" >}}).
 
 ## More info
 


### PR DESCRIPTION
This PR corrects a few warnings that were introduced by this PR:

https://github.com/redis/docs/pull/288

It's important to pay attention to Hugo warnings, as they usually point to some unwanted behavior. In this case, the affected links, when clicked, took you to the top of the page, not to the command pages.

Also, in general, it's better to get into the habit of using `[<CMD>]({{< baseurl >}}/commands/<cmd>)` for links to command pages. If you try to use relref with a command that has a dot in the name (e.g., FT.SEARCH), relref will tip over.