### PR TITLE
DOC-5428 Fix search-and-query documentation aliases 

### DIFF
--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
 - /develop/interact/search-and-query
+- /develop/interact/search-and-query/
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/administration/_index.md
+++ b/content/develop/ai/search-and-query/administration/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-- /develop/interact/search-and-query/administration/_index
+- /develop/interact/search-and-query/administration
+- /develop/interact/search-and-query/administration/
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/administration/configuration.md
+++ b/content/develop/ai/search-and-query/administration/configuration.md
@@ -1,5 +1,7 @@
 ---
-aliases: /develop/ai/search-and-query/basic-constructs/configuration-parameters
+aliases:
+- /develop/interact/search-and-query/administration/configuration
+- /develop/interact/search-and-query/basic-constructs/configuration-parameters
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/advanced-concepts/_index.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-- /develop/interact/search-and-query/advanced-concepts/_index
+- /develop/interact/search-and-query/advanced-concepts
+- /develop/interact/search-and-query/advanced-concepts/
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/best-practices/_index.md
+++ b/content/develop/ai/search-and-query/best-practices/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-- /develop/interact/search-and-query/best-practices/_index
+- /develop/interact/search-and-query/best-practices
+- /develop/interact/search-and-query/best-practices/
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/best-practices/index-mgmt-best-practices.md
+++ b/content/develop/ai/search-and-query/best-practices/index-mgmt-best-practices.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/interact/search-and-query/best-practices/index-mgmt-best-practices
 Title: Index management best practices for Redis Query Engine
 alwaysopen: false
 categories:

--- a/content/develop/ai/search-and-query/deprecated/_index.md
+++ b/content/develop/ai/search-and-query/deprecated/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-- /develop/interact/search-and-query/deprecated/_index
+- /develop/interact/search-and-query/deprecated
+- /develop/interact/search-and-query/deprecated/
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/indexing/_index.md
+++ b/content/develop/ai/search-and-query/indexing/_index.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-- /develop/interact/search-and-query/indexing/_index
+- /develop/interact/search-and-query/indexing
+- /develop/interact/search-and-query/indexing/
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/indexing/field-and-type-options.md
+++ b/content/develop/ai/search-and-query/indexing/field-and-type-options.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-- /develop/ai/search-and-query/basic-constructs/field-and-type-options
+- /develop/interact/search-and-query/indexing/field-and-type-options
+- /develop/interact/search-and-query/basic-constructs/field-and-type-options
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/indexing/schema-definition.md
+++ b/content/develop/ai/search-and-query/indexing/schema-definition.md
@@ -1,6 +1,7 @@
 ---
 aliases:
-- /develop/ai/search-and-query/basic-constructs/schema-definition
+- /develop/interact/search-and-query/indexing/schema-definition
+- /develop/interact/search-and-query/basic-constructs/schema-definition
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/query/_index.md
+++ b/content/develop/ai/search-and-query/query/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/interact/search-and-query/query
+- /develop/interact/search-and-query/query/
 categories:
 - docs
 - develop

--- a/content/develop/ai/search-and-query/vectors.md
+++ b/content/develop/ai/search-and-query/vectors.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- /develop/ai/search-and-query/advanced-concepts/vectors
+- /develop/interact/search-and-query/advanced-concepts/vectors
 categories:
 - docs
 - develop


### PR DESCRIPTION
## Alias fixes to resolve 404 errors and incorrect redirects:

### Fixed broken basic-constructs aliases:
- field-and-type-options.md: Fixed alias to point to correct interact paths
- schema-definition.md: Fixed alias to point to correct interact paths
- configuration.md: Added missing interact aliases and fixed format

### Fixed directory redirect issues (_index.md files):
- Added trailing slash variants for all directory aliases
- Fixed indexing/ and query/ URLs that were redirecting to home page
- Updated: _index.md, indexing/_index.md, query/_index.md, advanced-concepts/_index.md, administration/_index.md, best-practices/_index.md, deprecated/_index.md

### Added missing aliases:
- index-mgmt-best-practices.md: Added missing interact alias
- aggregations-syntax.md: Added missing interact alias

### Root causes addressed:
- Aliases were incorrectly pointing to /ai/ paths instead of /interact/ paths
- Directory aliases needed both with/without trailing slash variants
- Some files missing interact aliases entirely

These fixes should resolve:
- 404 errors on basic-constructs URLs
- Directory URLs redirecting to home page instead of correct AI locations
- Missing backward compatibility for moved files

Addresses DOC-5428