### PR TITLE
Update Products menu to match main site structure (DOC-5305)

### DIFF
--- a/layouts/partials/header/products-dropdown.html
+++ b/layouts/partials/header/products-dropdown.html
@@ -3,19 +3,12 @@
   <div class="p-10">
     <h2 class="mb-6 border-b border-redis-pencil-250 pb-2 text-xs font-medium uppercase tracking-[2px] text-gray-400">
       Products</h2>
-    <ul class="grid grid-cols-2 gap-x-7 gap-y-3.5">
+    <ul class="grid grid-cols-1 gap-x-7 gap-y-3.5">
       <li class="w-[16rem]">
         <a class="font-medium hover:text-redis-red-500" href="https://redis.io/cloud/">
           Redis Cloud
           <p class="mt-2 text-xs font-normal text-gray-600">Fully managed and integrated with Google Cloud, Azure, and
             AWS.</p>
-        </a>
-      </li>
-      <li class="w-[16rem]">
-        <a class="font-medium hover:text-redis-red-500" href="https://redis.io/redis-for-ai/">
-          Redis for AI
-          <p class="mt-2 text-xs font-normal text-gray-600">Build the fastest, most reliable GenAI apps with our
-            advanced vector database.</p>
         </a>
       </li>
       <li class="w-[16rem]">
@@ -26,14 +19,7 @@
         </a>
       </li>
       <li class="w-[16rem]">
-        <a class="font-medium hover:text-redis-red-500" href="https://redis.io/data-integration/">
-          Redis Data Integration (RDI)
-          <p class="mt-2 text-xs font-normal text-gray-600">Synchronize data in near-real time to make data fast—without
-            writing code.</p>
-        </a>
-      </li>
-      <li class="w-[16rem]">
-        <a class="font-medium hover:text-redis-red-500" href="https://redis.io/docs/latest/get-started/">
+        <a class="font-medium hover:text-redis-red-500" href="https://redis.io/open-source/">
           Redis Open Source
           <p class="mt-2 text-xs font-normal text-gray-600">In-memory database for caching &amp; streaming.</p>
         </a>
@@ -46,10 +32,14 @@
       <h2 class="mb-6 border-b border-redis-pencil-250 pb-2 text-xs font-medium uppercase tracking-[2px] text-gray-400">
         Tools</h2>
       <ul class="space-y-4">
+        <li><a class="font-medium hover:text-redis-red-500" href="https://redis.io/langcache/">Redis
+            LangCache</a></li>
         <li><a class="font-medium hover:text-redis-red-500" href="https://redis.io/insight/">Redis
             Insight</a></li>
+        <li><a class="font-medium hover:text-redis-red-500" href="https://redis.io/data-integration/">Redis
+            Data Integration</a></li>
         <li><a class="font-medium hover:text-redis-red-500" href="https://redis.io/clients/">Clients
-            and connectors</a></li>
+            & Connectors</a></li>
       </ul>
     </div>
     <div class="mt-auto">

--- a/layouts/partials/header/products-mobile.html
+++ b/layouts/partials/header/products-mobile.html
@@ -8,13 +8,6 @@
             </a>
         </li>
         <li class="active:text-redis-red-500">
-            <a class="block w-full py-2" href="https://redis.io/redis-for-ai/">
-                Redis for AI
-                <p class="mt-2 text-xs font-normal text-gray-600">Build the fastest, most reliable GenAI apps with our
-                    advanced vector database.</p>
-            </a>
-        </li>
-        <li class="active:text-redis-red-500">
             <a class="block w-full py-2" href="https://redis.io/software/">
                 Redis Software
                 <p class="mt-2 text-xs font-normal text-gray-600">Self-managed software with enterprise-grade compliance
@@ -22,14 +15,7 @@
             </a>
         </li>
         <li class="active:text-redis-red-500">
-            <a class="block w-full py-2" href="https://redis.io/data-integration/">
-                Redis Data Integration (RDI)
-                <p class="mt-2 text-xs font-normal text-gray-600">Synchronize data in near-real time to make data
-                    fast—without writing code.</p>
-            </a>
-        </li>
-        <li class="active:text-redis-red-500">
-            <a class="block w-full py-2" href="https://redis.io/docs/latest/get-started/">
+            <a class="block w-full py-2" href="https://redis.io/open-source/">
                 Redis Open Source
                 <p class="mt-2 text-xs font-normal text-gray-600">In-memory database for caching &amp; streaming.</p>
             </a>
@@ -40,9 +26,13 @@
             <h2 class="mb-6 pb-2 text-xs uppercase tracking-[2px] text-gray-400">Tools</h2>
             <ul class="space-y-4">
                 <li class="active:text-redis-red-500"><a class="block w-full py-2"
+                        href="https://redis.io/langcache/">Redis LangCache</a></li>
+                <li class="active:text-redis-red-500"><a class="block w-full py-2"
                         href="https://redis.io/insight/">Redis Insight</a></li>
                 <li class="active:text-redis-red-500"><a class="block w-full py-2"
-                        href="https://redis.io/clients/">Clients and connectors</a></li>
+                        href="https://redis.io/data-integration/">Redis Data Integration</a></li>
+                <li class="active:text-redis-red-500"><a class="block w-full py-2"
+                        href="https://redis.io/clients/">Clients & Connectors</a></li>
             </ul>
         </div>
         <div class="pt-4">


### PR DESCRIPTION
- Reorganize Products section from 3 columns to 2 columns layout
- Remove Redis for AI from Products section (now separate top-level menu)
- Move Redis Data Integration from Products to Tools section
- Add Redis LangCache to Tools section
- Update Redis Open Source link to point to /open-source/ instead of /docs/latest/get-started/
- Update Clients link text to 'Clients & Connectors' for consistency
- Apply changes to both desktop dropdown and mobile menu

Products section now contains:
- Redis Cloud
- Redis Software
- Redis Open Source

Tools section now contains:
- Redis LangCache
- Redis Insight
- Redis Data Integration
- Clients & Connectors

Matches the current structure on redis.io main site