### PR TITLE
DEV: update examples on two JSON pages

### DIFF
--- a/content/commands/json.debug-memory/index.md
+++ b/content/commands/json.debug-memory/index.md
@@ -69,7 +69,7 @@ Get the values' memory usage in bytes.
 
 {{< highlight bash >}}
 redis> JSON.DEBUG MEMORY item:2
-(integer) 253
+(integer) 685
 {{< / highlight >}}
 </details>
 

--- a/content/develop/data-types/json/ram.md
+++ b/content/develop/data-types/json/ram.md
@@ -9,9 +9,7 @@ categories:
 - oss
 - kubernetes
 - clients
-description: 'Debugging memory consumption
-
-  '
+description: Debugging memory consumption
 linkTitle: Memory Usage
 title: Redis JSON RAM Usage
 weight: 6
@@ -22,7 +20,7 @@ well as some per-key overhead that Redis uses. On top of that, the value in the 
 RAM.
 
 Redis JSON stores JSON values as binary data after deserializing them. This representation is often more
-expensive, size-wise, than the serialized form. The JSON data type uses at least 24 bytes (on
+expensive, size-wise, than the serialized form. The JSON data type uses at least 8 bytes (on
 64-bit architectures) for every value, as can be seen by sampling an empty string with the
 [`JSON.DEBUG MEMORY`]({{< relref "commands/json.debug-memory/" >}}) command:
 
@@ -30,7 +28,7 @@ expensive, size-wise, than the serialized form. The JSON data type uses at least
 127.0.0.1:6379> JSON.SET emptystring . '""'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY emptystring
-(integer) 24
+(integer) 8
 ```
 
 This RAM requirement is the same for all scalar values, but strings require additional space
@@ -40,20 +38,20 @@ depending on their actual length. For example, a 3-character string will use 3 a
 127.0.0.1:6379> JSON.SET foo . '"bar"'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY foo
-(integer) 27
+(integer) 11
 ```
 
-Empty containers take up 32 bytes to set up:
+Empty containers take up 8 bytes to set up:
 
 ```
 127.0.0.1:6379> JSON.SET arr . '[]'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY arr
-(integer) 32
+(integer) 8
 127.0.0.1:6379> JSON.SET obj . '{}'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY obj
-(integer) 32
+(integer) 8
 ```
 
 The actual size of a container is the sum of sizes of all items in it on top of its own
@@ -65,7 +63,7 @@ A container with a single scalar is made up of 32 and 24 bytes, respectively:
 127.0.0.1:6379> JSON.SET arr . '[""]'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY arr
-(integer) 56
+(integer) 64
 ```
 
 A container with two scalars requires 40 bytes for the container (each pointer to an entry in the
@@ -74,7 +72,7 @@ container is 8 bytes), and 2 * 24 bytes for the values themselves:
 127.0.0.1:6379> JSON.SET arr . '["", ""]'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY arr
-(integer) 88
+(integer) 72
 ```
 
 A 3-item (each 24 bytes) container will be allocated with capacity for 4 items, i.e. 56 bytes:
@@ -83,7 +81,7 @@ A 3-item (each 24 bytes) container will be allocated with capacity for 4 items, 
 127.0.0.1:6379> JSON.SET arr . '["", "", ""]'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY arr
-(integer) 128
+(integer) 80
 ```
 
 The next item will not require an allocation in the container, so usage will increase only by that
@@ -93,24 +91,23 @@ scalar's requirement, but another value will scale the container again:
 127.0.0.1:6379> JSON.SET arr . '["", "", "", ""]'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY arr
-(integer) 152
+(integer) 88
 127.0.0.1:6379> JSON.SET arr . '["", "", "", "", ""]'
 OK
 127.0.0.1:6379> JSON.DEBUG MEMORY arr
-(integer) 208
+(integer) 128
 ```
 
-This table gives the size (in bytes) of a few of the test files on disk and when stored using
-JSON. The _MessagePack_ column is for reference purposes and reflects the length of the value
-when stored using MessagePack.
+This table gives the size (in bytes) of a few of the test files from the [module repo](https://github.com/RedisJSON/RedisJSON), stored using
+JSON. The _MessagePack_ column is for reference purposes and reflects the length of the value when stored using [MessagePack](https://msgpack.org/index.html).
 
-| File                                   | Filesize  | Redis JSON | MessagePack |
-| -------------------------------------- | --------- | ------ | ----------- |
-| /tests/files/pass-100.json              | 380       | 1079   | 140         |
-| /tests/files/pass-jsonsl-1.json         | 1441      | 3666   | 753         |
-| /tests/files/pass-json-parser-0000.json | 3468      | 7209   | 2393        |
-| /tests/files/pass-jsonsl-yahoo2.json    | 18446     | 37469  | 16869       |
-| /tests/files/pass-jsonsl-yelp.json      | 39491     | 75341  | 35469       |
+| File                                    | File size | Redis JSON | MessagePack |
+| --------------------------------------- | --------- | ---------- | ----------- |
+| /tests/files/pass-100.json              | 381       | 1349       | 140         |
+| /tests/files/pass-jsonsl-1.json         | 1387      | 2734       | 757         |
+| /tests/files/pass-json-parser-0000.json | 3718      | 6157       | 2393        |
+| /tests/files/pass-jsonsl-yahoo2.json    | 22466     | 29957      | 16869       |
+| /tests/files/pass-jsonsl-yelp.json      | 46333     | 63489      | 35529       |
 
 > Note: In the current version, deleting values from containers **does not** free the container's
 allocated memory.


### PR DESCRIPTION
[DOC-5003](https://redislabs.atlassian.net/browse/DOC-5003)

@LiorKogan:

I've updated the return values from each example on the two modified pages using the latest available Redis Stack Docker image. What I can't work it is how the values stack. For example, in the following sequence of commands,

```
127.0.0.1:6379> JSON.SET arr . '[""]'
OK
127.0.0.1:6379> JSON.DEBUG MEMORY arr
(integer) 64
```

the size, if I believe the current write-up, should be 8 + 8 = 16 bytes. But, inexplicably, it's 64 bytes. I don't know how that result is calculated. So, I definitely need your help with the sizing explanations in the `content/develop/data-types/json/ram.md` document.