### PR TITLE
RS: Change localhost to name/IP in the Cluster Manager UI URL in quick starts

### DIFF
--- a/content/embeds/cluster-setup.md
+++ b/content/embeds/cluster-setup.md
@@ -1,12 +1,8 @@
-1. In the web browser on the host machine, go to [https://localhost:8443](https://localhost:8443) to see
-the new Redis Enterprise Software Cluster Manager UI. The cluster generates self-signed TLS certificates to secure the connection.  These self-signed certificates are unknown to the browser and must be accepted before you proceed.
+1. In a browser, go to `https://<name or IP address of the machine with Redis Enterprise Software installed>:8443` to access the Cluster Manager UI. If you use a browser on the host machine, you can also access the Cluster Manager UI at `https://localhost:8443`.
 
-    To use the legacy UI for this quickstart instead, see the [6.4 version of the quickstarts](https://docs.redis.com/6.4/rs/installing-upgrading/quickstarts/).
+    The cluster generates self-signed TLS certificates to secure the connection. Because these self-signed certificates are unknown to the browser, you must accept them before you proceed.
 
-    {{< note >}}
-- If the server does not show the login screen, try again after a few minutes.
-
-    {{< /note >}}
+    If the server does not show the sign-in screen, try again after a few minutes.
 
 1. Select **Create new cluster**.
 

--- a/content/embeds/cluster-setup.md
+++ b/content/embeds/cluster-setup.md
@@ -1,4 +1,4 @@
-1. In a browser, go to `https://<name or IP address of the machine with Redis Enterprise Software installed>:8443` to access the Cluster Manager UI. If you use a browser on the host machine, you can also access the Cluster Manager UI at `https://localhost:8443`.
+1. In a browser, go to `https://<name-or-IP-address-of-the-machine-with-Redis-Enterprise-Software-installed>:8443` to access the Cluster Manager UI. If you use a browser on the host machine, you can also access the Cluster Manager UI at `https://localhost:8443`.
 
     The cluster generates self-signed TLS certificates to secure the connection. Because these self-signed certificates are unknown to the browser, you must accept them before you proceed.
 


### PR DESCRIPTION
DOC-2773

I changed the main Cluster Manager UI URL example from localhost to name/IP, but I thought it might be worth keeping the localhost example as an option too.

Staged previews:
1. https://redis.io/docs/staging/DOC-2773/operate/rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart/#set-up-a-cluster
2. https://redis.io/docs/staging/DOC-2773/operate/rs/installing-upgrading/quickstarts/docker-quickstart/#set-up-a-cluster