### PR TITLE
Fix typo in install for redis-py entraid extension

### DIFF
--- a/content/develop/clients/redis-py/amr.md
+++ b/content/develop/clients/redis-py/amr.md
@@ -31,7 +31,7 @@ if you have not already done so. Then, install `redis-entra-id` with the
 following command:
 
 ```bash
-pip install redis-entra-id
+pip install redis-entraid
 ```
 
 ## Create a `CredentialProvider` instance


### PR DESCRIPTION
Fix typo in pip install command for redis-py entraid extension