### PR TITLE
DOC-4831 updated link to Dart docs

### DIFF
--- a/content/develop/clients/_index.md
+++ b/content/develop/clients/_index.md
@@ -48,7 +48,7 @@ Redis does not document directly:
 | :-- | :-- | :-- | :-- |
 | C | hiredis | https://github.com/redis/hiredis | https://github.com/redis/hiredis |
 | [C++](https://en.wikipedia.org/wiki/C%2B%2B) | Boost.Redis | https://github.com/boostorg/redis | https://www.boost.org/doc/libs/develop/libs/redis/doc/html/index.html |
-| [Dart](https://dart.dev/) | redis_dart_link | https://github.com/toolsetlink/redis_dart_link | https://pub.dev/documentation/redis/latest/ |
+| [Dart](https://dart.dev/) | redis_dart_link | https://github.com/toolsetlink/redis_dart_link | https://github.com/toolsetlink/redis_dart_link |
 | [PHP](https://www.php.net/) | PhpRedis extension | https://github.com/phpredis/phpredis | https://github.com/phpredis/phpredis/blob/develop/README.md |
 | [Ruby](https://www.ruby-lang.org/en/) | redis-rb | https://github.com/redis/redis-rb | https://rubydoc.info/gems/redis |
 | [Rust](https://www.rust-lang.org/) | redis-rs | https://github.com/redis-rs/redis-rs | https://docs.rs/redis/latest/redis/ |


### PR DESCRIPTION
[DOC-4831](https://redislabs.atlassian.net/browse/DOC-4831)

The Dart client developer prefers to have the docs link point to the Github README, as noted [in this issue](https://github.com/RedisJSON/RedisJSON/issues/1323).

[DOC-4831]: https://redislabs.atlassian.net/browse/DOC-4831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ