### PR TITLE
DOC-4647 updated supported sources table with AWS RDS details

### DIFF
--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -1,0 +1,12 @@
+| Database                    | Versions               | Versions for Amazon RDS |
+| :-------------------------- | :--------------------- | :-- |
+| Oracle                      | 12c, 19c, 21c          | 19c, 21c |
+| MariaDB                     | 10.5, 11.4.3                | 10.4 to 10.11, 11.4.3 |
+| MySQL                       | 5.7, 8.0.x, 8.2             | 8.0.x |
+| Postgres                    | 10, 11, 12, 13, 14, 15, 16  | 11, 12, 13, 14, 15, 16 |
+| SQL Server                  | 2017, 2019, 2022             | 2016, 2017, 2019, 2022 |
+| Google Cloud SQL MySQL      | 8.0                    | None |
+| Google Cloud SQL Postgres   | 15                     | None |
+| Google Cloud SQL SQL Server | 2019                   | None |
+| Google Cloud AlloyDB for PostgreSQL | | None |
+| AWS Aurora/PostgreSQL | 15 | 15 |

--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -1,4 +1,4 @@
-| Database | Versions | Versions for Amazon RDS | Versions for Google Cloud SQL |
+| Database | Versions | AWS RDS  Versions | GCP SQL Versions |
 | :-- | :-- | :-- | :-- |
 | Oracle | 12c, 19c, 21c | 19c, 21c | - |
 | MariaDB | 10.5, 11.4.3 | 10.4 to 10.11, 11.4.3 | - |

--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -1,12 +1,9 @@
-| Database                    | Versions               | Versions for Amazon RDS |
-| :-------------------------- | :--------------------- | :-- |
-| Oracle                      | 12c, 19c, 21c          | 19c, 21c |
-| MariaDB                     | 10.5, 11.4.3                | 10.4 to 10.11, 11.4.3 |
-| MySQL                       | 5.7, 8.0.x, 8.2             | 8.0.x |
-| Postgres                    | 10, 11, 12, 13, 14, 15, 16  | 11, 12, 13, 14, 15, 16 |
-| SQL Server                  | 2017, 2019, 2022             | 2016, 2017, 2019, 2022 |
-| Google Cloud SQL MySQL      | 8.0                    | None |
-| Google Cloud SQL Postgres   | 15                     | None |
-| Google Cloud SQL SQL Server | 2019                   | None |
-| Google Cloud AlloyDB for PostgreSQL | | None |
-| AWS Aurora/PostgreSQL | 15 | 15 |
+| Database | Versions | Versions for Amazon RDS | Versions for Google Cloud SQL |
+| :-- | :-- | :-- | :-- |
+| Oracle | 12c, 19c, 21c | 19c, 21c | - |
+| MariaDB | 10.5, 11.4.3 | 10.4 to 10.11, 11.4.3 | - |
+| MySQL | 5.7, 8.0.x, 8.2 | 8.0.x | 8.0 |
+| PostgreSQL | 10, 11, 12, 13, 14, 15, 16  | 11, 12, 13, 14, 15, 16 | 15 |
+| SQL Server | 2017, 2019, 2022 | 2016, 2017, 2019, 2022 | 2019 |
+| AlloyDB for PostgreSQL | 14.2, 15.7 | - | 14.2, 15.7 |
+| AWS Aurora/PostgreSQL | 15 | 15 | - |

--- a/content/integrate/redis-data-integration/_index.md
+++ b/content/integrate/redis-data-integration/_index.md
@@ -106,17 +106,18 @@ You should *not* use RDI when:
 
 RDI can capture data from any of the following sources:
 
-| Database                    | Versions               |
-| :-------------------------- | :--------------------- |
-| Oracle                      | 12c, 19c, 21c          |
-| MariaDB                     | >= 10.5                |
-| MySQL                       | 5.7, 8.0.x             |
-| Postgres                    | 10, 11, 12, 13, 14, 15 |
-| SQL Server                  | 2017, 2019             |
-| Google Cloud SQL MySQL      | 8.0                    |
-| Google Cloud SQL Postgres   | 15                     |
-| Google Cloud SQL SQL Server | 2019                   |
-| Google Cloud AlloyDB for PostgreSQL | |
+| Database                    | Versions               | Supports Amazon RDS |
+| :-------------------------- | :--------------------- | :-- |
+| Oracle                      | 12c, 19c, 21c          | Yes |
+| MariaDB                     | >= 10.5                | No |
+| MySQL                       | 5.7, 8.0.x             | No |
+| Postgres                    | 10, 11, 12, 13, 14, 15 | Yes |
+| SQL Server                  | 2017, 2019             | No |
+| Google Cloud SQL MySQL      | 8.0                    | No |
+| Google Cloud SQL Postgres   | 15                     | No |
+| Google Cloud SQL SQL Server | 2019                   | No |
+| Google Cloud AlloyDB for PostgreSQL | | No |
+| AWS Aurora/PostgreSQL | 15 | Yes |
 
 
 ## Documentation

--- a/content/integrate/redis-data-integration/_index.md
+++ b/content/integrate/redis-data-integration/_index.md
@@ -106,19 +106,7 @@ You should *not* use RDI when:
 
 RDI can capture data from any of the following sources:
 
-| Database                    | Versions               | Supports Amazon RDS |
-| :-------------------------- | :--------------------- | :-- |
-| Oracle                      | 12c, 19c, 21c          | Yes |
-| MariaDB                     | >= 10.5                | No |
-| MySQL                       | 5.7, 8.0.x             | No |
-| Postgres                    | 10, 11, 12, 13, 14, 15 | Yes |
-| SQL Server                  | 2017, 2019             | No |
-| Google Cloud SQL MySQL      | 8.0                    | No |
-| Google Cloud SQL Postgres   | 15                     | No |
-| Google Cloud SQL SQL Server | 2019                   | No |
-| Google Cloud AlloyDB for PostgreSQL | | No |
-| AWS Aurora/PostgreSQL | 15 | Yes |
-
+{{< embed-md "rdi-supported-source-versions.md" >}}
 
 ## Documentation
 

--- a/content/integrate/redis-data-integration/architecture.md
+++ b/content/integrate/redis-data-integration/architecture.md
@@ -89,17 +89,18 @@ the backpressure mechanism.
 
 RDI supports the following database sources using [Debezium Server](https://debezium.io/documentation/reference/stable/operations/debezium-server.html) connectors:
 
-| Database                    | Versions               |
-| --------------------------- | ---------------------- |
-| Oracle                      | 12c, 19c, 21c          |
-| MariaDB                     | >= 10.5                |
-| MySQL                       | 5.7, 8.0.x             |
-| Postgres                    | 10, 11, 12, 13, 14, 15 |
-| SQL Server                  | 2017, 2019             |
-| Google Cloud SQL MySQL      | 8.0                    |
-| Google Cloud SQL Postgres   | 15                     |
-| Google Cloud SQL SQL Server | 2019                   |
-| Google Cloud AlloyDB for PostgreSQL | |
+| Database                    | Versions               | Supports Amazon RDS |
+| :-------------------------- | :--------------------- | :-- |
+| Oracle                      | 12c, 19c, 21c          | Yes |
+| MariaDB                     | >= 10.5                | No |
+| MySQL                       | 5.7, 8.0.x             | No |
+| Postgres                    | 10, 11, 12, 13, 14, 15 | Yes |
+| SQL Server                  | 2017, 2019             | No |
+| Google Cloud SQL MySQL      | 8.0                    | No |
+| Google Cloud SQL Postgres   | 15                     | No |
+| Google Cloud SQL SQL Server | 2019                   | No |
+| Google Cloud AlloyDB for PostgreSQL | | No |
+| AWS Aurora/PostgreSQL | 15 | Yes |
 
 ## How RDI is deployed
 

--- a/content/integrate/redis-data-integration/architecture.md
+++ b/content/integrate/redis-data-integration/architecture.md
@@ -89,18 +89,7 @@ the backpressure mechanism.
 
 RDI supports the following database sources using [Debezium Server](https://debezium.io/documentation/reference/stable/operations/debezium-server.html) connectors:
 
-| Database                    | Versions               | Supports Amazon RDS |
-| :-------------------------- | :--------------------- | :-- |
-| Oracle                      | 12c, 19c, 21c          | Yes |
-| MariaDB                     | >= 10.5                | No |
-| MySQL                       | 5.7, 8.0.x             | No |
-| Postgres                    | 10, 11, 12, 13, 14, 15 | Yes |
-| SQL Server                  | 2017, 2019             | No |
-| Google Cloud SQL MySQL      | 8.0                    | No |
-| Google Cloud SQL Postgres   | 15                     | No |
-| Google Cloud SQL SQL Server | 2019                   | No |
-| Google Cloud AlloyDB for PostgreSQL | | No |
-| AWS Aurora/PostgreSQL | 15 | Yes |
+{{< embed-md "rdi-supported-source-versions.md" >}}
 
 ## How RDI is deployed
 


### PR DESCRIPTION
I got the details of the supported AWS RDS databases from the existing pages - please check if they're all correct. Also, I got the supported version of Aurora/PostgreSQL from [this screenshot](https://redislabs.atlassian.net/wiki/spaces/~6318b461316bbc56c425f7f9/pages/4753588337/RDI+with+AWS+Aurora+and+PostgreSQL#Create-Aurora-PostgreSQL-DB-cluster) in George's original document - please let me know if we need to add any other supported versions here.