### PR TITLE
Fix redis service name on installation page

### DIFF
--- a/content/operate/oss_and_stack/install/install-redis/install-redis-on-linux.md
+++ b/content/operate/oss_and_stack/install/install-redis/install-redis-on-linux.md
@@ -72,13 +72,13 @@ If your Linux distribution does not currently have Snap installed, you can insta
 You can start the Redis server as a background process using the `systemctl` command. This only applies to Ubuntu/Debian when installed using `apt`, and Red Hat/Rocky when installed using `yum`.
 
 {{< highlight bash  >}}
-sudo systemctl start redis
+sudo systemctl start redis-server
 {{< / highlight  >}}
 
 To stop the server, use:
 
 {{< highlight bash  >}}
-sudo systemctl stop redis
+sudo systemctl stop redis-server
 {{< / highlight  >}}
 
 ## Connect to Redis

--- a/content/operate/oss_and_stack/install/install-redis/install-redis-on-linux.md
+++ b/content/operate/oss_and_stack/install/install-redis/install-redis-on-linux.md
@@ -72,13 +72,13 @@ If your Linux distribution does not currently have Snap installed, you can insta
 You can start the Redis server as a background process using the `systemctl` command. This only applies to Ubuntu/Debian when installed using `apt`, and Red Hat/Rocky when installed using `yum`.
 
 {{< highlight bash  >}}
-sudo systemctl start redis-server
+sudo systemctl start <redis-service-name> # redis or redis-server depending on platform
 {{< / highlight  >}}
 
 To stop the server, use:
 
 {{< highlight bash  >}}
-sudo systemctl stop redis-server
+sudo systemctl stop <redis-service-name> # redis or redis-server depending on platform
 {{< / highlight  >}}
 
 ## Connect to Redis


### PR DESCRIPTION
I'm not sure if `redis-server` should also be used in the "Install on Red Hat/Rocky" section.