### PR TITLE
DOC-4833 updated deploy instructions for K8s

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/deploy.md
+++ b/content/integrate/redis-data-integration/data-pipelines/deploy.md
@@ -156,12 +156,16 @@ kubectl create secret generic target-db-ssl --namespace=rdi \
 
 ## Deploy a pipeline
 
-When you have created your configuration, including the [jobs]({{< relref "/integrate/redis-data-integration/data-pipelines/data-pipelines#job-files" >}}), use the
+When you have created your configuration, including the [jobs]({{< relref "/integrate/redis-data-integration/data-pipelines/data-pipelines#job-files" >}}), they are
+ready to deploy. Use [Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}})
+to configure and deploy pipelines for both VM and K8s installations.
+
+For VM installations, you can also use the
 [`redis-di deploy`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-deploy" >}})
-command to deploy them:
+command to deploy a pipeline:
 
 ```bash
 redis-di deploy --dir <path to pipeline folder>
 ```
 
-You can also deploy a pipeline using [Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}}).
+

--- a/content/integrate/redis-data-integration/installation/install-k8s.md
+++ b/content/integrate/redis-data-integration/installation/install-k8s.md
@@ -524,7 +524,7 @@ You must ensure that an appropriate
 [ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)
 is available in your K8s cluster to expose the RDI API service via the K8s
 [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-resource,. Follow the documentation of your cloud provider or of
+resource. Follow the documentation of your cloud provider or of
 the ingress controller to install the controller correctly.
 
 ### Using the `nginx` ingress controller on AKS

--- a/content/integrate/redis-data-integration/installation/install-k8s.md
+++ b/content/integrate/redis-data-integration/installation/install-k8s.md
@@ -520,10 +520,11 @@ You can verify that the RDI API works by adding the server in
 
 ## Using ingress controllers
 
-If you want to expose the RDI API service via the K8s
+You must ensure that an appropriate
+[ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)
+is available in your K8s cluster to expose the RDI API service via the K8s
 [`Ingress`](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-resource, you must ensure that an appropriate
-[ingress controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) is available in your K8s cluster. Follow the documentation of your cloud provider or of
+resource,. Follow the documentation of your cloud provider or of
 the ingress controller to install the controller correctly.
 
 ### Using the `nginx` ingress controller on AKS
@@ -548,12 +549,12 @@ section to learn how to do this.
 
 ## Deploy a pipeline
 
-When the Helm installation is complete,  and you have prepared the source database for CDC,
-you are ready to start using RDI. See the guides to
-[configuring]({{< relref "/integrate/redis-data-integration/data-pipelines/data-pipelines" >}}) and
-[deploying]({{< relref "/integrate/redis-data-integration/data-pipelines/deploy" >}})
-RDI pipelines for more information. You can also configure and deploy a pipeline
-using [Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}}).
+When the Helm installation is complete and you have prepared the source database for CDC,
+you are ready to start using RDI.
+Use [Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}}) to
+[configure]({{< relref "/integrate/redis-data-integration/data-pipelines/data-pipelines" >}}) and
+[deploy]({{< relref "/integrate/redis-data-integration/data-pipelines/deploy" >}})
+your pipeline.
 
 ## Uninstall RDI
 


### PR DESCRIPTION
[DOC-4833](https://redislabs.atlassian.net/browse/DOC-4833)

Clarifies that you need Redis Insight to configure/deploy RDI on K8s.

[DOC-4833]: https://redislabs.atlassian.net/browse/DOC-4833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ