### PR TITLE
Fix Attribute's first byte in protocol spec

### DIFF
--- a/content/develop/reference/protocol-spec.md
+++ b/content/develop/reference/protocol-spec.md
@@ -132,7 +132,7 @@ The following table summarizes the RESP data types that Redis supports:
 | [Bulk errors](#bulk-errors) | RESP3 | Aggregate | `!` |
 | [Verbatim strings](#verbatim-strings) | RESP3 | Aggregate | `=` |
 | [Maps](#maps) | RESP3 | Aggregate | `%` |
-| [Attributes](#attributes) | RESP3 | Aggregate | `|` |
+| [Attributes](#attributes) | RESP3 | Aggregate | <code>&#124;</code> |
 | [Sets](#sets) | RESP3 | Aggregate | `~` |
 | [Pushes](#pushes) | RESP3 | Aggregate | `>` |
 


### PR DESCRIPTION
This appeared in the table as just a backtick in the [protocol spec page](https://redis.io/docs/latest/develop/reference/protocol-spec/) so it confused me for a bit. I think in a markdown table, using `|` is pretty risky. This fix seems to render the `|` correctly in a markdown preview:

![Screenshot 2025-06-26 at 12 04 41 PM](https://github.com/user-attachments/assets/0bbeb6e7-b5e9-45a4-b648-48efb965c3c7)
