### PR TITLE
DOC-4345 added testable JSON index/query examples for Python

### DIFF
--- a/content/develop/clients/dotnet/queryjson.md
+++ b/content/develop/clients/dotnet/queryjson.md
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 - clients
 description: Learn how to use the Redis query engine with JSON
-linkTitle: JSON query example
+linkTitle: Index and query JSON
 title: Example - Index and query JSON documents
 weight: 2
 ---

--- a/content/develop/clients/go/queryjson.md
+++ b/content/develop/clients/go/queryjson.md
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 - clients
 description: Learn how to use the Redis query engine with JSON
-linkTitle: JSON query example
+linkTitle: Index and query JSON
 title: Example - Index and query JSON documents
 weight: 2
 ---

--- a/content/develop/clients/jedis/queryjson.md
+++ b/content/develop/clients/jedis/queryjson.md
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 - clients
 description: Learn how to use the Redis query engine with JSON
-linkTitle: JSON query example
+linkTitle: Index and query JSON
 title: Example - Index and query JSON documents
 weight: 2
 ---

--- a/content/develop/clients/php/queryjson.md
+++ b/content/develop/clients/php/queryjson.md
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 - clients
 description: Learn how to use the Redis query engine with JSON
-linkTitle: JSON query example
+linkTitle: Index and query JSON
 title: Example - Index and query JSON documents
 weight: 2
 ---

--- a/content/develop/clients/redis-py/queryjson.md
+++ b/content/develop/clients/redis-py/queryjson.md
@@ -10,7 +10,7 @@ categories:
 - kubernetes
 - clients
 description: Learn how to use the Redis query engine with JSON
-linkTitle: JSON query example
+linkTitle: Index and query JSON
 title: Example - Index and query JSON documents
 weight: 2
 ---


### PR DESCRIPTION
[DOC-4345](https://redislabs.atlassian.net/browse/DOC-4345)

Also changed the link titles for the JSON query example pages (previous ones were considered a bit "boring').

[DOC-4345]: https://redislabs.atlassian.net/browse/DOC-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ