### PR TITLE
Update aws-console.md

### DIFF
--- a/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/aws-console.md
+++ b/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/aws-console.md
@@ -30,7 +30,7 @@ Follow the steps to [create an IAM policy using the JSON editor](https://docs.aw
 
     {{< expand "View RedisLabsInstanceRolePolicy.json" >}}
 ```js
- {
+{
     "Version": "2012-10-17",
     "Statement": [
         {


### PR DESCRIPTION
AWS returned an error: JSON strings must not have leading spaces

removed an extra space on the first JSON