### PR TITLE
Update quick-start.md

### DIFF
--- a/content/operate/kubernetes/deployment/quick-start.md
+++ b/content/operate/kubernetes/deployment/quick-start.md
@@ -27,6 +27,7 @@ To deploy Redis Enterprise for Kubernetes, you'll need:
 - minimum of three worker nodes
 - Kubernetes client (kubectl)
 - access to DockerHub, RedHat Container Catalog, or a private repository that can hold the required images.
+NOTE: If you are applying version 7.8.2-6 or above, check if the [OS](https://redis.io/docs/latest/operate/kubernetes/release-notes/7-8-2-releases/7-8-2-6-nov24/#breaking-changes) installed on the node is supported.
 
 ### Create a new namespace
 


### PR DESCRIPTION
I tested it on Rhel 8.5 and encountered the following issues:

![이슈1](https://github.com/user-attachments/assets/e01f96d5-5a0f-4a67-8340-d3a5f7db1af7)

In pod/my-rec-1, 1/2 pod is failing.
kubectl describe pod my-rec-1

![이슈2](https://github.com/user-attachments/assets/7c0d66c2-eb50-4beb-a3d3-456f9e246a02)

Normally READY my-rec-2 2/2 Running 0 54m
kubectl describe pod my-rec-2 When I checked the log, it was as follows.

![이슈3](https://github.com/user-attachments/assets/3ad902ec-a94d-49ae-9185-1d4a6c899959)

The cause was an OS version issue.
If you were to guide us again that it is affected by the OS when installing version 7.8.2-6 on k8s, you wouldn't run into issues.
