### PR TITLE
fix: typo `JSON.ARRAPEND` -> `JSON.ARRAPPEND`

### DIFF
--- a/content/commands/json.arrappend/index.md
+++ b/content/commands/json.arrappend/index.md
@@ -67,7 +67,7 @@ is JSONPath to specify. Default is root `$`.
 
 ## Return value 
 
-`JSON.ARRAPEND` returns an [array]({{< relref "develop/reference/protocol-spec#resp-arrays" >}}) of integer replies for each path, the array's new size, or `nil`, if the matching JSON value is not an array. 
+`JSON.ARRAPPEND` returns an [array]({{< relref "develop/reference/protocol-spec#resp-arrays" >}}) of integer replies for each path, the array's new size, or `nil`, if the matching JSON value is not an array. 
 For more information about replies, see [Redis serialization protocol specification]({{< relref "/develop/reference/protocol-spec" >}}). 
 
 ## Examples
@@ -82,7 +82,7 @@ redis> JSON.SET item:1 $ '{"name":"Noise-cancelling Bluetooth headphones","descr
 OK
 {{< / highlight >}}
 
-Add color `blue` to the end of the `colors` array. `JSON.ARRAPEND` returns the array's new size.
+Add color `blue` to the end of the `colors` array. `JSON.ARRAPPEND` returns the array's new size.
 
 {{< highlight bash >}}
 redis> JSON.ARRAPPEND item:1 $.colors '"blue"'


### PR DESCRIPTION
Small typo fix in the `JSON.ARRAPPEND` docs.