### PR TITLE
Add RHEL 8 crypto policy limitation for certificate key sizes

### DIFF
--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -76,7 +76,13 @@ The RHEL-compatible distributions CentOS, CentOS Stream, Alma Linux, Rocky Linux
 
 ### TLS 1.0 and TLS 1.1
 
-Redis Enterprise Software version 6.2.8 removed support for TLS 1.0 and TLS 1.1 on Red Hat Enterprise Linux 8 (RHEL 8) because that operating system [does not enable support](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening) for these versions by default.  
+Redis Enterprise Software version 6.2.8 removed support for TLS 1.0 and TLS 1.1 on Red Hat Enterprise Linux 8 (RHEL 8) because that operating system [does not enable support](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening) for these versions by default.
+
+### RHEL 8 crypto policy and certificate key size
+
+In RHEL 8, if the crypto policy is set to `FUTURE`, the system will not accept certificates with private key sizes smaller than 3072 bits. This affects users who use custom certificates with smaller keys (such as 2048-bit keys).
+
+If you want to continue using certificates with smaller key sizes, you need to change the crypto policy from `FUTURE` to `DEFAULT`. For more information about crypto policies, see the [Red Hat documentation on system-wide cryptographic policies](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening).
 
 ### Ubuntu 20 rejects SHA1 certificates
 

--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -82,7 +82,7 @@ Redis Enterprise Software version 6.2.8 removed support for TLS 1.0 and TLS 1.1 
 
 In RHEL 8, if the crypto policy is set to `FUTURE`, the system will not accept certificates with private key sizes smaller than 3072 bits. This affects users who use custom certificates with smaller keys (such as 2048-bit keys).
 
-If you want to continue using certificates with smaller key sizes, you need to change the crypto policy from `FUTURE` to `DEFAULT`. For more information about crypto policies, see the [Red Hat documentation on system-wide cryptographic policies](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening).
+To use certificates with smaller key sizes, you need to change the crypto policy from `FUTURE` to `DEFAULT`. For more information about crypto policies, see the [Red Hat documentation on system-wide cryptographic policies](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening).
 
 ### Ubuntu 20 rejects SHA1 certificates
 

--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -80,7 +80,7 @@ Redis Enterprise Software version 6.2.8 removed support for TLS 1.0 and TLS 1.1 
 
 ### RHEL 8 crypto policy and certificate key size
 
-In RHEL 8, if the crypto policy is set to `FUTURE`, the system will not accept certificates with private key sizes smaller than 3072 bits. This affects users who use custom certificates with smaller keys (such as 2048-bit keys).
+In RHEL 8, if the crypto policy is set to `FUTURE`, the system will not accept certificates with private key sizes smaller than 3072 bits. This affects use of custom certificates with smaller keys (such as 2048-bit keys).
 
 To use certificates with smaller key sizes, you need to change the crypto policy from `FUTURE` to `DEFAULT`. For more information about crypto policies, see the [Red Hat documentation on system-wide cryptographic policies](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening).
 

--- a/content/operate/rs/security/certificates/updating-certificates.md
+++ b/content/operate/rs/security/certificates/updating-certificates.md
@@ -142,7 +142,7 @@ To update your syncer certificate on clusters running Active-Active databases, f
 - Do not run any other `crdb-cli crdb update` operations between the two steps.<br/>
 {{</note>}}
 
-### Troubleshoot RHEL 8 crypto policy and certificate key size
+## Troubleshoot RHEL 8 crypto policy and certificate key size
 
 In RHEL 8, if the crypto policy is set to `FUTURE`, the system will not accept certificates with private key sizes smaller than 3072 bits. This affects the use of custom certificates with smaller keys (such as 2048-bit keys).
 

--- a/content/operate/rs/security/certificates/updating-certificates.md
+++ b/content/operate/rs/security/certificates/updating-certificates.md
@@ -141,3 +141,9 @@ To update your syncer certificate on clusters running Active-Active databases, f
 - Run step 2 as quickly as possible after step 1. Between the two steps, new syncer connections that use the ‘old’ certificate will get rejected by the cluster that has been updated with the new certificate (in step 1).<br/>
 - Do not run any other `crdb-cli crdb update` operations between the two steps.<br/>
 {{</note>}}
+
+### Troubleshoot RHEL 8 crypto policy and certificate key size
+
+In RHEL 8, if the crypto policy is set to `FUTURE`, the system will not accept certificates with private key sizes smaller than 3072 bits. This affects the use of custom certificates with smaller keys (such as 2048-bit keys).
+
+To use certificates with smaller key sizes, you need to change the crypto policy from `FUTURE` to `DEFAULT`. For more information about crypto policies, see the [Red Hat documentation on system-wide cryptographic policies](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening).


### PR DESCRIPTION
- Document that FUTURE crypto policy rejects certificates with keys < 3072 bits
- Explain impact on users with custom 2048-bit certificates
- Provide guidance to change policy from FUTURE to DEFAULT
- Include reference to Red Hat crypto policy documentation

Addresses DOC-1629