### PR TITLE
DOC-5457: add the new SVS-VAMANA vector algorithm type

### DIFF
--- a/content/develop/ai/search-and-query/indexing/field-and-type-options.md
+++ b/content/develop/ai/search-and-query/indexing/field-and-type-options.md
@@ -157,6 +157,7 @@ Where:
 
     - `FLAT`: brute force algorithm.
     - `HNSW`: hierarchical, navigable, small world algorithm.
+    - `SVS-VAMANA`: a graph-based nearest neighbor search algorithm.
 
     The `{algorithm}` attribute specifies the algorithm to use when searching `k` most similar vectors in the index or filtering vectors by range.
 

--- a/content/develop/ai/search-and-query/indexing/field-and-type-options.md
+++ b/content/develop/ai/search-and-query/indexing/field-and-type-options.md
@@ -157,7 +157,7 @@ Where:
 
     - `FLAT`: brute force algorithm.
     - `HNSW`: hierarchical, navigable, small world algorithm.
-    - `SVS-VAMANA`: a graph-based nearest neighbor search algorithm.
+    - `SVS-VAMANA`: a graph-based nearest neighbor search algorithm, which is optimized for use with compression methods to reduce its memory footprint.
 
     The `{algorithm}` attribute specifies the algorithm to use when searching `k` most similar vectors in the index or filtering vectors by range.
 

--- a/content/develop/ai/search-and-query/vectors.md
+++ b/content/develop/ai/search-and-query/vectors.md
@@ -144,7 +144,7 @@ Choose the `SYS-VAMANA` index type when you need vector search
 | Attribute          | Description                              |
 |:-------------------|:-----------------------------------------|
 | `TYPE`             | Vector type (`FLOAT16` or `FLOAT32`). Note: `COMPRESSION` is supported with both types. |
-| `DIM`              | The width, or number of dimensions, of the vector embeddings stored in this field. In other words, the number of floating point elements comprising the vector. `DIM` must be a positive integer. The vector used to query this field must have the exact dimensions as the field itself.  |
+| `DIM`              | The width, or number of dimensions, of the vector embeddings stored in this field. In other words, the number of floating point elements comprising the vector. `DIM` must be a positive integer. The vector used to query this field must have the exact same dimensions as the field itself.  |
 | `DISTANCE_METRIC`  | Distance metric (`L2`, `IP`, `COSINE`).  |
 
 **Optional attributes**
@@ -156,7 +156,7 @@ Choose the `SYS-VAMANA` index type when you need vector search
 | `COMPRESSION`              | Compression algorithm (`LVQ8`, `LVQ8`, `LVQ4`, `LVQ4x4`, `LVQ4x8`, `LeanVec4x8`, or `LeanVec8x8`). Vectors will be compressed during indexing. Note: On non-Intel platforms, `SVS-VAMANA` with `COMPRESSION` will fall back to Intel’s basic quantization implementation. |
 | `CONSTRUCTION_WINDOW_SIZE` | The search window size (the default is 200) to use during graph construction. A higher search window size will yield a higher quality graph since more overall vertexes are considered, but will increase construction time. |
 | `GRAPH_MAX_DEGREE`         | The maximum node degree in the graph (the default is 32). A higher max degree may yield a higher quality graph in terms of recall for performance, but the memory footprint of the graph is directly proportional to the maximum degree. |
-| `SEARCH_WINDOW_SIZE`       | The size of the search window size (the default is 10). Increasing the search window size and capacity generally yields more accurate but slower search results. |
+| `SEARCH_WINDOW_SIZE`       | The size of the search window (the default is 10). Increasing the search window size and capacity generally yields more accurate but slower search results. |
 | `EPSILON`                  | The range search approximation factor (default is 0.01). |
 | `TRAINING_THRESHOLD`       | The number of vectors after which training is triggered. Applicable only when used with `COMPRESSION`. The default value is `10 * DEFAULT_BLOCK_SIZE` or, if provided, the value is limited to `100 * DEFAULT_BLOCK_SIZE`, where `DEFAULT_BLOCK_SIZE` is 1024. |
 | `LEANVEC_DIM`              | The dimension used when using `LeanVec4x8` or `LeanVec8x8` compression for dimensionality reduction. The default value is `DIM / 2`. If provided, the value should be less than `DIM`. |
@@ -433,9 +433,9 @@ Optional runtime parameters for SYS-VAMANA indexes are:
 
 | Parameter | Description | Default value |
 |:----------|:------------|:--------------|
-| `SEARCH_WINDOW_SIZE` | The size of the search window size (applies only to KNN searches). | 10 or the value that was passed upon index creation. |
+| `SEARCH_WINDOW_SIZE` | The size of the search window (applies only to KNN searches). | 10 or the value that was passed upon index creation. |
 | `GRAPH_MAX_DEGREE` | The maximum node degree in the graph. | 32 or the value that was passed upon index creation. |
-| `SEARCH_WINDOW_SIZE` | The size of the search window size. | 10 or the value that was passed upon index creation. |
+| `SEARCH_WINDOW_SIZE` | The size of the search window. | 10 or the value that was passed upon index creation. |
 | `EPSILON` | The range search approximation factor. | 0.01 or the value that was passed upon index creation. |
 
 

--- a/content/develop/ai/search-and-query/vectors.md
+++ b/content/develop/ai/search-and-query/vectors.md
@@ -586,6 +586,6 @@ Here are some additional resources that apply vector search for different use ca
 - [Retrieval augmented generation from scratch](https://github.com/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/01_redisvl.ipynb)
 - [Semantic caching](https://github.com/redis-developer/redis-ai-resources/blob/main/python-recipes/semantic-cache/semantic_caching_gemini.ipynb)
 
-<!-- ## Continue learning with Redis University
+## Continue learning with Redis University
 
-{{< university-links >}}-->
+{{< university-links >}}

--- a/content/develop/ai/search-and-query/vectors.md
+++ b/content/develop/ai/search-and-query/vectors.md
@@ -133,7 +133,7 @@ In the example above, an index named `documents` is created over hashes with the
 
 Scalable Vector Search (SVS) is an Intel project in which a new vector search library, VAMANA graph index, was created. SVS-VAMANA supports highly accurate compressed vector indexes. You can read more about the project [here](https://intel.github.io/ScalableVectorSearch/intro.html). Support for `SVS-VAMANA` indexing was added in Redis 8.2.
 
-Choose the `SYS-VAMANA` index type when you need vector search
+Choose the `SVS-VAMANA` index type when you need vector search
 
 - on billions of high-dimensional vectors,
 - at high accuracy and state-of-the-art speed,
@@ -429,7 +429,7 @@ Optional runtime parameters for HNSW indexes are:
 
 **SVS-VAMANA**
 
-Optional runtime parameters for SYS-VAMANA indexes are:
+Optional runtime parameters for SVS-VAMANA indexes are:
 
 | Parameter | Description | Default value |
 |:----------|:------------|:--------------|

--- a/static/resources/redisuniversity.yaml
+++ b/static/resources/redisuniversity.yaml
@@ -63,6 +63,6 @@ links:
     text: See the [Get started with Redis Software learning path](https://university.redis.io/learningpath/an0mgw5bjpjfbe) for courses.
 
   # Redis Develop links
-  - page: /develop/interact/search-and-query/advanced-concepts/vectors
+  - page: /develop/ai/search-and-query/vectors
     text: See the [Introduction to vector search course](https://university.redis.io/course/yz1lretjfpdlew?tab=details) to learn more.
     


### PR DESCRIPTION
[DOC-5457](https://redislabs.atlassian.net/browse/DOC-5457)

Note to reviewers: there were no applicable changes to the FT.CREATE command page; it refers to the main vector indexing page for all vector-related parameters. This is where the lion's share of the changes were made.

[DOC-5457]: https://redislabs.atlassian.net/browse/DOC-5457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ