### PR TITLE
DOC-4163 removed Commands tile from home page

### DIFF
--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -120,6 +120,7 @@
       {{ $pages = (where $pages ".Parent" "!=" nil) }}
       {{ $pages = (where $pages "Parent.File.UniqueID" "==" $parent.File.UniqueID) }}
       {{ $pages = (where $pages ".Params.hidden" "!=" true) }}
+      {{ $pages = (where $pages "Kind" "!=" "section") }}
       <div id="commands-grid" class="flex flex-col md:grid grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-4 text-redis-ink-900 mx-auto">
         {{ range $index, $page := $pages }}
           <article 


### PR DESCRIPTION
Very minor - just removed the extra "Commands" tile from the commands home page (it just linked back to the top of the same page).

Staging link: https://redis.io/docs/staging/DOC-4163-spurious-commands-tile/commands/?alpha=c