### PR TITLE
Fix typo: "exist" --> "exists"

### DIFF
--- a/content/commands/ttl/index.md
+++ b/content/commands/ttl/index.md
@@ -55,7 +55,7 @@ Returns the remaining time to live of a key that has a timeout.
 This introspection capability allows a Redis client to check how many seconds a
 given key will continue to be part of the dataset.
 
-In Redis 2.6 or older the command returns `-1` if the key does not exist or if the key exist but has no associated expire.
+In Redis 2.6 or older the command returns `-1` if the key does not exist or if the key exists but has no associated expire.
 
 Starting with Redis 2.8 the return value in case of error changed:
 


### PR DESCRIPTION
This PR corrects a typo on the [TTL command page](https://redis.io/docs/latest/commands/ttl/).

# Before
> ![image](https://github.com/user-attachments/assets/c0713f9e-3327-49d0-a5d2-cd1723a7675c)

# After
The red rectangle annotation was added to the screenshot for illustration.
> ![image](https://github.com/user-attachments/assets/27f0a69f-03ad-4191-b0af-fe92b14a581d)

