### PR TITLE
DOC-4012 fix URL in GitHub issue form

### DIFF
--- a/layouts/partials/meta-links.html
+++ b/layouts/partials/meta-links.html
@@ -9,14 +9,10 @@
   {{ $gh_branch := "main" }}
 {{ end }}
 
+{{ $path := replaceRE `(_index.md)$|(index.md)$|(.md)$` "" $gh_file }}
+
 {{ $editURL := printf "%s/edit/%s/content/%s" $gh_repo $gh_branch $gh_file }}
-{{ $path := "" }}
-{{ with .File }}
-{{ $path = .Path }}
-{{ else }}
-{{ $path = .Path }}
-{{ end }}
-{{ $issuesURL := printf "%s/issues/new?title=Feedback: %s&body=Page https://redis.io/docs/latest/%s" $gh_repo (safeURL $.Title ) (path.Dir $path | safeURL )}}
+{{ $issuesURL := printf "%s/issues/new?title=Feedback: %s&body=Page https://redis.io/docs/latest/%s" $gh_repo (safeURL $.Title ) $path }}
 
 <nav class="flex flex-col gap-3 pb-3 w-52 text-redis-pencil-600 border-b border-b-redis-pen-700 border-opacity-50">
   <a {{ printf "href=%q" $editURL | safeHTMLAttr }} target="_blank" class="group inline-flex items-center gap-1  hover:text-redis-pen-400 mt-auto self-start">


### PR DESCRIPTION
Currently the issue url does not work properly for certain pages. For instance, for https://redis.io/docs/latest/develop/connect/clients/java/ the url is correct, but for https://redis.io/docs/latest/develop/connect/clients/java/jedis/ the url isn't correct in that it does not include `jedis`.

With this change, the logic is simplified and a regex replace is used instead to remove either a trailing `_index.md`, `index.md` or `.md` from the url.