### PR TITLE
DOC-5225 Python probabilistic data type examples

### DIFF
--- a/content/develop/clients/redis-py/prob.md
+++ b/content/develop/clients/redis-py/prob.md
@@ -9,7 +9,7 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Learn how to use approximate statistics with Redis.
+description: Learn how to use approximate calculations with Redis.
 linkTitle: Probabilistic data types
 title: Probabilistic data types
 weight: 45
@@ -17,9 +17,17 @@ weight: 45
 
 Redis supports several
 [probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
-that let you gather approximate statistical information. To see why
-this would be useful, consider the task of counting the number
-of distinct IP addresses that access a website in one day.
+that let you calculate values approximately rather than exactly.
+The types fall into two basic categories:
+
+-   [Set operations](#set-operations): These types let you calculate (approximately)
+    the number of items in a set of distinct values, and whether or not a given value is
+    a member of a set.
+-   [Numeric data calculations](#numeric-data): These types give you an approximation of
+    statistics such as the percentile, rank, and frequency of numeric data points in a list.
+
+To see why these approximate calculations would be useful, consider the task of
+counting the number of distinct IP addresses that access a website in one day.
 
 Assuming that you already have code that supplies you with each IP
 address as a string, you could record the addresses in Redis using
@@ -46,15 +54,132 @@ The count of distinct IP addresses would probably be rounded to the
 nearest thousand or more when the usage statistics are delivered, so
 getting it exactly right is not important. It would be useful
 if you could trade off some precision in exchange for lower memory
-consumption and obfuscation of IP address strings. The probabilistic
-data types provide exactly this kind of trade-off for statistics.
-Specifically, you can count the approximate number of items in a
+consumption. The probabilistic data types provide exactly this kind of
+trade-off. Specifically, you can count the approximate number of items in a
 set using the
 [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
 data type, as described below.
 
-## HyperLogLog
+In general, the probabilistic data types let you perform approximations with a
+bounded degree of error that have much lower memory or execution time than
+the equivalent precise calculations.
 
-A HyperLogLog object works in a similar way to a [set]({{< relref "/develop/data-types/sets" >}}),
-except that it only lets you add items and approximate the number of items
-in the set (also known as the *cardinality* of the set). 
+## Set operations
+
+Redis supports the following approximate set operations:
+
+-   [Membership](#set-membership): The Bloom filter and Cuckoo filter data types
+    let you track whether or not a given item is a member of a set.
+-   [Cardinality](#set-cardinality): The HyperLogLog data type gives you an approximate
+    value for the number of items in a set, also known as the *cardinality* of
+    the set.
+
+The sections below describe these operations in more detail.
+
+### Set membership
+
+[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
+[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+objects provide a set membership operation that lets you track whether or not a
+particular item has been added to a set. These two types provide different
+trade-offs for memory usage and speed, so you can select the best one for your
+use case. Note that for both types, there is an asymmetry between presence and
+absence of items in the set. If an item is reported as absent, then it is definitely
+absent, but if it is reported as present, then there is a small chance it may really be
+absent.
+
+Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+a Bloom filter records the presence or absence of the
+[hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
+This gives a very compact representation of the
+set's membership with a fixed memory size, regardless of how many items you
+add. The following example adds some names to a Bloom filter representing
+a list of users and checks for the presence or absence of users in the list.
+Note that you must use the `bf()` method to access the Bloom filter commands.
+
+```py
+res1 = r.bf().madd("recorded_users", "andy", "cameron", "david", "michelle")
+print(res1)  # >>> [1, 1, 1, 1]
+
+res2 = r.bf().exists("recorded_users", "cameron")
+print(res2)  # >>> 1
+
+res3 = r.bf().exists("recorded_users", "kaitlyn")
+print(res3)  # >>> 0
+```
+
+A Cuckoo filter has similar features to a Bloom filter, but also supports
+a deletion operation to remove hashes from a set, as shown in the example
+below. Note that you must use the `cf()` method to access the Cuckoo filter
+commands.
+
+```py
+res4 = r.cf().add("other_users", "paolo")
+print(res4)  # >>> 1
+
+res5 = r.cf().add("other_users", "kaitlyn")
+print(res5)  # >>> 1
+
+res6 = r.cf().add("other_users", "rachel")
+print(res6)  # >>> 1
+
+res7 = r.cf().mexists("other_users", "paolo", "rachel", "andy")
+print(res7)  # >>> [1, 1, 0]
+
+res8 = r.cf().delete("other_users", "paolo")
+print(res8)
+
+res9 = r.cf().exists("other_users", "paolo")
+print(res9)  # >>> 0
+```
+
+Which of these two data types you choose depends on your use case.
+Bloom filters are generally faster than Cuckoo filters when adding new items,
+and also have better memory usage. Cuckoo filters are generally faster
+at checking membership and also support the delete operation. See the
+[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
+[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+reference pages for more information and comparison between the two types.
+
+### Set cardinality
+
+A HyperLogLog object doesn't support the set membership operation but
+instead is specialized to calculate the cardinality of the set. You can
+also merge two or more HyperLogLogs to find the cardinality of the
+union of the sets they represent.
+
+```py
+res10 = r.pfadd("group:1", "andy", "cameron", "david")
+print(res10)  # >>> 1
+
+res11 = r.pfcount("group:1")
+print(res11)  # >>> 3
+
+res12 = r.pfadd("group:2", "kaitlyn", "michelle", "paolo", "rachel")
+print(res12)  # >>> 1
+
+res13 = r.pfcount("group:2")
+print(res13)  # >>> 4
+
+res14 = r.pfmerge("both_groups", "group:1", "group:2")
+print(res14)  # >>> True
+
+res15 = r.pfcount("both_groups")
+print(res15)  # >>> 7
+```
+
+The main benefit that HyperLogLogs offer is their very low
+memory usage. They can count up to 2^64 items with less than
+1% standard error using a maximum 12KB of memory.
+
+## Numeric data
+
+Redis supports several approximate statistical calculations
+on numeric data sets:
+
+-   Frequency: The Count-min sketch data type lets you find the
+    approximate frequency of a labeled item in a data stream.
+-   Percentiles: The t-digest data type estimates the percentile
+    of a supplied value in a data stream.
+-   Ranking: The Top-K data type estimates the ranking of items
+    by frequency in a data stream.

--- a/content/develop/clients/redis-py/prob.md
+++ b/content/develop/clients/redis-py/prob.md
@@ -132,7 +132,7 @@ res7 = r.cf().mexists("other_users", "paolo", "rachel", "andy")
 print(res7)  # >>> [1, 1, 0]
 
 res8 = r.cf().delete("other_users", "paolo")
-print(res8)
+print(res8)  # >>> 1
 
 res9 = r.cf().exists("other_users", "paolo")
 print(res9)  # >>> 0

--- a/content/develop/clients/redis-py/prob.md
+++ b/content/develop/clients/redis-py/prob.md
@@ -24,7 +24,8 @@ The types fall into two basic categories:
     the number of items in a set of distinct values, and whether or not a given value is
     a member of a set.
 -   [Statistics](#statistics): These types give you an approximation of
-    statistics such as the percentile, rank, and frequency of numeric data points in a list.
+    statistics such as the quantiles, ranks, and frequencies of numeric data points in
+    a list.
 
 To see why these approximate calculations would be useful, consider the task of
 counting the number of distinct IP addresses that access a website in one day.
@@ -50,8 +51,8 @@ This approach is simple, effective, and precise but if your website
 is very busy, the `ip_tracker` set could become very large and consume
 a lot of memory.
 
-The count of distinct IP addresses would probably be rounded to the
-nearest thousand or more when the usage statistics are delivered, so
+You would probably round the count of distinct IP addresses to the
+nearest thousand or more when you deliver the usage statistics, so
 getting it exactly right is not important. It would be useful
 if you could trade off some precision in exchange for lower memory
 consumption. The probabilistic data types provide exactly this kind of
@@ -194,12 +195,15 @@ bank card numbers that make purchases within a day.
 Redis supports several approximate statistical calculations
 on numeric data sets:
 
--   [Frequency](#frequency): The Count-min sketch data type lets you
-    find the approximate frequency of a labeled item in a data stream.
--   Percentiles: The t-digest data type estimates the percentile
-    of a supplied value in a data stream.
--   Ranking: The Top-K data type estimates the ranking of items
-    by frequency in a data stream.
+-   [Frequency](#frequency): The
+    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    data type lets you find the approximate frequency of a labeled item in a data stream.
+-   [Quantiles](#quantiles): The
+    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    data type estimates the quantile of a query value in a data stream.
+-   [Ranking](#ranking): The
+    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    estimates the ranking of labeled items by frequency in a data stream.
 
 ### Frequency
 
@@ -222,6 +226,49 @@ large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
 other similar statistics.
 
-### Percentiles
+### Quantiles
 
+A [quantile](https://en.wikipedia.org/wiki/Quantile) is the value
+below which a certain fraction of samples lie. For example, with
+a set of measurements of people's heights, the quantile of 0.75 is
+the value of height below which 75% of people's heights lie.
+[Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
+to quantiles, except that the fraction is expressed as a percentage.
 
+A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+object can estimate quantiles from a set of values added to it
+without having to store each value in the set explicitly. This can
+save a lot of memory when you have a large number of samples.
+
+The example below shows how to add data samples to a t-digest
+object and obtain some basic statistics, such as the minimum and
+maximum values, the quantile of 0.75, and the 
+[cumulative distribution function](https://en.wikipedia.org/wiki/Cumulative_distribution_function)
+(CDF), which is effectively the inverse of the quantile function. It also
+shows how to merge two or more t-digest objects to query the combined
+data set.
+
+{{< clients-example home_prob_dts tdigest Python >}}
+{{< /clients-example >}}
+
+A t-digest object also supports several other related commands, such
+as querying by rank. See the
+[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+reference for more information.
+
+### Ranking
+
+A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+object estimates the rankings of different labeled items in a data
+stream according to frequency. For example, you could use this to
+track the top ten most frequently-accessed pages on a website, or the
+top five most popular items sold.
+
+The example below adds several different items to a Top-K object
+that tracks the top three items (this is the second parameter to
+the `topk().reserve()` method). It also shows how to list the
+top *k* items and query whether or not a given item is in the
+list.
+
+{{< clients-example home_prob_dts topk Python >}}
+{{< /clients-example >}}

--- a/content/develop/clients/redis-py/prob.md
+++ b/content/develop/clients/redis-py/prob.md
@@ -1,0 +1,60 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Learn how to use approximate statistics with Redis.
+linkTitle: Probabilistic data types
+title: Probabilistic data types
+weight: 45
+---
+
+Redis supports several
+[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+that let you gather approximate statistical information. To see why
+this would be useful, consider the task of counting the number
+of distinct IP addresses that access a website in one day.
+
+Assuming that you already have code that supplies you with each IP
+address as a string, you could record the addresses in Redis using
+a [set]({{< relref "/develop/data-types/sets" >}}):
+
+```py
+r.sadd("ip_tracker", new_ip_address)
+```
+
+The set can only contain each key once, so if the same address
+appears again during the day, the new instance will not change
+the set. At the end of the day, you could get the exact number of
+distinct addresses using the `scard()` function:
+
+```py
+num_distinct_ips = r.scard("ip_tracker")
+```
+
+This approach is simple, effective, and precise but if your website
+is very busy, the `ip_tracker` set could become very large and consume
+a lot of memory.
+
+The count of distinct IP addresses would probably be rounded to the
+nearest thousand or more when the usage statistics are delivered, so
+getting it exactly right is not important. It would be useful
+if you could trade off some precision in exchange for lower memory
+consumption and obfuscation of IP address strings. The probabilistic
+data types provide exactly this kind of trade-off for statistics.
+Specifically, you can count the approximate number of items in a
+set using the
+[HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+data type, as described below.
+
+## HyperLogLog
+
+A HyperLogLog object works in a similar way to a [set]({{< relref "/develop/data-types/sets" >}}),
+except that it only lets you add items and approximate the number of items
+in the set (also known as the *cardinality* of the set). 

--- a/content/develop/data-types/probabilistic/t-digest.md
+++ b/content/develop/data-types/probabilistic/t-digest.md
@@ -25,7 +25,8 @@ It can answer questions like:
 - What's the highest value that's smaller than *p* percent of the values in the data stream? (what is the p-percentile value)?
 
 
-### What is t-digest?
+## What is t-digest?
+
 t-digest is a data structure that will estimate a percentile point without having to store and order all the data points in a set. For example: to answer the question "What's the average latency for 99% of my database operations" we would have to store the average latency for every user, order the values, cut out the last 1% and only then find the average value of all the rest. This kind of process is costly not just in terms of the processing needed to order those values but also in terms of the space needed to store them. Those are precisely the problems t-digest solves.
 
 t-digest can also be used to estimate other values related to percentiles, like trimmed means.   


### PR DESCRIPTION
[DOC-5225](https://redislabs.atlassian.net/browse/DOC-5225)

...and as a bonus feature, it fixes a small issue with the headings in the main t-digest page.

A few points:
- I thought it was best to cover all these types fairly briefly in one page, but it has turned out to be quite a long page. I think it's just about comfortable to read, but let me know if you think it should be split into two or more pages.
- I've kept the examples brief to introduce these types rather than cover them in detail (we already have reference pages for them all). Do the examples need any more info or is there anything major missing from them?
- Does the breakdown of set operations and stats basically make sense?

[DOC-5225]: https://redislabs.atlassian.net/browse/DOC-5225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ