### PR TITLE
DOC-4985 added section about restricting privileges

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/oracle.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/oracle.md
@@ -216,7 +216,7 @@ you might want to prevent the Debezium user from creating tables, or
 selecting or locking any table.
 
 The Debezium user needs the `CREATE TABLE` privilege to create the
-`LOG_MINING_FLUSH` and `signals` tables when it connects for the first
+`LOG_MINING_FLUSH` table when it connects for the first
 time. After this point, it doesn't need to create any more tables,
 so you can safely revoke this privilege with the following command:
 
@@ -225,8 +225,8 @@ REVOKE CREATE TABLE FROM c##dbzuser container=all;
 ```
 
 [The example above](#create-dbz-user) grants the `SELECT ANY TABLE` and
-`FLASHBACK ANY TABLE` privileges for convenience, but only the tables synced to RDI,
-the `signals` table, and the `V_$XXX` tables strictly need these privileges.
+`FLASHBACK ANY TABLE` privileges for convenience, but only the tables synced to RDI
+and the `V_$XXX` tables strictly need these privileges.
 You can replace the `GRANT SELECT ANY TABLE` command with explicit
 commands for each table. For example, you would use commands like the
 following for the tables in our sample
@@ -235,7 +235,6 @@ database. (Note that Oracle 19c requires you to run a separate `GRANT`
 command for each table individually.)
 
 ```sql
-GRANT SELECT ON signals TO c##dbzuser;
 GRANT SELECT ON chinook.album TO c##dbzuser;
 GRANT SELECT ON chinook.artist TO c##dbzuser;
 GRANT SELECT ON chinook.customer TO c##dbzuser;
@@ -246,7 +245,6 @@ Similarly, instead of `GRANT FLASHBACK ANY TABLE`, you would use the following
 commands:
 
 ```sql
-GRANT FLASHBACK ON signals TO c##dbzuser;
 GRANT FLASHBACK ON chinook.album TO c##dbzuser;
 GRANT FLASHBACK ON chinook.artist TO c##dbzuser;
 GRANT FLASHBACK ON chinook.customer TO c##dbzuser;

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/oracle.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/oracle.md
@@ -142,7 +142,7 @@ use the following setting:
 }
 ```
 
-## 5. Create a user for the connector
+## 5. Create a user for the connector {#create-dbz-user}
 
 The Debezium Oracle connector must run as an Oracle LogMiner user with
 specific permissions. The following example shows some SQL that creates
@@ -166,37 +166,128 @@ CREATE USER c##dbzuser IDENTIFIED BY dbz
     QUOTA UNLIMITED ON logminer_tbs
     CONTAINER=ALL;
 
-GRANT CREATE SESSION TO c##dbzuser CONTAINER=ALL; 
-GRANT SET CONTAINER TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$DATABASE to c##dbzuser CONTAINER=ALL; 
-GRANT FLASHBACK ANY TABLE TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ANY TABLE TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL; 
-GRANT EXECUTE_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ANY TRANSACTION TO c##dbzuser CONTAINER=ALL; 
-GRANT LOGMINING TO c##dbzuser CONTAINER=ALL; 
+GRANT CREATE SESSION TO c##dbzuser CONTAINER=ALL;
+GRANT SET CONTAINER TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$DATABASE to c##dbzuser CONTAINER=ALL;
 
-GRANT CREATE TABLE TO c##dbzuser CONTAINER=ALL; 
-GRANT LOCK ANY TABLE TO c##dbzuser CONTAINER=ALL; 
-GRANT CREATE SEQUENCE TO c##dbzuser CONTAINER=ALL; 
+-- See `Limiting privileges` below if the privileges
+-- granted by these two commands raise security concerns.
+GRANT FLASHBACK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TABLE TO c##dbzuser CONTAINER=ALL;
+-- 
 
-GRANT EXECUTE ON DBMS_LOGMNR TO c##dbzuser CONTAINER=ALL; 
-GRANT EXECUTE ON DBMS_LOGMNR_D TO c##dbzuser CONTAINER=ALL; 
+GRANT SELECT_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE_CATALOG_ROLE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ANY TRANSACTION TO c##dbzuser CONTAINER=ALL;
+GRANT LOGMINING TO c##dbzuser CONTAINER=ALL;
 
-GRANT SELECT ON V_$LOG TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$LOG_HISTORY TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$LOGMNR_LOGS TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$LOGMNR_CONTENTS TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$LOGMNR_PARAMETERS TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$LOGFILE TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$ARCHIVED_LOG TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$ARCHIVE_DEST_STATUS TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$TRANSACTION TO c##dbzuser CONTAINER=ALL; 
+-- See `Limiting privileges` below if the privileges
+-- granted by these two commands raise security concerns.
+GRANT CREATE TABLE TO c##dbzuser CONTAINER=ALL;
+GRANT LOCK ANY TABLE TO c##dbzuser CONTAINER=ALL;
+-- 
 
-GRANT SELECT ON V_$MYSTAT TO c##dbzuser CONTAINER=ALL; 
-GRANT SELECT ON V_$STATNAME TO c##dbzuser CONTAINER=ALL; 
+GRANT CREATE SEQUENCE TO c##dbzuser CONTAINER=ALL;
+
+GRANT EXECUTE ON DBMS_LOGMNR TO c##dbzuser CONTAINER=ALL;
+GRANT EXECUTE ON DBMS_LOGMNR_D TO c##dbzuser CONTAINER=ALL;
+
+GRANT SELECT ON V_$LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOG_HISTORY TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_LOGS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_CONTENTS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGMNR_PARAMETERS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$LOGFILE TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVED_LOG TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$ARCHIVE_DEST_STATUS TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$TRANSACTION TO c##dbzuser CONTAINER=ALL;
+
+GRANT SELECT ON V_$MYSTAT TO c##dbzuser CONTAINER=ALL;
+GRANT SELECT ON V_$STATNAME TO c##dbzuser CONTAINER=ALL;
 
 exit;
+```
+
+### Limiting privileges
+
+The privileges granted in the example above are convenient,
+but you may prefer to restrict them further to improve security. In particular,
+you might want to prevent the Debezium user from creating tables, or
+selecting or locking any table.
+
+The Debezium user needs the `CREATE TABLE` privilege to create the
+`LOG_MINING_FLUSH` and `signals` tables when it connects for the first
+time. After this point, it doesn't need to create any more tables,
+so you can safely revoke this privilege with the following command:
+
+```sql
+REVOKE CREATE TABLE FROM c##dbzuser container=all;
+```
+
+[The example above](#create-dbz-user) grants the `SELECT ANY TABLE` and
+`FLASHBACK ANY TABLE` privileges for convenience, but only the tables synced to RDI,
+the `signals` table, and the `V_$XXX` tables strictly need these privileges.
+You can replace the `GRANT SELECT ANY TABLE` command with explicit
+commands for each table. For example, you would use commands like the
+following for the tables in our sample
+[`chinook`](https://github.com/Redislabs-Solution-Architects/rdi-quickstart-postgres)
+database. (Note that Oracle 19c requires you to run a separate `GRANT`
+command for each table individually.)
+
+```sql
+GRANT SELECT ON signals TO c##dbzuser;
+GRANT SELECT ON chinook.album TO c##dbzuser;
+GRANT SELECT ON chinook.artist TO c##dbzuser;
+GRANT SELECT ON chinook.customer TO c##dbzuser;
+...
+```
+
+Similarly, instead of `GRANT FLASHBACK ANY TABLE`, you would use the following
+commands:
+
+```sql
+GRANT FLASHBACK ON signals TO c##dbzuser;
+GRANT FLASHBACK ON chinook.album TO c##dbzuser;
+GRANT FLASHBACK ON chinook.artist TO c##dbzuser;
+GRANT FLASHBACK ON chinook.customer TO c##dbzuser;
+...
+```
+
+The `LOCK` privilege is automatically granted by the `SELECT`
+privilege, so you can omit this command if you have granted `SELECT`
+on specific tables.
+
+### Revoking existing privileges
+
+If you initially set the Debezium user's privileges on all tables,
+but you now want to restrict them, you can revoke the existing
+privileges before resetting them as described in the
+[Limiting privileges](#limiting-privileges) section.
+
+Use the following commands to revoke and reset the `SELECT` privileges:
+
+```sql
+REVOKE SELECT ANY TABLE FROM c##dbzuser container=all;
+ALTER SESSION SET container=orclpdb1;
+
+GRANT SELECT ON chinook.album TO c##dbzuser;
+-- ...etc
+```
+
+The equivalent commands for `FLASHBACK` are:
+
+```sql
+REVOKE FLASHBACK ANY TABLE FROM c##dbzuser container=all;
+ALTER SESSION SET container=orclpdb1;
+GRANT FLASHBACK ON chinook.album TO c##dbzuser;
+```
+
+The `SELECT` privilege automatically includes the `LOCK`
+privilege, so when you grant `SELECT` for specific tables
+you should also revoke `LOCK` on all tables:
+
+```sql
+REVOKE LOCK ANY TABLE FROM c##dbzuser container=all;
 ```
 
 ## 6. Configuration is complete


### PR DESCRIPTION
[DOC-4985](https://redislabs.atlassian.net/browse/DOC-4985)

The info in the new "Limiting privileges" and "Revoking existing privileges" sections mainly comes from George's [technical note](https://redislabs.atlassian.net/wiki/spaces/~6318b461316bbc56c425f7f9/pages/4399136793/RDI+Notes#Improved-Security-for-Oracle), but I've also attempted to tie the new content in with the existing example.

Hopefully this works OK, but let me know if are any errors or possible improvements. In particular, Yaron's comments on the technical note mention privileges for the `signals` table and the `V_$XXX` tables. Maybe in the main example, we should set privileges on `signals` explicitly, like we do with the `V_$XXX` tables?

[DOC-4985]: https://redislabs.atlassian.net/browse/DOC-4985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ