### PR TITLE
Update upgrade-cluster.md

### DIFF
--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
@@ -75,9 +75,9 @@ Starting with the primary node, follow these steps for every node in the cluster
 Do not proceed if any shard, node, or endpoint is not `OK`.
     {{</warning>}}
 
-2.  Download the Redis Enterprise Software installation package to the machine running the node from the Download Center on [https://cloud.redis.io](https://cloud.redis.io).  
+1.  Download the Redis Enterprise Software installation package to the machine running the node from the Download Center on [https://cloud.redis.io](https://cloud.redis.io).  
 
-3.  Extract the installation package:
+1.  Extract the installation package:
 
     ```sh
     tar vxf <tarfile name>
@@ -96,15 +96,15 @@ You cannot change the installation path or the user during the upgrade.
     The installation script automatically recognizes the upgrade and responds accordingly.
 
     The upgrade replaces all node processes, which might briefly interrupt any active connections.
-    
-3.  Verify the node was upgraded to the new version and is still operational:
+
+1.  Verify the node was upgraded to the new version and is still operational:
 
     ``` shell
     $ rlcheck
     $ rladmin status extra all
     ```
 
-4.  Visit the Cluster Manager UI.
+1.  Visit the Cluster Manager UI.
 
     If the Cluster Manager UI was open in a web browser during the upgrade, refresh the browser to reload the console.
 

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
@@ -102,14 +102,14 @@ You should only run the ./install.sh command while upgrade.
 During the upgrade, --*-dir <dir> cannot be set, and an error will occur. Please note.
     {{<note>}}
     
-3.  Verify the node was upgraded to the new version and is still operational:
+2.  Verify the node was upgraded to the new version and is still operational:
 
     ``` shell
     $ rlcheck
     $ rladmin status extra all
     ```
 
-4.  Visit the Cluster Manager UI.
+3.  Visit the Cluster Manager UI.
 
     If the Cluster Manager UI was open in a web browser during the upgrade, refresh the browser to reload the console.
 

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
@@ -97,14 +97,19 @@ You cannot change the installation path or the user during the upgrade.
 
     The upgrade replaces all node processes, which might briefly interrupt any active connections.
 
-2.  Verify the node was upgraded to the new version and is still operational:
+    {{<note>}}
+You should only run the ./install.sh command while upgrade. 
+During the upgrade, --*-dir <dir> cannot be set, and an error will occur. Please note.
+    {{<note>}}
+    
+3.  Verify the node was upgraded to the new version and is still operational:
 
     ``` shell
     $ rlcheck
     $ rladmin status extra all
     ```
 
-3.  Visit the Cluster Manager UI.
+4.  Visit the Cluster Manager UI.
 
     If the Cluster Manager UI was open in a web browser during the upgrade, refresh the browser to reload the console.
 

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
@@ -87,7 +87,7 @@ Do not proceed if any shard, node, or endpoint is not `OK`.
 You cannot change the installation path or the user during the upgrade.
     {{</note>}}
 
-1.  Run the install command. See [installation script options]({{< relref "/operate/rs/installing-upgrading/install/install-script" >}}) for a list of command-line options you can add to the following command:
+1.  Run the install command. See [installation script options]({{< relref "/operate/rs/installing-upgrading/install/install-script" >}}) for a list of command-line options you can add to the following command. You cannot use options marked as "new installs only" during an in-place upgrade.
 
     ``` shell
     sudo ./install.sh
@@ -96,20 +96,15 @@ You cannot change the installation path or the user during the upgrade.
     The installation script automatically recognizes the upgrade and responds accordingly.
 
     The upgrade replaces all node processes, which might briefly interrupt any active connections.
-
-    {{<note>}}
-You should only run the ./install.sh command while upgrade. 
-During the upgrade, --*-dir <dir> cannot be set, and an error will occur. Please note.
-    {{<note>}}
     
-2.  Verify the node was upgraded to the new version and is still operational:
+3.  Verify the node was upgraded to the new version and is still operational:
 
     ``` shell
     $ rlcheck
     $ rladmin status extra all
     ```
 
-3.  Visit the Cluster Manager UI.
+4.  Visit the Cluster Manager UI.
 
     If the Cluster Manager UI was open in a web browser during the upgrade, refresh the browser to reload the console.
 


### PR DESCRIPTION
During the upgrade process, you should only run the ./install.sh command.

The manual is unclear about this part and may be misleading.

Additional explanation is needed.
Ex) You may be confused about the install script when you first install redis and when you upgrade it. 
```
# ./install.sh --install-dir /redis --var-dir /ifp_data/redis --config-dir /redis/config
2025-06-24 20:56:59.274 [x] Error: --install-dir cannot be set during upgrade.
 ..
2025-06-24 20:57:30.286 [x] Error: --var-dir cannot be set during upgrade.
 ..
2025-06-24 20:57:37.335 [x] Error: --config-dir cannot be set during upgrade.
```