### PR TITLE
DOC-5073 added TCE markup

### DIFF
--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -60,7 +60,7 @@ Start by adding the point vectors to a set called `points` using
 The [`TYPE`]({{< relref "/commands/type" >}}) command returns a type of `vectorset`
 for this object.
 
-```
+{{< clients-example vecset_tutorial vadd >}}
 > VADD points VALUES 2 1.0 1.0 pt:A
 (integer) 1
 > VADD points VALUES 2 -1.0 -1.0 pt:B
@@ -73,18 +73,19 @@ for this object.
 (integer) 1
 > TYPE points
 vectorset
-```
+{{< /clients-example >}}
+
 
 Get the number of elements in the set (also known as the *cardinality* of the set)
 using [`VCARD`]({{< relref "/commands/vcard" >}}) and the number of dimensions of
 the vectors using [`VDIM`]({{< relref "/commands/vdim" >}}):
 
-```
+{{< clients-example vecset_tutorial vcardvdim >}}
 > VCARD points
 (integer) 5
 > VDIM points
 (integer) 2
-```
+{{< /clients-example >}}
 
 Get the coordinate values from the elements using [`VEMB`]({{< relref "/commands/vemb" >}}).
 Note that the values will not typically be the exact values you supplied when you added
@@ -92,7 +93,7 @@ the vector because
 [quantization]({{< relref "/develop/data-types/vector-sets/performance#quantization-effects" >}})
 is applied to improve performance.
 
-```
+{{< clients-example vecset_tutorial vemb >}}
 > VEMB points pt:A
 1) "0.9999999403953552"
 2) "0.9999999403953552"
@@ -108,14 +109,14 @@ is applied to improve performance.
 > VEMB points pt:E
 1) "1"
 2) "0"
-```
+{{< /clients-example >}}
 
 Set and retrieve an element's JSON attribute data using
 [`VSETATTR`]({{< relref "/commands/vsetattr" >}})
 and [`VGETATTR`]({{< relref "/commands/vgetattr" >}}). You can also pass an empty string
 to `VSETATTR` to delete the attribute data:
 
-```
+{{< clients-example vecset_tutorial attr >}}
 > VSETATTR points pt:A "{\"name\": \"Point A\", \"description\": \"First point added\"}" 
 (integer) 1
 > VGETATTR points pt:A
@@ -124,11 +125,11 @@ to `VSETATTR` to delete the attribute data:
 (integer) 1
 > VGETATTR points pt:A
 (nil)
-```
+{{< /clients-example >}}
 
 Remove an unwanted element with [`VREM`]({{< relref "/commands/vrem" >}})
 
-```
+{{< clients-example vecset_tutorial vrem >}}
 > VADD points VALUES 2 0 0 pt:F
 (integer) 1
 127.0.0.1:6379> VCARD points
@@ -137,24 +138,24 @@ Remove an unwanted element with [`VREM`]({{< relref "/commands/vrem" >}})
 (integer) 1
 127.0.0.1:6379> VCARD points
 (integer) 5
-```
+{{< /clients-example >}}
 
 ### Vector similarity search
 
 Use [`VSIM`]({{< relref "/commands/vsim" >}}) to rank the points in order of their vector distance from a sample point:
 
-```
+{{< clients-example vecset_tutorial vsim_basic >}}
 > VSIM points values 2 0.9 0.1
 1) "pt:E"
 2) "pt:A"
 3) "pt:D"
 4) "pt:C"
 5) "pt:B"
-```
+{{< /clients-example >}}
 
 Find the four elements that are closest to point A and show their distance "scores":
 
-```
+{{< clients-example vecset_tutorial vsim_options >}}
 > VSIM points ELE pt:A WITHSCORES COUNT 4
 1) "pt:A"
 2) "1"
@@ -164,13 +165,13 @@ Find the four elements that are closest to point A and show their distance "scor
 6) "0.5"
 7) "pt:D"
 8) "0.5"
-```
+{{< /clients-example >}}
 
 Add some JSON attributes and use
 [filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
 to include them in the search:
 
-```
+{{< clients-example vecset_tutorial vsim_filter >}}
 > VSETATTR points pt:A "{\"size\":\"large\",\"price\": 18.99}"
 (integer) 1
 > VSETATTR points pt:B "{\"size\":\"large\",\"price\": 35.99}"
@@ -194,7 +195,7 @@ to include them in the search:
 > VSIM points ELE pt:A FILTER '.size == "large" && .price > 20.00'
 1) "pt:C"
 2) "pt:B"
-```
+{{< /clients-example >}}
 
 ## More information
 


### PR DESCRIPTION
[DOC-5073](https://redislabs.atlassian.net/browse/DOC-5073)

The examples are already merged to the redis-py repo, so these are good to go.

[DOC-5073]: https://redislabs.atlassian.net/browse/DOC-5073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ