### PR TITLE
ioredis migration docs suggestions

### DIFF
--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -137,15 +137,13 @@ objects are flattened into sequential key-value pairs:
 
 ```js
 // These commands are all equivalent.
-client.hset('user' {
+await client.hSet('user' {
     name: 'Bob',
     age: 20,
     description: 'I am a programmer',
 });
 
-client.hset('user', ['name', 'Bob', 'age', 20, 'description', 'I am a programmer']);
-
-client.hset('user', 'name', 'Bob', 'age', 20, 'description', 'I am a programmer');
+await client.hSet('user', ['name', 'Bob', 'age', 20, 'description', 'I am a programmer']);
 ```
 
 `node-redis` uses predefined formats for command arguments. These include specific

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -137,13 +137,15 @@ objects are flattened into sequential key-value pairs:
 
 ```js
 // These commands are all equivalent.
-await client.hSet('user' {
+client.hset('user' {
     name: 'Bob',
     age: 20,
     description: 'I am a programmer',
 });
 
-await client.hSet('user', ['name', 'Bob', 'age', 20, 'description', 'I am a programmer']);
+client.hset('user', ['name', 'Bob', 'age', 20, 'description', 'I am a programmer']);
+
+client.hset('user', 'name', 'Bob', 'age', 20, 'description', 'I am a programmer');
 ```
 
 `node-redis` uses predefined formats for command arguments. These include specific

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -85,7 +85,7 @@ to make the connection:
 ```js
 import { createClient } from 'redis';
 
-const client = await createClient();
+const client = createClient();
 await client.connect(); // Requires explicit connection.
 ```
 

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -43,7 +43,7 @@ each feature.
 | :-- | :-- | :-- |
 | [Command case](#command-case) | Lowercase only (eg, `hset`) | Uppercase or camel case (eg, `HSET` or `hSet`) |
 | [Command argument handling](#command-argument-handling) | Argument objects flattened and items passed directly | Argument objects parsed to generate correct argument list |
-| [Asynchronous command result handling](#async-result) | Callbacks and Promises | Promises only |
+| [Asynchronous command result handling](#async-result) | Callbacks and Promises | Promises and Callbacks (via Legacy Mode) |
 | [Arbitrary command execution](#arbitrary-command-execution) | Uses the `call()` method | Uses the `sendCommand()` method |
 
 ### Techniques
@@ -189,7 +189,22 @@ client.get('mykey').then(
 `node-redis` supports only `Promise` objects for results, so
 you must always use a `then()` handler or the
 [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
-operator to receive them.
+operator to receive them, however callbacks are still supported via the legacy mode:
+
+```js
+// Promise
+await client.set('mykey', 'myvalue');
+
+// Callback
+const legacyClient = client.legacy();
+legacyClient.set("mykey", "myvalue", (err, result) => {
+  if (err) {
+    console.error(err);
+  } else {
+    console.log(result);
+  }
+});
+```
 
 ### Arbitrary command execution
 

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -43,7 +43,7 @@ each feature.
 | :-- | :-- | :-- |
 | [Command case](#command-case) | Lowercase only (eg, `hset`) | Uppercase or camel case (eg, `HSET` or `hSet`) |
 | [Command argument handling](#command-argument-handling) | Argument objects flattened and items passed directly | Argument objects parsed to generate correct argument list |
-| [Asynchronous command result handling](#async-result) | Callbacks and Promises | Promises and Callbacks (via Legacy Mode) |
+| [Asynchronous command result handling](#async-result) | Callbacks and Promises | Promises (but supports callbacks via Legacy Mode) |
 | [Arbitrary command execution](#arbitrary-command-execution) | Uses the `call()` method | Uses the `sendCommand()` method |
 
 ### Techniques
@@ -189,7 +189,7 @@ client.get('mykey').then(
 `node-redis` supports only `Promise` objects for results, so
 you must always use a `then()` handler or the
 [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
-operator to receive them, however callbacks are still supported via the legacy mode:
+operator to receive them. However, you can still use callbacks with the legacy mode if you need them:
 
 ```js
 // Promise
@@ -354,9 +354,8 @@ command with an explicit method:
 client.setnx('bike:1', 'bike');
 ```
 
-`node-redis` provides a `SETNX` method but due to the command being deprecated the same
-functionality can be achieved with the `NX` option to the [`SET`]({{< relref "/commands/set" >}})
-command instead:
+`node-redis` provides a `SETNX` method but this command is deprecated. Use the `NX` option to the [`SET`]({{< relref "/commands/set" >}})
+command to get the same functionality as `SETNX`:
 
 ```js
 await client.set('bike:1', 'bike', {'NX': true});

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -352,9 +352,9 @@ command with an explicit method:
 client.setnx('bike:1', 'bike');
 ```
 
-`node-redis` doesn't provide a `SETNX` method but implements the same
-functionality with the `NX` option to the [`SET`]({{< relref "/commands/set" >}})
-command:
+`node-redis` provides a `SETNX` method but due to the command being deprecated the same
+functionality can be achieved with the `NX` option to the [`SET`]({{< relref "/commands/set" >}})
+command instead:
 
 ```js
 await client.set('bike:1', 'bike', {'NX': true});

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -137,7 +137,7 @@ objects are flattened into sequential key-value pairs:
 
 ```js
 // These commands are all equivalent.
-client.hset('user' {
+client.hset('user', {
     name: 'Bob',
     age: 20,
     description: 'I am a programmer',


### PR DESCRIPTION
Below are some findings and suggestions for improving the [ioredis migration docs](https://redis.io/docs/latest/develop/clients/nodejs/migration/)

# ioredis migration suggestions

## [Initial Connection](https://redis.io/docs/latest/develop/clients/nodejs/migration/#initial-connection)

The below `await` in the node-redis section is redundant

```js
const client = await createClient();
```

## [Asynchronous command result handling](https://redis.io/docs/latest/develop/clients/nodejs/migration/#async-result)

`node-redis` supports callbacks via Legacy Mode

## [SETNX command](https://redis.io/docs/latest/develop/clients/nodejs/migration/#setnx-command)

`node-redis` has a [SETNX command](https://github.com/redis/node-redis/blob/master/packages/client/lib/commands/SETNX.ts)