### PR TITLE
DEV: beginning of Develop landing page redesign

### DIFF
--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -1,8 +1,7 @@
 ---
 title: Develop with Redis
 description: Learn how to develop with Redis
-hideListLinks: true
 linkTitle: Develop
 ---
 
-The rest of the landing page.
+Explore the pages below to learn more about developing with Redis Open Source.

--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -6,10 +6,3 @@ linkTitle: Develop
 ---
 
 The rest of the landing page.
-
-{{% redis-cli %}}
-SET mykey "Hello"
-GET mykey
-
-SET anotherkey "will expire in a minute" EX 60
-{{% /redis-cli %}}

--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -1,5 +1,10 @@
 ---
 title: Develop with Redis
 description: Learn how to develop with Redis
+hideListLinks: true
 linkTitle: Develop
 ---
+
+| Try these commands                       |  Redis Console (redis-cli)           |
+|:-----                                    |-----                                 |
+|                                          | {{< redis-cli >}}{{< /redis-cli >}}  |

--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -7,4 +7,4 @@ linkTitle: Develop
 
 | Try these commands                       |  Redis Console (redis-cli)           |
 |:-----                                    |-----                                 |
-|                                          | {{< redis-cli >}}{{< /redis-cli >}}  |
+|                                          | {{< redis-cli >}}LOLWUT VERSION 6{{< /redis-cli >}}  |

--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -5,6 +5,11 @@ hideListLinks: true
 linkTitle: Develop
 ---
 
-| Try these commands                       |  Redis Console (redis-cli)           |
-|:-----                                    |-----                                 |
-|                                          | {{< redis-cli >}}LOLWUT VERSION 6{{< /redis-cli >}}  |
+The rest of the landing page.
+
+{{% redis-cli %}}
+SET mykey "Hello"
+GET mykey
+
+SET anotherkey "will expire in a minute" EX 60
+{{% /redis-cli %}}

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -46,14 +46,14 @@
             </thead>
             <tbody>
               <tr class="flex flex-col md:table-row">
-                <td class="align-top p-4 w-full md:w-[40%] text-sm font-mono">
-                  <p><code><a href="/commands/ping">PING</a></code></br>
+                <td class="align-top p-4 w-full md:w-[40%] text-base font-mono">
+                  <code><a href="/commands/ping">PING</a></code></br>
                   <code><a href="/commands/hset">HSET</a> user:1 name antirez vocation artist</code></br>
                   <code><a href="/commands/hgetall">HGETALL</a> user:1</code></br>
                   <code><a href="/commands/set">SET</a> e 2.71</code></br>
                   <code><a href="/commands/incrbyfloat">INCRBYFLOAT</a> e 0.43</code></br>
                   <code><a href="/commands/rename">RENAME</a> e pi</code></br>
-                  <code><a href="/commands/get">GET</a> pi</code></p>
+                  <code><a href="/commands/get">GET</a> pi</code>
                 </td>
                 <td class="align-top p-4 w-full md:w-[60%]">
                   <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10 h-60 overflow-y-auto">

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -52,7 +52,8 @@
                   <code><a href="/commands/hgetall">HGETALL</a> user:1</code></br>
                   <code><a href="/commands/set">SET</a> e 2.71</code></br>
                   <code><a href="/commands/incrbyfloat">INCRBYFLOAT</a> e 0.43</code></br>
-                  <code><a href="/commands/rename">RENAME</a> e pi</code></p>
+                  <code><a href="/commands/rename">RENAME</a> e pi</code></br>
+                  <code><a href="/commands/get">GET</a> pi</code></p>
                 </td>
                 <td class="align-top p-4 w-full md:w-[60%]">
                   <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10 h-60 overflow-y-auto">

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -5,7 +5,7 @@
 {{ define "main" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav.html" . }}
-    <div class="py-12 md:pl-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:pl-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
       <section class="prose w-full py-12 max-w-none">
         <h1>

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -1,4 +1,5 @@
 {{ define "head" }}
+  <script src='{{ relURL "js/cli.js" }}' defer></script>
   <script src='{{ relURL "js/codetabs.js" }}' defer></script>
 {{ end }}
 

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -34,6 +34,45 @@
           {{ end }}
         {{ end }}
         
+        <!-- CLI Display Block as Table -->
+        <table class="w-full border-collapse">
+          <thead>
+            <tr>
+              <th class="p-4 text-left">Try these Redis commands in the CLI to the right</th>
+              <th class="p-4 text-left">Redis CLI</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="align-top p-4">
+                <p>PING</p>
+                <p>HSET user:1 name antirez vocation artist</p>
+                <p>SET e 2.71</p>
+                <p>INCRBYFLOAT e 0.43</p>
+                <p>RENAME e pi</p>
+              </td>
+              <td class="align-top p-4">
+                <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10">
+                  <div class="border-b border-slate-700 rounded-t-xl px-4 py-3 w-full flex">
+                    {{ partial "icons/cli-circle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
+                    {{ partial "icons/cli-triangle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
+                    {{ partial "icons/cli-star" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
+                  </div>            
+                  <form class="redis-cli" typewriter>
+                    <pre tabindex="0" class="whitespace-pre">
+PING
+HSET user:1 name antirez vocation artist
+SET e 2.71
+INCRBYFLOAT e 0.43
+RENAME e pi
+                    </pre>
+                  </form>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        
         {{ .Content }}
         {{ if not .Params.hideListLinks }}
           <nav>

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -45,15 +45,15 @@
           </thead>
           <tbody>
             <tr>
-              <td class="align-top p-4">
+              <td class="align-top p-4 w-[40%]">
                 <p>PING</p>
                 <p>HSET user:1 name antirez vocation artist</p>
                 <p>SET e 2.71</p>
                 <p>INCRBYFLOAT e 0.43</p>
                 <p>RENAME e pi</p>
               </td>
-              <td class="align-top p-4">
-                <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10">
+              <td class="align-top p-4 w-[60%]">
+                <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10 h-60 overflow-y-auto">
                   <div class="border-b border-slate-700 rounded-t-xl px-4 py-3 w-full flex">
                     {{ partial "icons/cli-circle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
                     {{ partial "icons/cli-triangle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
@@ -62,10 +62,6 @@
                   <form class="redis-cli" typewriter>
                     <pre tabindex="0" class="whitespace-pre">
 PING
-HSET user:1 name antirez vocation artist
-SET e 2.71
-INCRBYFLOAT e 0.43
-RENAME e pi
                     </pre>
                   </form>
                 </div>

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -46,12 +46,13 @@
             </thead>
             <tbody>
               <tr class="flex flex-col md:table-row">
-                <td class="align-top p-4 w-full md:w-[40%]">
-                  <p>PING</p>
-                  <p>HSET user:1 name antirez vocation artist</p>
-                  <p>SET e 2.71</p>
-                  <p>INCRBYFLOAT e 0.43</p>
-                  <p>RENAME e pi</p>
+                <td class="align-top p-4 w-full md:w-[40%] text-sm font-mono">
+                  <p><code><a href="/commands/ping">PING</a></code></br>
+                  <code><a href="/commands/hset">HSET</a> user:1 name antirez vocation artist</code></br>
+                  <code><a href="/commands/hgetall">HGETALL</a> user:1</code></br>
+                  <code><a href="/commands/set">SET</a> e 2.71</code></br>
+                  <code><a href="/commands/incrbyfloat">INCRBYFLOAT</a> e 0.43</code></br>
+                  <code><a href="/commands/rename">RENAME</a> e pi</code></p>
                 </td>
                 <td class="align-top p-4 w-full md:w-[60%]">
                   <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10 h-60 overflow-y-auto">

--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -35,40 +35,42 @@
           {{ end }}
         {{ end }}
         
-        <!-- CLI Display Block as Table -->
-        <table class="w-full border-collapse">
-          <thead>
-            <tr>
-              <th class="p-4 text-left">Try these Redis commands in the CLI to the right</th>
-              <th class="p-4 text-left">Redis CLI</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="align-top p-4 w-[40%]">
-                <p>PING</p>
-                <p>HSET user:1 name antirez vocation artist</p>
-                <p>SET e 2.71</p>
-                <p>INCRBYFLOAT e 0.43</p>
-                <p>RENAME e pi</p>
-              </td>
-              <td class="align-top p-4 w-[60%]">
-                <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10 h-60 overflow-y-auto">
-                  <div class="border-b border-slate-700 rounded-t-xl px-4 py-3 w-full flex">
-                    {{ partial "icons/cli-circle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
-                    {{ partial "icons/cli-triangle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
-                    {{ partial "icons/cli-star" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
-                  </div>            
-                  <form class="redis-cli" typewriter>
-                    <pre tabindex="0" class="whitespace-pre">
+        <!-- Responsive CLI Display Block as Table -->
+        <div class="overflow-x-auto">
+          <table class="w-full border-collapse md:table">
+            <thead>
+              <tr>
+                <th class="p-4 text-left">Try these Redis commands</th>
+                <th class="p-4 text-left hidden md:table-cell">Redis CLI</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="flex flex-col md:table-row">
+                <td class="align-top p-4 w-full md:w-[40%]">
+                  <p>PING</p>
+                  <p>HSET user:1 name antirez vocation artist</p>
+                  <p>SET e 2.71</p>
+                  <p>INCRBYFLOAT e 0.43</p>
+                  <p>RENAME e pi</p>
+                </td>
+                <td class="align-top p-4 w-full md:w-[60%]">
+                  <div class="bg-slate-900 rounded-xl shadow-lg shadow-slate-900/10 h-60 overflow-y-auto">
+                    <div class="border-b border-slate-700 rounded-t-xl px-4 py-3 w-full flex">
+                      {{ partial "icons/cli-circle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
+                      {{ partial "icons/cli-triangle" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
+                      {{ partial "icons/cli-star" (dict "class" "shrink-0 h-[1.0625rem] w-[1.0625rem] fill-slate-50") }}
+                    </div>            
+                    <form class="redis-cli" typewriter>
+                      <pre tabindex="0" class="whitespace-pre">
 PING
-                    </pre>
-                  </form>
-                </div>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+                      </pre>
+                    </form>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         
         {{ .Content }}
         {{ if not .Params.hideListLinks }}

--- a/layouts/develop/single.html
+++ b/layouts/develop/single.html
@@ -5,9 +5,9 @@
 {{ define "main" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav.html" . }}
-    <div class="py-12 md:pl-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:pl-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
-      <section class="prose w-full py-12">
+      <section class="prose w-full py-12 max-w-none">
         <h1>
           {{ .Title }}</h1>
         {{ with .Params.description }}<p class="text-lg -mt-5 mb-10">{{ . | markdownify }}</p>{{ end }}


### PR DESCRIPTION
[DOC-5244](https://redislabs.atlassian.net/browse/DOC-5244)

Add a Redis CLI widget to the top of the Develop page, kind of like the former IO page.

The changes to layouts/develop/list.html can go either before or after the `{{ .Content }}` line. For any other placement, we'd need a custom (one-off) partial.

[DOC-5244]: https://redislabs.atlassian.net/browse/DOC-5244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ