### PR TITLE
Create hugo shortcode for embedding external json files

### DIFF
--- a/layouts/shortcodes/external-json.html
+++ b/layouts/shortcodes/external-json.html
@@ -1,0 +1,4 @@
+{{ $raw := resources.GetRemote (.Get 0) }}
+{{ $data := transform.Unmarshal $raw.Content }}
+{{ $prettyJson := $data | jsonify (dict "prefix" " " "indent" "  ") }}
+{{ highlight $prettyJson "json" "" }}


### PR DESCRIPTION
Example usage:

```
{{< external-json "https://raw.githubusercontent.com/Redislabs-Solution-Architects/cloudformation-aws-Redislabs-Cloud-Account-IAM-Resources/refs/heads/master/RedisLabsInstanceRolePolicy.json" >}}
```