### PR TITLE
SITE: eliminate more double-slashes

### DIFF
--- a/content/develop/get-started/vector-database.md
+++ b/content/develop/get-started/vector-database.md
@@ -134,7 +134,7 @@ Iterate over all the Redis keys with the prefix `bikes:`:
 
 {{< clients-example search_vss get_keys />}}
 
-Use the keys as input to the [JSON.MGET]({{< baseurl >}}/commands/json.mget//) command, along with the `$.description` field, to collect the descriptions in a list. Then, pass the list of descriptions to the `.encode()` method:
+Use the keys as input to the [JSON.MGET]({{< baseurl >}}/commands/json.mget/) command, along with the `$.description` field, to collect the descriptions in a list. Then, pass the list of descriptions to the `.encode()` method:
 
 {{< clients-example search_vss generate_embeddings />}}
 

--- a/content/operate/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/operate/kubernetes/reference/supported_k8s_distributions.md
@@ -233,4 +233,4 @@ For details on this platform, see the [TKGI documentation](https://docs.vmware.c
 
 ## Supported upgrade paths
 
-   If you are using a version earlier than 6.2.10-45, [you must upgrade]({{<relref "content/operate/kubernetes/upgrade/">}}) to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.
+   If you are using a version earlier than 6.2.10-45, [you must upgrade]({{< relref "/operate/kubernetes/upgrade" >}}) to 6.2.10-45 before you can upgrade to versions 6.2.18 or later.

--- a/content/operate/rc/changelog/2023/march-2023.md
+++ b/content/operate/rc/changelog/2023/march-2023.md
@@ -24,7 +24,7 @@ A preview of Redis 7.0 is available for [Fixed subscriptions]({{< relref "/opera
 
 The following tables show which new open source Redis 7.0 commands are supported in Redis 7.0 subscriptions.
 
-#### [Cluster management commands]({{< relref "/commands" >}}/?group=cluster)
+#### [Cluster management commands]({{< relref "/commands" >}}?group=cluster)
 
 | <span style="min-width: 10em; display: table-cell">Command</span> | Supported |
 |:--------|:----------|
@@ -33,7 +33,7 @@ The following tables show which new open source Redis 7.0 commands are supported
 | [CLUSTER LINKS]({{< relref "/commands/cluster-links" >}}) | <span title="Not supported">&#x274c; Not supported</span> |
 | [CLUSTER SHARDS]({{< relref "/commands/cluster-shards" >}}) | <span title="Not supported">&#x274c; Not supported</span> |
 
-#### [Connection management commands]({{< relref "/commands" >}}/?group=connection)
+#### [Connection management commands]({{< relref "/commands" >}}?group=connection)
 
 | <span style="min-width: 10em; display: table-cell">Command</span> | Supported |
 |:--------|:----------|
@@ -43,14 +43,14 @@ The following tables show which new open source Redis 7.0 commands are supported
 
 | Data type | Command | Supported |
 |:----------|:--------|:----------|
-| [List]({{< relref "/commands" >}}/?group=list) | [BLMPOP]({{< relref "/commands/blmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
-| [List]({{< relref "/commands" >}}/?group=list) | [LMPOP]({{< relref "/commands/lmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
-| [Set]({{< relref "/commands" >}}/?group=set) | [SINTERCARD]({{< relref "/commands/sintercard" >}}) | <span title="Supported">&#x2705; Supported</span>|
-| [Sorted set]({{< relref "/commands" >}}/?group=sorted-set) | [BZMPOP]({{< relref "/commands/bzmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
-| [Sorted set]({{< relref "/commands" >}}/?group=sorted-set) | [ZINTERCARD]({{< relref "/commands/zintercard" >}}) | <span title="Supported">&#x2705; Supported</span>|
-| [Sorted set]({{< relref "/commands" >}}/?group=sorted-set) | [BZMPOP]({{< relref "/commands/bzmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
+| [List]({{< relref "/commands" >}}?group=list) | [BLMPOP]({{< relref "/commands/blmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
+| [List]({{< relref "/commands" >}}?group=list) | [LMPOP]({{< relref "/commands/lmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
+| [Set]({{< relref "/commands" >}}?group=set) | [SINTERCARD]({{< relref "/commands/sintercard" >}}) | <span title="Supported">&#x2705; Supported</span>|
+| [Sorted set]({{< relref "/commands" >}}?group=sorted-set) | [BZMPOP]({{< relref "/commands/bzmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
+| [Sorted set]({{< relref "/commands" >}}?group=sorted-set) | [ZINTERCARD]({{< relref "/commands/zintercard" >}}) | <span title="Supported">&#x2705; Supported</span>|
+| [Sorted set]({{< relref "/commands" >}}?group=sorted-set) | [BZMPOP]({{< relref "/commands/bzmpop" >}}) | <span title="Supported">&#x2705; Supported</span>|
 
-#### [Keys (generic) commands]({{< relref "/commands" >}}/?group=generic)
+#### [Keys (generic) commands]({{< relref "/commands" >}}?group=generic)
 
 | <span style="min-width: 10em; display: table-cell">Command</span> | Supported |
 |:--------|:----------|
@@ -58,7 +58,7 @@ The following tables show which new open source Redis 7.0 commands are supported
 | [PEXPIRETIME]({{< relref "/commands/pexpiretime" >}}) | <span title="Supported">&#x2705; Supported</span>|
 | [SORT_RO]({{< relref "/commands/sort_ro" >}}) | <span title="Supported">&#x2705; Supported</span>|
 
-#### [Pub/sub commands]({{< relref "/commands" >}}/?group=pubsub)
+#### [Pub/sub commands]({{< relref "/commands" >}}?group=pubsub)
 
 | <span style="min-width: 10em; display: table-cell">Command</span> | Supported |
 |:--------|:----------|
@@ -68,7 +68,7 @@ The following tables show which new open source Redis 7.0 commands are supported
 | [SSUBSCRIBE]({{< relref "/commands/ssubscribe" >}}) | <span title="Not supported">&#x274c; Not supported</span> |
 | [SUNSUBSCRIBE]({{< relref "/commands/sunsubscribe" >}}) | <span title="Not supported">&#x274c; Not supported</span> |
 
-#### [Scripting and function commands]({{< relref "/commands" >}}/?group=scripting)
+#### [Scripting and function commands]({{< relref "/commands" >}}?group=scripting)
 
 | <span style="min-width: 10em; display: table-cell">Command</span> | Supported |
 |:--------|:----------|
@@ -84,7 +84,7 @@ The following tables show which new open source Redis 7.0 commands are supported
 | [FUNCTION RESTORE]({{< relref "/commands/function-restore" >}}) | <span title="Supported">&#x2705; Supported</span>|
 | [FUNCTION STATS]({{< relref "/commands/function-stats" >}}) | <span title="Not supported">&#x274c; Not supported</span> |
 
-#### [Server management commands]({{< relref "/commands" >}}/?group=server)
+#### [Server management commands]({{< relref "/commands" >}}?group=server)
 
 | <span style="min-width: 10em; display: table-cell">Command</span> | Supported |
 |:--------|:----------|

--- a/content/operate/rs/references/compatibility/commands/cluster.md
+++ b/content/operate/rs/references/compatibility/commands/cluster.md
@@ -13,7 +13,7 @@ weight: 10
 
 [Clustering in Redis Enterprise Software]({{< relref "/operate/rs/databases/durability-ha/clustering" >}}) and [Redis Cloud]({{< relref "/operate/rc/databases/configuration/clustering" >}}) differs from the [Redis Community Edition cluster]({{<relref "/operate/oss_and_stack/management/scaling">}}) and works with all standard Redis clients.
 
-Redis Enterprise blocks most [cluster commands]({{< relref "/commands" >}}/?group=cluster). If you try to use a blocked cluster command, it returns an error.
+Redis Enterprise blocks most [cluster commands]({{< relref "/commands" >}}?group=cluster). If you try to use a blocked cluster command, it returns an error.
 
 | Command | Redis<br />Enterprise | Redis<br />Cloud | Notes |
 |:--------|:----------------------|:-----------------|:------|

--- a/content/operate/rs/references/compatibility/commands/connection.md
+++ b/content/operate/rs/references/compatibility/commands/connection.md
@@ -11,7 +11,7 @@ linkTitle: Connection management
 weight: 10
 ---
 
-The following tables show which Redis Community Edition [connection management commands]({{< relref "/commands" >}}/?group=connection) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
+The following tables show which Redis Community Edition [connection management commands]({{< relref "/commands" >}}?group=connection) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
 
 
 | Command | Redis<br />Enterprise | Redis<br />Cloud | Notes |

--- a/content/operate/rs/references/compatibility/commands/generic.md
+++ b/content/operate/rs/references/compatibility/commands/generic.md
@@ -11,7 +11,7 @@ linkTitle: Keys (generic)
 weight: 10
 ---
 
-The following table shows which Redis Community Edition [key (generic) commands]({{< relref "/commands" >}}/?group=generic) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
+The following table shows which Redis Community Edition [key (generic) commands]({{< relref "/commands" >}}?group=generic) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
 
 | Command | Redis<br />Enterprise | Redis<br />Cloud | Notes |
 |:--------|:----------------------|:-----------------|:------|

--- a/content/operate/rs/references/compatibility/commands/pub-sub.md
+++ b/content/operate/rs/references/compatibility/commands/pub-sub.md
@@ -11,7 +11,7 @@ linkTitle: Pub/sub
 weight: 10
 ---
 
-The following table shows which Redis Community Edition [pub/sub commands]({{< relref "/commands" >}}/?group=pubsub) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
+The following table shows which Redis Community Edition [pub/sub commands]({{< relref "/commands" >}}?group=pubsub) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
 
 | Command | Redis<br />Enterprise | Redis<br />Cloud | Notes |
 |:--------|:----------------------|:-----------------|:------|

--- a/content/operate/rs/references/compatibility/commands/scripting.md
+++ b/content/operate/rs/references/compatibility/commands/scripting.md
@@ -11,7 +11,7 @@ linkTitle: Scripting
 weight: 10
 ---
 
-The following table shows which Redis Community Edition [scripting and function commands]({{< relref "/commands" >}}/?group=scripting) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
+The following table shows which Redis Community Edition [scripting and function commands]({{< relref "/commands" >}}?group=scripting) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
 
 ## Function commands
 

--- a/content/operate/rs/references/compatibility/commands/server.md
+++ b/content/operate/rs/references/compatibility/commands/server.md
@@ -12,7 +12,7 @@ toc: 'true'
 weight: 10
 ---
 
-The following tables show which Redis Community Edition [server management commands]({{< relref "/commands" >}}/?group=server) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
+The following tables show which Redis Community Edition [server management commands]({{< relref "/commands" >}}?group=server) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
 
 ## Access control commands
 

--- a/content/operate/rs/references/compatibility/commands/transactions.md
+++ b/content/operate/rs/references/compatibility/commands/transactions.md
@@ -11,7 +11,7 @@ linkTitle: Transactions
 weight: 10
 ---
 
-The following table shows which Redis Community Edition [transaction commands]({{< relref "/commands" >}}/?group=transactions) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
+The following table shows which Redis Community Edition [transaction commands]({{< relref "/commands" >}}?group=transactions) are compatible with standard and Active-Active databases in Redis Enterprise Software and Redis Cloud.
 
 | Command | Redis<br />Enterprise | Redis<br />Cloud | Notes |
 |:--------|:----------------------|:-----------------|:------|


### PR DESCRIPTION
This PR eliminates more double-slashes in URLs issue.

It also fixes a Hugo warning that was introduced in a recent merge.