### PR TITLE
DOC-3988 added separate write-behind rel notes folder

### DIFF
--- a/content/integrate/redis-data-integration/write-behind/release-notes/_index.md
+++ b/content/integrate/redis-data-integration/write-behind/release-notes/_index.md
@@ -17,6 +17,6 @@ type: integration
 weight: 100
 ---
 
-Here's what changed recently in RDI Ingest:
+Here's what changed recently in RDI Write-behind:
 
 {{< table-children columnNames="Version&nbsp;(Release&nbsp;date)&nbsp;,Major changes" columnSources="LinkTitle,Description" enableLinks="LinkTitle" >}}


### PR DESCRIPTION
[DOC-3988](https://redislabs.atlassian.net/browse/DOC-3988)
The eagle-eyed will have noticed that there aren't actually any release notes in the write-behind folder. This PR is just a preparatory step for when the notes arrive and you shouldn't merge it until then.