### PR TITLE
Update installing-redisgears.md

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/installing-redisgears.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/installing-redisgears.md
@@ -96,6 +96,10 @@ The following example shows how to upgrade a database named `shopping-cart` to R
 rladmin upgrade db shopping-cart and module module_name rg version 10209 module_args keep_args
 ```
 
+{{<note>}}
+These command examples also upgrade the database to the latest Redis version on the cluster. For more module upgrade information and examples, see [Upgrade modules]({{<relref "/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module">}}).
+{{</note>}}
+
 ## Uninstall RedisGears
 
 To uninstall RedisGears, make a [`DELETE` request to the `/v2/modules` REST API endpoint]({{< relref "/operate/rs/references/rest-api/requests/modules#delete-module-v2" >}}).

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/installing-redisgears.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/installing-redisgears.md
@@ -82,17 +82,20 @@ After installation, create a new database and enable RedisGears:
 
 - [With the JVM]({{< relref "/operate/oss_and_stack/stack-with-enterprise/gears-v1/jvm/install" >}})
 
+## Upgrade RedisGears for existing databases
+
+To upgrade RedisGears for an existing database after installing a new version, use [`rladmin upgrade db`]({{<relref "/operate/rs/references/cli-utilities/rladmin/upgrade#upgrade-db">}}):
+
+```sh
+rladmin upgrade db <database-name-or-ID> and module module_name rg version <new_version_integer> module_args "<module arguments>"
+```
+
+The following example shows how to upgrade a database named `shopping-cart` to RedisGears version 1.2.9 without changing its configuration:
+
+```sh
+rladmin upgrade db shopping-cart and module module_name rg version 10209 module_args keep_args
+```
+
 ## Uninstall RedisGears
 
 To uninstall RedisGears, make a [`DELETE` request to the `/v2/modules` REST API endpoint]({{< relref "/operate/rs/references/rest-api/requests/modules#delete-module-v2" >}}).
-
-## Upgrade existing databases to a new version of RedisGear
-
-To upgrade an existing database, use the following `rladmin` command:
-   ```sh
-   rladmin upgrade db <database-name-or-ID> and module module_name rg version <new_version_integer> module_args "<module arguments>"
-   ```
-Example: To upgrade database `shoppingcart` to RedisGears version 1.2.9 and to continue to use the same configuration:
-   ```sh
-   rladmin upgrade db shopping-cart and module module_name rg version 10209 module_args keep_args
-   ```

--- a/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/installing-redisgears.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/gears-v1/installing-redisgears.md
@@ -85,3 +85,14 @@ After installation, create a new database and enable RedisGears:
 ## Uninstall RedisGears
 
 To uninstall RedisGears, make a [`DELETE` request to the `/v2/modules` REST API endpoint]({{< relref "/operate/rs/references/rest-api/requests/modules#delete-module-v2" >}}).
+
+## Upgrade existing databases to a new version of RedisGear
+
+To upgrade an existing database, use the following `rladmin` command:
+   ```sh
+   rladmin upgrade db <database-name-or-ID> and module module_name rg version <new_version_integer> module_args "<module arguments>"
+   ```
+Example: To upgrade database `shoppingcart` to RedisGears version 1.2.9 and to continue to use the same configuration:
+   ```sh
+   rladmin upgrade db shopping-cart and module module_name rg version 10209 module_args keep_args
+   ```


### PR DESCRIPTION
I'm adding directions on how to use the newly installed Redisgears version to upgrade a database. It was a little jarring not having this available on this page. It left me hanging when I needed to upgrade a database. It took me a good five minutes to find the information on how to apply the upgrade to a database. A link to where the `rladmin upgrade db...` command is explained in our documentation would be good too. I couldn't find one though.