### PR TITLE
[RediSearch] `\` is the only valid symbol for escaping in wildcard matching

### DIFF
--- a/content/develop/interact/search-and-query/advanced-concepts/query_syntax.md
+++ b/content/develop/interact/search-and-query/advanced-concepts/query_syntax.md
@@ -335,7 +335,7 @@ As of v2.6.0, you can use the dictionary for wildcard matching queries with thes
 
 * `?` - for any single character
 * `*` - for any character repeating zero or more times
-* ' and \ - for escaping; other special characters are ignored
+* `\` - for escaping; other special characters are ignored
 
 An example of the syntax is `"w'foo*bar?'"`.
 


### PR DESCRIPTION
The escaping logic is implemented [here](https://github.com/RediSearch/RediSearch/blob/d988bde19385cd4e6aeec7987d344819eda66ab4/src/wildcard.c#L136) and it doesn't treat `'` as an escaping symbol.