### PR TITLE
Use the main integration branch for documentation

### DIFF
--- a/data/components/lettuce_async.json
+++ b/data/components/lettuce_async.json
@@ -9,7 +9,7 @@
   },
   "examples": {
       "git_uri": "https://github.com/redis/lettuce",
-      "dev_branch": "doctests",
+      "dev_branch": "main",
       "path": "src/test/java/io/redis/examples/async",
       "pattern": "*.java"
   }

--- a/data/components/lettuce_reactive.json
+++ b/data/components/lettuce_reactive.json
@@ -9,7 +9,7 @@
   },
   "examples": {
       "git_uri": "https://github.com/redis/lettuce",
-      "dev_branch": "doctests",
+      "dev_branch": "main",
       "path": "src/test/java/io/redis/examples/reactive",
       "pattern": "*.java"
   }


### PR DESCRIPTION
Up until now we were using the doctests branch to prepare the integration of Lettuce.
Switching to main to make sure we are up-to-date with the latest development.