### PR TITLE
DEV/OP: make is possible to hide in-page TOC with frontmatter

### DIFF
--- a/layouts/develop/single.html
+++ b/layouts/develop/single.html
@@ -36,7 +36,9 @@
         {{ partial "feedback.html" . }}
       </section>
     </div>
-    {{ partial "docs-toc.html" . }}
+    {{ if not .Params.hideTOC }}
+      {{ partial "docs-toc.html" . }}
+    {{ end }}
     {{ partial "scripts.html" . }}
   </main>
 {{ end }}

--- a/layouts/integration/list.html
+++ b/layouts/integration/list.html
@@ -5,7 +5,7 @@
 {{ define "main" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav.html" . }}
-    <div class="py-12 md:pl-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:pl-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
       <section class="prose w-full py-12 max-w-none">
         <h1>{{ .Title }}</h1>

--- a/layouts/integration/single.html
+++ b/layouts/integration/single.html
@@ -5,7 +5,7 @@
 {{ define "main" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav.html" . }}
-    <div class="py-12 md:pl-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:pl-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
       <section class="prose w-full py-12 max-w-none">
         <h1>{{ .Title }}</h1>

--- a/layouts/operate/list.html
+++ b/layouts/operate/list.html
@@ -5,7 +5,7 @@
 {{ define "main" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav.html" . }}
-    <div class="py-12 md:pl-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:pl-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
       <section class="prose w-full py-12 max-w-none">
         <h1>
@@ -92,7 +92,9 @@
         {{ partial "feedback.html" . }}
       </section>
     </div>
-    {{ partial "docs-toc.html" . }}
+    {{ if not .Params.hideTOC }}
+      {{ partial "docs-toc.html" . }}
+    {{ end }}
     {{ partial "scripts.html" . }}
   </main>
 {{ end }}

--- a/layouts/operate/single.html
+++ b/layouts/operate/single.html
@@ -5,7 +5,7 @@
 {{ define "main" }}
   <main class="docs w-full max-w-[1920px] mx-auto px-5 flex flex-col md:flex-row overflow-hidden">
     {{ partial "docs-nav.html" . }}
-    <div class="py-12 md:pl-4 xl:px-16 overflow-hidden">
+    <div class="w-full py-12 md:pl-4 xl:px-16 overflow-hidden">
       {{ partial "breadcrumbs" . }}
       <section class="prose w-full py-12 max-w-none">
         <h1>{{ .Title }}</h1>
@@ -82,7 +82,9 @@
         {{ partial "feedback.html" . }}
       </section>
     </div>
-    {{ partial "docs-toc.html" . }}
+    {{ if not .Params.hideTOC }}
+      {{ partial "docs-toc.html" . }}
+    {{ end }}
     {{ partial "scripts.html" . }}
   </main>
 {{ end }}


### PR DESCRIPTION
[DOC-5262](https://redislabs.atlassian.net/browse/DOC-5262)

These changes:

1. Allow the right side, in-page TOC to be hidden if more horizontal space is needed on a list or single page.

To trigger, use the following frontmatter:

`hideTOC: true`

2. Make is possible for pages in OP and (individual) Integrate to take up all the horizontal space in the current view frame.

[DOC-5262]: https://redislabs.atlassian.net/browse/DOC-5262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ