### PR TITLE
DOC-4214 added troubleshooting page

### DIFF
--- a/content/integrate/redis-data-integration/ingest/architecture.md
+++ b/content/integrate/redis-data-integration/ingest/architecture.md
@@ -119,7 +119,7 @@ with the control plane. Use the CLI tool to install and administer RDI
 and to deploy and manage a pipeline. Use the pipeline editor
 (included in Redis Insight) to design or edit a pipeline. The
 diagram below shows the components of the control and management
-planes and the connections betweeen them:
+planes and the connections between them:
 
 {{< image filename="images/rdi/ingest/ingest-control-plane.png" >}}
 

--- a/content/integrate/redis-data-integration/ingest/installation/_index.md
+++ b/content/integrate/redis-data-integration/ingest/installation/_index.md
@@ -19,6 +19,12 @@ weight: 2
 
 This guide explains how to install RDI and integrate it with your source database.
 
+{{< note >}}RDI v1.2.7 had a CoreDNS issue where in some installations the host DNS could not
+resolve hostnames for the RDI components. This meant that it couldn't connect to the RDI database
+and resume the installation. This problem is fixed in v1.2.8, so we recommend you use this version
+instead of v1.2.7.
+{{< /note >}}
+
 ## Install RDI on VMs
 
 You would normally install RDI on two VMs for high availability (HA) but you can also install

--- a/content/integrate/redis-data-integration/ingest/installation/_index.md
+++ b/content/integrate/redis-data-integration/ingest/installation/_index.md
@@ -20,7 +20,7 @@ weight: 2
 This guide explains how to install RDI and integrate it with your source database.
 
 {{< note >}}RDI v1.2.7 had a CoreDNS issue. In some installations, the host DNS could not
-resolve hostnames for the RDI components. This meant that it couldn't connect to the RDI database
+resolve hostnames for the RDI components. This meant it couldn't connect to the RDI database
 and resume the installation. This problem is fixed in v1.2.8, so we recommend you use this version
 instead of v1.2.7.
 {{< /note >}}

--- a/content/integrate/redis-data-integration/ingest/installation/_index.md
+++ b/content/integrate/redis-data-integration/ingest/installation/_index.md
@@ -17,12 +17,13 @@ type: integration
 weight: 2
 ---
 
-This guide explains how to install RDI and integrate it with your source database.
+This guide explains how to install Redis Data Integration (RDI) and integrate it with
+your source database.
 
-{{< note >}}RDI v1.2.7 had a CoreDNS issue. In some installations, the host DNS could not
+{{< note >}}We recommend you use RDI v1.2.8 version instead of v1.2.7.
+RDI v1.2.7 had a CoreDNS issue. In some installations, the host DNS could not
 resolve hostnames for the RDI components. This meant it couldn't connect to the RDI database
-and resume the installation. This problem is fixed in v1.2.8, so we recommend you use this version
-instead of v1.2.7.
+and resume the installation. This problem is fixed in v1.2.8.
 {{< /note >}}
 
 ## Install RDI on VMs

--- a/content/integrate/redis-data-integration/ingest/installation/_index.md
+++ b/content/integrate/redis-data-integration/ingest/installation/_index.md
@@ -19,7 +19,7 @@ weight: 2
 
 This guide explains how to install RDI and integrate it with your source database.
 
-{{< note >}}RDI v1.2.7 had a CoreDNS issue where in some installations the host DNS could not
+{{< note >}}RDI v1.2.7 had a CoreDNS issue. In some installations, the host DNS could not
 resolve hostnames for the RDI components. This meant that it couldn't connect to the RDI database
 and resume the installation. This problem is fixed in v1.2.8, so we recommend you use this version
 instead of v1.2.7.

--- a/content/integrate/redis-data-integration/ingest/observability.md
+++ b/content/integrate/redis-data-integration/ingest/observability.md
@@ -94,27 +94,16 @@ the logs are available for you to inspect.
 By default, RDI stores logs in the host VM file system at `/opt/rdi/logs`.
 The logs are recorded at the minimum `INFO` level and get rotated when they reach a size of 100MB.
 RDI retains the last five log rotated files by default.
-Logs are in JSON format, which lets you analyze them with several different observability tools.
+Logs are in a straightforward text format, which lets you analyze them with several different observability tools.
 You can change the default log settings using the
 [`redis-di config-rdi`]({{< relref "/integrate/redis-data-integration/ingest/reference/cli/redis-di-config-rdi" >}})
 command.
 
-## Support package
+## Dump support package
 
 If you ever need to send a comprehensive set of forensics data to Redis support then you should
 run the
 [`redis-di dump-support-package`]({{< relref "/integrate/redis-data-integration/ingest/reference/cli/redis-di-dump-support-package" >}})
-command from the CLI.
-
-This command gathers the following data:
-
-- All the internal RDI components and their status
-- All internal RDI configuration
-- List of secret names used by RDI components (but not the secrets themselves)
-- RDI logs
-- RDI component versions
-- Output from the [`redis-di status`]({{< relref "/integrate/redis-data-integration/ingest/reference/cli/redis-di-status" >}}) command
-- Text of the `config.yaml` file
-- Text of the Job configuration files
-- [optional] RDI DLQ streams content
-- Rejected records along with the reason for their rejection (should not exist in production)
+command from the CLI. See
+[Troubleshooting]({{< relref "/integrate/redis-data-integration/ingest/troubleshooting#dump-support-package" >}})
+for more information.

--- a/content/integrate/redis-data-integration/ingest/troubleshooting.md
+++ b/content/integrate/redis-data-integration/ingest/troubleshooting.md
@@ -51,7 +51,7 @@ Logs are recorded at the minimum `INFO` level in a simple format that
 log analysis tools can use.
 
 {{< note >}}Often during the initial sync phase, the collector source log will contain a message
-saying that RDI is out of
+saying RDI is out of
 memory. This is not an error but an informative message to say that RDI
 is applying *backpressure* to the collector. See
 [Backpressure mechanism]({{< relref "/integrate/redis-data-integration/ingest/architecture#backpressure-mechanism" >}})

--- a/content/integrate/redis-data-integration/ingest/troubleshooting.md
+++ b/content/integrate/redis-data-integration/ingest/troubleshooting.md
@@ -18,7 +18,7 @@ weight: 50
 ---
 
 The following sections explain how you can get extra information from
-RDI to help you solve problems that you may encounter. Redis support may
+Redis Data Integration (RDI) to help you solve problems that you may encounter. Redis support may
 also ask you to provide this information if you need to contact them.
 
 ## Debug information during installation {#install-debug}

--- a/content/integrate/redis-data-integration/ingest/troubleshooting.md
+++ b/content/integrate/redis-data-integration/ingest/troubleshooting.md
@@ -19,7 +19,7 @@ weight: 50
 
 The following sections explain how you can get extra information from
 Redis Data Integration (RDI) to help you solve problems that you may encounter. Redis support may
-also ask you to provide this information if you need to contact them.
+also ask you to provide this information to help you resolve issues.
 
 ## Debug information during installation {#install-debug}
 

--- a/content/integrate/redis-data-integration/ingest/troubleshooting.md
+++ b/content/integrate/redis-data-integration/ingest/troubleshooting.md
@@ -41,18 +41,19 @@ By default, RDI records the following logs in the host VM file system at
 
 | Filename | Phase |
 | :-- | :-- |
-| `rdi_collector-collector-initializer.log` | Initializing the Debezium collector. |
-| `rdi_collector-debezium-ssl-init.log` | Establishing the Debezium SSL connections to the source and RDI database (if you are using SSL). |
-| `rdi_collector-collector-source.log` | Debezium [change data capture (CDC)]({{< relref "/integrate/redis-data-integration/ingest/architecture" >}}) operations. |
-| `rdi_rdi-rdi-operator.log` | RDI and Kubernetes deployment. |
+| `rdi_collector-collector-initializer.log` | Initializing the collector. |
+| `rdi_collector-debezium-ssl-init.log` | Establishing the connector SSL connections to the source and RDI database (if you are using SSL). |
+| `rdi_collector-collector-source.log` | Collector [change data capture (CDC)]({{< relref "/integrate/redis-data-integration/ingest/architecture" >}}) operations. |
+| `rdi_rdi-rdi-operator.log` | Main [RDI control plane]({{< relref "/integrate/redis-data-integration/ingest/architecture#how-rdi-is-deployed" >}}) component. |
 | `rdi_processor-processor.log` | RDI stream processing. |
 
 Logs are recorded at the minimum `INFO` level in a simple format that
 log analysis tools can use.
 
-{{< note >}}Sometimes the Debezium collector source log will contain a message saying that RDI is out of
+{{< note >}}Often during the initial sync phase, the collector source log will contain a message
+saying that RDI is out of
 memory. This is not an error but an informative message to say that RDI
-is applying *backpressure* to Debezium. See
+is applying *backpressure* to the collector. See
 [Backpressure mechanism]({{< relref "/integrate/redis-data-integration/ingest/architecture#backpressure-mechanism" >}})
 in the Architecture guide for more information.
 {{< /note >}}

--- a/content/integrate/redis-data-integration/ingest/troubleshooting.md
+++ b/content/integrate/redis-data-integration/ingest/troubleshooting.md
@@ -1,0 +1,78 @@
+---
+Title: Ingest troubleshooting
+aliases: null
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+- rdi
+description: Solve and report simple problems with RDI ingest
+group: di
+hideListLinks: false
+linkTitle: Troubleshooting
+summary: Redis Data Integration keeps Redis in sync with the primary database in near
+  real time.
+type: integration
+weight: 50
+---
+
+The following sections explain how you can get extra information from
+RDI to help you solve problems that you may encounter. Redis support may
+also ask you to provide this information if you need to contact them.
+
+## Debug information during installation {#install-debug}
+
+If the installer fails with an error then try installing again with the
+log level set to `DEBUG`:
+
+```bash
+./install.sh -l DEBUG   # Installer script
+redis-di install -l DEBUG    # Install command
+```
+
+This gives you more detail about the installation steps and can often
+help you to pinpoint the source of the error.
+
+## RDI logs
+
+By default, RDI records the following logs in the host VM file system at
+`/opt/rdi/logs` (or whichever path you specified during installation);
+
+| Filename | Phase |
+| :-- | :-- |
+| `rdi_collector-collector-initializer.log` | Initializing the Debezium collector. |
+| `rdi_collector-debezium-ssl-init.log` | Establishing the Debezium SSL connections to the source and RDI database (if you are using SSL). |
+| `rdi_collector-collector-source.log` | Debezium [change data capture (CDC)]({{< relref "/integrate/redis-data-integration/ingest/architecture" >}}) operations. |
+| `rdi_rdi-rdi-operator.log` | RDI and Kubernetes deployment. |
+| `rdi_processor-processor.log` | RDI stream processing. |
+
+Logs are recorded at the minimum `INFO` level in a simple format that
+log analysis tools can use.
+
+{{< note >}}Sometimes the Debezium collector source log will contain a message saying that RDI is out of
+memory. This is not an error but an informative message to say that RDI
+is applying *backpressure* to Debezium. See
+[Backpressure mechanism]({{< relref "/integrate/redis-data-integration/ingest/architecture#backpressure-mechanism" >}})
+in the Architecture guide for more information.
+{{< /note >}}
+
+## Dump support package
+
+If you ever need to send a comprehensive set of forensics data to Redis support then you should
+run the
+[`redis-di dump-support-package`]({{< relref "/integrate/redis-data-integration/ingest/reference/cli/redis-di-dump-support-package" >}})
+command from the CLI.
+
+This command gathers the following data:
+
+- All the internal RDI components and their status
+- All internal RDI configuration
+- List of secret names used by RDI components (but not the secrets themselves)
+- RDI logs
+- RDI component versions
+- Output from the [`redis-di status`]({{< relref "/integrate/redis-data-integration/ingest/reference/cli/redis-di-status" >}}) command
+- Text of the `config.yaml` file
+- Text of the Job configuration files
+- [optional] RDI DLQ streams content
+- Rejected records along with the reason for their rejection (should not exist in production)

--- a/content/integrate/redis-data-integration/ingest/troubleshooting.md
+++ b/content/integrate/redis-data-integration/ingest/troubleshooting.md
@@ -23,7 +23,7 @@ also ask you to provide this information to help you resolve issues.
 
 ## Debug information during installation {#install-debug}
 
-If the installer fails with an error then try installing again with the
+If the installer fails with an error, then try installing again with the
 log level set to `DEBUG`:
 
 ```bash

--- a/content/integrate/redis-data-integration/ingest/troubleshooting.md
+++ b/content/integrate/redis-data-integration/ingest/troubleshooting.md
@@ -60,7 +60,7 @@ in the Architecture guide for more information.
 
 ## Dump support package
 
-If you ever need to send a comprehensive set of forensics data to Redis support then you should
+If you need to send a comprehensive set of forensics data to Redis support,
 run the
 [`redis-di dump-support-package`]({{< relref "/integrate/redis-data-integration/ingest/reference/cli/redis-di-dump-support-package" >}})
 command from the CLI.


### PR DESCRIPTION
[DOC-4214](https://redislabs.atlassian.net/browse/DOC-4214)

Also moved some of the detail about `redis-di dump-support-package` from Observability to the new page.

[DOC-4214]: https://redislabs.atlassian.net/browse/DOC-4214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ