### PR TITLE
Update grammar on  distributed-locks.md

### DIFF
--- a/content/develop/use/patterns/distributed-locks.md
+++ b/content/develop/use/patterns/distributed-locks.md
@@ -29,7 +29,7 @@ This page describes a more canonical algorithm to implement
 distributed locks with Redis. We propose an algorithm, called **Redlock**,
 which implements a DLM which we believe to be safer than the vanilla single
 instance approach. We hope that the community will analyze it, provide
-feedback, and use it as a starting point for the implementations or more
+feedback, and use it as a starting point for the implementations of more
 complex or alternative designs.
 
 ## Implementations


### PR DESCRIPTION
Fixed grammatical mistake on the sentence use it as a starting point for the implementations `or` more complex or alternative designs. to use it as a starting point for the implementations `of` more complex or alternative designs.