### PR TITLE
Update _index.md reinforcing that the example is a TOML file.

### DIFF
--- a/content/integrate/redis-data-integration/ingest/installation/_index.md
+++ b/content/integrate/redis-data-integration/ingest/installation/_index.md
@@ -182,7 +182,7 @@ to the installer's questions automatically using properties from a
 
 ### Silent install example
 
-The following example shows the properties for a typical
+The following TOML file example shows the properties for a typical
 silent install configuration:
 
 ```toml


### PR DESCRIPTION
The fact that the example was a TOML file wasn't explicitly stated, so I added adjectives to make it clear what the example file is.