### PR TITLE
DOC-4772 added latest RDI version variable and updated a command line

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -55,6 +55,7 @@ rdi_redis_gears_version = "1.2.6"
 rdi_debezium_server_version = "2.3.0.Final"
 rdi_db_types = "cassandra|mysql|oracle|postgresql|sqlserver"
 rdi_cli_latest = "latest"
+rdi_current_version = "v1.4.4"
 
 [params.clientsConfig]
 "Python"={quickstartSlug="redis-py"}

--- a/content/integrate/redis-data-integration/installation/install-vm.md
+++ b/content/integrate/redis-data-integration/installation/install-vm.md
@@ -20,8 +20,7 @@ This guide explains how to install Redis Data Integration (RDI) on one or more V
 your source database. You can also
 [Install RDI on Kubernetes]({{< relref "/integrate/redis-data-integration/installation/install-k8s" >}}).
 
-{{< note >}}We recommend you use RDI v1.4.2 or above. The previous version, RDI v1.2.8,
-will not work on VMs where IPv6 is disabled. This problem is solved with version 1.4.0.
+{{< note >}}We recommend you use the latest version, which is RDI {{< field "rdi_current_version" >}}.
 {{< /note >}}
 
 ## Hardware sizing
@@ -133,7 +132,7 @@ We recommend you turn off
 before installation with the command:
 
 ```bash
-ufw disable
+sudo ufw disable
 ```
 
 However, if you do need to use `ufw`, you must add the following rules:

--- a/content/integrate/redis-data-integration/installation/install-vm.md
+++ b/content/integrate/redis-data-integration/installation/install-vm.md
@@ -20,7 +20,7 @@ This guide explains how to install Redis Data Integration (RDI) on one or more V
 your source database. You can also
 [Install RDI on Kubernetes]({{< relref "/integrate/redis-data-integration/installation/install-k8s" >}}).
 
-{{< note >}}We recommend you use the latest version, which is RDI {{< field "rdi_current_version" >}}.
+{{< note >}}We recommend you always use the latest version, which is RDI {{< field "rdi_current_version" >}}.
 {{< /note >}}
 
 ## Hardware sizing


### PR DESCRIPTION
[DOC-4772](https://redislabs.atlassian.net/browse/DOC-4772) (which basically just references [RDSC-3174](https://redislabs.atlassian.net/browse/RDSC-3174) and [RDSC-3175](https://redislabs.atlassian.net/browse/RDSC-3175)).

Note that I've assumed it's only the `ufw disable` that needs `sudo`, but let me know if the other `ufw` commands do too and I'll add it in.

[DOC-4772]: https://redislabs.atlassian.net/browse/DOC-4772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RDSC-3174]: https://redislabs.atlassian.net/browse/RDSC-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RDSC-3175]: https://redislabs.atlassian.net/browse/RDSC-3175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ