### PR TITLE
RS: Fix DB names in rladmin upgrade examples to correctly follow DB naming rules

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module.md
@@ -58,13 +58,13 @@ To upgrade a module enabled for a database:
     - For clusters with Redis Enterprise Software versions 7.8.2 or later, run:
 
         ```sh
-        rladmin upgrade db < database_name | database_ID >
+        rladmin upgrade db < database-name | database-ID >
         ```
 
     - For clusters with versions earlier than 7.8.2, include the `latest_with_modules` option:
 
         ```sh
-        rladmin upgrade db < database_name | database_ID > latest_with_modules
+        rladmin upgrade db < database-name | database-ID > latest_with_modules
         ```
 
     {{<warning>}}
@@ -96,13 +96,13 @@ The following module upgrade examples are supported for Redis Enterprise Softwar
 - Keep the current Redis database version, which is 7.2 in this example, and upgrade to the latest version of the enabled modules:
 
     ```sh
-    rladmin upgrade db shopping_cart redis_version 7.2
+    rladmin upgrade db shopping-cart redis_version 7.2
     ```
 
 - Upgrade the database to use the latest version of Redis and the latest versions of the enabled modules:
 
     ```sh
-    rladmin upgrade db shopping_cart
+    rladmin upgrade db shopping-cart
     ```
 
 ## Deprecated examples
@@ -112,19 +112,19 @@ As of Redis Enterprise Software version 7.8.2, the following module upgrade exam
 - Keep the current version of Redis and upgrade to the latest version of the enabled modules:
 
     ```sh
-    rladmin upgrade db shopping_cart keep_redis_version latest_with_modules
+    rladmin upgrade db shopping-cart keep_redis_version latest_with_modules
     ```
 
 - Upgrade the database to the latest Redis version and upgrade RediSearch to 1.6.7 with the specified arguments:
 
     ```sh
-    rladmin upgrade db shopping_cart and module db_name shopping_cart module_name ft version 10607 module_args "PARTITIONS AUTO"
+    rladmin upgrade db shopping-cart and module db_name shopping-cart module_name ft version 10607 module_args "PARTITIONS AUTO"
     ```
 
 - Upgrade the database to the latest Redis version and upgrade RedisBloom to version 2.2.1 without arguments:
 
     ```sh
-    rladmin upgrade db db:3 and module db_name shopping_cart module_name bf version 20201 module_args ""
+    rladmin upgrade db db:3 and module db_name shopping-cart module_name bf version 20201 module_args ""
     ```
 
 - Upgrade RedisJSON to 1.0.4 with the existing arguments and RedisBloom to version 2.2.1 without arguments:
@@ -136,5 +136,5 @@ As of Redis Enterprise Software version 7.8.2, the following module upgrade exam
 - Upgrade the database to use the latest version of Redis and use the latest version of the enabled modules:
 
     ```sh
-    rladmin upgrade db shopping_cart latest_with_modules
+    rladmin upgrade db shopping-cart latest_with_modules
     ```


### PR DESCRIPTION
DOC-4566 DOC-4567

Note: Underscores are not allowed in RS DB names, but hyphens are allowed.