### PR TITLE
Update _index.md

### DIFF
--- a/content/operate/rs/_index.md
+++ b/content/operate/rs/_index.md
@@ -78,4 +78,4 @@ To view documentation earlier than version 7.4, see the archived website:
 
 ## Continue learning with Redis University
 
-{{< university-links >}}
+See the [Get started with Redis Software learning path](https://university.redis.io/learningpath/an0mgw5bjpjfbe?_gl=1*4gjdoe*_gcl_au*MTkyMTIyOTY3Mi4xNzM5MTk5Mjc4) for courses.


### PR DESCRIPTION
this embed for univeristy-links doesn't appear on an index page (its just a blank section), so replacing it with a hard link