### PR TITLE
DOC-4912 fix broken link to RDI configure command

### DIFF
--- a/content/integrate/redis-data-integration/observability.md
+++ b/content/integrate/redis-data-integration/observability.md
@@ -96,7 +96,7 @@ The logs are recorded at the minimum `INFO` level and get rotated when they reac
 RDI retains the last five log rotated files by default.
 Logs are in a straightforward text format, which lets you analyze them with several different observability tools.
 You can change the default log settings using the
-[`redis-di config-rdi`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-config-rdi" >}})
+[`redis-di configure-rdi`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-configure-rdi" >}})
 command.
 
 ## Dump support package


### PR DESCRIPTION
[DOC-4912](https://redislabs.atlassian.net/browse/DOC-4912)

Basically `redis-di config-rdi` is now called `redis-di configure-rdi`, so the link to the old page name was broken.

[DOC-4912]: https://redislabs.atlassian.net/browse/DOC-4912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ