### PR TITLE
DOC-4638 DOC-5396 TCE box improvements

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -382,7 +382,7 @@ select {
 
 .codetabs.cli > .panel .highlight > .chroma {
     margin: 1rem 1rem 0.1rem 0.1rem;
-    overflow-x: hidden;
+    overflow-x: auto;
     padding-bottom: 0;
 }
 

--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -22,7 +22,7 @@
     {{ $language := index $example "language" }}
     {{ $quickstartSlug := index $clientConfig "quickstartSlug" }}
     
-    {{ if and ($example) (or (eq $lang "") (eq $lang $client)) }}
+    {{ if and ($example) (or (eq $lang "") (strings.Contains $lang $client)) }}
         {{ $examplePath := index $example "target" }}
         {{ $options := printf "linenos=false" }}
         


### PR DESCRIPTION
[DOC-4638](https://redislabs.atlassian.net/browse/DOC-4638) and [DOC-5396](https://redislabs.atlassian.net/browse/DOC-5396)

Both changes are mainly to accommodate Lettuce examples: they have long lines and big indents, and also each Lettuce snippet typically needs two examples (async and reactive). 

[DOC-4638]: https://redislabs.atlassian.net/browse/DOC-4638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-5396]: https://redislabs.atlassian.net/browse/DOC-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ