### PR TITLE
Fix docs about the A param of KSN config

### DIFF
--- a/content/develop/pubsub/keyspace-notifications.md
+++ b/content/develop/pubsub/keyspace-notifications.md
@@ -82,10 +82,10 @@ following table:
     d     Module key type events
     x     Expired events (events generated every time a key expires)
     e     Evicted events (events generated when a key is evicted for maxmemory)
-    m     Key miss events (events generated when a key that doesn't exist is accessed)
-    n     New key events (Note: not included in the 'A' class)
-    o     Overwritten events (events generated every time a key is overwritten)
-    c     Type-changed events (events generated every time a key's type changes)
+    m     Key miss events generated when a key that doesn't exist is accessed (Note: not included in the 'A' class)
+    n     New key events generated whenever a new key is created (Note: not included in the 'A' class)
+    o     Overwritten events generated every time a key is overwritten (Note: not included in the 'A' class)
+    c     Type-changed events generated every time a key's type changes (Note: not included in the 'A' class)
     A     Alias for "g$lshztdxe", so that the "AKE" string means all the events except "m", "n", "o" and "c".
 
 At least `K` or `E` should be present in the string, otherwise no event

--- a/content/develop/pubsub/keyspace-notifications.md
+++ b/content/develop/pubsub/keyspace-notifications.md
@@ -86,7 +86,7 @@ following table:
     n     New key events (Note: not included in the 'A' class)
     o     Overwritten events (events generated every time a key is overwritten)
     c     Type-changed events (events generated every time a key's type changes)
-    A     Alias for "g$lshztxed", so that the "AKE" string means all the events except "m" and "n".
+    A     Alias for "g$lshztxedoc", so that the "AKE" string means all the events except "m" and "n".
 
 At least `K` or `E` should be present in the string, otherwise no event
 will be delivered regardless of the rest of the string.

--- a/content/develop/pubsub/keyspace-notifications.md
+++ b/content/develop/pubsub/keyspace-notifications.md
@@ -86,7 +86,7 @@ following table:
     n     New key events (Note: not included in the 'A' class)
     o     Overwritten events (events generated every time a key is overwritten)
     c     Type-changed events (events generated every time a key's type changes)
-    A     Alias for "g$lshztxedoc", so that the "AKE" string means all the events except "m" and "n".
+    A     Alias for "g$lshztdxe", so that the "AKE" string means all the events except "m", "n", "o" and "c".
 
 At least `K` or `E` should be present in the string, otherwise no event
 will be delivered regardless of the rest of the string.


### PR DESCRIPTION
In recent [PR](https://github.com/redis/docs/pull/1789) about adding docs for new KSN types I forgot to add some docs, so this PR fixes that