### PR TITLE
RS: Fix potentially misleading entries in supported upgrade paths table

### DIFF
--- a/content/embeds/rs-upgrade-paths.md
+++ b/content/embeds/rs-upgrade-paths.md
@@ -7,8 +7,8 @@
 | Current Redis Software cluster version | Upgrade to Redis Software 6.2.x | Upgrade to Redis Software 6.4.x | Upgrade to Redis Software 7.2.x | Upgrade to Redis Software 7.4.x |  Upgrade to Redis Software 7.8.x |
 |:-----------------------:|:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
 | 6.0.x | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> |
-| 6.2.4<br />6.2.8 | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Not supported">:x:</span> |
-| 6.2.10<br />6.2.12<br />6.2.18 | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| 6.4.x | – | – | <span title="Supported">&#x2705;</span> |  <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| 7.2.x | – | – | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| 7.4.x | – | – | – | - | <span title="Supported">&#x2705;</span> |
+| 6.2.4<br />6.2.8 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Not supported">:x:</span> |
+| 6.2.10<br />6.2.12<br />6.2.18 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| 6.4.x | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| 7.2.x | – | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| 7.4.x | – | – | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
@@ -27,7 +27,7 @@ The default Redis database version differs between Redis Enterprise releases as 
 
 | Redis<br />Software | Bundled Redis<br />DB versions | Default DB version<br />(upgraded/new databases) |
 |-------|----------|-----|
-| 7.8.2 | 6.2, 7.2, 7.4 | 7.4 |
+| 7.8.x | 6.2, 7.2, 7.4 | 7.4 |
 | 7.4.x | 6.0, 6.2, 7.2 | 7.2 |
 | 7.2.4 | 6.0, 6.2, 7.2 | 7.2 |
 | 6.4.2 | 6.0, 6.2 | 6.2 |


### PR DESCRIPTION
DOC-4780

Staged preview: https://redis.io/docs/staging/DOC-4780/operate/rs/installing-upgrading/upgrading/upgrade-cluster/