### PR TITLE
DOC-4732 added TCE markup to geo index page

### DIFF
--- a/content/develop/interact/search-and-query/indexing/geoindex.md
+++ b/content/develop/interact/search-and-query/indexing/geoindex.md
@@ -35,32 +35,32 @@ reference page for a full description of both types.
 The following command creates a `GEO` index for JSON objects that contain
 the geospatial data in a field called `location`:
 
-```bash
+{{< clients-example geoindex create_geo_idx >}}
 > FT.CREATE productidx ON JSON PREFIX 1 product: SCHEMA $.location AS location GEO
 OK
-```
+{{< /clients-example >}}
 
 If you now add JSON objects with the `product:` prefix and a `location` field,
 they will be added to the index automatically:
 
-```bash
+{{< clients-example geoindex add_geo_json >}}
 > JSON.SET product:46885 $ '{"description": "Navy Blue Slippers","price": 45.99,"city": "Denver","location": "-104.991531, 39.742043"}'
 OK
 > JSON.SET product:46886 $ '{"description": "Bright Green Socks","price": 25.50,"city": "Fort Collins","location": "-105.0618814,40.5150098"}'
 OK
-```
+{{< /clients-example >}}
 
 The query below finds products within a 100 mile radius of Colorado Springs
 (Longitude=-104.800644, Latitude=38.846127). This returns only the location in
 Denver, but a radius of 200 miles would also include the location in Fort Collins:
 
-```bash
+{{< clients-example geoindex geo_query >}}
 > FT.SEARCH productidx '@location:[-104.800644 38.846127 100 mi]'
 1) "1"
 2) "product:46885"
 3) 1) "$"
    2) "{\"description\":\"Navy Blue Slippers\",\"price\":45.99,\"city\":\"Denver\",\"location\":\"-104.991531, 39.742043\"}"
-```
+{{< /clients-example >}}
 
 See [Geospatial queries]({{< relref "/develop/interact/search-and-query/query/geo-spatial" >}})
 for more information about the available options.
@@ -73,14 +73,14 @@ of the field definition specifies Cartesian coordinates instead of
 the default spherical geographical coordinates. Use `SPHERICAL` in
 place of `FLAT` to choose the coordinate space explicitly.
 
-```bash
+{{< clients-example geoindex create_gshape_idx >}}
 > FT.CREATE geomidx ON JSON PREFIX 1 shape: SCHEMA $.name AS name TEXT $.geom AS geom GEOSHAPE FLAT
 OK
-```
+{{< /clients-example >}}
 
 Use the `shape:` prefix for the JSON objects to add them to the index:
 
-```bash
+{{< clients-example geoindex add_gshape_json >}}
 > JSON.SET shape:1 $ '{"name": "Green Square", "geom": "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))"}'
 OK
 > JSON.SET shape:2 $ '{"name": "Red Rectangle", "geom": "POLYGON ((2 2.5, 2 3.5, 3.5 3.5, 3.5 2.5, 2 2.5))"}'
@@ -89,20 +89,20 @@ OK
 OK
 > JSON.SET shape:4 $ '{"name": "Purple Point", "geom": "POINT (2 2)"}'
 OK
-```
+{{< /clients-example >}}
 
 You can now run various geospatial queries against the index. For
 example, the query below returns any shapes within the boundary
 of the green square but omits the green square itself:
 
-```bash
+{{< clients-example geoindex gshape_query >}}
 > FT.SEARCH geomidx "(-@name:(Green Square) @geom:[WITHIN $qshape])" PARAMS 2 qshape "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))" RETURN 1 name DIALECT 4
 
 1) (integer) 1
 2) "shape:4"
 3) 1) "name"
    2) "[\"Purple Point\"]"
-```
+{{< /clients-example >}}
 
 You can also run queries to find whether shapes in the index completely contain
 or overlap each other. See


### PR DESCRIPTION
[DOC-4731](https://redislabs.atlassian.net/browse/DOC-4731) (I used the wrong ticket number for the branch - 4732 is actually the Jedis ticket :-( )

Markup for geo indexing TCEs.

As usual, we shouldn't merge this until we get at least one client's worth of examples merged to their repo.

[DOC-4731]: https://redislabs.atlassian.net/browse/DOC-4731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ