### PR TITLE
Quick .gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /data/versions.json
 /data/components_local/
 /examples
-build/components/__pycache__/
+**/__pycache__/
 venv/**
 node_modules/
 package-lock.json 


### PR DESCRIPTION
No ticket. Just a quick update to `.gitignore`, telling it to ignore all occurrences of `__pycache__` directories.