### PR TITLE
RS: Added latest redis_upgrade_policy and Redis DB 6.2 prerequisites for upgrading clusters from 6.2 to 7.8

### DIFF
--- a/content/operate/rs/7.8/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/operate/rs/7.8/installing-upgrading/upgrading/upgrade-cluster.md
@@ -37,6 +37,16 @@ Before upgrading a cluster:
 
 - Verify that you meet the upgrade path requirements for the target cluster version and review the relevant [release notes](https://redis.io/docs/latest/operate/rs/release-notes/) for any preparation instructions.
 
+- Before you upgrade a cluster from Redis Enterprise Software version 6.2.x to 7.8.x, you must follow these steps if the cluster has any databases with Redis version 6.0:
+
+    1. Set the Redis upgrade policy to `latest`:
+
+        ```sh
+        rladmin tune cluster redis_upgrade_policy latest
+        ```
+
+    1. [Upgrade Redis 6.0 databases]({{<relref "/operate/rs/installing-upgrading/upgrading/upgrade-database">}}) to Redis 6.2.
+
 - [Upgrade your databases]({{<relref "/operate/rs/7.8/installing-upgrading/upgrading/upgrade-database">}}) to a version that is supported by the target Redis Enterprise Software version before upgrading the cluster. We recommend you upgrade the databases to the latest supported version if possible. Make sure to test the upgrade in a non-production environment to determine any impact.
 
 - Avoid changing the database configuration or performing other cluster management operations during the cluster upgrade process, as this might cause unexpected results.

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
@@ -36,6 +36,16 @@ Before upgrading a cluster:
 
 - Verify that you meet the upgrade path requirements for the target cluster version and review the relevant [release notes]({{< relref "/operate/rs/release-notes" >}}) for any preparation instructions.
 
+- Before you upgrade a cluster from Redis Enterprise Software version 6.2.x to 7.8.x, you must follow these steps if the cluster has any databases with Redis version 6.0:
+
+    1. Set the Redis upgrade policy to `latest`:
+
+        ```sh
+        rladmin tune cluster redis_upgrade_policy latest
+        ```
+
+    1. [Upgrade Redis 6.0 databases]({{<relref "/operate/rs/installing-upgrading/upgrading/upgrade-database">}}) to Redis 6.2.
+
 - [Upgrade your databases]({{<relref "/operate/rs/installing-upgrading/upgrading/upgrade-database">}}) to a version that is supported by the target Redis Enterprise Software version before upgrading the cluster. We recommend you upgrade the databases to the latest supported version if possible. Make sure to test the upgrade in a non-production environment to determine any impact.
 
 - Avoid changing the database configuration or performing other cluster management operations during the cluster upgrade process, as this might cause unexpected results.

--- a/content/operate/rs/release-notes/rs-7-8-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/_index.md
@@ -194,7 +194,15 @@ Redis database version 6.0 was deprecated in Redis Software version 7.4.2 and is
 
 To prepare for the removal of Redis database version 6.0 before you upgrade to Redis Software version 7.8.2:
 
-- For Redis Software 6.2.* clusters, upgrade Redis 6.0 databases to Redis 6.2. See the [Redis 6.2 release notes](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES) for the list of changes.
+- For Redis Software 6.2.* clusters:
+
+    1. Set the Redis upgrade policy to `latest`:
+
+        ```sh
+        rladmin tune cluster redis_upgrade_policy latest
+        ```
+
+    1. [Upgrade Redis 6.0 databases]({{<relref "/operate/rs/installing-upgrading/upgrading/upgrade-database">}}) to Redis 6.2. See the [Redis 6.2 release notes](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES) for the list of changes.
 
 - For Redis Software 7.2.4 and 7.4.2 clusters, upgrade Redis 6.0 databases to Redis 7.2. Before you upgrade your databases, see the list of [Redis 7.2 breaking changes]({{< relref "/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52#redis-72-breaking-changes" >}}) and update any applications that connect to your database to handle these changes.
 

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
@@ -373,7 +373,15 @@ Redis database version 6.0 was deprecated in Redis Software version 7.4.2 and is
 
 To prepare for the removal of Redis database version 6.0 before you upgrade to Redis Software version 7.8.2:
 
-- For Redis Software 6.2.* clusters, upgrade Redis 6.0 databases to Redis 6.2. See the [Redis 6.2 release notes](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES) for the list of changes.
+- For Redis Software 6.2.* clusters:
+
+    1. Set the Redis upgrade policy to `latest`:
+
+        ```sh
+        rladmin tune cluster redis_upgrade_policy latest
+        ```
+
+    1. [Upgrade Redis 6.0 databases]({{<relref "/operate/rs/installing-upgrading/upgrading/upgrade-database">}}) to Redis 6.2. See the [Redis 6.2 release notes](https://raw.githubusercontent.com/redis/redis/6.2/00-RELEASENOTES) for the list of changes.
 
 - For Redis Software 7.2.4 and 7.4.2 clusters, upgrade Redis 6.0 databases to Redis 7.2. Before you upgrade your databases, see the list of [Redis 7.2 breaking changes]({{< relref "/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52#redis-72-breaking-changes" >}}) and update any applications that connect to your database to handle these changes.
 


### PR DESCRIPTION
DOC-4793