### PR TITLE
DOC-4369 changed HGETALL to HRANDFIELD in CSC docs

### DIFF
--- a/content/develop/connect/clients/client-side-caching.md
+++ b/content/develop/connect/clients/client-side-caching.md
@@ -82,7 +82,7 @@ will use cached data, except for the following:
     [probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}}).
     These types are designed to be updated frequently, which means that caching
     has little or no benefit.
--   Non-deterministic commands such as [`HGETALL`]({{< relref "/commands/hgetall" >}}),
+-   Non-deterministic commands such as [`HRANDFIELD`]({{< relref "/commands/hrandfield" >}}),
     [`HSCAN`]({{< relref "/commands/hscan" >}}),
     and [`ZRANDMEMBER`]({{< relref "/commands/zrandmember" >}}). By design, these commands
     give different results each time they are called.


### PR DESCRIPTION
[DOC-4369](https://redislabs.atlassian.net/browse/DOC-4369)

[DOC-4369]: https://redislabs.atlassian.net/browse/DOC-4369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ