### PR TITLE
Add PHP Redis extension

### DIFF
--- a/content/develop/connect/clients/_index.md
+++ b/content/develop/connect/clients/_index.md
@@ -39,7 +39,8 @@ Redis does not support directly:
 | Language | Client name | Github | Docs |
 | :-- | :-- | :-- | :-- |
 | C | hiredis | https://github.com/redis/hiredis | https://github.com/redis/hiredis |
-| [PHP](https://www.php.net/) | predis | https://github.com/predis/predis | https://github.com/predis/predis/wiki |
+| [PHP](https://www.php.net/) | redis extension | https://github.com/phpredis/phpredis | https://github.com/phpredis/phpredis/blob/develop/README.md |
+| [PHP](https://www.php.net/) | predis library | https://github.com/predis/predis | https://github.com/predis/predis/wiki |
 | [Ruby](https://www.ruby-lang.org/en/) | redis-rb | https://github.com/redis/redis-rb | https://rubydoc.info/gems/redis |
 | [Rust](https://www.rust-lang.org/) | redis-rs | https://github.com/redis-rs/redis-rs | https://docs.rs/redis/latest/redis/ | 
 


### PR DESCRIPTION
There are two ways to use Redis with PHP. One is with a library (written in PHP) and the other one is with a PHP extension (written in C). 

The extension is faster but the library is easier to install, especially if you are on shared hosts.