### PR TITLE
Update protocol-spec.md to fix a typo in code comment.

### DIFF
--- a/content/develop/reference/protocol-spec.md
+++ b/content/develop/reference/protocol-spec.md
@@ -689,7 +689,7 @@ int main(void) {
         p++;
     }
 
-    /* Now p points at '\r', and the len is in bulk_len. */
+    /* Now p points at '\r', and the length is in len. */
     printf("%d\n", len);
     return 0;
 }


### PR DESCRIPTION
Fixed the typo in the code comment: 
Previously mentioned 'bulk_len' which was incorrect.  The length is actually stored in the 'len' variable