### PR TITLE
DOC-3970 Add redis_docs_sync workflow

### DIFF
--- a/.github/workflows/redis_docs_sync.yaml
+++ b/.github/workflows/redis_docs_sync.yaml
@@ -1,0 +1,59 @@
+name: redis_docs_sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        type: string
+        required: true
+        description: ''
+
+jobs:
+  redis_docs_sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DOCS_APP_ID }}
+          private-key: ${{ secrets.DOCS_APP_PRIVATE_KEY }}
+
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: 'Generate modules-api-ref.md file and push if necessary'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |-
+          RELEASE="${{ github.event.inputs.release }}"
+          
+          # Generate modules-api-ref.md
+          gh repo clone redis/redis
+          pushd redis
+          git fetch origin --tags
+          git checkout "tags/${RELEASE}"
+          utils/generate-module-api-doc.rb > generated-modules-api-ref.md
+          popd
+
+          mv redis/generated-modules-api-ref.md content/develop/reference/modules/modules-api-ref.md
+
+          # Apply frontmatter patch
+          git apply content/develop/reference/modules/modules-api-ref-frontmatter.patch
+          
+          # Check if there are any changes
+          modules_api_is_different=$(git diff content/develop/reference/modules/modules-api-ref.md)
+
+          # If file has changed, push it to repo
+          if [[ ! -z $modules_api_is_different ]]; then
+            git add content/develop/reference/modules/modules-api-ref.md
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git config user.name "github-actions[bot]"
+            git commit -m "Update modules-api-ref.md for release ${RELEASE}"
+            git push origin main
+          fi


### PR DESCRIPTION
This workflow will be triggered from the `redis/redis` repo on releases. This workflow generates the `modules-api-ref.md` file and pushes it to this repo.