### PR TITLE
Fix meta-links

### DIFF
--- a/layouts/partials/meta-links.html
+++ b/layouts/partials/meta-links.html
@@ -1,5 +1,6 @@
 {{ $gh_repo := .Site.Params.gitHubRepo }}
-{{ $gh_file := .File }}
+{{ $gh_path := .File.Dir }}
+{{ $gh_file := .File.LogicalName }}
 {{ $gh_branch := "main" }}
 {{ $parts := split .RelPermalink "/" }}
 {{ if eq (index $parts 1) "staging" }}
@@ -9,10 +10,10 @@
   {{ $gh_branch := "main" }}
 {{ end }}
 
-{{ $path := replaceRE `(_index.md)$|(index.md)$|(.md)$` "" $gh_file }}
+{{ $stripped_filename := replaceRE `(_index.md)$|(index.md)$|(.md)$` "" $gh_file | lower }}
 
-{{ $editURL := printf "%s/edit/%s/content/%s" $gh_repo $gh_branch $gh_file }}
-{{ $issuesURL := printf "%s/issues/new?title=Feedback: %s&body=Page https://redis.io/docs/latest/%s" $gh_repo (safeURL $.Title ) $path }}
+{{ $editURL := printf "%s/edit/%s/content/%s%s" $gh_repo $gh_branch $gh_path $gh_file }}
+{{ $issuesURL := printf "%s/issues/new?title=Feedback: %s&body=Page https://redis.io/docs/latest/%s%s" $gh_repo (safeURL $.Title ) $gh_path $stripped_filename }}
 
 <nav class="flex flex-col gap-3 pb-3 w-52 text-redis-pencil-600 border-b border-b-redis-pen-700 border-opacity-50">
   <a {{ printf "href=%q" $editURL | safeHTMLAttr }} target="_blank" class="group inline-flex items-center gap-1  hover:text-redis-pen-400 mt-auto self-start">


### PR DESCRIPTION
The hugo upgrade broke the meta-links because of changes introduced in hugo v0.123.0