### PR TITLE
DOC-5254 starter docs for Redis MCP

### DIFF
--- a/content/integrate/redis-mcp/_index.md
+++ b/content/integrate/redis-mcp/_index.md
@@ -18,7 +18,7 @@ The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction)
 is a standard that lets AI agents access data and perform actions. Using MCP,
 your server can publish a set of commands that are usable by any MCP-compatible
 client app (such as [Claude Desktop](https://claude.ai/download) or
-[VSCode](https://code.visualstudio.com/)). These commands can retrieve
+[VS Code](https://code.visualstudio.com/)). These commands can retrieve
 whatever data you wish to provide and you can also let the agent make
 changes to the data. For example, you could publish a feed of news items that
 an agent can use in its responses, and also let the agent add the user's
@@ -36,5 +36,5 @@ an LLM chat using instructions and questions like the following:
 - "What is user:1's email?"
 
 See the other pages in this section to learn how to set up and use Redis MCP.
-See also the [Github repository](https://github.com/redis/mcp-redis) for
+See also the [GitHub repository](https://github.com/redis/mcp-redis) for
 the latest changes.

--- a/content/integrate/redis-mcp/_index.md
+++ b/content/integrate/redis-mcp/_index.md
@@ -35,4 +35,6 @@ an LLM chat using instructions and questions like the following:
 - "How many keys does my database have?"
 - "What is user:1's email?"
 
-See the other pages in this section to learn how to set up and use Redis MCP:
+See the other pages in this section to learn how to set up and use Redis MCP.
+See also the [Github repository](https://github.com/redis/mcp-redis) for
+the latest changes.

--- a/content/integrate/redis-mcp/_index.md
+++ b/content/integrate/redis-mcp/_index.md
@@ -1,0 +1,37 @@
+---
+Title: Redis MCP
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+description: Access a Redis server using any MCP client.
+group: service
+hideListLinks: false
+linkTitle: Redis MCP
+summary: Redis MCP server lets MCP clients access the features of Redis.
+type: integration
+weight: 1
+---
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction)
+is a standard that lets AI agents access data and perform actions. Using MCP,
+your server can publish a set of commands that are usable by any MCP-compatible
+client app (such as [Claude Desktop](https://claude.ai/download) or
+[VSCode](https://code.visualstudio.com/)). These commands can retrieve
+whatever data you wish to provide and you can also let the agent make
+changes to the data. For example, you could publish a feed of news items that
+an agent can use in its responses, and also let the agent add the user's
+comments to those items.
+
+Redis MCP is a general-purpose implementation that lets agents read, write, and
+query data in Redis and also has some basic commands to manage the Redis
+server. With this enabled, you can use an LLM client as a very high-level
+interface to Redis. Add, query, and analyze any Redis data set directly from
+an LLM chat:
+
+- "Store the entire conversation in the 'recent_chats' stream"
+- "Cache this item"
+- "How many keys does my database have?"
+- "What is user:1's email?"
+

--- a/content/integrate/redis-mcp/_index.md
+++ b/content/integrate/redis-mcp/_index.md
@@ -28,10 +28,11 @@ Redis MCP is a general-purpose implementation that lets agents read, write, and
 query data in Redis and also has some basic commands to manage the Redis
 server. With this enabled, you can use an LLM client as a very high-level
 interface to Redis. Add, query, and analyze any Redis data set directly from
-an LLM chat:
+an LLM chat using instructions and questions like the following:
 
 - "Store the entire conversation in the 'recent_chats' stream"
 - "Cache this item"
 - "How many keys does my database have?"
 - "What is user:1's email?"
 
+See the other pages in this section to learn how to set up and use Redis MCP:

--- a/content/integrate/redis-mcp/ciient-conf.md
+++ b/content/integrate/redis-mcp/ciient-conf.md
@@ -1,0 +1,99 @@
+---
+Title: Configure client apps
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+summary: Access a Redis server using any MCP client.
+group: service
+linkTitle: Configure client apps
+description: Configure client apps to use the Redis MCP server.
+type: integration
+weight: 20
+---
+
+When you have [installed]({{< relref "/integrate/redis-mcp/install" >}})
+the Redis MCP server, you must also configure your client app to use it.
+The sections below describe the ways you can do this.
+
+## Smithery
+
+Smithery provides a searchable repository of scripts that add configurations
+for many MCP services to client apps.
+The easiest way to configure your client is to use the
+[Smithery tool for Redis MCP](https://smithery.ai/server/@redis/mcp-redis).
+
+When you select your client from the **Install** bar on the Redis MCP page,
+you will see a command line that you can copy and paste into a terminal.
+Running this command will configure your client app to use Redis MCP. (Note
+that you need to have [Node.js](https://nodejs.org/en) installed to run
+the Smithery scripts.) For example, the command line for
+[Claude Desktop](https://claude.ai/download) is
+
+```bash
+npx -y @smithery/cli@latest install @redis/mcp-redis --client claude
+```
+
+The script will prompt you for the information required to connect to
+your Redis database.
+
+## Manual configuration
+
+You can also add the configuration for Redis MCP to your client app
+manually. The exact method varies from client to client but the
+basic approach is similar in each case.
+
+For a locally-running MCP server, you need to edit the configuration
+file to add the command that launches the server, along with its
+arguments. For example, with Claude Desktop, you can locate the
+file by selecting **Settings** from the menu, then selecting the
+**Developer** tab, and then clicking the **Edit Config** button.
+When you open this JSON file, you should add your settings as
+shown below:
+
+```json
+{
+    "mcpServers": {
+        .
+        .
+      "redis": {
+            "command": "<path-to-uv-command>>",
+            "args": [
+                "--directory",
+                "<your-folder-path>/mcp-redis",
+                "run",
+                "src/main.py"
+            ]
+        }
+    },
+        .
+        .
+  }
+```
+
+You can find the path to the `uv` command using `which uv`, or
+the equivalent. You can also optionally set the environment for
+the command shell here in the `env` section:
+
+```json
+"redis": {
+    "command": "<path-to-uv-command>>",
+    "args": [
+        "--directory",
+        "<your-folder-path>/mcp-redis",
+        "run",
+        "src/main.py"
+    ],
+    "env": {
+        "REDIS_HOST": "<your_redis_database_hostname>",
+        "REDIS_PORT": "<your_redis_database_port>",
+        "REDIS_PWD": "<your_redis_database_password>",
+        "REDIS_SSL": True|False,
+        "REDIS_CA_PATH": "<your_redis_ca_path>",
+        "REDIS_CLUSTER_MODE": True|False
+    }
+}
+```
+
+

--- a/content/integrate/redis-mcp/client-conf.md
+++ b/content/integrate/redis-mcp/client-conf.md
@@ -19,15 +19,15 @@ The sections below describe the ways you can do this.
 
 ## Smithery
 
-Smithery provides a searchable repository of scripts that add configurations
-for many MCP services to client apps.
+[Smithery](https://smithery.ai/) provides a searchable repository of scripts
+that add configurations for many MCP services to client apps.
 The easiest way to configure your client is to use the
 [Smithery tool for Redis MCP](https://smithery.ai/server/@redis/mcp-redis).
 
 When you select your client from the **Install** bar on the Redis MCP page,
 you will see a command line that you can copy and paste into a terminal.
 Running this command will configure your client app to use Redis MCP. (Note
-that you need to have [Node.js](https://nodejs.org/en) installed to run
+that you must have [Node.js](https://nodejs.org/en) installed to run
 the Smithery scripts.) For example, the command line for
 [Claude Desktop](https://claude.ai/download) is
 
@@ -42,14 +42,21 @@ your Redis database.
 
 You can also add the configuration for Redis MCP to your client app
 manually. The exact method varies from client to client but the
-basic approach is similar in each case.
+basic approach is similar in each case. The pages listed below
+give the general configuration details for some common MCP client tools:
+
+-   [Claude Desktop](https://modelcontextprotocol.io/quickstart/user)
+-   [Github Copilot for VSCode](https://code.visualstudio.com/docs/copilot/chat/mcp-servers)
+-   [OpenAI](https://openai.github.io/openai-agents-python/mcp/)
+
+### Local servers
 
 For a locally-running MCP server, you need to edit the configuration
 file to add the command that launches the server, along with its
 arguments. For example, with Claude Desktop, you can locate the
 file by selecting **Settings** from the menu, then selecting the
 **Developer** tab, and then clicking the **Edit Config** button.
-When you open this JSON file, you should add your settings as
+Open this JSON file and add your settings as
 shown below:
 
 ```json
@@ -58,7 +65,7 @@ shown below:
         .
         .
       "redis": {
-            "command": "<path-to-uv-command>>",
+            "command": "<path-to-uv-command>",
             "args": [
                 "--directory",
                 "<your-folder-path>/mcp-redis",
@@ -96,4 +103,55 @@ the command shell here in the `env` section:
 }
 ```
 
+If you are using
+[Docker]({{< relref "/integrate/redis-mcp/install#install-using-docker" >}})
+to deploy the server, change the `command` and `args` sections of the
+configuration as shown below:
 
+```json
+"redis": {
+    "command": "docker",
+    "args": ["run",
+            "--rm",
+            "--name",
+            "redis-mcp-server",
+            "-i",
+            "-e", "REDIS_HOST=<redis_hostname>",
+            "-e", "REDIS_PORT=<redis_port>",
+            "-e", "REDIS_USERNAME=<redis_username>",
+            "-e", "REDIS_PWD=<redis_password>",
+            "mcp-redis"]
+}
+```
+
+### Remote servers
+
+If you set up an
+[externally visible]({{< relref "/integrate/redis-mcp/install#making-mcp-visible-externally" >}})
+MCP server, you may be able to configure it directly from the app (but
+if you can't, then see [Using a gateway](#using-a-gateway) for an alternative approach). For
+example, the following `JSON` element configures
+[Github Copilot for VSCode](https://code.visualstudio.com/docs/copilot/overview)
+to use an `sse` type server running at `127.0.0.1`:
+
+```json
+    .
+    .
+"mcp": {
+    "servers": {
+        "redis-mcp": {
+            "type": "sse",
+            "url": "http://127.0.0.1:8000/sse"
+        },
+    }
+},
+    .
+    .
+```
+
+### Using a gateway
+
+Apps that don't currently support external MCP servers directly, such as Claude
+Desktop, can still access them using a *gateway*. See
+[MCP server gateway](https://github.com/lightconetech/mcp-gateway)
+for more information.

--- a/content/integrate/redis-mcp/client-conf.md
+++ b/content/integrate/redis-mcp/client-conf.md
@@ -46,7 +46,7 @@ basic approach is similar in each case. The pages listed below
 give the general configuration details for some common MCP client tools:
 
 -   [Claude Desktop](https://modelcontextprotocol.io/quickstart/user)
--   [Github Copilot for VSCode](https://code.visualstudio.com/docs/copilot/chat/mcp-servers)
+-   [GitHub Copilot for VS Code](https://code.visualstudio.com/docs/copilot/chat/mcp-servers)
 -   [OpenAI](https://openai.github.io/openai-agents-python/mcp/)
 
 ### Local servers
@@ -131,7 +131,7 @@ If you set up an
 MCP server, you may be able to configure it directly from the app (but
 if you can't, then see [Using a gateway](#using-a-gateway) for an alternative approach). For
 example, the following `JSON` element configures
-[Github Copilot for VSCode](https://code.visualstudio.com/docs/copilot/overview)
+[GitHub Copilot for VS Code](https://code.visualstudio.com/docs/copilot/overview)
 to use an `sse` type server running at `127.0.0.1`:
 
 ```json

--- a/content/integrate/redis-mcp/client-conf.md
+++ b/content/integrate/redis-mcp/client-conf.md
@@ -155,3 +155,53 @@ Apps that don't currently support external MCP servers directly, such as Claude
 Desktop, can still access them using a *gateway*. See
 [MCP server gateway](https://github.com/lightconetech/mcp-gateway)
 for more information.
+
+## Redis Cloud MCP
+
+If you are using
+[Redis Cloud MCP]({{< relref "/integrate/redis-mcp/install#redis-cloud-mcp" >}}),
+the configuration is similar to [basic MCP](#manual-configuration), but with a
+few differences. Set the client to run the server using the `node` command, as shown 
+in the example for Claude Desktop below:
+
+```json
+{
+  "mcpServers": {
+    "mcp-redis-cloud": {
+      "command": "node",
+      "args": ["--experimental-fetch", "<absolute_path_to_project_root>/dist/index.js"],
+      "env": {
+        "API_KEY": "<redis_cloud_api_key>",
+        "SECRET_KEY": "<redis_cloud_api_secret_key>"
+      }
+    }
+  }
+}
+```
+
+Here, the environment includes the Redis Cloud API key and API secret key
+(see [Redis Cloud REST API]({{< relref "/operate/rc/api" >}}) for more
+information).
+
+If you are deploying Redis Cloud MCP with Docker, use a configuration like
+the following to launch the server with the `docker` command:
+
+```json
+{
+  "mcpServers": {
+    "redis-cloud": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "API_KEY=<your_redis_cloud_api_key>",
+        "-e",
+        "SECRET_KEY=<your_redis_cloud_api_secret_key>",
+        "mcp/redis-cloud"
+      ]
+    }
+  }
+}
+```

--- a/content/integrate/redis-mcp/client-conf.md
+++ b/content/integrate/redis-mcp/client-conf.md
@@ -64,16 +64,16 @@ shown below:
     "mcpServers": {
         .
         .
-      "redis": {
-            "command": "<path-to-uv-command>",
+        "redis-mcp-server": {
+            "type": "stdio",
+            "command": "uvx",
             "args": [
-                "--directory",
-                "<your-folder-path>/mcp-redis",
-                "run",
-                "src/main.py"
+                "--from", "git+https://github.com/redis/mcp-redis.git",
+                "redis-mcp-server",
+                "--url", "redis://localhost:6379/0"
             ]
         }
-    },
+    }
         .
         .
   }
@@ -85,12 +85,12 @@ the command shell here in the `env` section:
 
 ```json
 "redis": {
-    "command": "<path-to-uv-command>>",
+    "type": "stdio",
+    "command": "uvx",
     "args": [
-        "--directory",
-        "<your-folder-path>/mcp-redis",
-        "run",
-        "src/main.py"
+        "--from", "git+https://github.com/redis/mcp-redis.git",
+        "redis-mcp-server",
+        "--url", "redis://localhost:6379/0"
     ],
     "env": {
         "REDIS_HOST": "<your_redis_database_hostname>",
@@ -123,38 +123,6 @@ configuration as shown below:
             "mcp-redis"]
 }
 ```
-
-### Remote servers
-
-If you set up an
-[externally visible]({{< relref "/integrate/redis-mcp/install#making-mcp-visible-externally" >}})
-MCP server, you may be able to configure it directly from the app (but
-if you can't, then see [Using a gateway](#using-a-gateway) for an alternative approach). For
-example, the following `JSON` element configures
-[GitHub Copilot for VS Code](https://code.visualstudio.com/docs/copilot/overview)
-to use an `sse` type server running at `127.0.0.1`:
-
-```json
-    .
-    .
-"mcp": {
-    "servers": {
-        "redis-mcp": {
-            "type": "sse",
-            "url": "http://127.0.0.1:8000/sse"
-        },
-    }
-},
-    .
-    .
-```
-
-### Using a gateway
-
-Apps that don't currently support external MCP servers directly, such as Claude
-Desktop, can still access them using a *gateway*. See
-[MCP server gateway](https://github.com/lightconetech/mcp-gateway)
-for more information.
 
 ## Redis Cloud MCP
 

--- a/content/integrate/redis-mcp/install.md
+++ b/content/integrate/redis-mcp/install.md
@@ -7,20 +7,23 @@ categories:
 - rs
 summary: Access a Redis server using any MCP client.
 group: service
-linkTitle: Install
+linkTitle: Install the server
 description: Install and configure the Redis MCP server.
 type: integration
 weight: 10
 ---
 
 The MCP server runs separately from Redis, so you will need a
-Redis server to access. See [Redis Cloud]({{< relref "/operate/rc" >}})
+Redis server for it to connect to. See [Redis Cloud]({{< relref "/operate/rc" >}})
 or [Redis Open Source]({{< relref "/operate/oss_and_stack" >}}) to learn
 how to get a test server active within minutes.
 
+When you have a Redis server available, use the instructions below to install and
+configure the Redis MCP server.
+
 ## Install the server from source
 
-When you have a Redis server, you can clone Redis MCP from the
+Clone Redis MCP from the
 [Github repository](https://github.com/redis/mcp-redis) using the following
 command:
 
@@ -33,7 +36,7 @@ tool to set up the server. See the `uv`
 [installation instructions](https://github.com/astral-sh/uv?tab=readme-ov-file#installation)
 for more information.
 
-When you have `uv`, go into the `mcp-redis` folder that you cloned and
+When you have installed `uv`, go to the `mcp-redis` folder that you cloned and
 enter the following commands to initialize the MCP server code:
 
 ```bash
@@ -47,9 +50,10 @@ uv sync
 ## Install using Docker
 
 You can use the [`mcp/redis`](https://hub.docker.com/r/mcp/redis)
-image (or build your own image from the source using the `Dockerfile`) to 
-run Redis MCP with [Docker](https://www.docker.com/). Use the following
-command to download `mcp/redis` from [DockerHub](https://hub.docker.com/):
+image to run Redis MCP with [Docker](https://www.docker.com/).
+Alternatively, use the following
+command to build the Docker image with the `Dockerfile` in the
+`mcp/redis` folder:
 
 ```
 docker build -t mcp-redis .
@@ -113,3 +117,10 @@ tool:
 curl -i http://127.0.0.1:8000/sse
 HTTP/1.1 200 OK
 ```
+
+## Next steps
+
+When you have installed the server, you will need a MCP client to
+connect to it and use its services. See
+[Configure client apps]({{< relref "/integrate/redis-mcp/client-conf" >}})
+for more information.

--- a/content/integrate/redis-mcp/install.md
+++ b/content/integrate/redis-mcp/install.md
@@ -78,8 +78,9 @@ to connect with.
 |----------------------|-----------------------------------------------------------|---------------|
 | `REDIS_HOST`         | Redis IP or hostname                                      | `"127.0.0.1"` |
 | `REDIS_PORT`         | Redis port                                                | `6379`        |
-| `REDIS_USERNAME`     | Default database username                                 | `"default"`   |
-| `REDIS_PWD`          | Default database password                                 | ""            |
+| `REDIS_DB`           | Database | 0 |
+| `REDIS_USERNAME`     | Database username                                 | `"default"`   |
+| `REDIS_PWD`          | Database password                                 | ""            |
 | `REDIS_SSL`          | Enables or disables SSL/TLS                               | `False`       |
 | `REDIS_CA_PATH`      | CA certificate for verifying server                       | None          |
 | `REDIS_SSL_KEYFILE`  | Client's private key file for client authentication       | None          |

--- a/content/integrate/redis-mcp/install.md
+++ b/content/integrate/redis-mcp/install.md
@@ -1,0 +1,115 @@
+---
+Title: Install
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+summary: Access a Redis server using any MCP client.
+group: service
+linkTitle: Install
+description: Install and configure the Redis MCP server.
+type: integration
+weight: 10
+---
+
+The MCP server runs separately from Redis, so you will need a
+Redis server to access. See [Redis Cloud]({{< relref "/operate/rc" >}})
+or [Redis Open Source]({{< relref "/operate/oss_and_stack" >}}) to learn
+how to get a test server active within minutes.
+
+## Install the server from source
+
+When you have a Redis server, you can clone Redis MCP from the
+[Github repository](https://github.com/redis/mcp-redis) using the following
+command:
+
+```bash
+git clone https://github.com/redis/mcp-redis.git
+```
+
+You will also need the [`uv`](https://github.com/astral-sh/uv) packaging
+tool to set up the server. See the `uv`
+[installation instructions](https://github.com/astral-sh/uv?tab=readme-ov-file#installation)
+for more information.
+
+When you have `uv`, go into the `mcp-redis` folder that you cloned and
+enter the following commands to initialize the MCP server code:
+
+```bash
+cd mcp-redis
+
+uv venv
+source .venv/bin/activate
+uv sync
+```
+
+## Install using Docker
+
+You can use the [`mcp/redis`](https://hub.docker.com/r/mcp/redis)
+image (or build your own image from the source using the `Dockerfile`) to 
+run Redis MCP with [Docker](https://www.docker.com/). Use the following
+command to download `mcp/redis` from [DockerHub](https://hub.docker.com/):
+
+```
+docker build -t mcp-redis .
+```
+
+## Configuration
+
+The default settings for MCP assume a Redis server is running on the
+local machine, with the default port and no security arrangements.
+To change these settings, use the environment variables shown in the
+table below. For example, for a `bash` shell, use
+
+```bash
+export REDIS_USERNAME="my_username"
+```
+
+from the command line or the `.bashrc` file to set the username you want
+to connect with.
+
+
+| Name                 | Description                                               | Default Value |
+|----------------------|-----------------------------------------------------------|---------------|
+| `REDIS_HOST`         | Redis IP or hostname                                      | `"127.0.0.1"` |
+| `REDIS_PORT`         | Redis port                                                | `6379`        |
+| `REDIS_USERNAME`     | Default database username                                 | `"default"`   |
+| `REDIS_PWD`          | Default database password                                 | ""            |
+| `REDIS_SSL`          | Enables or disables SSL/TLS                               | `False`       |
+| `REDIS_CA_PATH`      | CA certificate for verifying server                       | None          |
+| `REDIS_SSL_KEYFILE`  | Client's private key file for client authentication       | None          |
+| `REDIS_SSL_CERTFILE` | Client's certificate file for client authentication       | None          |
+| `REDIS_CERT_REQS`    | Whether the client should verify the server's certificate | `"required"`  |
+| `REDIS_CA_CERTS`     | Path to the trusted CA certificates file                  | None          |
+| `REDIS_CLUSTER_MODE` | Enable Redis Cluster mode                                 | `False`       |
+| `MCP_TRANSPORT`      | Use the `stdio` or `sse` transport                        | `stdio`       |
+
+### Making MCP visible externally
+
+{{< note >}}The configuration for an MCP client includes the commands
+to start a local server, so you can ignore this section if you don't
+want your Redis MCP to be externally accessible.
+{{< /note >}}
+
+The default configuration assumes you only want to use the MCP server
+locally, but you can make it externally available by setting
+`MCP_TRANSPORT` to `sse`:
+
+```bash
+export MCP_TRANSPORT="sse"
+```
+
+Then, start the server with the following command:
+
+```bash
+uv run src/main.py
+```
+
+You can test the server is responding with the [`curl`](https://curl.se/)
+tool:
+
+```bash
+curl -i http://127.0.0.1:8000/sse
+HTTP/1.1 200 OK
+```

--- a/content/integrate/redis-mcp/install.md
+++ b/content/integrate/redis-mcp/install.md
@@ -21,7 +21,31 @@ how to get a test server active within minutes.
 When you have a Redis server available, use the instructions below to install and
 configure the Redis MCP server.
 
+## Quick Start with uvx
+
+The easiest way to use the Redis MCP Server is with [`uvx`](https://docs.astral.sh/uv/guides/tools/),
+which lets you run it directly from a GitHub branch or a tagged release (see the `uv`
+[installation instructions](https://github.com/astral-sh/uv?tab=readme-ov-file#installation)
+for more information.)
+
+```bash
+# Run with Redis URI
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server --url redis://localhost:6379/0
+
+# Run with Redis URI and SSL 
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server --url "rediss://<USERNAME>:<PASSWORD>@<HOST>:<PORT>?ssl_cert_reqs=required&ssl_ca_certs=<PATH_TO_CERT>"
+
+# Run with individual parameters
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server --host localhost --port 6379 --password mypassword
+
+# See all options
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server --help
+```
+
 ## Install the server from source
+
+You can also run Redis MCP from source, which may be useful if you want to
+contribute to the project.
 
 Clone Redis MCP from the
 [Github repository](https://github.com/redis/mcp-redis) using the following
@@ -45,6 +69,12 @@ cd mcp-redis
 uv venv
 source .venv/bin/activate
 uv sync
+
+# Run with CLI interface
+uv run redis-mcp-server --help
+
+# Or run the main file directly (uses environment variables)
+uv run src/main.py
 ```
 
 ## Install using Docker
@@ -63,8 +93,9 @@ docker build -t mcp-redis .
 
 The default settings for MCP assume a Redis server is running on the
 local machine, with the default port and no security arrangements.
-To change these settings, use the environment variables shown in the
-table below. For example, for a `bash` shell, use
+You can use environment variables to change these settings
+(see [Environment variables](#environment-variables) below for the full list).
+For example, for a `bash` shell, use
 
 ```bash
 export REDIS_USERNAME="my_username"
@@ -73,6 +104,44 @@ export REDIS_USERNAME="my_username"
 from the command line or the `.bashrc` file to set the username you want
 to connect with.
 
+Alternatively, you can use a `.env` file in your project folder to set the
+environment variables as key-value pairs, one per line:
+
+```
+REDIS_HOST=your_redis_host
+REDIS_PORT=6379
+    .
+    .
+```
+
+See the [`.env.example` file](https://github.com/redis/mcp-redis/blob/main/.env.example)
+in the repository for the full list of variables and their default values.
+
+You can also set the configuration using command-line arguments, which
+may be useful if you only want to change a few settings from the defaults:
+
+```bash
+# Basic Redis connection
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server \
+  --host localhost \
+  --port 6379 \
+  --password mypassword
+
+# Using Redis URI (simpler)
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server \
+  --url redis://user:pass@localhost:6379/0
+
+# SSL connection
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server \
+  --url rediss://user:pass@redis.example.com:6379/0
+
+# See all available options
+uvx --from git+https://github.com/redis/mcp-redis.git redis-mcp-server --help
+```
+
+### Environment variables
+
+The full set of environment variables is shown in the table below:
 
 | Name                 | Description                                               | Default Value |
 |----------------------|-----------------------------------------------------------|---------------|
@@ -89,35 +158,6 @@ to connect with.
 | `REDIS_CA_CERTS`     | Path to the trusted CA certificates file                  | None          |
 | `REDIS_CLUSTER_MODE` | Enable Redis Cluster mode                                 | `False`       |
 | `MCP_TRANSPORT`      | Use the `stdio` or `sse` transport                        | `stdio`       |
-
-### Making MCP visible externally
-
-{{< note >}}The configuration for an MCP client includes the commands
-to start a local server, so you can ignore this section if you don't
-want your Redis MCP to be externally accessible.
-{{< /note >}}
-
-The default configuration assumes you only want to use the MCP server
-locally, but you can make it externally available by setting
-`MCP_TRANSPORT` to `sse`:
-
-```bash
-export MCP_TRANSPORT="sse"
-```
-
-Then, start the server with the following command:
-
-```bash
-uv run src/main.py
-```
-
-You can test the server is responding with the [`curl`](https://curl.se/)
-tool:
-
-```bash
-curl -i http://127.0.0.1:8000/sse
-HTTP/1.1 200 OK
-```
 
 ## Redis Cloud MCP
 

--- a/content/integrate/redis-mcp/install.md
+++ b/content/integrate/redis-mcp/install.md
@@ -119,6 +119,42 @@ curl -i http://127.0.0.1:8000/sse
 HTTP/1.1 200 OK
 ```
 
+## Redis Cloud MCP
+
+A separate version of the MCP server is available for
+[Redis Cloud]({{< relref "/operate/rc" >}}). This has the same main
+functionality as the basic MCP server but also has some features
+specific to Redis Cloud, including subscription management and
+billing details. For example, you can use questions and instructions
+like the following:
+
+-   "Create a new Redis database in AWS"
+-   "What are my current subscriptions?"
+-   "Help me choose the right Redis database for my e-commerce application"
+
+You will need [Node.js](https://nodejs.org/en) installed to run Redis Cloud MCP.
+Clone the GitHub repository using the following command:
+
+```bash
+git clone https://github.com/redis/mcp-redis-cloud.git
+```
+
+Go into the `mcp-redis-cloud` folder and install the dependencies:
+
+```bash
+npm run build
+```
+
+The server is now ready for use.
+
+You can also deploy Redis Cloud MCP using Docker. Build the image
+using the `Dockerfile` in the repository folder with the following
+command:
+
+```bash
+docker build -t mcp/redis-cloud .
+```
+
 ## Next steps
 
 When you have installed the server, you will need a MCP client to


### PR DESCRIPTION
[DOC-5254](https://redislabs.atlassian.net/browse/DOC-5254)

Currently just a starting point, so all suggestions welcome. In particular:

- Is "Libraries and tools" the best place for this? I think it probably does belong here, but maybe it would most commonly be used a bit like Redis Insight and it should therefore go under `develop/tools`?
- Do we want a puny banner in the page to state that this is a preview, or is it effectively GA now?
- Any other info to add? Is the API solid enough now to add code examples directly in the page or is it better just to point to Github for now?


[DOC-5254]: https://redislabs.atlassian.net/browse/DOC-5254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ