### PR TITLE
DEV: collapse cmd categories and remove Stack from layouts and cmd pages

### DIFF
--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -39,35 +39,31 @@
                 {{ $id }}
               </option>
           {{ end */}}
-          <optgroup label="Core">
-            <option value="bitmap" data-kind="core">Bitmap</option>
-            <option value="cluster" data-kind="core">Cluster management</option>
-            <option value="connection" data-kind="core">Connection management</option>
-            <option value="generic" data-kind="core">Generic</option>
-            <option value="geo" data-kind="core">Geospatial indices</option>
-            <option value="hash" data-kind="core">Hash</option>
-            <option value="hyperloglog" data-kind="core">HyperLogLog</option>
-            <option value="list" data-kind="core">List</option>
-            <option value="pubsub" data-kind="core">Pub/Sub</option>
-            <option value="scripting" data-kind="core">Scripting and functions</option>
-            <option value="server" data-kind="core">Server management</option>
-            <option value="set" data-kind="core">Set</option>
-            <option value="sorted-set" data-kind="core">Sorted set</option>
-            <option value="stream" data-kind="core">Stream</option>
-            <option value="string" data-kind="core">String</option>
-            <option value="transactions" data-kind="core">Transactions</option>
-          </optgroup>
-          <optgroup label="Stack">
-            <option value="bf" data-kind="stack">Bloom filter</option>
-            <option value="cf" data-kind="stack">Cuckoo filter</option>
-            <option value="cms" data-kind="stack">Count-min sketch</option>
-            <option value="json" data-kind="stack">JSON</option>
-            <option value="search" data-kind="stack">Redis Query Engine</option>
-            <option value="suggestion" data-kind="stack">Auto-suggest</option>
-            <option value="tdigest" data-kind="stack">T-digest</option>
-            <option value="timeseries" data-kind="stack">Time series</option>
-            <option value="topk" data-kind="stack">Top-k</option>
-          </optgroup>
+          <option value="bf" data-kind="stack">Bloom filter</option>
+          <option value="bitmap" data-kind="core">Bitmap</option>
+          <option value="cf" data-kind="stack">Cuckoo filter</option>
+          <option value="cluster" data-kind="core">Cluster management</option>
+          <option value="cms" data-kind="stack">Count-min sketch</option>
+          <option value="connection" data-kind="core">Connection management</option>
+          <option value="generic" data-kind="core">Generic</option>
+          <option value="geo" data-kind="core">Geospatial indices</option>
+          <option value="hash" data-kind="core">Hash</option>
+          <option value="hyperloglog" data-kind="core">HyperLogLog</option>
+          <option value="json" data-kind="stack">JSON</option>
+          <option value="list" data-kind="core">List</option>
+          <option value="pubsub" data-kind="core">Pub/Sub</option>
+          <option value="scripting" data-kind="core">Scripting and functions</option>
+          <option value="search" data-kind="stack">Redis Query Engine</option>
+          <option value="server" data-kind="core">Server management</option>
+          <option value="set" data-kind="core">Set</option>
+          <option value="sorted-set" data-kind="core">Sorted set</option>
+          <option value="stream" data-kind="core">Stream</option>
+          <option value="string" data-kind="core">String</option>
+          <option value="suggestion" data-kind="stack">Auto-suggest</option>
+          <option value="tdigest" data-kind="stack">T-digest</option>
+          <option value="timeseries" data-kind="stack">Time series</option>
+          <option value="topk" data-kind="stack">Top-k</option>
+          <option value="transactions" data-kind="core">Transactions</option>
         </select>
         <div style="display:none">
           <label for="version-filter">by version</label>

--- a/layouts/commands/single.html
+++ b/layouts/commands/single.html
@@ -45,12 +45,11 @@
         <dl class="grid grid-cols-[auto,1fr] gap-2 mb-12">
           {{ if not $isModule }}
           <dt class="font-semibold text-redis-ink-900 m-0">Available since:</dt>
-          <dd class="m-0">{{ .Params.since }}</dd>
+          <dd class="m-0">Redis CE {{ .Params.since }}</dd>
           {{ else }}
           <dt class="font-semibold text-redis-ink-900 m-0">Available in:</dt>
           <dd class="m-0">
-            <a href="/docs/stack">Redis Stack</a> /
-            <a href="/{{ .Params.stack_path }}">{{ .Params.module }} {{ .Params.since }}</a>
+            Redis CE</a> / {{ .Params.module }} {{ .Params.since }}</a>
           </dd>
           {{ end }}
           <dt class="font-semibold text-redis-ink-900 m-0">Time complexity:</dt>


### PR DESCRIPTION
[DOC-4874](https://redislabs.atlassian.net/browse/DOC-4874)

This PR changes the grouping and sorting order of the command **Filter by group...** menu and also removes the word "Stack" from each module command page. For example,

Available in: Stack / Bloom 1.0.0

becomes

Available in: Redis CE / Bloom 1.0.0

[DOC-4874]: https://redislabs.atlassian.net/browse/DOC-4874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ