### PR TITLE
DOC-5197 remove mentions of Debezium `application.config` in RDI config docs

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/data-denormalization.md
+++ b/content/integrate/redis-data-integration/data-pipelines/data-denormalization.md
@@ -39,7 +39,7 @@ You configure normalization with a `nest` block in the child entities' RDI job, 
 
 ```yaml
 source:
-  server_name: chinook # Optional. Use the value of `debezium.source.topic.prefix` property in Debezium's `application.properties`
+  server_name: chinook
   schema: public
   table: InvoiceLine
 output:

--- a/content/integrate/redis-data-integration/data-pipelines/data-pipelines.md
+++ b/content/integrate/redis-data-integration/data-pipelines/data-pipelines.md
@@ -301,8 +301,7 @@ The main sections of these files are:
 
 - `source`: This is a mandatory section that specifies the data items that you want to 
   use. You can add the following properties here:
-  - `server_name`: Logical server name (optional). This corresponds to the `debezium.source.topic.prefix`
-  property specified in the Debezium Server's `application.properties` config file.
+  - `server_name`: Logical server name (optional).
   - `db`: Database name (optional)
   - `schema`: Database schema (optional)
   - `table`: Database table name. This refers to a table name you supplied in `config.yaml`. The default


### PR DESCRIPTION
[DOC-5197](https://redislabs.atlassian.net/browse/DOC-5197)

Only used in a couple of places, as it turns out.

[DOC-5197]: https://redislabs.atlassian.net/browse/DOC-5197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ