### PR TITLE
install-redis-on-linux spelling mistake correction

### DIFF
--- a/content/operate/oss_and_stack/install/install-redis/install-redis-on-linux.md
+++ b/content/operate/oss_and_stack/install/install-redis/install-redis-on-linux.md
@@ -58,7 +58,7 @@ Redis will start automatically, but it won't restart at boot time. To do this, r
 sudo snap set redis service.start=true
 {{< /highlight  >}}
 
-You an use these additional snap-related commands to start, stop, restart, and check the status of Redis:
+You can use these additional snap-related commands to start, stop, restart, and check the status of Redis:
 
 * `sudo snap start redis`
 * `sudo snap stop redis`


### PR DESCRIPTION
Corrected spelling of 'an' to 'can' in content/operate/oss_and_stack/install/install-redis/install-redis-on-linux.md