### PR TITLE
Fix typo in redis docs

### DIFF
--- a/content/commands/hexpire.md
+++ b/content/commands/hexpire.md
@@ -119,7 +119,7 @@ In this case, the time to live is _updated_ to the new value.
 redis> HEXPIRE no-key 20 NX FIELDS 2 field1 field2
 (nil)
 redis> HSET mykey field1 "hello" field2 "world"
-(integer 2)
+(integer) 2
 redis> HEXPIRE mykey 10 FIELDS 3 field1 field2 field3
 1) (integer) 1
 2) (integer) 1

--- a/content/commands/hexpireat.md
+++ b/content/commands/hexpireat.md
@@ -106,7 +106,7 @@ The `NS`, `XX`, `GT`, and `LT` options are mutually exclusive.
 
 ```
 redis> HSET mykey field1 "hello" field2 "world"
-(integer 2)
+(integer) 2
 redis> HEXPIREAT mykey 1715704971 FIELDS 2 field1 field2
 1) (integer) 1
 2) (integer) 1

--- a/content/commands/hpersist.md
+++ b/content/commands/hpersist.md
@@ -65,7 +65,7 @@ is associated).
 
 ```
 redis> HSET mykey field1 "hello" field2 "world"
-(integer 2)
+(integer) 2
 redis> HEXPIRE mykey 300 FIELDS 2 field1 field2
 1) (integer) 1
 2) (integer) 1

--- a/content/commands/hpexpire.md
+++ b/content/commands/hpexpire.md
@@ -101,7 +101,7 @@ The `NX`, `XX`, `GT`, and `LT` options are mutually exclusive.
 
 ```
 redis> HSET mykey field1 "hello" field2 "world"
-(integer 2)
+(integer) 2
 redis> HPEXPIRE mykey 2000 FIELDS 2 field1 field2
 1) (integer) 1
 2) (integer) 1

--- a/content/commands/hpexpireat.md
+++ b/content/commands/hpexpireat.md
@@ -102,7 +102,7 @@ The `NX`, `XX`, `GT`, and `LT` options are mutually exclusive.
 
 ```
 redis> HSET mykey field1 "hello" field2 "world"
-(integer 2)
+(integer) 2
 redis> HPEXPIREAT mykey 1715704971000 FIELDS 2 field1 field2
 1) (integer) 1
 2) (integer) 1

--- a/content/develop/ai/search-and-query/advanced-concepts/autocomplete.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/autocomplete.md
@@ -111,7 +111,7 @@ To remove a specific suggestion from the dictionary, use the `FT.SUGDEL` command
 
 ```
 redis> FT.SUGDEL autocomplete "help me"
-(integer 1)
+(integer) 1
 ```
 
 After deletion, running `FT.SUGGET autocomplete hell FUZZY` will no longer return "help me".


### PR DESCRIPTION
Fix typos in redis docs
* hexpire
* hexpireat
* hpersist
* hpexpire
* hpexpireat
* autocomplete