### PR TITLE
Add Active-Passive replication warnings to data eviction policies

### DIFF
--- a/content/operate/rc/databases/configuration/data-eviction-policies.md
+++ b/content/operate/rc/databases/configuration/data-eviction-policies.md
@@ -35,7 +35,34 @@ For each database, you can choose from these data eviction policies:
 
 ## Prevent data eviction
 
-Redis Cloud supports [Auto Tiering]({{< relref "/operate/rs/databases/auto-tiering/" >}}) 
+Redis Cloud supports [Auto Tiering]({{< relref "/operate/rs/databases/auto-tiering/" >}})
 to prevent data eviction but maintain high performance.
 
 Auto Tiering can extend your database across RAM and Flash Memory and intelligently manage "hot" (active) data in RAM and "cold" (less active) data in Flash memory (SSD).
+
+## Active-Passive replication considerations
+
+When using Active-Passive replication with [Replica Of]({{< relref "/operate/rs/databases/import-export/replica-of/" >}}), data eviction and expiration policies have important implications for data consistency.
+
+{{< warning >}}
+**Do not write to the destination (passive) replica database.** Writing to the destination replica can cause serious data consistency issues and replication failures.
+{{< /warning >}}
+
+### Problems caused by writing to passive replicas
+
+In Active-Passive setups, eviction and expiration only operate on the active (source) database. When you write to the passive replica:
+
+- **Memory management conflicts**: The passive replica cannot rely on eviction or expiration to manage local writes, requiring sufficient memory to handle both replicated data and local writes.
+- **Data inconsistency**: Local writes create differences between the source and destination databases, causing replicated commands to behave differently on each database.
+- **Replication failures**: Inconsistent data can cause replicated commands to fail with errors, which will cause the synchronization process to exit and break replication.
+
+### Transitioning from passive to active
+
+To properly transition a passive replica to become an active, writable database:
+
+1. **Stop replication** using the Redis Cloud console interface
+2. **Remove the replicaOf source** by running the `REPLICAOF NO ONE` command on the database
+
+Both steps are required to ensure the database can safely accept writes and manage its own eviction and expiration policies.
+
+

--- a/content/operate/rc/databases/configuration/data-eviction-policies.md
+++ b/content/operate/rc/databases/configuration/data-eviction-policies.md
@@ -42,19 +42,10 @@ Auto Tiering can extend your database across RAM and Flash Memory and intelligen
 
 ## Active-Passive replication considerations
 
-When using Active-Passive replication with [Replica Of]({{< relref "/operate/rs/databases/import-export/replica-of/" >}}), data eviction and expiration policies have important implications for data consistency.
+When using [Active-Passive replication]({{< relref "/operate/rc/databases/migrate-databases#sync-using-active-passive" >}}), eviction and expiration only operate on the source (active) database. The target database does not evict or expire data while Active-Passive is enabled. 
 
-{{< warning >}}
-**Do not write to the destination (passive) replica database.** Writing to the destination replica can cause data consistency issues and replication failures.
-{{< /warning >}}
+Do not write to the target database while Active-Passive is enabled. Doing so can cause the following issues:
 
-### Problems caused by writing to passive replicas
-
-In Active-Passive setups, eviction and expiration only operate on the active (source) database. When you write to the passive replica:
-
-- **Memory management conflicts**: The passive replica cannot rely on eviction or expiration to manage local writes, requiring sufficient memory to handle both replicated data and local writes.
-- **Data inconsistency**: Local writes create differences between the source and destination databases, causing replicated commands to behave differently on each database.
-- **Replication failures**: Inconsistent data can cause replicated commands to fail with errors, which will cause the synchronization process to exit and break replication.
-
-
-
+- The target database cannot rely on eviction or expiration to manage local writes, requiring sufficient memory to handle both replicated data and local writes.
+- Local writes create differences between the source and target databases, causing replicated commands to behave differently on each database.
+- Inconsistent data can cause replicated commands to fail with errors, which will cause the synchronization process to exit and break replication.

--- a/content/operate/rc/databases/configuration/data-eviction-policies.md
+++ b/content/operate/rc/databases/configuration/data-eviction-policies.md
@@ -45,7 +45,7 @@ Auto Tiering can extend your database across RAM and Flash Memory and intelligen
 When using Active-Passive replication with [Replica Of]({{< relref "/operate/rs/databases/import-export/replica-of/" >}}), data eviction and expiration policies have important implications for data consistency.
 
 {{< warning >}}
-**Do not write to the destination (passive) replica database.** Writing to the destination replica can cause serious data consistency issues and replication failures.
+**Do not write to the destination (passive) replica database.** Writing to the destination replica can cause data consistency issues and replication failures.
 {{< /warning >}}
 
 ### Problems caused by writing to passive replicas
@@ -56,13 +56,5 @@ In Active-Passive setups, eviction and expiration only operate on the active (so
 - **Data inconsistency**: Local writes create differences between the source and destination databases, causing replicated commands to behave differently on each database.
 - **Replication failures**: Inconsistent data can cause replicated commands to fail with errors, which will cause the synchronization process to exit and break replication.
 
-### Transitioning from passive to active
-
-To properly transition a passive replica to become an active, writable database:
-
-1. **Stop replication** using the Redis Cloud console interface
-2. **Remove the replicaOf source** by running the `REPLICAOF NO ONE` command on the database
-
-Both steps are required to ensure the database can safely accept writes and manage its own eviction and expiration policies.
 
 

--- a/content/operate/rc/databases/migrate-databases.md
+++ b/content/operate/rc/databases/migrate-databases.md
@@ -56,7 +56,7 @@ Before you use Active-Passive, be aware of the following limitations:
 
 - An error will appear when syncing the two databases if the source and target databases are hosted on different Redis Cloud accounts. [Contact support](https://redis.io/support/) if you want to migrate a database between accounts using Active-Passive.
 
-- As long as Active-Passive is enabled, data in the target database will not expire and will not be evicted regardless of the set [data eviction policy]({{< relref "/operate/rc/databases/configuration/data-eviction-policies.md" >}}). We recommend that you turn off Active-Passive after the databases are synced. 
+- As long as Active-Passive is enabled, data in the target database will not expire and will not be evicted regardless of the set [data eviction policy]({{< relref "/operate/rc/databases/configuration/data-eviction-policies.md" >}}). **Do not write to the target database while Active-Passive is enabled.** We recommend that you turn off Active-Passive after the databases are synced. 
 
 - Turning on Active-Passive will flush the target database. Make sure that your target database has no important data before you turn on Active-Passive.
 {{< /note >}}
@@ -135,7 +135,11 @@ Follow these detailed steps to migrate data using Active-Passive syncing:
 
     {{<image filename="images/rc/migrate-data-status-synced.png" alt="When the data is migrated, the target database status displays `Synced`." width=100px >}}
 
-Active-Passive sync lets you migrate data while apps and other connections are using the source database.  Once the data is migrated, you should migrate active connections to the target database.  
+Active-Passive sync lets you migrate data while apps and other connections are using the source database.  Once the data is migrated, you should migrate active connections to the target database.
+
+{{< warning >}}
+Do not write to the target database until turning off Active-Passive. Writing to the target database of an Active-Passive setup can cause data consistency issues and replication failures. See [Active-Passive replication considerations]({{< relref "/operate/rc/databases/configuration/data-eviction-policies.md#active-passive-replication-considerations" >}}) for more information.
+{{< /warning >}}
 
 ## Active-Passive memory requirements
 


### PR DESCRIPTION
- Document that writing to destination (passive) replica causes data inconsistency
- Explain eviction/expiration only operates on active replica
- Detail memory management conflicts and replication failures
- Provide proper steps for transitioning passive to active database
- Include warning about syncer exit due to command failures

Addresses DOC-824