### PR TITLE
Fix broken links in metrics documentation.

### DIFF
--- a/content/operate/rs/7.4/references/metrics/database-operations.md
+++ b/content/operate/rs/7.4/references/metrics/database-operations.md
@@ -120,7 +120,7 @@ Maximum number of write operations queued per [Active-Active]({{< relref "/opera
 
 Number of operations per second that are not [read operations](#readssec) or [write operations](#writessec).
 
-Examples of other operations include [PING]({{< relref "/commands/ping" >}}), [AUTH]({{< relref "/commands/auth" >}}, and [INFO]({{< relref "/commands/info" >}}
+Examples of other operations include [PING]({{< relref "/commands/ping" >}}), [AUTH]({{< relref "/commands/auth" >}}), and [INFO]({{< relref "/commands/info" >}}).
 
 **Components measured**: Database
 

--- a/content/operate/rs/7.8/references/metrics/database-operations.md
+++ b/content/operate/rs/7.8/references/metrics/database-operations.md
@@ -120,7 +120,7 @@ Maximum number of write operations queued per [Active-Active]({{< relref "/opera
 
 Number of operations per second that are not [read operations](#readssec) or [write operations](#writessec).
 
-Examples of other operations include [PING]({{< relref "/commands/ping" >}}), [AUTH]({{< relref "/commands/auth" >}}, and [INFO]({{< relref "/commands/info" >}}
+Examples of other operations include [PING]({{< relref "/commands/ping" >}}), [AUTH]({{< relref "/commands/auth" >}}), and [INFO]({{< relref "/commands/info" >}}).
 
 **Components measured**: Database
 

--- a/content/operate/rs/references/metrics/database-operations.md
+++ b/content/operate/rs/references/metrics/database-operations.md
@@ -119,7 +119,7 @@ Maximum number of write operations queued per [Active-Active]({{< relref "/opera
 
 Number of operations per second that are not [read operations](#readssec) or [write operations](#writessec).
 
-Examples of other operations include [PING]({{< relref "/commands/ping" >}}), [AUTH]({{< relref "/commands/auth" >}}, and [INFO]({{< relref "/commands/info" >}}
+Examples of other operations include [PING]({{< relref "/commands/ping" >}}), [AUTH]({{< relref "/commands/auth" >}}), and [INFO]({{< relref "/commands/info" >}}).
 
 **Components measured**: Database
 


### PR DESCRIPTION
These links were broken by the following commit:
76fdf8b0 (SITE-WIDE: double-slash (//) correction (#363), 2024-06-27)