### PR TITLE
DOC-4608 can't switch Java tabs in published build

### DIFF
--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -35,7 +35,7 @@
         {{ end }}
         {{ $params := dict "language" $language "contentPath" $examplePath "options" $options }}
         {{ $content := partial "tabs/source.html" $params }}
-        {{ $tabs = $tabs | append (dict "title" $client "language" $language "quickstartSlug" $quickstartSlug "content" $content "sourceUrl" (index $example "sourceUrl")) }}
+        {{ $tabs = $tabs | append (dict "title" $client "language" $client "quickstartSlug" $quickstartSlug "content" $content "sourceUrl" (index $example "sourceUrl")) }}
     {{ end }}
 {{ end }}
 


### PR DESCRIPTION
[DOC-4608](https://redislabs.atlassian.net/browse/DOC-4608)

Tried using the client name rather than the language name to identify the tabs in the layout file.
Tested a few TCEs (including the [Strings](https://redis.io/docs/staging/DOC-4608-lettuce-breaks-code-tabs/develop/data-types/strings/) page, which is the only one that currently has Lettuce tabs) and it seems to work OK.

[DOC-4608]: https://redislabs.atlassian.net/browse/DOC-4608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ