### PR TITLE
DOC-4815 changed ordering of Python AMR page

### DIFF
--- a/content/develop/clients/redis-py/amr.md
+++ b/content/develop/clients/redis-py/amr.md
@@ -12,7 +12,7 @@ categories:
 description: Learn how to authenticate to an Azure Managed Redis (AMR) database
 linkTitle: Connect to AMR
 title: Connect to Azure Managed Redis
-weight: 2
+weight: 25
 ---
 
 The [`redis-entra-id`](https://github.com/redis/redis-py-entraid) package


### PR DESCRIPTION
Minor fix - AMR docs were recently added but specifically for Python, the weighting of the AMR page put it above the basic Connect page in the listing (we definitely want basic connect to be first).