### PR TITLE
DEV+RS: hash field limitation in RediSearch v2.10

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
@@ -84,4 +84,5 @@ Improvements (since 2.10.4):
 - The version inside Redis will be 2.10.5 in semantic versioning. Since the version of a module in Redis is numeric, we could not add a Release Candidate flag.
 - Minimal Redis version: 7.4
 - If indexing and querying RedisJSON data structures, this version is best combined with RedisJSON 2.8 (v2.8.2 onwards)
+- If one or more fields of a hash key expire after a query begins (using FT.SEARCH or FT.AGGREGATE), Redis does not account for these lazily expired fields. As a result, expired fields may still be included in the query results, leading to potentially incorrect or inconsistent results.
 {{< /note >}}

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisstack/redisstack-7.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisstack/redisstack-7.4-release-notes.md
@@ -89,6 +89,10 @@ There are many additional improvements, including new command arguments, securit
 - Developers can now match `TAG` fields without needing to escape special characters, making the onboarding process and use of the query syntax simpler.
 - Geospatial search capabilities have been expanded with new `INTERSECT` and `DISJOINT` operators, and ergonomics have been improved by providing better reporting of the memory consumed by the index and exposing the Full-text scoring in the aggregation pipeline.
 
+{{< warning >}}
+If one or more fields of a hash key expire after a query begins (using FT.SEARCH or FT.AGGREGATE), Redis does not account for these lazily expired fields. As a result, expired fields may still be included in the query results, leading to potentially incorrect or inconsistent results.
+{{< /warning >}}
+
 **Removal of triggers and functions**
 
 Redis Stack 7.4 will no longer include triggers and functions. To ensure a seamless upgrade, remove any T&F functions created before loading an RDB file into the new Redis Stack.

--- a/content/operate/rs/release-notes/rs-7-8-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/_index.md
@@ -247,6 +247,6 @@ The following legacy UI features are not yet available in the new Cluster Manage
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Software cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached end-of-life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
 
-#### Query results might include lazily expired hash key fields
+#### Query results might include hash keys with lazily expired fields
 
-If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.
+If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, keys with expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.

--- a/content/operate/rs/release-notes/rs-7-8-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/_index.md
@@ -246,3 +246,7 @@ The following legacy UI features are not yet available in the new Cluster Manage
 #### RedisGraph prevents upgrade to RHEL 9 
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Software cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached end-of-life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
+
+#### Query results might include lazily expired hash key fields
+
+If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
@@ -423,6 +423,10 @@ The following legacy UI features are not yet available in the new Cluster Manage
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Software cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached End-of-Life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
 
+#### Query results might include lazily expired hash key fields
+
+If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.
+
 ## Security
 
 #### Open source Redis security fixes compatibility

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
@@ -423,9 +423,9 @@ The following legacy UI features are not yet available in the new Cluster Manage
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Software cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached End-of-Life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
 
-#### Query results might include lazily expired hash key fields
+#### Query results might include hash keys with lazily expired fields
 
-If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.
+If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, keys with expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.
 
 ## Security
 

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-60.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-60.md
@@ -117,6 +117,10 @@ The following legacy UI features are not yet available in the new Cluster Manage
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Software cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached End-of-Life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
 
+#### Query results might include lazily expired hash key fields
+
+If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.
+
 ## Security
 
 #### Open source Redis security fixes compatibility

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-60.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-60.md
@@ -117,9 +117,9 @@ The following legacy UI features are not yet available in the new Cluster Manage
 
 You cannot upgrade from a prior RHEL version to RHEL 9 if the Redis Software cluster contains a RedisGraph module, even if unused by any database. The [RedisGraph module has reached End-of-Life](https://redis.com/blog/redisgraph-eol/) and is completely unavailable in RHEL 9.
 
-#### Query results might include lazily expired hash key fields
+#### Query results might include hash keys with lazily expired fields
 
-If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.
+If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE` query begins, Redis does not account for these lazily expired fields. As a result, keys with expired fields might still be included in the query results, leading to potentially incorrect or inconsistent results.
 
 ## Security
 


### PR DESCRIPTION
[DOC-4670](https://redislabs.atlassian.net/browse/DOC-4670)

@rrelledge: I added a note in both the Redis Stack 7.4 and RediSearch 2.10 release notes.

[DOC-4670]: https://redislabs.atlassian.net/browse/DOC-4670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ