### PR TITLE
DEV: add RESP2/3 return information to the CMS commands

### DIFF
--- a/content/commands/cms.incrby.md
+++ b/content/commands/cms.incrby.md
@@ -45,13 +45,6 @@ Increases the count of item by increment. Multiple items can be increased with o
 * **item**: The item which counter is to be increased.
 * **increment**: Amount by which the item counter is to be increased.
 
-## Return
-
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) with an updated min-count of each of the items in the sketch.
-
-Count of each item after increment.
-
 ## Examples
 
 ```
@@ -59,3 +52,23 @@ redis> CMS.INCRBY test foo 10 bar 42
 1) (integer) 10
 2) (integer) 42
 ```
+
+## Return information
+
+{{< multitabs id=“cms-incrby-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) representing updated min-counts of each of the provided items in the sketch.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, missing key, overflow, or wrong key type.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) representing updated min-counts of each of the provided items in the sketch.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, missing key, overflow, or wrong key type.
+
+{{< /multitabs >}}

--- a/content/commands/cms.info.md
+++ b/content/commands/cms.info.md
@@ -35,10 +35,6 @@ Returns width, depth and total count of the sketch.
 
 * **key**: The name of the sketch.
 
-## Return
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with information of the filter.
-
 ## Examples
 
 ```
@@ -50,3 +46,21 @@ redis> CMS.INFO test
  5) count
  6) (integer) 0
 ```
+
+{{< multitabs id=“cms-info-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) and [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) pairs containing sketch information.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, missing key, or wrong key type.
+
+-tab-sep-
+
+One of the following:
+
+* [Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) of [simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) and [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) pairs containing sketch information.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, missing key, or wrong key type.
+
+{{< /multitabs >}}

--- a/content/commands/cms.initbydim.md
+++ b/content/commands/cms.initbydim.md
@@ -42,13 +42,29 @@ Initializes a Count-Min Sketch to dimensions specified by user.
 * **depth**: Number of counter-arrays. Reduces the probability for an
     error of a certain size (percentage of total count).
 
-## Return
-
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) - `OK` if executed correctly, or [] otherwise.
-
 ## Examples
 
 ```
 redis> CMS.INITBYDIM test 2000 5
 OK
 ```
+
+## Return information
+
+{{< multitabs id=“cms-initbydim-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the given key already exists.
+
+-tab-sep-
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the given key already exists.
+
+{{< /multitabs >}}

--- a/content/commands/cms.initbyprob.md
+++ b/content/commands/cms.initbyprob.md
@@ -44,11 +44,7 @@ Initializes a Count-Min Sketch to accommodate requested tolerances.
     be a decimal value between 0 and 1. This effects the depth of the sketch.
     For example, for a desired false positive rate of 0.1% (1 in 1000),
     error_rate should be set to 0.001. The closer this number is to zero, the
-    greater the memory consumption per item and the more CPU usage per operation. 
-    
-## Return
-
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) - `OK` if executed correctly, or [] otherwise.
+    greater the memory consumption per item and the more CPU usage per operation.
 
 ## Examples
 
@@ -56,3 +52,23 @@ Initializes a Count-Min Sketch to accommodate requested tolerances.
 redis> CMS.INITBYPROB test 0.001 0.01
 OK
 ```
+
+## Return information
+
+{{< multitabs id=“cms-initbyprob-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the given key already exists.
+
+-tab-sep-
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the given key already exists.
+
+{{< /multitabs >}}

--- a/content/commands/cms.merge.md
+++ b/content/commands/cms.merge.md
@@ -53,13 +53,29 @@ Merges several sketches into one sketch. All sketches must have identical width 
 * **src**: Names of source sketches to be merged.
 * **weight**: Multiple of each sketch. Default =1.
 
-## Return
-
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) - `OK` if executed correctly, or [] otherwise.
-
 ## Examples
 
 ```
 redis> CMS.MERGE dest 2 test1 test2 WEIGHTS 1 3
 OK
 ```
+
+## Return information
+
+{{< multitabs id=“cms-merge-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: non-existent key or destination key is not of the same width and/or depth.
+
+-tab-sep-
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: non-existent key or destination key is not of the same width and/or depth.
+
+{{< /multitabs >}}

--- a/content/commands/cms.query.md
+++ b/content/commands/cms.query.md
@@ -38,12 +38,6 @@ Returns the count for one or more items in a sketch.
 * **key**: The name of the sketch.
 * **item**: One or more items for which to return the count.
 
-## Return
-
-Count of one or more items
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) with a min-count of each of the items in the sketch.
-
 ## Examples
 
 ```
@@ -51,3 +45,21 @@ redis> CMS.QUERY test foo bar
 1) (integer) 10
 2) (integer) 42
 ```
+
+{{< multitabs id=“cms-merge-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}})  representing the min-counts of each of the provided items in the sketch.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, missing key, or wrong key type.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) representing the min-counts of each of the provided items in the sketch.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, missing key, or wrong key type.
+
+{{< /multitabs >}}


### PR DESCRIPTION
[DOC-5319](https://redislabs.atlassian.net/browse/DOC-5319)

The return information is at the bottom of each page.

[DOC-5319]: https://redislabs.atlassian.net/browse/DOC-5319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ