### PR TITLE
flush-commands-docs

### DIFF
--- a/content/commands/flushall/index.md
+++ b/content/commands/flushall/index.md
@@ -66,7 +66,7 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 * An asynchronous `FLUSHALL` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 * This command does not delete functions.
-* Other than emptying all databases (similar to `FLUSHDB`), this command clears the RDB persistence file, aborts any snapshot that is in progress, and, if the `save` config is enabled, it saves an empty RDB file.
+* Other than emptying all databases (similar to `FLUSHDB`), this command clears the RDB persistence file, aborts any snapshot that is in progress, and, if the `save` config is enabled, saves an empty RDB file.
 
 ## Behavior change history
 

--- a/content/commands/flushall/index.md
+++ b/content/commands/flushall/index.md
@@ -66,6 +66,7 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 * An asynchronous `FLUSHALL` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 * This command does not delete functions.
+* When using Redis Cluster, this command is identical to `FLUSHDB` since a Redis Cluster supports only database zero.
 
 ## Behavior change history
 

--- a/content/commands/flushall/index.md
+++ b/content/commands/flushall/index.md
@@ -66,7 +66,7 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 * An asynchronous `FLUSHALL` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 * This command does not delete functions.
-* When using Redis Cluster, this command is identical to `FLUSHDB` since a Redis Cluster supports only database zero.
+* Other than emptying all databases (similar to `FLUSHDB`), this command clears the RDB persistence file, aborts any snapshot that is in progress, and, if the `save` config is enabled, it saves an empty RDB file.
 
 ## Behavior change history
 

--- a/content/commands/flushdb/index.md
+++ b/content/commands/flushdb/index.md
@@ -66,7 +66,7 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 * An asynchronous `FLUSHDB` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 * This command does not delete functions.
-* When using Redis Cluster, this command is identical to `FLUSHALL` since a Redis Cluster supports only database zero.
+* When using Redis Cluster, this command is identical to `FLUSHALL` since a Redis Cluster supports only one database with and ID of zero.
 
 ## Behavior change history
 

--- a/content/commands/flushdb/index.md
+++ b/content/commands/flushdb/index.md
@@ -66,7 +66,7 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 * An asynchronous `FLUSHDB` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 * This command does not delete functions.
-* When using Redis Cluster, this command is identical to `FLUSHALL` since a Redis Cluster supports only one database with and ID of zero.
+* When using Redis Cluster, this command is identical to `FLUSHALL` since a Redis Cluster supports only one database with an ID of zero.
 
 ## Behavior change history
 

--- a/content/commands/flushdb/index.md
+++ b/content/commands/flushdb/index.md
@@ -66,6 +66,7 @@ It is possible to use one of the following modifiers to dictate the flushing mod
 
 * An asynchronous `FLUSHDB` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
 * This command does not delete functions.
+* When using Redis Cluster, this command is identical to `FLUSHALL` since a Redis Cluster supports only database zero.
 
 ## Behavior change history
 


### PR DESCRIPTION
Added notes: `FLUSHDB` and `FLUSHALL` are identical on a Redis cluster.

(following https://redis.slack.com/archives/CLZCLHWQ0/p1731468610504539)