### PR TITLE
Update file-locations.md

### DIFF
--- a/content/operate/rs/installing-upgrading/install/plan-deployment/file-locations.md
+++ b/content/operate/rs/installing-upgrading/install/plan-deployment/file-locations.md
@@ -35,7 +35,7 @@ The default directories that Redis Enterprise Software uses for data and metadat
 | /var/opt/redislabs/log | System logs for Redis Enterprise Software |
 | /var/opt/redislabs/run | Socket files for Redis Enterprise Software |
 | /etc/opt/redislabs | Default location for cluster manager configuration and certificates |
-| /tmp | Temporary files |
+| /tmp | Temporary files (The /tmp filesystem size should be sized according to this formula: <number-of-cluster-nodes> * <size-of-/var/opt/redislabs/log-filesystem> |
 
 You can change these file locations for:
 


### PR DESCRIPTION
Providing guidance on how large the /tmp filesystem should be. In support, we are constantly finding customers who have /tmp filesystems that are far too small to accommodate support package creation.

Hopefully by adding this proposed calculation, we will help prevent future situations where customers are unable to create support packages because /tmp is too small.