### PR TITLE
DEV: fix bug on indexing page

### DIFF
--- a/content/develop/interact/search-and-query/indexing/_index.md
+++ b/content/develop/interact/search-and-query/indexing/_index.md
@@ -382,7 +382,7 @@ For more information on vector similarity syntax, see [Vector fields]({{< relref
 
 ## Index JSON objects
 
-You cannot index JSON objects. If the JSONPath expression returns an object, it will be ignored.
+You cannot index JSON objects. If the JSONPath expression returns an object, an indexing error will be returned.
 
 To index the contents of a JSON object, you need to index the individual elements within the object in separate attributes.
 

--- a/content/develop/interact/search-and-query/indexing/_index.md
+++ b/content/develop/interact/search-and-query/indexing/_index.md
@@ -382,7 +382,7 @@ For more information on vector similarity syntax, see [Vector fields]({{< relref
 
 ## Index JSON objects
 
-You cannot index JSON objects. If the JSONPath expression returns an object, an indexing error will be returned.
+You cannot index JSON objects. FT.CREATE will return an error if the JSONPath expression returns an object.
 
 To index the contents of a JSON object, you need to index the individual elements within the object in separate attributes.
 


### PR DESCRIPTION
[DOC-5357](https://redislabs.atlassian.net/browse/DOC-5357)

Change:

"You cannot index JSON objects. If the JSONPath expression returns an object, it will be ignored."

to:

"You cannot index JSON objects. If the JSONPath expression returns an object, an indexing error will be returned."

[DOC-5357]: https://redislabs.atlassian.net/browse/DOC-5357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ