### PR TITLE
DOC: typo for __vec_score sortby field

### DIFF
--- a/content/develop/interact/search-and-query/advanced-concepts/vectors.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/vectors.md
@@ -441,7 +441,7 @@ FT.SEARCH movies "(@category:{action} ~@category:{drama})=>[KNN 10 @doc_embeddin
 Among the movies that have `drama` or `action` as a category tag, return the top 10 nearest neighbors and explicitly set the filter mode (hybrid policy) to "ad-hoc brute force" rather than it being auto-selected:
 
 ```
-FT.SEARCH movies "(@category:{drama | action})=>[KNN 10 @doc_embedding $BLOB HYBRID_POLICY ADHOC_BF]" PARAMS 2 BLOB "\x12\xa9\xf5\x6c" SORTBY __vec_scores DIALECT 4
+FT.SEARCH movies "(@category:{drama | action})=>[KNN 10 @doc_embedding $BLOB HYBRID_POLICY ADHOC_BF]" PARAMS 2 BLOB "\x12\xa9\xf5\x6c" SORTBY __vec_score DIALECT 4
 ```
 
 Among the movies that have `action` as a category tag, return the top 10 nearest neighbors and explicitly set the filter mode (hybrid policy) to "batches" and batch size 50 using a query parameter:


### PR DESCRIPTION
**Describe the changes in the pull request**

1. In the documentation, `__vec_scores` was used to demonstrate the SORTBY capabilities for `FT.SEARCH` when working with vectors.
2. If execute the documentation suggested with `__vec_scores` field, an error will be thrown: ``Property `__vec_scores` not loaded nor in schema``
3. Update the documentation to `__vec_score`

**Which issues this PR fixes**

1. Typo of extra `s` present in the documentation.
2. PR is already opened at https://github.com/RediSearch/RediSearch/pull/5117

**Main objects this PR modified**

1. Documentation of `content/develop/interact/search-and-query/advanced-concepts/vectors.md`