### PR TITLE
Add syncer error recovery troubleshooting documentation

### DIFF
--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -93,5 +93,5 @@ To restart an Active-Active database's syncer after an unrecoverable error, use 
    ```
 
 {{< note >}}
-Replace `<username>`, `<password>`, `<cluster-endpoint>`, `<bdb_id>`, and `<crdb-guid>` with your actual values.
+Replace `<username>`, `<password>`, `<host>`, `<port>`, `<database-id>`, and `<crdb-guid>` with your actual values.
 {{< /note >}}

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -75,9 +75,9 @@ curl -v -k -u <username>:<password> -X PUT \
 
 #### Restart syncer for Active-Active databases
 
-For Active-Active databases, you have two options:
+To restart an Active-Active database's syncer after an unrecoverable error, use one of the following methods.
 
-1. **Call the API on all participating clusters:**
+-  For each participating cluster, [update the database configuration]({{<relref "/operate/rs/references/rest-api/requests/bdbs#put-bdbs">}}) with the REST API to enable `sync`:
 
    ```sh
    curl -v -k -u <username>:<password> -X PUT \

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -28,7 +28,7 @@ When a new primary is appointed, the replication ID changes, but a partial sync 
 
 
 In a partial sync, the backlog of operations since the offset are transferred as raw operations.
-In a full sync, the data from the primary is transferred to the replica as an RDB file which is followed by a partial sync. 
+In a full sync, the data from the primary is transferred to the replica as an RDB file which is followed by a partial sync.
 
 Partial synchronization requires a backlog large enough to store the data operations until connection is restored. See [replication backlog]({{< relref "/operate/rs/databases/active-active/manage#replication-backlog" >}}) for more info on changing the replication backlog size.
 
@@ -36,11 +36,11 @@ Partial synchronization requires a backlog large enough to store the data operat
 
 In the case of an Active-Active database:
 
-- Multiple past replication IDs and offsets are stored to allow for multiple syncs 
-- The [Active-Active replication backlog]({{< relref "/operate/rs/databases/active-active/manage#replication-backlog" >}}) is also sent to the replica during a full sync. 
+- Multiple past replication IDs and offsets are stored to allow for multiple syncs
+- The [Active-Active replication backlog]({{< relref "/operate/rs/databases/active-active/manage#replication-backlog" >}}) is also sent to the replica during a full sync.
 
 {{< warning >}}
-Full sync triggers heavy data transfers between geo-replicated instances of an Active-Active database. 
+Full sync triggers heavy data transfers between geo-replicated instances of an Active-Active database.
 {{< /warning >}}
 
 An Active-Active database uses partial synchronization in the following situations:
@@ -53,4 +53,48 @@ An Active-Active database uses partial synchronization in the following situatio
 
 {{< note >}}
 Synchronization of data from the primary shard to the replica shard is always a full synchronization.
+{{< /note >}}
+
+## Troubleshooting syncer errors
+
+### Unrecoverable syncer errors
+
+Some syncer errors are unrecoverable and cause the syncer to exit with exit code 4. When this occurs, the Database Management Component (DMC) automatically sets the `crdt_sync` or `replica_sync` value to `stopped`.
+
+### Recovery procedures
+
+To re-enable the syncer after an unrecoverable error:
+
+#### For regular databases
+
+Use the cluster REST API to enable sync:
+
+```sh
+curl -v -k -u <username>:<password> -X PUT \
+  -H "Content-Type: application/json" \
+  -d '{"sync":"enabled"}' \
+  http://<cluster-endpoint>:8080/v1/bdbs/<bdb_id>
+```
+
+#### For Active-Active databases (CRDB)
+
+For Active-Active databases, you have two options:
+
+1. **Call the API on all participating clusters:**
+
+   ```sh
+   curl -v -k -u <username>:<password> -X PUT \
+     -H "Content-Type: application/json" \
+     -d '{"sync":"enabled"}' \
+     http://<cluster-endpoint>:8080/v1/bdbs/<bdb_id>
+   ```
+
+2. **Use crdb-cli (recommended):**
+
+   ```sh
+   crdb-cli crdb update --crdb-guid <crdb-guid> --force
+   ```
+
+{{< note >}}
+Replace `<username>`, `<password>`, `<cluster-endpoint>`, `<bdb_id>`, and `<crdb-guid>` with your actual values.
 {{< /note >}}

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -69,8 +69,8 @@ To restart a regular database's syncer after an unrecoverable error, [update the
 ```sh
 curl -v -k -u <username>:<password> -X PUT \
   -H "Content-Type: application/json" \
-  -d '{"sync":"enabled"}' \
-  http://<cluster-endpoint>:8080/v1/bdbs/<bdb_id>
+  -d '{"sync": "enabled"}' \
+  https://<host>:<port>/v1/bdbs/<database-id>
 ```
 
 #### Restart syncer for Active-Active databases

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -73,7 +73,7 @@ curl -v -k -u <username>:<password> -X PUT \
   http://<cluster-endpoint>:8080/v1/bdbs/<bdb_id>
 ```
 
-#### For Active-Active databases (CRDB)
+#### Restart syncer for Active-Active databases
 
 For Active-Active databases, you have two options:
 

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -59,7 +59,7 @@ Synchronization of data from the primary shard to the replica shard is always a 
 
 ### Unrecoverable syncer errors
 
-Some syncer errors are unrecoverable and cause the syncer to exit with exit code 4. When this occurs, the Database Management Component (DMC) automatically sets the `crdt_sync` or `replica_sync` value to `stopped`.
+Some syncer errors are unrecoverable and cause the syncer to exit with exit code 4. When this occurs, the Data Management Controller (DMC) automatically sets the `crdt_sync` or `replica_sync` value to `stopped`.
 
 ### Recovery procedures
 

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -86,7 +86,7 @@ To restart an Active-Active database's syncer after an unrecoverable error, use 
      http://<cluster-endpoint>:8080/v1/bdbs/<bdb_id>
    ```
 
-2. **Use crdb-cli (recommended):**
+- Run [`crdb-cli crdb update`]({{<relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/update">}}):
 
    ```sh
    crdb-cli crdb update --crdb-guid <crdb-guid> --force

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -61,13 +61,10 @@ Synchronization of data from the primary shard to the replica shard is always a 
 
 Some syncer errors are unrecoverable and cause the syncer to exit with exit code 4. When this occurs, the Data Management Controller (DMC) automatically sets the `crdt_sync` or `replica_sync` value to `stopped`.
 
-### Recovery procedures
+#### Restart syncer for regular databases
 
-To re-enable the syncer after an unrecoverable error:
+To restart a regular database's syncer after an unrecoverable error, [update the database configuration]({{<relref "/operate/rs/references/rest-api/requests/bdbs#put-bdbs">}}) with the REST API to enable `sync`:
 
-#### For regular databases
-
-Use the cluster REST API to enable sync:
 
 ```sh
 curl -v -k -u <username>:<password> -X PUT \

--- a/content/operate/rs/databases/active-active/syncer.md
+++ b/content/operate/rs/databases/active-active/syncer.md
@@ -82,8 +82,8 @@ To restart an Active-Active database's syncer after an unrecoverable error, use 
    ```sh
    curl -v -k -u <username>:<password> -X PUT \
      -H "Content-Type: application/json" \
-     -d '{"sync":"enabled"}' \
-     http://<cluster-endpoint>:8080/v1/bdbs/<bdb_id>
+     -d '{"sync": "enabled"}' \
+     https://<host>:<port>/v1/bdbs/<database-id>
    ```
 
 - Run [`crdb-cli crdb update`]({{<relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/update">}}):


### PR DESCRIPTION
- Add troubleshooting section for unrecoverable syncer errors
- Document exit code 4 behavior and DMC response
- Provide recovery procedures for regular and Active-Active databases
- Include REST API and crdb-cli recovery methods
- Add clear examples with placeholder values

Resolves DOC-1554