### PR TITLE
DOC-4623 attempted fix for tab issues

### DIFF
--- a/build/components/example.py
+++ b/build/components/example.py
@@ -11,12 +11,18 @@ EXAMPLE = 'EXAMPLE:'
 GO_OUTPUT = 'Output:'
 TEST_MARKER = {
     'java': '@Test',
+    'java-sync': '@Test',
+    'java-async': '@Test',
+    'java-reactive': '@Test',
     'c#': '\[Fact\]|\[SkipIfRedis\(.*\)\]'
 }
 PREFIXES = {
     'python': '#',
     'node.js': '//',
     'java': '//',
+    'java-sync': '//',
+    'java-async': '//',
+    'java-reactive': '//',
     'go': '//',
     'c#': '//',
     'redisvl': '#',

--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ tagManagerId = "GTM-TKZ6J9R"
 gitHubRepo = "https://github.com/redis/docs"
 
 # Display and sort order for client examples
-clientsExamples = ["Python", "Node.js", "Java Sync", "Java Async", "Java Reactive", "Go", "C#", "RedisVL"]
+clientsExamples = ["Python", "Node.js", "Java-Sync", "Java-Async", "Java-Reactive", "Go", "C#", "RedisVL"]
 searchService = "/convai/api/search-service"
 ratingsService = "/docusight/api/rate"
 
@@ -59,9 +59,9 @@ rdi_cli_latest = "latest"
 [params.clientsConfig]
 "Python"={quickstartSlug="redis-py"}
 "Node.js"={quickstartSlug="nodejs"}
-"Java sync"={quickstartSlug="jedis"}
-"Java async"={quickstartSlug="lettuce"}
-"Java reactive"={quickstartSlug="lettuce"}
+"Java-sync"={quickstartSlug="jedis"}
+"Java-async"={quickstartSlug="lettuce"}
+"Java-reactive"={quickstartSlug="lettuce"}
 "Go"={quickstartSlug="go"}
 "C#"={quickstartSlug="dotnet"}
 "RedisVL"={quickstartSlug="redis-vl"}

--- a/data/components/jedis.json
+++ b/data/components/jedis.json
@@ -2,14 +2,14 @@
   "id": "jedis",
   "type": "client",
   "name": "jedis",
-  "language": "Java",
-  "label": "Java Sync",
+  "language": "Java-Sync",
+  "label": "Java-Sync",
   "repository": {
       "git_uri": "https://github.com/redis/jedis"
   },
   "examples": {
-      "git_uri": "https://github.com/redis/jedis",
-      "dev_branch": "master",
+      "git_uri": "/Users/andrew.stark/Documents/Repos/forks/jedis",
+      "dev_branch": "DOC-4560-trans-pipe-examples",
       "path": "src/test/java/io/redis/examples",
       "pattern": "*.java"
   }

--- a/data/components/jedis.json
+++ b/data/components/jedis.json
@@ -8,8 +8,8 @@
       "git_uri": "https://github.com/redis/jedis"
   },
   "examples": {
-      "git_uri": "/Users/andrew.stark/Documents/Repos/forks/jedis",
-      "dev_branch": "DOC-4560-trans-pipe-examples",
+      "git_uri": "https://github.com/redis/jedis",
+      "dev_branch": "master",
       "path": "src/test/java/io/redis/examples",
       "pattern": "*.java"
   }

--- a/data/components/lettuce_async.json
+++ b/data/components/lettuce_async.json
@@ -2,8 +2,8 @@
   "id": "lettuce_async",
   "type": "client",
   "name": "lettuce_async",
-  "language": "Java",
-  "label": "Java Async",
+  "language": "Java-Async",
+  "label": "Java-Async",
   "repository": {
       "git_uri": "https://github.com/redis/lettuce"
   },

--- a/data/components/lettuce_reactive.json
+++ b/data/components/lettuce_reactive.json
@@ -2,8 +2,8 @@
   "id": "lettuce_reactive",
   "type": "client",
   "name": "lettuce_reactive",
-  "language": "Java",
-  "label": "Java Reactive",
+  "language": "Java-Reactive",
+  "label": "Java-Reactive",
   "repository": {
       "git_uri": "https://github.com/redis/lettuce"
   },

--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -21,11 +21,11 @@
     {{ $clientConfig := index $.Site.Params.clientsconfig $client }}
     {{ $language := index $example "language" }}
     {{ $quickstartSlug := index $clientConfig "quickstartSlug" }}
-
+    
     {{ if and ($example) (or (eq $lang "") (eq $lang $client)) }}
         {{ $examplePath := index $example "target" }}
         {{ $options := printf "linenos=false" }}
-
+        
         {{ if and (ne $step "") (isset $example "named_steps") (isset $example.named_steps $step) }}
             {{ $options = printf "%s,hl_lines=%s" $options (index $example.named_steps $step) }}
         {{ else }}
@@ -33,6 +33,7 @@
                 {{ $options = printf "%s,hl_lines=%s" $options (delimit (index $example "highlight") " ") }}
             {{ end }}
         {{ end }}
+        {{ if hasPrefix $language "java" }}{{ $language = "java"}}{{ end }}
         {{ $params := dict "language" $language "contentPath" $examplePath "options" $options }}
         {{ $content := partial "tabs/source.html" $params }}
         {{ $tabs = $tabs | append (dict "title" $client "language" $client "quickstartSlug" $quickstartSlug "content" $content "sourceUrl" (index $example "sourceUrl")) }}

--- a/layouts/partials/tabs/wrapper.html
+++ b/layouts/partials/tabs/wrapper.html
@@ -17,7 +17,7 @@
         <input tabindex="1" type="radio" name="{{ $id }}" id="{{ $tid }}" data-lang="{{ $dataLang }}" class="radiotab w-0 h-0"
                {{ if eq $i 0 }}checked{{ end }}
         />
-        <label class="justify-left label ml-4 pt-3.5 px-3 pb-1 cursor-pointer text-sm text-center bg-redis-ink-900
+        <label class="justify-left label ml-1.5 pt-3.5 px-1 pb-1 cursor-pointer text-sm text-center bg-redis-ink-900
         hover:text-redis-red-600  rounded rounded-mx transition duration-150 ease-in-out"
                title="Open example" for="{{ $tid }}">
             {{ if eq (index $tab "title") "redis-cli" }}

--- a/layouts/partials/tabs/wrapper.html
+++ b/layouts/partials/tabs/wrapper.html
@@ -13,6 +13,7 @@
         {{ $tid := printf "%s_%s" (replace (replace (index $tab "title") "#" "sharp") "." "") $id }}
         {{ $pid := printf "panel_%s" $tid }}
         {{ $dataLang := replace (or (index $tab "language") "redis-cli") "C#" "dotnet" }}
+        {{ $dataLang := replace $dataLang "." "-" }}
         <input tabindex="1" type="radio" name="{{ $id }}" id="{{ $tid }}" data-lang="{{ $dataLang }}" class="radiotab w-0 h-0"
                {{ if eq $i 0 }}checked{{ end }}
         />


### PR DESCRIPTION
[DOC-4623](https://redislabs.atlassian.net/browse/DOC-4623)

The tabs appear to be "sticky" again and you can now select the Java clients for individual code examples (use Java-Sync, etc). Also, I'm trying out a smaller text size in the tab bar to prevent it from wrapping when all the clients are present (eg, compare [current](https://redis.io/docs/latest/develop/data-types/strings/#strings-as-counters) with [new](https://redis.io/docs/staging/DOC-4623-java-code-tab-issues/develop/data-types/strings/#strings-as-counters)).

Any thoughts about the tab formatting, client names with hyphens, etc, are most welcome :-) 

[DOC-4623]: https://redislabs.atlassian.net/browse/DOC-4623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ