### PR TITLE
Silence Python warnings about invalid backslashes.

### DIFF
--- a/build/components/component.py
+++ b/build/components/component.py
@@ -461,7 +461,7 @@ class Module(Component):
                 md.persist()
 
             files = run(
-                f'find {self._content} -regex ".*\.md"').strip().split('\n')
+                fr'find {self._content} -regex ".*\.md"').strip().split('\n')
             for f in files:
                 md = Markdown(f)
                 t = md.fm_data.pop('type', None)

--- a/build/components/example.py
+++ b/build/components/example.py
@@ -14,7 +14,7 @@ TEST_MARKER = {
     'java-sync': '@Test',
     'java-async': '@Test',
     'java-reactive': '@Test',
-    'c#': '\[Fact\]|\[SkipIfRedis\(.*\)\]'
+    'c#': r'\[Fact]|\[SkipIfRedis\(.*\)]'
 }
 PREFIXES = {
     'python': '#',

--- a/build/components/markdown.py
+++ b/build/components/markdown.py
@@ -77,9 +77,8 @@ class Markdown:
         self.fm_data['github_path'] = github_path
 
     def report_links(self) -> None:
-        links = re.findall(r'(\[.+\])(\(.+\))', self.payload)
         exc = ['./', '#', '/commands', '/community', '/docs', '/topics']
-        for link in links:
+        for link in re.finditer(r'(\[.+])(\(.+\))', self.payload):
             ex = False
             for e in exc:
                 if link[1].startswith(f'({e}'):
@@ -247,4 +246,4 @@ class Markdown:
                 return r
             else:
                 return x.group(0)
-        self.payload = re.sub(f'(\[.+?\])(\(.+?\))', rep, self.payload)
+        self.payload = re.sub(r'(\[.+])(\(.+\))', rep, self.payload)


### PR DESCRIPTION
This patch fixes the following warnings:

    /home/collin/.local/src/redis-docs/build/components/component.py:464: SyntaxWarning: invalid escape sequence '\.'
      f'find {self._content} -regex ".*\.md"').strip().split('\n')
    /home/collin/.local/src/redis-docs/build/components/markdown.py:250: SyntaxWarning: invalid escape sequence '\['
      self.payload = re.sub(f'(\[.+?\])(\(.+?\))', rep, self.payload)
    /home/collin/.local/src/redis-docs/build/components/example.py:17: SyntaxWarning: invalid escape sequence '\['
      'c#': '\[Fact\]|\[SkipIfRedis\(.*\)\]'

The first one should be marked raw since we want the `\` to be passed to the shell.

The others are not needed. Using "\]" is only required when trying to match the literal ']' in a set of characers.