### PR TITLE
Add doc for used_memory_peak_time

### DIFF
--- a/content/commands/info.md
+++ b/content/commands/info.md
@@ -152,6 +152,7 @@ Here is the meaning of all fields in the **memory** section:
 *   `used_memory_rss_human`: Human readable representation of previous value
 *   `used_memory_peak`: Peak memory consumed by Redis (in bytes)
 *   `used_memory_peak_human`: Human readable representation of previous value
+*   `used_memory_peak_time`: Time when peak memory was recorded
 *   `used_memory_peak_perc`: The percentage of `used_memory` out of `used_memory_peak`
 *   `used_memory_overhead`: The sum in bytes of all overheads that the server
      allocated for managing its internal data structures


### PR DESCRIPTION
Add a new field `used_memory_peak_time` for `INFO MEMORY`.
See https://github.com/redis/redis/pull/14067