### PR TITLE
DOC-5306 updated Jedis and Lettuce versions and added node-redis CSC

### DIFF
--- a/content/develop/clients/client-side-caching.md
+++ b/content/develop/clients/client-side-caching.md
@@ -81,6 +81,7 @@ The following client libraries support CSC from the stated version onwards:
 | :-- | :-- |
 | [`redis-py`]({{< relref "/develop/clients/redis-py/connect#connect-using-client-side-caching" >}}) | v5.1.0 |
 | [`Jedis`]({{< relref "/develop/clients/jedis/connect#connect-using-client-side-caching" >}}) | v5.2.0 |
+| [`node-redis`]({{< relref "/develop/clients/nodejs/connect#connect-using-client-side-caching" >}}) | v5.1.0 |
 
 ## Which commands can cache data?
 

--- a/content/develop/clients/jedis/_index.md
+++ b/content/develop/clients/jedis/_index.md
@@ -34,7 +34,7 @@ To include `Jedis` as a dependency in your application, edit the dependency file
   <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>5.2.0</version>
+      <version>6.0.0</version>
   </dependency>
   ```
 
@@ -46,7 +46,7 @@ To include `Jedis` as a dependency in your application, edit the dependency file
   }
   //...
   dependencies {
-      implementation 'redis.clients:jedis:5.2.0'
+      implementation 'redis.clients:jedis:6.0.0'
       //...
   }
   ```

--- a/content/develop/clients/lettuce/_index.md
+++ b/content/develop/clients/lettuce/_index.md
@@ -36,7 +36,7 @@ If you use Maven, add the following dependency to your `pom.xml`:
 <dependency>
     <groupId>io.lettuce</groupId>
     <artifactId>lettuce-core</artifactId>
-    <version>6.3.2.RELEASE</version> <!-- Check for the latest version on Maven Central -->
+    <version>6.7.1.RELEASE</version> <!-- Check for the latest version on Maven Central -->
 </dependency>
 ```
 
@@ -44,7 +44,7 @@ If you use Gradle, include this line in your `build.gradle` file:
 
 ```
 dependencies {
-    compileOnly 'io.lettuce:lettuce-core:6.3.2.RELEASE'
+    compileOnly 'io.lettuce:lettuce-core:6.7.1.RELEASE'
 }
 ```
 


### PR DESCRIPTION
[DOC-5306](https://redislabs.atlassian.net/browse/DOC-5306)

As a bonus fix, I also added a line for node-redis to the table of clients supporting CSC.

[DOC-5306]: https://redislabs.atlassian.net/browse/DOC-5306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ