### PR TITLE
Add missing checkout action in redis_modules_docs_sync workflow

### DIFF
--- a/.github/workflows/redis_modules_docs_sync.yaml
+++ b/.github/workflows/redis_modules_docs_sync.yaml
@@ -12,6 +12,9 @@ jobs:
       contents: write
       actions: write
     steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v3'
+
       - name: 'Fetch commands json files from modules'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This fixes a bug in the workflow