### PR TITLE
DEV: modules lifecycle updates for Redis CE 8.0

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/modules-lifecycle.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/modules-lifecycle.md
@@ -11,7 +11,7 @@ weight: 7
 ---
 Redis Enterprise Software follows the [Redis Enterprise lifecycle]({{< relref "/operate/rs/installing-upgrading/product-lifecycle" >}}).  (For complete details, see the Redis Enterprise Software [subscription agreement](https://redis.com/software-subscription-agreement).)
 
-The modules included in Redis Stack also follow a release lifecycle and schedule. Here, you'll find the "end-of-life" dates for each module and release.
+The modules included in Redis Community Edition (CE), formerly called Redis Stack, also follow a release lifecycle and schedule. Here, you'll find the "end-of-life" dates for each module and release.
 
 ## Module release numbering
 
@@ -23,10 +23,27 @@ The format is “Major1.Major2.Minor”.
 
 - The _Minor_ section of the version number represents quality improvements and fixes to existing capabilities.  The minor release number is increased when release quality improves.
 
-## Module end-of-life schedule {#modules-endoflife-schedule}
-
 End-of-Life for a given Major version is 18 months after the formal release of
 that version or 12 months after the release of the next subsequent (following) version, whichever comes last.
+
+## Module end-of-life schedule after Redis CE 8.0
+
+In Redis CE 8.0 and beyond, module version numbers will align exactly with the Redis CE versions that include them.
+For example, the modules included with Redis CE 8.0 will all have version number 8.0.
+
+This also means that Redis CE versions 8.0+ require modules with an exact match in version number.
+
+### Redis Community Edition
+
+Included modules:
+- Redis scalable query engine
+- JSON data structure
+- Probabilistic data structures
+- Time series data structure
+
+{{< table-csv "redisce-lifecycle.csv" 2 >}}
+
+## Module end-of-life schedule before Redis CE 8.0 {#modules-endoflife-schedule}
 
 ### RediSearch
 

--- a/static/tables/redisce-lifecycle.csv
+++ b/static/tables/redisce-lifecycle.csv
@@ -1,0 +1,2 @@
+Release Date,End-of-Life (EOL)
+8.0 – TBD,–


### PR DESCRIPTION
[DOC-4312](https://redislabs.atlassian.net/browse/DOC-4312)

This page has a placeholder for the Redis CE 8.0 release date. If this is known at review time, please provide it in a comment.

Adding @rrelledge as this is historically her content.

[DOC-4312]: https://redislabs.atlassian.net/browse/DOC-4312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ