### PR TITLE
DOC-4588 fixed layout links to old develop/connect section

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -114,13 +114,13 @@
         {{ partial "docs-section.html" (dict
           "Title" "Redis Insight"
           "Description" "A cross-platform GUI for Redis, with focus on reducing memory usage and improving application performance."
-          "ButtonLink" "./develop/connect/insight/"
+          "ButtonLink" "./develop/tools/insight/"
           "ButtonLabel" "Learn more"
           "LinksLeftTitle" "Learn more"
           "LinksLeft" (slice
             (dict "Text" "Install" "URL" "./operate/redisinsight/install/")
-            (dict "Text" "User guide" "URL" "./develop/connect/insight/")
-            (dict "Text" "Manage Streams in Redis Insight" "URL" "./develop/connect/insight/tutorials/insight-stream-consumer/")
+            (dict "Text" "User guide" "URL" "./develop/tools/insight/")
+            (dict "Text" "Manage Streams in Redis Insight" "URL" "./develop/tools/insight/tutorials/insight-stream-consumer/")
           )
         ) }}
       </div>

--- a/layouts/partials/tabs/wrapper.html
+++ b/layouts/partials/tabs/wrapper.html
@@ -72,8 +72,8 @@ group-hover:opacity-100 group-hover:visible">
                     </a>
                 </div>
             {{ else }}
-              <!--<a href='/docs/latest/develop/connect/clients/{{ index $tab "quickstartSlug" }}/' tabindex="1" class="rounded rounded-mx px-3 py-1 text-white text-xs-->
-              <a href='{{ absURL (print "develop/connect/clients/" (index $tab "quickstartSlug")) }}/' tabindex="1" class="rounded rounded-mx px-3 py-1 text-white text-xs
+              <!--<a href='/docs/latest/develop/clients/{{ index $tab "quickstartSlug" }}/' tabindex="1" class="rounded rounded-mx px-3 py-1 text-white text-xs-->
+              <a href='{{ absURL (print "develop/clients/" (index $tab "quickstartSlug")) }}/' tabindex="1" class="rounded rounded-mx px-3 py-1 text-white text-xs
                                 hover:text-white hover:bg-slate-600 hover:border-transparent focus:outline-none
                                 focus:ring-2 focus:white focus:border-slate-500" title="{{$btnQuickStartText}}">
                 {{ index $tab "title" }} {{ $btnQuickStartText }}


### PR DESCRIPTION
[DOC-4588](https://redislabs.atlassian.net/browse/DOC-4588)

Also found some links to Redis Insight in the layouts that were pointing to the wrong place. The links still worked OK, btw, but making use of alias redirects rather than linking to the right place.

[DOC-4588]: https://redislabs.atlassian.net/browse/DOC-4588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ