### PR TITLE
DEV: fix typo on cluster spec page

### DIFF
--- a/content/operate/oss_and_stack/reference/cluster-spec.md
+++ b/content/operate/oss_and_stack/reference/cluster-spec.md
@@ -198,7 +198,7 @@ Then instead of hashing the key, only what is between the first occurrence of `{
 Examples:
 
 * The two keys `{user1000}.following` and `{user1000}.followers` will hash to the same hash slot since only the substring `user1000` will be hashed in order to compute the hash slot.
-* For the key `foo{}{bar}` the whole key will be hashed as usually since the first occurrence of `{` is followed by `}` on the right without characters in the middle.
+* For the key `foo{}{bar}` the whole key will be hashed as usual since the first occurrence of `{` is followed by `}` on the right without characters in the middle.
 * For the key `foo{{bar}}zap` the substring `{bar` will be hashed, because it is the substring between the first occurrence of `{` and the first occurrence of `}` on its right.
 * For the key `foo{bar}{zap}` the substring `bar` will be hashed, since the algorithm stops at the first valid or invalid (without bytes inside) match of `{` and `}`.
 * What follows from the algorithm is that if the key starts with `{}`, it is guaranteed to be hashed as a whole. This is useful when using binary data as key names.


### PR DESCRIPTION
[DOC-4747](https://redislabs.atlassian.net/browse/DOC-4747)

Fixes #1074.

[DOC-4747]: https://redislabs.atlassian.net/browse/DOC-4747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ