### PR TITLE
Fix typo error of the word streams

### DIFF
--- a/content/commands/xadd/index.md
+++ b/content/commands/xadd/index.md
@@ -182,7 +182,7 @@ IDs to match the one of this other system.
 
 `XADD` incorporates the same semantics as the [`XTRIM`]({{< relref "/commands/xtrim" >}}) command - refer to its documentation page for more information.
 This allows adding new entries and keeping the stream's size in check with a single call to `XADD`, effectively capping the stream with an arbitrary threshold.
-Although exact trimming is possible and is the default, due to the internal representation of steams it is more efficient to add an entry and trim stream with `XADD` using **almost exact** trimming (the `~` argument).
+Although exact trimming is possible and is the default, due to the internal representation of streams it is more efficient to add an entry and trim stream with `XADD` using **almost exact** trimming (the `~` argument).
 
 For example, calling `XADD` in the following form:
 


### PR DESCRIPTION
There is a small typo error in `XADD` command doc [page](https://redis.io/docs/latest/commands/xadd/#capped-streams).

In the description of **Capped streams**, the sentence:

> due to the internal representation of steams

is using incorrect spelling "**steams**" instead of "**streams**".