### PR TITLE
DEV: add RESP2/3 return information to the t-digest commands

### DIFF
--- a/content/commands/tdigest.add.md
+++ b/content/commands/tdigest.add.md
@@ -40,16 +40,14 @@ Adds one or more observations to a t-digest sketch.
 ## Required arguments
 
 <details open><summary><code>key</code></summary> 
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
 
 <details open><summary><code>value</code></summary> 
-is value of an observation (floating-point).
+
+is the floating-point value of an observation.
 </details>
-
-## Return value
-
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) - `OK` if executed correctly, or [] otherwise.
 
 ## Examples
 
@@ -62,3 +60,23 @@ OK
 redis> TDIGEST.ADD t string
 (error) ERR T-Digest: error parsing val parameter
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-add-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or the value parameter is of the incorrect type.
+
+-tab-sep-
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or the value parameter is of the incorrect type.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.byrank.md
+++ b/content/commands/tdigest.byrank.md
@@ -19,7 +19,7 @@ categories:
 - kubernetes
 - clients
 complexity: O(N) where N is the number of ranks specified.
-description: Returns, for each input rank, an estimation of the value (floating-point)
+description: Returns, for each input rank, a floating-point estimation of the value
   with that rank
 group: tdigest
 hidden: false
@@ -27,43 +27,32 @@ linkTitle: TDIGEST.BYRANK
 module: Bloom
 since: 2.4.0
 stack_path: docs/data-types/probabilistic
-summary: Returns, for each input rank, an estimation of the value (floating-point)
+summary: Returns, for each input rank, a floating-point estimation of the value
   with that rank
 syntax_fmt: TDIGEST.BYRANK key rank [rank ...]
 syntax_str: rank [rank ...]
 title: TDIGEST.BYRANK
 ---
-Returns, for each input rank, an estimation of the value (floating-point) with that rank.
-
-Multiple estimations can be retrieved in a signle call.
+Returns, for each input rank, a floating-point estimation of the value with that rank.
+Multiple estimations can be retrieved in a single call.
 
 ## Required arguments
 
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name of an existing t-digest sketch.
 </details>
 
 <details open><summary><code>rank</code></summary>
 
-Rank, for which the value should be retrieved.
+Ranks for which the values should be retrieved.
 
 0 is the rank of the value of the smallest observation.
 
-_n_-1 is the rank of the value of the largest observation; _n_ denotes the number of observations added to the sketch.
-
+_n_-1 is the rank of the value of the largest observation, where _n_ denotes the number of observations that have been added to the sketch.
 </details>
 
-## Return value
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) - an array of floating-points populated with value_1, value_2, ..., value_R:
-
-- Return an accurate result when `rank` is 0 (the value of the smallest observation)
-- Return an accurate result when `rank` is _n_-1 (the value of the largest observation), where _n_ denotes the number of observations added to the sketch.
-- Return 'inf' when `rank` is equal to _n_ or larger than _n_
-
-All values are 'nan' if the sketch is empty.
-
-## Examples
+## Example
 
 {{< highlight bash >}}
 redis> TDIGEST.CREATE t COMPRESSION 1000
@@ -88,3 +77,31 @@ redis> TDIGEST.BYRANK t 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
 15) "5"
 16) "inf"
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-byrank-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk strings]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) as floating-points, populated with value_1, value_2, ..., value_R:
+    * an accurate result when `rank` is `0`, the value of the smallest observation.
+    * an accurate result when `rank` is _n_-1, the value of the largest observation, where _n_ denotes the number of observations added to the sketch.
+    * `inf` when `rank` is equal to _n_ or larger than _n_.
+    * `nan` for all ranks when the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, rank parsing errors, or incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [doubles]({{< relref "/develop/reference/protocol-spec#doubles" >}}) as floating-points, populated with value_1, value_2, ..., value_R:
+    * an accurate result when `rank` is `0`, the value of the smallest observation.
+    * an accurate result when `rank` is _n_-1, the value of the largest observation, where _n_ denotes the number of observations added to the sketch.
+    * `inf` when `rank` is equal to _n_ or larger than _n_.
+    * `nan` for all ranks when the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, rank parsing errors, or incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.byrevrank.md
+++ b/content/commands/tdigest.byrevrank.md
@@ -19,7 +19,7 @@ categories:
 - kubernetes
 - clients
 complexity: O(N) where N is the number of reverse ranks specified.
-description: Returns, for each input reverse rank, an estimation of the value (floating-point)
+description: Returns, for each input reverse rank, an estimation of the floating-point value
   with that reverse rank
 group: tdigest
 hidden: false
@@ -27,40 +27,30 @@ linkTitle: TDIGEST.BYREVRANK
 module: Bloom
 since: 2.4.0
 stack_path: docs/data-types/probabilistic
-summary: Returns, for each input reverse rank, an estimation of the value (floating-point)
+summary: Returns, for each input reverse rank, an estimation of the floating-point value
   with that reverse rank
 syntax_fmt: TDIGEST.BYREVRANK key reverse_rank [reverse_rank ...]
 syntax_str: reverse_rank [reverse_rank ...]
 title: TDIGEST.BYREVRANK
 ---
-Returns, for each input reverse rank, an estimation of the value (floating-point) with that reverse rank.
-
+Returns, for each input reverse rank (`revrank`), an estimation of the floating-point value with that reverse rank.
 Multiple estimations can be retrieved in a single call.
 
 ## Required arguments
 
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name of an existing t-digest sketch.
 </details>
 
 <details open><summary><code>revrank</code></summary>
 
-Reverse rank, for which the value should be retrieved.
+Reverse ranks for which the values should be retrieved.
 
 0 is the reverse rank of the value of the largest observation.
   
-_n_-1 is the reverse rank of the value of the smallest observation; _n_ denotes the number of observations added to the sketch.
+_n_-1 is the reverse rank of the value of the smallest observation, where _n_ denotes the number of observations added to the sketch.
 </details>
-
-## Return value
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) - an array of floating-points populated with value_1, value_2, ..., value_R:
-
-- Return an accurate result when `revrank` is 0 (the value of the largest observation)
-- Return an accurate result when `revrank` is _n_-1 (the value of the smallest observation), where _n_ denotes the number of observations added to the sketch.
-- Return '-inf' when `revrank` is equal to _n_ or larger than _n_
-
-All values are 'nan' if the sketch is empty.
 
 ## Examples
 
@@ -87,3 +77,31 @@ redis> TDIGEST.BYREVRANK t 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
 15) "1"
 16) "-inf"
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-byrevrank-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk strings]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) as floating-points, populated with value_1, value_2, ..., value_R:
+    * an accurate result when `rank` is `0`, the value of the largest observation.
+    * an accurate result when `rank` is _n_-1, the value of the smallest observation, where _n_ denotes the number of observations added to the sketch.
+    * `inf` when `rank` is equal to _n_ or larger than _n_.
+    * `nan` for all ranks when the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, rank parsing errors, or an incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [doubles]({{< relref "/develop/reference/protocol-spec#doubles" >}}) as floating-points, populated with value_1, value_2, ..., value_R:
+    * an accurate result when `rank` is `0`, the value of the largest observation.
+    * an accurate result when `rank` is _n_-1, the value of the smallest observation, where _n_ denotes the number of observations added to the sketch.
+    * `inf` when `rank` is equal to _n_ or larger than _n_.
+    * `nan` for all ranks when the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, rank parsing errors, or an incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.cdf.md
+++ b/content/commands/tdigest.cdf.md
@@ -19,7 +19,7 @@ categories:
 - kubernetes
 - clients
 complexity: O(N) where N is the number of values specified.
-description: Returns, for each input value, an estimation of the fraction (floating-point)
+description: Returns, for each input value, an estimation of the floating-point fraction
   of (observations smaller than the given value + half the observations equal to the
   given value)
 group: tdigest
@@ -28,32 +28,27 @@ linkTitle: TDIGEST.CDF
 module: Bloom
 since: 2.4.0
 stack_path: docs/data-types/probabilistic
-summary: Returns, for each input value, an estimation of the fraction (floating-point)
+summary: Returns, for each input value, an estimation of the floating-point fraction
   of (observations smaller than the given value + half the observations equal to the
   given value)
 syntax_fmt: TDIGEST.CDF key value [value ...]
 syntax_str: value [value ...]
 title: TDIGEST.CDF
 ---
-Returns, for each input value, an estimation of the fraction (floating-point) of (observations smaller than the given value + half the observations equal to the given value).
-
+Returns, for each input value, an estimation of the floating-point fraction of (_observations smaller than the given value_ + _half the observations equal to the given value_).
 Multiple fractions can be retrieved in a single call.
 
 ## Required arguments
 
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
 
 <details open><summary><code>value</code></summary>
-is value for which the CDF (Cumulative Distribution Function) should be retrieved.
+
+are the values for which the CDF (Cumulative Distribution Function) should be retrieved.
 </details>
-
-## Return value
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) - the command returns an array of floating-points populated with fraction_1, fraction_2, ..., fraction_N. 
-
-All values are 'nan' if the sketch is empty.
 
 ## Examples
 
@@ -71,3 +66,25 @@ redis> TDIGEST.CDF t 0 1 2 3 4 5 6
 6) "0.83333333333333337"
 7) "1"
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-cdf-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) as floating-points, populated with fraction_1, fraction_2, ..., fraction_N.
+All values are `nan` if the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, value parsing errors, or an incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [doubles]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})populated with fraction_1, fraction_2, ..., fraction_N.
+All values are `nan` if the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, value parsing errors, or an incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.cdf.md
+++ b/content/commands/tdigest.cdf.md
@@ -83,7 +83,7 @@ All values are `nan` if the given sketch is empty.
 
 One of the following:
 
-* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [doubles]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})populated with fraction_1, fraction_2, ..., fraction_N.
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [doubles]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) populated with fraction_1, fraction_2, ..., fraction_N.
 All values are `nan` if the given sketch is empty.
 * [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, value parsing errors, or an incorrect number of arguments.
 

--- a/content/commands/tdigest.create.md
+++ b/content/commands/tdigest.create.md
@@ -37,24 +37,40 @@ Allocates memory and initializes a new t-digest sketch.
 ## Required arguments
 
 <details open><summary><code>key</code></summary> 
-is key name for this new t-digest sketch.
+
+is the key name for this new t-digest sketch.
 </details>
 
 ## Optional arguments
 
-<details open><summary><code>COMPRESSION compression</code></summary> 
+<details open><summary><code>COMPRESSION compression</code></summary>
 
-is a controllable tradeoff between accuracy and memory consumption. 100 is a common value for normal uses. 1000 is more accurate. If no value is passed by default the compression will be 100. For more information on scaling of accuracy versus the compression parameter see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
-
+is a controllable tradeoff between accuracy and memory consumption. 100 is a common value for normal uses and also the default if not specified. 1000 is more accurate. For more information on scaling of accuracy versus the compression value see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
 </details>
-  
-## Return value
 
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) - `OK` if executed correctly, or [] otherwise.
-
-## Examples
+## Example
 
 {{< highlight bash >}}
 redis> TDIGEST.CREATE t COMPRESSION 100
 OK
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-create-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: incorrect key type or incorrect keyword.
+
+-tab-sep-
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: incorrect key type or incorrect keyword.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.info.md
+++ b/content/commands/tdigest.info.md
@@ -34,24 +34,8 @@ Returns information and statistics about a t-digest sketch.
 
 <details open><summary><code>key</code></summary> 
 
-is key name for an existing t-digest sketch.
+is the key name for an existing t-digest sketch.
 </details>
-
-## Return value
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with information about the sketch (name-value pairs):
-
-| Name<br>[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) | Description
-| ---------------------------- | -
-| `Compression`        | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> The compression (controllable trade-off between accuracy and memory consumption) of the sketch 
-| `Capacity`           | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Size of the buffer used for storing the centroids and for the incoming unmerged observations
-| `Merged nodes`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of merged observations
-| `Unmerged nodes`     | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of buffered nodes (uncompressed observations)
-| `Merged weight`      | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Weight of values of the merged nodes
-| `Unmerged weight`    | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Weight of values of the unmerged nodes (uncompressed observations)
-| `Observations`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of observations added to the sketch
-| `Total compressions` | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of times this sketch compressed data together
-| `Memory usage`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of bytes allocated for the sketch
 
 ## Examples
 
@@ -80,3 +64,47 @@ redis> TDIGEST.INFO t
 17) Memory usage
 18) (integer) 9768
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-info-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with information about the given sketch as name-value pairs:
+
+    | Name<br>[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) | Description
+    | ---------------------------- | -
+    | `Compression`        | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> The compression (controllable trade-off between accuracy and memory consumption) of the sketch 
+    | `Capacity`           | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Size of the buffer used for storing the centroids and for the incoming unmerged observations
+    | `Merged nodes`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of merged observations
+    | `Unmerged nodes`     | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of buffered nodes (uncompressed observations)
+    | `Merged weight`      | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Weight of values of the merged nodes
+    | `Unmerged weight`    | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Weight of values of the unmerged nodes (uncompressed observations)
+    | `Observations`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of observations added to the sketch
+    | `Total compressions` | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of times this sketch compressed data together
+    | `Memory usage`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of bytes allocated for the sketch
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type or an incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) with information about the given sketch as name-value pairs:
+
+    | Name<br>[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) | Description
+    | ---------------------------- | -
+    | `Compression`        | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> The compression (controllable trade-off between accuracy and memory consumption) of the sketch 
+    | `Capacity`           | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Size of the buffer used for storing the centroids and for the incoming unmerged observations
+    | `Merged nodes`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of merged observations
+    | `Unmerged nodes`     | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of buffered nodes (uncompressed observations)
+    | `Merged weight`      | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Weight of values of the merged nodes
+    | `Unmerged weight`    | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Weight of values of the unmerged nodes (uncompressed observations)
+    | `Observations`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of observations added to the sketch
+    | `Total compressions` | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of times this sketch compressed data together
+    | `Memory usage`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of bytes allocated for the sketch
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type or an incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.max.md
+++ b/content/commands/tdigest.max.md
@@ -34,12 +34,9 @@ Returns the maximum observation value from a t-digest sketch.
 ## Required arguments
 
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
-
-## Return value
-
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) of maximum observation value from a sketch. The result is always accurate. 'nan' if the sketch is empty.
 
 ## Examples
 
@@ -53,3 +50,23 @@ OK
 redis>TDIGEST.MAX t
 "5"
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-max-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) as floating-point representing the maximum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) in these cases: incorrect number of arguments or incorrect key type.
+
+-tab-sep-
+
+One of the following:
+
+* [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}}) representing the maximum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) in these cases: incorrect number of arguments or incorrect key type.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.merge.md
+++ b/content/commands/tdigest.merge.md
@@ -54,40 +54,39 @@ Merges multiple t-digest sketches into a single sketch.
 ## Required arguments
 <details open><summary><code>destination-key</code></summary>
 
-is key name for a t-digest sketch to merge observation values to.
+is the key name for a t-digest sketch to merge observation values to.
 
-If `destination-key` does not exist - a new sketch is created.
+If `destination-key` does not exist, a new sketch is created.
 
 If `destination-key` is an existing sketch, its values are merged with the values of the source keys. To override the destination key contents use `OVERRIDE`.
 </details>
 
 <details open><summary><code>numkeys</code></summary>
-Number of sketches to merge observation values from (1 or more).
+
+the number of sketches from which to merge observation values (one or more).
 </details>
 
 <details open><summary><code>source-key</code></summary>
-each is a key name for a t-digest sketch to merge observation values from.
+
+Each `source-key` is a key name for a t-digest sketch from which to merge observation values.
 </details>
 
 ## Optional arguments
 
 <details open><summary><code>COMPRESSION compression</code></summary>
   
-is a controllable tradeoff between accuracy and memory consumption. 100 is a common value for normal uses. 1000 is more accurate. If no value is passed by default the compression will be 100. For more information on scaling of accuracy versus the compression parameter see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
+is a controllable tradeoff between accuracy and memory consumption. 100 is a common value for normal uses and also the default if not specified. 1000 is more accurate. For more information on scaling of accuracy versus the compression value see [_The t-digest: Efficient estimates of distributions_](https://www.sciencedirect.com/science/article/pii/S2665963820300403).
   
 When `COMPRESSION` is not specified:
-- If `destination-key` does not exist or if `OVERRIDE` is specified, the compression is set to the maximal value among all source sketches.
+- If `destination-key` does not exist or if `OVERRIDE` is specified, the compression is set to the maximum value among all source sketches.
 - If `destination-key` already exists and `OVERRIDE` is not specified, its compression is not changed.
 
 </details>
 
 <details open><summary><code>OVERRIDE</code></summary>
-When specified, if `destination-key` already exists, it is overwritten.
+
+If `destination-key` already exists and `OVERRIDE` is specified, the key is overwritten.
 </details>
-
-## Return value
-
-OK on success, error otherwise.
 
 ## Examples
 {{< highlight bash >}}
@@ -108,3 +107,23 @@ redis> TDIGEST.BYRANK sM 0 1 2 3 4
 4) "40"
 5) "inf"
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-merge-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if successful.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in the following cases: incorrect key type, incorrect keyword, or incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if successful.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in the following cases: incorrect key type, incorrect keyword, or incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.min.md
+++ b/content/commands/tdigest.min.md
@@ -32,13 +32,11 @@ title: TDIGEST.MIN
 Returns the minimum observation value from a t-digest sketch.
 
 ## Required arguments
+
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
-
-## Return value
-
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) of minimum observation value from a sketch. The result is always accurate. 'nan' if the sketch is empty.
 
 ## Examples
 
@@ -52,3 +50,23 @@ OK
 redis> TDIGEST.MIN t
 "1"
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-min-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) as floating-point representing the minimum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) in these cases: incorrect number of arguments or incorrect key type.
+
+-tab-sep-
+
+One of the following:
+
+* [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}}) representing the minimum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) in these cases: incorrect number of arguments or incorrect key type.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.quantile.md
+++ b/content/commands/tdigest.quantile.md
@@ -19,42 +19,34 @@ categories:
 - kubernetes
 - clients
 complexity: O(N) where N is the number of quantiles specified.
-description: Returns, for each input fraction, an estimation of the value (floating
-  point) that is smaller than the given fraction of observations
+description: Returns, for each input fraction, a floating-point estimation of the value
+  that is smaller than the given fraction of observations
 group: tdigest
 hidden: false
 linkTitle: TDIGEST.QUANTILE
 module: Bloom
 since: 2.4.0
 stack_path: docs/data-types/probabilistic
-summary: Returns, for each input fraction, an estimation of the value (floating point)
+summary: Returns, for each input fraction, a floating-point estimation of the value
   that is smaller than the given fraction of observations
 syntax_fmt: TDIGEST.QUANTILE key quantile [quantile ...]
 syntax_str: quantile [quantile ...]
 title: TDIGEST.QUANTILE
 ---
-Returns, for each input fraction, an estimation of the value (floating point) that is smaller than the given fraction of observations.
-
+Returns, for each input fraction, a floating-point estimation of the value that is smaller than the given fraction of observations.
 Multiple quantiles can be retrieved in a single call.
 
 ## Required arguments
 
 <details open><summary><code>key</code></summary> 
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
 
 <details open><summary><code>quantile</code></summary> 
-is the input fraction (between 0 and 1 inclusively)
+
+is the input fraction between 0 and 1 inclusively.
 </details>
-
-## Return value
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) - an array of estimates (floating-point) populated with value_1, value_2, ..., value_N.
-
-- Return an accurate result when `quantile` is 0 (the value of the smallest observation)
-- Return an accurate result when `quantile` is 1 (the value of the largest observation)
-
-All values are 'nan' if the sketch is empty.
 
 ## Examples
 
@@ -75,5 +67,30 @@ redis> TDIGEST.QUANTILE t 0 0.1 0.2 0.3 0.4 0.5 0.6 0.7 0.8 0.9 1
  9) "5"
 10) "5"
 11) "5"
-
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-quantile-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) as floating-point estimates, populated with value_1, value_2, ..., value_N.
+    * an accurate result when `quantile` is `0`, the value of the smallest observation.
+    * an accurate result when `quantile` is `1`, the value of the largest observation.
+    * `nan` for all quantiles when the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantile parsing errors, or incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [double replies]({{< relref "/develop/reference/protocol-spec#doubles" >}}) as estimates, populated with value_1, value_2, ..., value_N.
+    * an accurate result when `quantile` is `0`, the value of the smallest observation.
+    * an accurate result when `quantile` is `1`, the value of the largest observation.
+    * `nan` for all quantiles when the given sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantile parsing errors, or incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.rank.md
+++ b/content/commands/tdigest.rank.md
@@ -19,7 +19,7 @@ categories:
 - kubernetes
 - clients
 complexity: O(N) where N is the number of values specified.
-description: Returns, for each input value (floating-point), the estimated rank of
+description: Returns, for each floating-point input value, the estimated rank of
   the value (the number of observations in the sketch that are smaller than the value
   + half the number of observations that are equal to the value)
 group: tdigest
@@ -28,38 +28,27 @@ linkTitle: TDIGEST.RANK
 module: Bloom
 since: 2.4.0
 stack_path: docs/data-types/probabilistic
-summary: Returns, for each input value (floating-point), the estimated rank of the
+summary: Returns, for each floating-point input value, the estimated rank of the
   value (the number of observations in the sketch that are smaller than the value
   + half the number of observations that are equal to the value)
 syntax_fmt: TDIGEST.RANK key value [value ...]
 syntax_str: value [value ...]
 title: TDIGEST.RANK
 ---
-Returns, for each input value (floating-point), the estimated rank of the value (the number of observations in the sketch that are smaller than the value + half the number of observations that are equal to the value).
-
+Returns, for each floating-point input value, the estimated rank of the value (_the number of observations in the sketch that are smaller than the value_ + _half the number of observations that are equal to the value_).
 Multiple ranks can be retrieved in a single call.
 
 ## Required arguments
+
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
 
 <details open><summary><code>value</code></summary>
-is input value for which the rank should be estimated.
 
-## Return value
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) - an array of integers populated with rank_1, rank_2, ..., rank_V:
-  
-- -1 - when `value` is smaller than the value of the smallest observation.
-- The number of observations - when `value` is larger than the value of the largest observation.
-- Otherwise: an estimation of the number of (observations smaller than `value` + half the observations equal to `value`).
-
-0 is the rank of the value of the smallest observation.
-
-_n_-1 is the rank of the value of the largest observation; _n_ denotes the number of observations added to the sketch.
-
-All values are -2 if the sketch is empty.
+is the input value for which the rank should be estimated.
+</details>
 
 ## Examples
 
@@ -100,3 +89,41 @@ redis> TDIGEST.REVRANK s 10 20
 1) (integer) 4
 2) (integer) 1
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-rank-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integers]({{< relref "/develop/reference/protocol-spec#integers" >}}) populated with rank_1, rank_2, ..., rank_V:
+    * `-1` when `value` is smaller than the value of the smallest observation.
+    * The number of observations when `value` is larger than the value of the largest observation.
+    * Otherwise, an estimation of the number of (_observations smaller than `value`_ + _half the observations equal to `value`_).
+
+    `0` is the rank of the value of the smallest observation.
+
+    _n_-1 is the rank of the value of the largest observation, where _n_ denotes the number of observations added to the sketch.
+
+    All values are `-2` if the sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantile parsing errors, or incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integers]({{< relref "/develop/reference/protocol-spec#integers" >}}) populated with rank_1, rank_2, ..., rank_V:
+    * `-1` when `value` is smaller than the value of the smallest observation.
+    * The number of observations when `value` is larger than the value of the largest observation.
+    * Otherwise, an estimation of the number of (_observations smaller than `value`_ + _half the observations equal to `value`_).
+
+    `0` is the rank of the value of the smallest observation.
+
+    _n_-1 is the rank of the value of the largest observation, where _n_ denotes the number of observations added to the sketch.
+
+    All values are `-2` if the sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantile parsing errors, or incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.reset.md
+++ b/content/commands/tdigest.reset.md
@@ -17,32 +17,51 @@ categories:
 - kubernetes
 - clients
 complexity: O(1)
-description: 'Resets a t-digest sketch: empty the sketch and re-initializes it.'
+description: Resets a t-digest sketch (empties the sketch and re-initializes it).
 group: tdigest
 hidden: false
 linkTitle: TDIGEST.RESET
 module: Bloom
 since: 2.4.0
 stack_path: docs/data-types/probabilistic
-summary: 'Resets a t-digest sketch: empty the sketch and re-initializes it.'
+summary: Resets a t-digest sketch (empties the sketch and re-initializes it).
 syntax_fmt: TDIGEST.RESET key
 syntax_str: ''
 title: TDIGEST.RESET
 ---
-Resets a t-digest sketch: empty the sketch and re-initializes it.
+Resets a t-digest sketch: empties the sketch and re-initializes it.
 
 ## Required arguments
+
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
 
-## Return value
 
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) - `OK` if executed correctly, or [] otherwise.
-
-## Examples
+## Example
 
 {{< highlight bash >}}
 redis> TDIGEST.RESET t
 OK
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-reset-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: key does not exist or is of the wrong type, or incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: key does not exist or is of the wrong type, or incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.revrank.md
+++ b/content/commands/tdigest.revrank.md
@@ -19,7 +19,7 @@ categories:
 - kubernetes
 - clients
 complexity: O(N) where N is the number of values specified.
-description: Returns, for each input value (floating-point), the estimated reverse
+description: Returns, for each floating-point input value, the estimated reverse
   rank of the value (the number of observations in the sketch that are larger than
   the value + half the number of observations that are equal to the value)
 group: tdigest
@@ -28,24 +28,27 @@ linkTitle: TDIGEST.REVRANK
 module: Bloom
 since: 2.4.0
 stack_path: docs/data-types/probabilistic
-summary: Returns, for each input value (floating-point), the estimated reverse rank
+summary: Returns, for each floating-point input value, the estimated reverse rank
   of the value (the number of observations in the sketch that are larger than the
   value + half the number of observations that are equal to the value)
 syntax_fmt: TDIGEST.REVRANK key value [value ...]
 syntax_str: value [value ...]
 title: TDIGEST.REVRANK
 ---
-Returns, for each input value (floating-point), the estimated reverse rank of the value (the number of observations in the sketch that are larger than the value + half the number of observations that are equal to the value).
-
+Returns, for each floating-point input value, the estimated reverse rank of the value (_the number of observations in the sketch that are larger than the value_ + _half the number of observations that are equal to the value_).
 Multiple reverse ranks can be retrieved in a single call.
 
 ## Required arguments
+
 <details open><summary><code>key</code></summary>
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
 
 <details open><summary><code>value</code></summary>
-is input value for which the reverse rank should be estimated.
+
+is the input value for which the reverse rank should be estimated.
+</details>
 
 ## Return value
 
@@ -100,3 +103,41 @@ redis> TDIGEST.REVRANK s 10 20
 1) (integer) 4
 2) (integer) 1
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-revrank-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integers]({{< relref "/develop/reference/protocol-spec#integers" >}}) populated with revrank_1, revrank_2, ..., revrank_V:
+    * `-1` when `value` is larger than the value of the largest observation.
+    * The number of observations when `value` is smaller than the value of the smallest observation.
+    * Otherwise, an estimation of the number of (_observations larger than `value`_ + _half the observations equal to `value`_).
+
+    `0` is the reverse rank of the value of the largest observation.
+
+    _n_-1 is the rank of the value of the smallest observation, where _n_ denotes the number of observations added to the sketch.
+
+    All values are `-2` if the sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantile parsing errors, or incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Array]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integers]({{< relref "/develop/reference/protocol-spec#integers" >}}) populated with revrank_1, revrank_2, ..., revrank_V:
+    * `-1` when `value` is larger than the value of the largest observation.
+    * The number of observations when `value` is smaller than the value of the smallest observation.
+    * Otherwise, an estimation of the number of (_observations larger than `value`_ + _half the observations equal to `value`_).
+
+    `0` is the reverse rank of the value of the largest observation.
+
+    _n_-1 is the rank of the value of the smallest observation, where _n_ denotes the number of observations added to the sketch.
+
+    All values are `-2` if the sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantile parsing errors, or incorrect number of arguments.
+
+{{< /multitabs >}}

--- a/content/commands/tdigest.trimmed_mean.md
+++ b/content/commands/tdigest.trimmed_mean.md
@@ -39,30 +39,27 @@ Returns an estimation of the mean value from the sketch, excluding observation v
 ## Required arguments
 
 <details open><summary><code>key</code></summary> 
-is key name for an existing t-digest sketch.
+
+is the key name for an existing t-digest sketch.
 </details>
 
 <details open><summary><code>low_cut_quantile</code></summary> 
   
-Foating-point value in the range [0..1], should be lower than `high_cut_quantile`
+a floating-point value in the range [0..1]. It must be lower than `high_cut_quantile`.
   
-When equal to 0: No low cut.
+When equal to 0, no low cut.
   
-When higher than 0: Exclude observation values lower than this quantile.
+When greater than 0, exclude observation values lower than this quantile.
 </details>
 
 <details open><summary><code>high_cut_quantile</code></summary> 
   
-Floating-point value in the range [0..1], should be higher than `low_cut_quantile`  
+a floating-point value in the range [0..1]. It must be higher than `low_cut_quantile`.
   
-When lower than 1: Exclude observation values higher than or equal to this quantile.
+When less than 1, exclude observation values greater than or equal to this quantile.
 
-When equal to 1: No high cut.
+When equal to 1, no high cut.
 </details>
-
-## Return value
-
-[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) estimation of the mean value. 'nan' if the sketch is empty.
 
 ## Examples
 
@@ -77,5 +74,26 @@ redis> TDIGEST.TRIMMED_MEAN t 0.3 0.9
 "6.5"
 redis> TDIGEST.TRIMMED_MEAN t 0 1
 "5.5"
-
 {{< / highlight >}}
+
+## Return information
+
+{{< multitabs id=“tdigest-trimmedmean-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+One of the following:
+
+* [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) as a floating-point estimation of the mean value.
+* `nan` if the sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantiles out of range [0..1], or incorrect number of arguments.
+
+-tab-sep-
+
+One of the following:
+
+* [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}}) as an estimation of the mean value.
+* `nan` if the sketch is empty.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: the given key does not exist or is of an incorrect type, quantiles out of range [0..1], or incorrect number of arguments.
+
+{{< /multitabs >}}


### PR DESCRIPTION
[DOC-5322](https://redislabs.atlassian.net/browse/DOC-5322)

The return info is at the bottom of each page.

[DOC-5322]: https://redislabs.atlassian.net/browse/DOC-5322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ