### PR TITLE
Langcache: Usability changes

### DIFF
--- a/content/develop/ai/langcache/_index.md
+++ b/content/develop/ai/langcache/_index.md
@@ -13,7 +13,9 @@ bannerText: LangCache is currently available in preview. Features and behavior a
 bannerChildren: true
 ---
 
-Redis LangCache is a fully-managed semantic caching service that reduces large language model (LLM) costs and improves response times for AI applications.
+Redis LangCache is a fully-managed semantic caching service that reduces large language model (LLM) costs and improves response times for AI applications. 
+
+[Get started](#get-started) with LangCache on [Redis Cloud]({{< relref "/operate/rc/langcache" >}}) or join the [private preview](https://redis.io/langcache/).
 
 ## LangCache overview
 

--- a/content/operate/rc/langcache/use-langcache.md
+++ b/content/operate/rc/langcache/use-langcache.md
@@ -11,7 +11,7 @@ title: Use the LangCache API on Redis Cloud
 weight: 10
 ---
 
-You can use the LangCache API from your client app to store and retrieve LLM, RAG, or agent responses.
+You can use the [LangCache API and SDK]({{< relref "/develop/ai/langcache/api-examples" >}}) from your client app to store and retrieve LLM, RAG, or agent responses. 
 
 To access the LangCache API, you need:
 
@@ -25,4 +25,4 @@ The LangCache API key is only available immediately after you create the LangCac
 
 When you call the API, you need to pass the LangCache API key in the `Authorization` header as a Bearer token and the Cache ID as the `cacheId` path parameter. 
 
-See the [LangCache API reference]({{< relref "/develop/ai/langcache/api-reference" >}}) for more information on how to use the LangCache API.
+See the [LangCache API and SDK examples]({{< relref "/develop/ai/langcache/api-examples" >}}) for more information on how to use the LangCache API.


### PR DESCRIPTION
DOC-5528 - Changes from meeting with Jen on 7/31:
- Send users to API/SDK examples instead of API reference in use langcache
- Add anchor to Getting started on the top of the Langcache overview page
- Move link in Use Langcache to API/SDK up so it’s immediately visible

