### PR TITLE
DEV: patch node_redis.json branch to match repo

### DIFF
--- a/data/components/node_redis.json
+++ b/data/components/node_redis.json
@@ -9,7 +9,7 @@
     },
     "examples": {
         "git_uri": "https://github.com/redis/node-redis",
-        "dev_branch": "emb-examples",
+        "dev_branch": "master",
         "path": "doctests",
         "pattern": "*.js"
     }


### PR DESCRIPTION
No ticket. Just a quick fix to point the build code at the node-redis master branch instead of the emb-examples branch.