### PR TITLE
DOC-4730 experimental build target that uses local client repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /data/repos.json
 /data/tool_types.json
 /data/versions.json
+/data/components_local/
 /examples
 build/components/__pycache__/
 venv/**

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ HUGO_BUILD=--gc
 
 all: clean deps components hugo
 serve: clean deps components serve_hugo
+localserve: clean deps components_local serve_hugo
 
 deps:
 	@npm install
@@ -12,6 +13,9 @@ deps:
 
 components:
 	@python3 build/make.py
+
+components_local:
+	@python3 build/make.py --stack ./data/components_local/index.json
 
 hugo:
 	@hugo $(HUGO_DEBUG) $(HUGO_BUILD)


### PR DESCRIPTION
[DOC-4730](https://redislabs.atlassian.net/browse/DOC-4730)

Summary:

- The `make.py` file that builds the docs has a `--stack` option that specifies where to locate the `index.json` file for the client repos. Currently, we don't specify any option, so it uses the default.
- I've added a new build target (`localserve`) that works the same as `make serve` but sets the `--stack` option of `make.py` to `data/components_local/index.json` instead of the default `data/components/index.json`. The `data/components_local` folder is just a copy of `data/components` to begin with, but you can change the individual client repo files (`redis-py.json`, etc) to reference your local clones of the repos instead of the ones on Github.
- I've also added `data/components_local` to `.gitignore`.

The theory, then, is that you can keep the files in `data/components_local` permanently set to your local client repo clones (changing the branch when necessary) and build with them using `make localserve`. You won't commit this folder by mistake because it is in `.gitignore`.

Any suggestions for a better approach, better names, showstoppers, etc, are all very welcome :-)

[DOC-4730]: https://redislabs.atlassian.net/browse/DOC-4730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ