### PR TITLE
RS: Prevent dnsmasq from using port 53

### DIFF
--- a/content/embeds/port-53.md
+++ b/content/embeds/port-53.md
@@ -1,6 +1,8 @@
-If port 53 is in use, the installation fails. This issue can occur in default installations of certain operating systems in which `systemd-resolved` (DNS server) is running.
+If port 53 is in use, the installation fails. This issue can occur in default installations of certain operating systems in which `systemd-resolved` (DNS server) or `dnsmasq` is running.
 
 To prevent this issue, change the system configuration to make this port available before installation.
+
+To prevent `systemd-resolved` from using port 53:
 
 1. Edit `/etc/systemd/resolved.conf`: 
 
@@ -30,4 +32,30 @@ You might encounter a temporary name resolution error (`sudo: unable to resolve 
 
     ```sh
     sudo service systemd-resolved restart
+    ```
+
+To prevent `dnsmasq` from using port 53:
+
+1. Stop the `dnsmasq` service if it's running:
+
+    ```sh
+    sudo systemctl stop dnsmasq
+    ```
+
+1. Prevent `dnsmasq` from starting automatically at system boot:
+
+    ```sh
+    sudo systemctl disable dnsmasq
+    ```
+
+1. Mask `dnsmasq` to prevent it from being started manually or by other services:
+
+    ```sh
+    sudo systemctl mask dnsmasq
+    ```
+
+1. Verify `dnsmasq` is no longer active and won't start at system boot:
+
+    ```sh
+    sudo systemctl status dnsmasq
     ```


### PR DESCRIPTION
DOC-3595

Staged preview: https://redis.io/docs/staging/DOC-3595/operate/rs/installing-upgrading/install/prepare-install/port-availability/#os-conflicts-with-port-53