### PR TITLE
DOC-5192 added C# production usage page

### DIFF
--- a/content/develop/clients/dotnet/condexec.md
+++ b/content/develop/clients/dotnet/condexec.md
@@ -12,7 +12,7 @@ categories:
 description: Understand how `NRedisStack` uses conditional execution
 linkTitle: Conditional execution
 title: Conditional execution
-weight: 6
+weight: 60
 ---
 
 Most Redis client libraries use transactions with the

--- a/content/develop/clients/dotnet/connect.md
+++ b/content/develop/clients/dotnet/connect.md
@@ -12,7 +12,7 @@ categories:
 description: Connect your .NET application to a Redis database
 linkTitle: Connect
 title: Connect to the server
-weight: 2
+weight: 20
 ---
 
 ## Basic connection

--- a/content/develop/clients/dotnet/produsage.md
+++ b/content/develop/clients/dotnet/produsage.md
@@ -1,0 +1,72 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Get your NRedisStack app ready for production
+linkTitle: Production usage
+title: Production usage
+weight: 70
+---
+
+This guide offers recommendations to get the best reliability and
+performance in your production environment.
+
+## Checklist
+
+Each item in the checklist below links to the section
+for a recommendation. Use the checklist icons to record your
+progress in implementing the recommendations.
+
+{{< checklist "prodlist" >}}
+    {{< checklist-item "#server-maintenance-event-handling" >}}Server maintenance event handling{{< /checklist-item >}}
+    {{< checklist-item "#exception-handling" >}}Exception handling{{< /checklist-item >}}
+{{< /checklist >}}
+
+## Recommendations
+
+The sections below offer recommendations for your production environment. Some
+of them may not apply to your particular use case.
+
+### Server maintenance event handling
+
+Some servers (such as Azure Cache for Redis) send notification events shortly
+before scheduled maintenance is due to happen. You can use code like the
+following to respond to these events (see the 
+[StackExchange.Redis](https://stackexchange.github.io/StackExchange.Redis/ServerMaintenanceEvent)
+docs for the full list of supported events). For example, you could
+inform users who try to connect that service is temporarily unavailable
+rather than letting them run into errors.
+
+```cs
+using NRedisStack;
+using StackExchange.Redis;
+
+ConnectionMultiplexer muxer = ConnectionMultiplexer.Connect("localhost:6379");
+
+muxer.ServerMaintenanceEvent += (object sender, ServerMaintenanceEvent e) => {
+    // Identify the event and respond to it here.
+    Console.WriteLine($"Maintenance event: {e.RawMessage}");
+};
+```
+
+### Exception handling
+
+Redis handles many errors using return values from commands, but there
+are also situations where exceptions can be thrown. In production code,
+you should handle exceptions as they occur. The list below describes some
+the most common Redis exceptions:
+
+- `RedisConnectionException`: Thrown when a connection attempt fails.
+- `RedisTimeoutException`: Thrown when a command times out.
+- `RedisCommandException`: Thrown when you issue an invalid command.
+- `RedisServerException`: Thrown when you attempt an invalid operation
+  (for example, trying to access a
+  [stream entry]({{< relref "/develop/data-types/streams#entry-ids" >}})
+  using an invalid ID).

--- a/content/develop/clients/dotnet/produsage.md
+++ b/content/develop/clients/dotnet/produsage.md
@@ -24,7 +24,7 @@ Each item in the checklist below links to the section
 for a recommendation. Use the checklist icons to record your
 progress in implementing the recommendations.
 
-{{< checklist "prodlist" >}}
+{{< checklist "dotnetprodlist" >}}
     {{< checklist-item "#server-maintenance-event-handling" >}}Server maintenance event handling{{< /checklist-item >}}
     {{< checklist-item "#exception-handling" >}}Exception handling{{< /checklist-item >}}
 {{< /checklist >}}

--- a/content/develop/clients/dotnet/queryjson.md
+++ b/content/develop/clients/dotnet/queryjson.md
@@ -12,7 +12,7 @@ categories:
 description: Learn how to use the Redis query engine with JSON and hash documents.
 linkTitle: Index and query documents
 title: Index and query documents
-weight: 2
+weight: 30
 ---
 
 This example shows how to create a

--- a/content/develop/clients/dotnet/transpipe.md
+++ b/content/develop/clients/dotnet/transpipe.md
@@ -12,7 +12,7 @@ categories:
 description: Learn how to use Redis pipelines and transactions
 linkTitle: Pipelines/transactions
 title: Pipelines and transactions
-weight: 5
+weight: 50
 ---
 
 Redis lets you send a sequence of commands to the server together in a batch.

--- a/content/develop/clients/dotnet/vecsearch.md
+++ b/content/develop/clients/dotnet/vecsearch.md
@@ -12,7 +12,7 @@ categories:
 description: Learn how to index and query vector embeddings with Redis
 linkTitle: Index and query vectors
 title: Index and query vectors
-weight: 3
+weight: 40
 ---
 
 [Redis Query Engine]({{< relref "/develop/interact/search-and-query" >}})


### PR DESCRIPTION
[DOC-5192](https://redislabs.atlassian.net/browse/DOC-5192)

This is intended to give recommendations for production usage like the [Jedis page](https://redis.io/docs/latest/develop/clients/jedis/produsage/), but it's actually quite difficult to find any advice for NRedisStack :-) (Client-side caching isn't implemented, and most of the stuff recommended for Jedis either happens by default or is handled automatically.)

I'd love to hear ideas - if we can't think of any more recommendations, then maybe this page isn't necessary for NRedisStack and we should just have a short section about this stuff in the landing page.

[DOC-5192]: https://redislabs.atlassian.net/browse/DOC-5192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ