### PR TITLE
DOC-4603 added missing sink HA properties

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/data-pipelines.md
+++ b/content/integrate/redis-data-integration/data-pipelines/data-pipelines.md
@@ -110,6 +110,14 @@ sources:
   #   sink:
   #     redis.memory.limit.mb: 100
   #     redis.memory.threshold.percentage: 85
+  #  Uncomment the lines below for production usage with high availability (HA). When writing data 
+  #  to the state database or the target with HA enabled, RDI should wait briefly for an
+  #  acknowledgment from the replica database. It should also retry a write operation after a 
+  #  certain delay if the original operation times out.
+  #     redis.wait.enabled:true
+  #     redis.wait.timeout.ms:2
+  #     redis.wait.retry.enabled:true
+  #     redis.wait.retry.delay.ms: 
   # Source specific properties - see the full list at https://debezium.io/documentation/reference/stable/connectors/
   #   source:
   #     snapshot.mode: initial


### PR DESCRIPTION
[DOC-4603](https://redislabs.atlassian.net/browse/DOC-4603) (relating to [RDSC-2937](https://redislabs.atlassian.net/browse/RDSC-2937))

I've added the description as comments in `config.yaml` but let me know if this is important enough to mention in the main text as well. Also, the value for `redis.wait.retry.delay.ms` is currently not specified - please let me know what it should be.

[DOC-4603]: https://redislabs.atlassian.net/browse/DOC-4603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RDSC-2937]: https://redislabs.atlassian.net/browse/RDSC-2937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ