### PR TITLE
DOC-4352 removed mention of DB2

### DIFF
--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -22,14 +22,6 @@ weight: 50
 You must purchase a commercial license for RDI with Redis Enterprise. This includes two extra
 Redis Enterprise shards (primary and replica) for the staging database.
 
-## Does RDI have any external dependencies?
-
-RDI is packaged with all of its dependencies except for two dependencies that
-you need if you use IBM Db2 as a source:
-
-- [Db2 JDBC driver](https://www.ibm.com/support/pages/db2-jdbc-driver-versions-and-downloads)
-- [IBM Infopshere Data Replication license](https://www.ibm.com/docs/en/db2/10.5?topic=information-licensing-replication)
-
 ## How does RDI track data changes in the source database?
 
 RDI uses mechanisms that are specific for each of the supported


### PR DESCRIPTION
[DOC-4352](https://redislabs.atlassian.net/browse/DOC-4352)

I'm pretty sure it was only mentioned by mistake in the FAQ.

[DOC-4352]: https://redislabs.atlassian.net/browse/DOC-4352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ