### PR TITLE
DEV: replace hackers with racers on sorted sets page

### DIFF
--- a/content/develop/data-types/sorted-sets.md
+++ b/content/develop/data-types/sorted-sets.md
@@ -57,7 +57,7 @@ As you can see [`ZADD`]({{< relref "/commands/zadd" >}}) is similar to [`SADD`](
 [`ZADD`]({{< relref "/commands/zadd" >}}) is also variadic, so you are free to specify multiple score-value
 pairs, even if this is not used in the example above.
 
-With sorted sets it is trivial to return a list of hackers sorted by their
+With sorted sets it is trivial to return a list of racers sorted by their
 birth year because actually *they are already sorted*.
 
 Implementation note: Sorted sets are implemented via a
@@ -163,7 +163,7 @@ Redis instance will reply with the same output).
 The main commands to operate with lexicographical ranges are [`ZRANGEBYLEX`]({{< relref "/commands/zrangebylex" >}}),
 [`ZREVRANGEBYLEX`]({{< relref "/commands/zrevrangebylex" >}}), [`ZREMRANGEBYLEX`]({{< relref "/commands/zremrangebylex" >}}) and [`ZLEXCOUNT`]({{< relref "/commands/zlexcount" >}}).
 
-For example, let's add again our list of famous hackers, but this time
+For example, let's add again our list of famous racers, but this time
 using a score of zero for all the elements. We'll see that because of the sorted sets ordering rules, they are already sorted lexicographically. Using [`ZRANGEBYLEX`]({{< relref "/commands/zrangebylex" >}}) we can ask for lexicographical ranges:
 
 {{< clients-example ss_tutorial zadd_lex >}}


### PR DESCRIPTION
[DOC-4360](https://redislabs.atlassian.net/browse/DOC-4360)

Fixes #748. `XD`

[DOC-4360]: https://redislabs.atlassian.net/browse/DOC-4360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ