### PR TITLE
DOC-4952 Python scan iterators page

### DIFF
--- a/content/develop/clients/redis-py/scaniter.md
+++ b/content/develop/clients/redis-py/scaniter.md
@@ -9,7 +9,7 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Iterate through results from `SCAN`, `HSCAN`, etc
+description: Iterate through results from `SCAN`, `HSCAN`, etc.
 linkTitle: Scan iteration
 title: Scan iteration
 weight: 5

--- a/content/develop/clients/redis-py/scaniter.md
+++ b/content/develop/clients/redis-py/scaniter.md
@@ -50,9 +50,6 @@ command page for examples).
 import redis
 
 r = redis.Redis(decode_responses=True)
-# REMOVE_START
-r.flushall()
-# REMOVE_END
 
 r.set("key:1", "a")
 r.set("key:2", "b")

--- a/content/develop/clients/redis-py/scaniter.md
+++ b/content/develop/clients/redis-py/scaniter.md
@@ -1,0 +1,66 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Iterate through results from `SCAN`, `HSCAN`, etc
+linkTitle: Scan iteration
+title: Scan iteration
+weight: 5
+---
+
+Redis has a small family of related commands that retrieve
+keys and sometimes their associated values:
+
+-   [`SCAN`]({{< relref "/commands/scan" >}}) retrieves keys
+    from the main Redis keyspace.
+-   [`HSCAN`]({{< relref "/commands/hscan" >}}) retrieves keys and optionally,
+    their values from a
+    [hash]({{< relref "/develop/data-types/hashes" >}}) object.
+-   [`SSCAN`]({{< relref "/commands/sscan" >}}) retrieves keys from a
+    [set]({{< relref "/develop/data-types/sets" >}}) object.
+-   [`ZSCAN`]({{< relref "/commands/zscan" >}}) retrieves keys and their score values from a
+    [sorted set]({{< relref "/develop/data-types/sorted-sets" >}}) object.
+
+These commands can potentially return large numbers of results, so Redis
+provides a paging mechanism to access the results in small, separate batches.
+With the basic commands, you must maintain a cursor value in your code
+to keep track of the current page. As a convenient alternative, `redis-py`
+also lets you access the results using an
+[iterator](https://docs.python.org/3/glossary.html#term-iterable).
+This handles the paging transparently, so you simply need to process
+the items it returns one-by-one in a `for` loop or pass the iterator
+object itself in place of a
+[sequence](https://docs.python.org/3/glossary.html#term-sequence).
+
+Each of the commands has its own equivalent iterator. The following example shows
+how to use a `SCAN` iterator on the Redis keyspace. Note that, as with the `SCAN`
+command, the results are not sorted into any particular order, . Also, you
+can pass `match`, `count`, and `_type` parameters to `scan_iter()` to constrain
+the set of keys it returns (see the [`SCAN`]({{< relref "/commands/scan" >}})
+command page for examples). 
+
+{{< clients-example scan_iter scan Python >}}
+{{< /clients-example >}}
+
+The iterators for the other commands are also named with `_iter()` after
+the name of the basic command (`hscan_iter()`, `sscan_iter()`, and `zscan_iter()`).
+They work in a similar way to `scan_iter()` except that you must pass a
+key to identify the object you want to scan. The example below shows how to
+iterate through the items in a sorted set using `zscan_iter()`.
+
+{{< clients-example scan_iter zscan Python >}}
+{{< /clients-example>}}
+
+Note that in this case, the item returned by the iterator is a
+[tuple](https://docs.python.org/3/tutorial/datastructures.html#tuples-and-sequences)
+with two elements for the key and score. By default, `hscan_iter()`
+also returns a 2-tuple for the key and value, but you can
+pass a value of `True` for the `no_values` parameter to retrieve just
+the keys.


### PR DESCRIPTION
[DOC-4952](https://redislabs.atlassian.net/browse/DOC-4952)

I'll add similar pages for the other clients also. The main reason for making this a separate page is to help with the separate ioredis migration docs and also because this is useful info for PHP, but we don't have any TCEs where we could add this stuff in.



[DOC-4952]: https://redislabs.atlassian.net/browse/DOC-4952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ