### PR TITLE
Add RESP2/3 return information to the Cuckoo filter commands

### DIFF
--- a/content/commands/cf.add.md
+++ b/content/commands/cf.add.md
@@ -50,13 +50,6 @@ If `key` does not exist - a new cuckoo filter is created.
 is an item to add.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - where "1" means that the item has been added successfully
-- [] on error (invalid arguments, wrong key type, etc.) and also when the filter is full
-
 ## Complexity
 
 O(n + i), where n is the number of `sub-filters` and i is `maxIterations`.
@@ -72,3 +65,21 @@ redis> CF.ADD cf item1
 redis> CF.ADD cf item1
 (integer) 1
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id="cf-add-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): `1` for successfully adding an item to the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when the filter is full.
+
+-tab-sep-
+
+One of the following:
+* [Boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}): `true` for successfully adding an item to the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when the filter is full.
+
+{{< /multitabs >}}

--- a/content/commands/cf.addnx.md
+++ b/content/commands/cf.addnx.md
@@ -56,13 +56,6 @@ If `key` does not exist - a new cuckoo filter is created.
 is an item to add.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), where `0` means that the item's fingerprint already exist in the filter, and `1` means that the item has been successfully added to the filter.
-- [] on error (invalid arguments, wrong key type, etc.) and also when the filter is full.
-
 ## Examples
 
 {{< highlight bash >}}
@@ -71,3 +64,21 @@ redis> CF.ADDNX cf item
 redis> CF.ADDNX cf item
 (integer) 0
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id="cf-addnx-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): `1` for successfully adding an item to the filter or `0` if the item's fingerprint already exists in the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when the filter is full.
+
+-tab-sep-
+
+One of the following:
+* [Boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}): `true` for successfully adding an item to the filter or `false` if the item's fingerprint already exists in the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when the filter is full.
+
+{{< /multitabs >}}

--- a/content/commands/cf.count.md
+++ b/content/commands/cf.count.md
@@ -48,13 +48,6 @@ is key name for a cuckoo filter.
 is an item to check.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), where a positive value is an estimation of the number of times `item` was added to the filter. An overestimation is possible, but not an underestimation. `0` means that `key` does not exist or that `item` had not been added to the filter. See note in [`CF.DEL`]({{< relref "commands/cf.del/" >}}).
-- [] on error (invalid arguments, wrong key type, etc.)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -67,3 +60,21 @@ redis> CF.COUNT cf item1
 redis> CF.COUNT cf item2
 (integer) 2
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“cf-count-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), where a positive value is an estimation of the number of times `item` was added to the filter. An overestimation is possible, but not an underestimation. `0` means that `key` does not exist or that `item` had not been added to the filter. See the note in [`CF.DEL`]({{< relref "commands/cf.del/" >}}).
+* [Simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments or wrong key type.
+
+-tab-sep-
+
+One of the following:
+* [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), where a positive value is an estimation of the number of times `item` was added to the filter. An overestimation is possible, but not an underestimation. `0` means that `key` does not exist or that `item` had not been added to the filter. See the note in [`CF.DEL`]({{< relref "commands/cf.del/" >}}).
+* [Simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments or wrong key type.
+
+{{< /multitabs >}}

--- a/content/commands/cf.del.md
+++ b/content/commands/cf.del.md
@@ -57,13 +57,6 @@ is an item to delete.
 O(n), where n is the number of `sub-filters`. Both alternative locations are
 checked on all `sub-filters`.
 
-## Return value
-
-Returns one of these replies:
-
-- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - where "1" means that the item has been deleted, and "0" means that such item was not found in the filter
-- [] on error (invalid arguments, wrong key type, etc.)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -82,3 +75,21 @@ redis> CF.DEL cf item2
 redis> CF.DEL cf item2
 (integer) 0
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“cf-del-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) `1` for successfully deleting an item, or `0` if no such item was found in the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments or wrong key type.
+
+-tab-sep-
+
+One of the following:
+* [Boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}) `true` for successfully deleting an item, or `false` if no such item was found in the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments or wrong key type.
+
+{{< /multitabs >}}

--- a/content/commands/cf.exists.md
+++ b/content/commands/cf.exists.md
@@ -48,13 +48,6 @@ is key name for a cuckoo filter.
 is an item to check.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), where `1` means that, with high probability, `item` had already been added to the filter, and `0` means that `key` does not exist or that `item` had not been added to the filter. See note in [`CF.DEL`]({{< relref "commands/cf.del/" >}}).
-- [] on error (invalid arguments, wrong key type, and so on)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -65,3 +58,19 @@ redis> CF.EXISTS cf item1
 redis> CF.EXISTS cf item2
 (integer) 0
 {{< / highlight >}}
+
+{{< multitabs id="cf-exists-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): `1` means that, with high probability, `item` was already added to the filter, and `0` means that either the `key` does not exist or that the `item` had not been added to the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if invalid arguments are passed.
+
+-tab-sep-
+
+One of the following:
+* [Boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}): `true` means that, with high probability, `item` was already added to the filter, and `false` means that either `key` does not exist or that `item` had not been added to the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if invalid arguments are passed or `key` is not of the correct type.
+
+{{< /multitabs >}}

--- a/content/commands/cf.info.md
+++ b/content/commands/cf.info.md
@@ -38,13 +38,6 @@ Returns information about a cuckoo filter.
 is key name for a cuckoo filter.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with argument name ([Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) and value ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})) pairs
-- [] on error (invalid arguments, key does not exist, wrong key type, and so on)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -66,3 +59,21 @@ redis> CF.INFO cf
 15) Max iteration
 16) (integer) 20
 {{< / highlight >}}
+
+## Return information
+
+One of the following:
+
+{{< multitabs id=“cf-info-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with argument name ([Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) and value ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})) pairs.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if invalid arguments are passed, `key` does not exist, or `key` is not of the correct type.
+
+-tab-sep-
+
+* [Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) with argument name ([Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) and value ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})) pairs.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if invalid arguments are passed, `key` does not exist, or `key` is not of the correct type.
+
+{{< /multitabs >}}

--- a/content/commands/cf.insert.md
+++ b/content/commands/cf.insert.md
@@ -84,13 +84,6 @@ If specified, prevents automatic filter creation if the filter does not exist (I
 This option is mutually exclusive with `CAPACITY`.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - where "1" means that the item has been successfully added to the filter, and "-1" means that the item was not added because the filter is full.
-- [] on error (invalid arguments, wrong key type, and so on) and also when `NOCREATE` is specified and `key` does not exist.
-
 ## Examples
 
 {{< highlight bash >}}
@@ -113,3 +106,21 @@ redis> CF.INSERT cf2 ITEMS 1 1 1 1
 3) (integer) -1
 4) (integer) -1
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“cf-insert-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}), where each element is an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) of `1` for successfully adding an item, or `-1` when the item cannot be added because the filter is full.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors">}}) when the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist.
+
+-tab-sep-
+
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}), where each element is a [boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}) of `1` for successfully adding an item, or `-1` when the item cannot be added because the filter is full.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors">}}) when the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist.
+
+{{< /multitabs >}}

--- a/content/commands/cf.insertnx.md
+++ b/content/commands/cf.insertnx.md
@@ -91,13 +91,6 @@ If specified, prevents automatic filter creation if the filter does not exist (I
 This option is mutually exclusive with `CAPACITY`.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), where `0` means that the item's fingerprint already exists in the filter, `1` means that the item has been successfully added to the filter, and `-1` means that the item was not added because the filter is full.
-- [] on error (invalid arguments, wrong key type, etc.) and also when `NOCREATE` is specified and `key` does not exist.
-
 ### Complexity
 
 O(n + i), where n is the number of `sub-filters` and i is `maxIterations`.
@@ -123,3 +116,21 @@ redis> CF.INSERTNX cf CAPACITY 1000 ITEMS item1 item2 item3
 redis> CF.INSERTNX cf_new CAPACITY 1000 NOCREATE ITEMS item1 item2 
 (error) ERR not found
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“cf-insert-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}), where each element is an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) of `0` means that the item's fingerprint already exists in the filter, `1` for successfully adding an item, or `-1` when the item cannot be added because the filter is full.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors">}}) when the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist.
+
+-tab-sep-
+
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}), where each element is a [boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}) of `1` for successfully adding an item, or `-1` when the item cannot be added because the filter is full.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors">}}) when the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist.
+
+{{< /multitabs >}}

--- a/content/commands/cf.loadchunk.md
+++ b/content/commands/cf.loadchunk.md
@@ -71,3 +71,21 @@ Returns one of these replies:
 ## Examples
 
 See [`CF.SCANDUMP`]({{< relref "commands/cf.scandump/" >}}) for an example.
+
+## Return information
+
+{{< multitabs id="bf-loadchunk-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}): `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when invalid data was passed.
+
+-tab-sep-
+
+One of the following:
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}): `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when invalid data was passed.
+
+{{< /multitabs >}}

--- a/content/commands/cf.mexists.md
+++ b/content/commands/cf.mexists.md
@@ -50,13 +50,6 @@ is key name for a cuckoo filter.
 One or more items to check.
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - where "1" means that, with high probability, `item` was already added to the filter, and "0" means that `key` does not exist or that `item` had not added to the filter. See note in [`CF.DEL`]({{< relref "commands/cf.del/" >}}).
-- [] on error (invalid arguments, wrong key type, etc.)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -68,3 +61,21 @@ redis> CF.MEXISTS cf item1 item2 item3
 2) (integer) 1
 3) (integer) 0
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id="bf-mexists-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}), where `1` means that, with high probability, `item` was already added to the filter, and `0` means that `key` does not exist or that `item` was definitely not added to the filter. See note in [`CF.DEL`]({{< relref "commands/cf.del/" >}}).
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: in these cases: invalid arguments, wrong key type, or when the key was not found.
+
+-tab-sep-
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [boolean replies]({{< relref "/develop/reference/protocol-spec#booleans" >}}), where `true` means that, with high probability, `item` was already added to the filter, and `false` means that `key` does not exist or that `item` was definitely not added to the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: in these cases: invalid arguments, wrong key type, or when the key was not found.
+
+{{< /multitabs >}}

--- a/content/commands/cf.reserve.md
+++ b/content/commands/cf.reserve.md
@@ -107,13 +107,6 @@ When a new filter is created, its size is the size of the current filter multipl
 Expansion is rounded to the next `2^n` number. 
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) - `OK` if filter created successfully
-- [] on error (invalid arguments, key already exists, etc.)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -126,3 +119,21 @@ redis> CF.RESERVE cf 1000
 redis> CF.RESERVE cf_params 1000 BUCKETSIZE 8 MAXITERATIONS 20 EXPANSION 2
 OK
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id="cf-reserve-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}): `OK` if the filter was created successfully.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments or the key already exists.
+
+-tab-sep-
+
+One of the following:
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}): `OK` if the filter was created successfully.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments or the key already exists.
+
+{{< /multitabs >}}

--- a/content/commands/cf.scandump.md
+++ b/content/commands/cf.scandump.md
@@ -51,18 +51,6 @@ is key name for a cuckoo filter to save.
 Iterator value; either 0 or the iterator from a previous invocation of this command
 </details>
 
-## Return value
-
-Returns one of these replies:
-
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) (_Iterator_) and [] (_Data_). 
-
-  The Iterator is passed as input to the next invocation of `CF.SCANDUMP`. If _Iterator_ is 0, then it means iteration has completed.
-
-  The iterator-data pair should also be passed to [`CF.LOADCHUNK`]({{< relref "commands/cf.loadchunk/" >}}) when restoring the filter.
-
-- [] on error (invalid arguments, key not found, wrong key type, etc.)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -105,3 +93,29 @@ for chunk in chunks:
     iter, data = chunk
     CF.LOADCHUNK(key, iter, data)
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id="cf-scandump-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a two-element array of an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) (_Iterator_) and a [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) (_Data_).
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, the key was not found, or the key is of the wrong type.
+
+The Iterator is passed as input to the next invocation of `CF.SCANDUMP`. If _Iterator_ is 0, then it means iteration has completed.
+
+The iterator-data pair should also be passed to [`CF.LOADCHUNK`]({{< relref "commands/cf.loadchunk/" >}}) when restoring the filter.
+
+-tab-sep-
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a two-element array of an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) (_Iterator_) and a [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) (_Data_).
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, the key was not found, or the key is of the wrong type.
+
+The Iterator is passed as input to the next invocation of `CF.SCANDUMP`. If _Iterator_ is 0, then it means iteration has completed.
+
+The iterator-data pair should also be passed to [`CF.LOADCHUNK`]({{< relref "commands/cf.loadchunk/" >}}) when restoring the filter.
+
+{{< /multitabs >}}


### PR DESCRIPTION
[DOC-5318](https://redislabs.atlassian.net/browse/DOC-5318)

The return information is at the bottom of each page.

[DOC-5318]: https://redislabs.atlassian.net/browse/DOC-5318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ