### PR TITLE
DOC-5201 added release notes for RDI v1.6.7

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -55,7 +55,7 @@ rdi_redis_gears_version = "1.2.6"
 rdi_debezium_server_version = "2.3.0.Final"
 rdi_db_types = "cassandra|mysql|oracle|postgresql|sqlserver"
 rdi_cli_latest = "latest"
-rdi_current_version = "v1.6.6"
+rdi_current_version = "v1.6.7"
 
 [params.clientsConfig]
 "Python"={quickstartSlug="redis-py"}

--- a/content/integrate/redis-data-integration/installation/install-k8s.md
+++ b/content/integrate/redis-data-integration/installation/install-k8s.md
@@ -38,7 +38,7 @@ You can use this installation on [OpenShift](https://docs.openshift.com/) and ot
 including cloud providers' K8s managed clusters.
 
 You can pull the RDI images from the 
-[download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.6.tgz)
+[download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.7.tgz)
 or from your own [private image registry](#using-a-private-image-registry).
 
 ## Before you install
@@ -51,7 +51,7 @@ Complete the following steps before running Helm:
     [Access control]({{< relref "/operate/rs/security/access-control" >}}) for
     more information).
 -   Download the RDI helm chart tar file from the
-    [download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.6.tgz).
+    [download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.7.tgz).
 -   If you want to use a private image registry,
     [prepare it with the RDI images](#using-a-private-image-registry).
 
@@ -69,7 +69,7 @@ file as described below.
 ### Using a private image registry
 
 Add the RDI images from the
-[download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.6.tgz)
+[download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.7.tgz)
 to your local registry.
 The example below shows how to specify the registry and image pull secret in the
 [`values.yaml`](#the-valuesyaml-file) file for the Helm chart:

--- a/content/integrate/redis-data-integration/installation/install-vm.md
+++ b/content/integrate/redis-data-integration/installation/install-vm.md
@@ -154,7 +154,7 @@ ufw allow 9121/tcp  # rdi-metric-exporter
 Follow the steps below for each of your VMs:
 
 1.  Download the RDI installer from the
-    [Redis download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-installation-1.6.6.tar.gz)
+    [Redis download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-installation-1.6.7.tar.gz)
     (from the *Modules, Tools & Integration* category) and extract it to your preferred installation
     folder.
 

--- a/content/integrate/redis-data-integration/installation/upgrade.md
+++ b/content/integrate/redis-data-integration/installation/upgrade.md
@@ -23,7 +23,7 @@ Follow the steps below to upgrade an existing
 of RDI:
 
 1.  Download the RDI installer from the
-    [Redis download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-installation-1.6.6.tar.gz)
+    [Redis download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-installation-1.6.7.tar.gz)
     (in the *Modules, Tools & Integration* category) and extract it to your
     preferred installation folder.
 
@@ -97,7 +97,7 @@ installation of RDI:
     ```
 
 1.  Download the RDI helm chart tar file from the 
-    [Redis download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.6.tgz).
+    [Redis download center](https://redis-enterprise-software-downloads.s3.amazonaws.com/redis-di/rdi-1.6.7.tgz).
 
 1.  Run the `helm upgrade` command:
     

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-6-7.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-6-7.md
@@ -1,0 +1,32 @@
+---
+Title: Redis Data Integration release notes 1.6.7 (May 2025)
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: Installation on Kubernetes with a Helm chart. Improvements for installation on VMs.
+linkTitle: 1.6.7 (May 2025)
+toc: 'true'
+weight: 985
+---
+
+> This maintenance release replaces the 1.6.6 release.
+
+RDI’s mission is to help Redis customers sync Redis Enterprise with live data from their slow disk-based databases to:
+
+- Meet the required speed and scale of read queries and provide an excellent and predictable user experience.
+- Save resources and time when building pipelines and coding data transformations.
+- Reduce the total cost of ownership by saving money on expensive database read replicas.
+
+RDI keeps the Redis cache up to date with changes in the primary database, using a [_Change Data Capture (CDC)_](https://en.wikipedia.org/wiki/Change_data_capture) mechanism.
+It also lets you _transform_ the data from relational tables into convenient and fast data structures that match your app's requirements. You specify the transformations using a configuration system, so no coding is required.
+
+## Headlines
+
+- Update the RDI API `/tables` and `/metadata` endpoints to filter the results by schema for MySQL and 
+  MariaDB. Schema and Database are the same for these databases.
+
+## Limitations
+
+RDI can write data to a Redis Active-Active database. However, it doesn't support writing data to two or more Active-Active replicas. Writing data from RDI to several Active-Active replicas could easily harm data integrity as RDI is not synchronous with the source database commits.


### PR DESCRIPTION
[DOC-5201](https://redislabs.atlassian.net/browse/DOC-5201)

I've taken a guess that the word "scheme" in the release note headline should have been "schema", but let me know if this is incorrect. Assuming it should be "schema", I'll update the release notes in the RDI repo with the same change.

[DOC-5201]: https://redislabs.atlassian.net/browse/DOC-5201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ