### PR TITLE
Remove and replace erroneous context

### DIFF
--- a/content/develop/data-types/sorted-sets.md
+++ b/content/develop/data-types/sorted-sets.md
@@ -58,7 +58,7 @@ As you can see [`ZADD`]({{< relref "/commands/zadd" >}}) is similar to [`SADD`](
 pairs, as shown in the example above.
 
 With sorted sets it is trivial to return a list of racers sorted by their
-birth year because actually *they are already sorted*.
+score because actually *they are already sorted*.
 
 Implementation note: Sorted sets are implemented via a
 dual-ported data structure containing both a skip list and a hash table, so


### PR DESCRIPTION
The mention of "birth year" is clearly incorrect. (Possibly relates to a previous, overwritten example?)

The example shown is about "racers" and their "scores". There are no birth years in the data examples.