### PR TITLE
DOC-5537 localise vector examples

### DIFF
--- a/content/develop/clients/go/vecsearch.md
+++ b/content/develop/clients/go/vecsearch.md
@@ -66,19 +66,8 @@ go get github.com/henomis/lingoose/embedder/huggingface
 
 Add the following imports to your module's main program file:
 
-```go
-package main
-
-import (
-	"context"
-	"encoding/binary"
-	"fmt"
-	"math"
-
-	huggingfaceembedder "github.com/henomis/lingoose/embedder/huggingface"
-	"github.com/redis/go-redis/v9"
-)
-```
+{{< clients-example set="home_query_vec" step="import" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 You must also create a [HuggingFace account](https://huggingface.co/join)
 and add a new access token to use the embedding model. See the
@@ -96,18 +85,8 @@ must convert this array to a `byte` string before adding it as a hash field.
 The function shown below uses Go's [`binary`](https://pkg.go.dev/encoding/binary)
 package to produce the `byte` string:
 
-```go
-func floatsToBytes(fs []float32) []byte {
-	buf := make([]byte, len(fs)*4)
-
-	for i, f := range fs {
-		u := math.Float32bits(f)
-		binary.NativeEndian.PutUint32(buf[i*4:], u)
-	}
-
-	return buf
-}
-```
+{{< clients-example set="home_query_vec" step="helper" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 Note that if you are using [JSON]({{< relref "/develop/data-types/json" >}})
 objects to store your documents instead of hashes, then you should store
@@ -120,22 +99,8 @@ below).
 In the `main()` function, connect to Redis and delete any index previously
 created with the name `vector_idx`:
 
-```go
-ctx := context.Background()
-rdb := redis.NewClient(&redis.Options{
-    Addr:     "localhost:6379",
-    Password: "", // no password docs
-    DB:       0,  // use default DB
-    Protocol: 2,
-})
-
-rdb.FTDropIndexWithArgs(ctx,
-    "vector_idx",
-    &redis.FTDropIndexOptions{
-        DeleteDocs: true,
-    },
-)
-```
+{{< clients-example set="home_query_vec" step="connect" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 Next, create the index.
 The schema in the example below specifies hash objects for storage and includes
@@ -149,38 +114,8 @@ indexing, the
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
-```go
-_, err := rdb.FTCreate(ctx,
-    "vector_idx",
-    &redis.FTCreateOptions{
-        OnHash: true,
-        Prefix: []any{"doc:"},
-    },
-    &redis.FieldSchema{
-        FieldName: "content",
-        FieldType: redis.SearchFieldTypeText,
-    },
-    &redis.FieldSchema{
-        FieldName: "genre",
-        FieldType: redis.SearchFieldTypeTag,
-    },
-    &redis.FieldSchema{
-        FieldName: "embedding",
-        FieldType: redis.SearchFieldTypeVector,
-        VectorArgs: &redis.FTVectorArgs{
-            HNSWOptions: &redis.FTHNSWOptions{
-                Dim:            384,
-                DistanceMetric: "L2",
-                Type:           "FLOAT32",
-            },
-        },
-    },
-).Result()
-
-if err != nil {
-    panic(err)
-}
-```
+{{< clients-example set="home_query_vec" step="create_index" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 ## Create an embedder instance
 
@@ -190,11 +125,8 @@ instance that uses the `sentence-transformers/all-MiniLM-L6-v2`
 model, passing your HuggingFace access token to the `WithToken()`
 method.
 
-```go
-hf := huggingfaceembedder.New().
-		WithToken("<your-access-token>").
-		WithModel("sentence-transformers/all-MiniLM-L6-v2")
-```
+{{< clients-example set="home_query_vec" step="embedder" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 ## Add data
 
@@ -210,44 +142,8 @@ Use the `ToFloat32()` method of `Embedding` to produce the array of float
 values that we need, and use the `floatsToBytes()` function we defined
 above to convert this array to a `byte` string.
 
-```go
-sentences := []string{
-    "That is a very happy person",
-    "That is a happy dog",
-    "Today is a sunny day",
-}
-
-tags := []string{
-    "persons", "pets", "weather",
-}
-
-embeddings, err := hf.Embed(ctx, sentences)
-
-if err != nil {
-    panic(err)
-}
-
-for i, emb := range embeddings {
-    buffer := floatsToBytes(emb.ToFloat32())
-
-    if err != nil {
-        panic(err)
-    }
-
-    _, err = rdb.HSet(ctx,
-        fmt.Sprintf("doc:%v", i),
-        map[string]any{
-            "content":   sentences[i],
-            "genre":     tags[i],
-            "embedding": buffer,
-        },
-    ).Result()
-
-    if err != nil {
-        panic(err)
-    }
-}
-```
+{{< clients-example set="home_query_vec" step="add_data" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 ## Run a query
 
@@ -263,47 +159,8 @@ the indexing, and passes it as a parameter when the query executes
 [Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
 for more information about using query parameters with embeddings).
 
-```go
-queryEmbedding, err := hf.Embed(ctx, []string{
-    "That is a happy person",
-})
-
-if err != nil {
-    panic(err)
-}
-
-buffer := floatsToBytes(queryEmbedding[0].ToFloat32())
-
-if err != nil {
-    panic(err)
-}
-
-results, err := rdb.FTSearchWithArgs(ctx,
-    "vector_idx",
-    "*=>[KNN 3 @embedding $vec AS vector_distance]",
-    &redis.FTSearchOptions{
-        Return: []redis.FTSearchReturn{
-            {FieldName: "vector_distance"},
-            {FieldName: "content"},
-        },
-        DialectVersion: 2,
-        Params: map[string]any{
-            "vec": buffer,
-        },
-    },
-).Result()
-
-if err != nil {
-    panic(err)
-}
-
-for _, doc := range results.Docs {
-    fmt.Printf(
-        "ID: %v, Distance:%v, Content:'%v'\n",
-        doc.ID, doc.Fields["vector_distance"], doc.Fields["content"],
-    )
-}
-```
+{{< clients-example set="home_query_vec" step="query" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 The code is now ready to run, but note that it may take a while to complete when
 you run it for the first time (which happens because `huggingfacetransformer`
@@ -334,37 +191,8 @@ every query. Also, you must set `OnJSON` to `true` when you create the index.
 The code below shows these differences, but the index is otherwise very similar to
 the one created previously for hashes:
 
-```go
-_, err = rdb.FTCreate(ctx,
-    "vector_json_idx",
-    &redis.FTCreateOptions{
-        OnJSON: true,
-        Prefix: []any{"jdoc:"},
-    },
-    &redis.FieldSchema{
-        FieldName: "$.content",
-        As:        "content",
-        FieldType: redis.SearchFieldTypeText,
-    },
-    &redis.FieldSchema{
-        FieldName: "$.genre",
-        As:        "genre",
-        FieldType: redis.SearchFieldTypeTag,
-    },
-    &redis.FieldSchema{
-        FieldName: "$.embedding",
-        As:        "embedding",
-        FieldType: redis.SearchFieldTypeVector,
-        VectorArgs: &redis.FTVectorArgs{
-            HNSWOptions: &redis.FTHNSWOptions{
-                Dim:            384,
-                DistanceMetric: "L2",
-                Type:           "FLOAT32",
-            },
-        },
-    },
-).Result()
-```
+{{< clients-example set="home_query_vec" step="json_index" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 Use [`JSONSet()`]({{< relref "/commands/json.set" >}}) to add the data
 instead of [`HSet()`]({{< relref "/commands/hset" >}}). The maps
@@ -375,23 +203,8 @@ specified using lists instead of binary strings. The loop below is similar
 to the one used previously to add the hash data, but it doesn't use the
 `floatsToBytes()` function to encode the `float32` array.
 
-```go
-for i, emb := range embeddings {
-    _, err = rdb.JSONSet(ctx,
-        fmt.Sprintf("jdoc:%v", i),
-        "$",
-        map[string]any{
-            "content":   sentences[i],
-            "genre":     tags[i],
-            "embedding": emb.ToFloat32(),
-        },
-    ).Result()
-
-    if err != nil {
-        panic(err)
-    }
-}
-```
+{{< clients-example set="home_query_vec" step="json_data" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 The query is almost identical to the one for the hash documents. This
 demonstrates how the right choice of aliases for the JSON paths can
@@ -400,32 +213,8 @@ is that the vector parameter for the query is still specified as a
 binary string (using the `floatsToBytes()` method), even though the data for
 the `embedding` field of the JSON was specified as an array.
 
-```go
-jsonQueryEmbedding, err := hf.Embed(ctx, []string{
-    "That is a happy person",
-})
-
-if err != nil {
-    panic(err)
-}
-
-jsonBuffer := floatsToBytes(jsonQueryEmbedding[0].ToFloat32())
-
-jsonResults, err := rdb.FTSearchWithArgs(ctx,
-    "vector_json_idx",
-    "*=>[KNN 3 @embedding $vec AS vector_distance]",
-    &redis.FTSearchOptions{
-        Return: []redis.FTSearchReturn{
-            {FieldName: "vector_distance"},
-            {FieldName: "content"},
-        },
-        DialectVersion: 2,
-        Params: map[string]any{
-            "vec": jsonBuffer,
-        },
-    },
-).Result()
-```
+{{< clients-example set="home_query_vec" step="json_query" lang_filter="Go" >}}
+{{< /clients-example >}}
 
 Apart from the `jdoc:` prefixes for the keys, the result from the JSON
 query is the same as for hash:

--- a/content/develop/clients/redis-py/vecsearch.md
+++ b/content/develop/clients/redis-py/vecsearch.md
@@ -56,7 +56,7 @@ pip install sentence-transformers
 
 In a new Python source file, start by importing the required classes:
 
-{{< clients-example set="home_query_vec" step="import" >}}
+{{< clients-example set="home_query_vec" step="import" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 The first of these imports is the
@@ -70,7 +70,7 @@ tokens (see
 at the [Hugging Face](https://huggingface.co/) docs to learn more about the way tokens
 are related to the original text).
 
-{{< clients-example set="home_query_vec" step="model" >}}
+{{< clients-example set="home_query_vec" step="model" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 ## Create the index
@@ -80,7 +80,7 @@ name `vector_idx`. (The `dropindex()` call throws an exception if
 the index doesn't already exist, which is why you need the
 `try: except:` block.)
 
-{{< clients-example set="home_query_vec" step="connect" >}}
+{{< clients-example set="home_query_vec" step="connect" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 Next, create the index.
@@ -95,7 +95,7 @@ indexing, the
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
-{{< clients-example set="home_query_vec" step="create_index" >}}
+{{< clients-example set="home_query_vec" step="create_index" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 ## Add data
@@ -113,7 +113,7 @@ Use the binary string representation when you are indexing hashes
 or running a query (but use a list of `float` for
 [JSON documents](#differences-with-json-documents)).
 
-{{< clients-example set="home_query_vec" step="add_data" >}}
+{{< clients-example set="home_query_vec" step="add_data" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 ## Run a query
@@ -130,7 +130,7 @@ the indexing, and passes it as a parameter when the query executes
 [Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
 for more information about using query parameters with embeddings).
 
-{{< clients-example set="home_query_vec" step="query" >}}
+{{< clients-example set="home_query_vec" step="query" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 The code is now ready to run, but note that it may take a while to complete when
@@ -139,7 +139,7 @@ you run it for the first time (which happens because RedisVL must download the
 generate the embeddings). When you run the code, it outputs the following result
 object (slightly formatted here for clarity):
 
-```Python
+```
 Result{
     3 total,
     docs: [
@@ -183,7 +183,7 @@ every query. Also, you must specify `IndexType.JSON` when you create the index.
 The code below shows these differences, but the index is otherwise very similar to
 the one created previously for hashes:
 
-{{< clients-example set="home_query_vec" step="json_index" >}}
+{{< clients-example set="home_query_vec" step="json_index" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 Use [`json().set()`]({{< relref "/commands/json.set" >}}) to add the data
@@ -197,7 +197,7 @@ specified using lists instead of binary strings. Generate the list
 using the `tolist()` method instead of `tobytes()` as you would with a
 hash.
 
-{{< clients-example set="home_query_vec" step="json_data" >}}
+{{< clients-example set="home_query_vec" step="json_data" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 The query is almost identical to the one for the hash documents. This
@@ -207,7 +207,7 @@ is that the vector parameter for the query is still specified as a
 binary string (using the `tobytes()` method), even though the data for
 the `embedding` field of the JSON was specified as a list.
 
-{{< clients-example set="home_query_vec" step="json_query" >}}
+{{< clients-example set="home_query_vec" step="json_query" lang_filter="Python" >}}
 {{< /clients-example >}}
 
 Apart from the `jdoc:` prefixes for the keys, the result from the JSON

--- a/content/develop/clients/redis-py/vecsearch.md
+++ b/content/develop/clients/redis-py/vecsearch.md
@@ -56,16 +56,8 @@ pip install sentence-transformers
 
 In a new Python source file, start by importing the required classes:
 
-```python
-from sentence_transformers import SentenceTransformer
-from redis.commands.search.query import Query
-from redis.commands.search.field import TextField, TagField, VectorField
-from redis.commands.search.indexDefinition import IndexDefinition, IndexType
-from redis.commands.json.path import Path
-
-import numpy as np
-import redis
-```
+{{< clients-example set="home_query_vec" step="import" >}}
+{{< /clients-example >}}
 
 The first of these imports is the
 `SentenceTransformer` class, which generates an embedding from a section of text.
@@ -78,9 +70,8 @@ tokens (see
 at the [Hugging Face](https://huggingface.co/) docs to learn more about the way tokens
 are related to the original text).
 
-```python
-model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
-```
+{{< clients-example set="home_query_vec" step="model" >}}
+{{< /clients-example >}}
 
 ## Create the index
 
@@ -89,14 +80,8 @@ name `vector_idx`. (The `dropindex()` call throws an exception if
 the index doesn't already exist, which is why you need the
 `try: except:` block.)
 
-```python
-r = redis.Redis(decode_responses=True)
-
-try:
-    r.ft("vector_idx").dropindex(True)
-except redis.exceptions.ResponseError:
-    pass
-```
+{{< clients-example set="home_query_vec" step="connect" >}}
+{{< /clients-example >}}
 
 Next, create the index.
 The schema in the example below specifies hash objects for storage and includes
@@ -110,24 +95,8 @@ indexing, the
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
-```python
-schema = (
-    TextField("content"),
-    TagField("genre"),
-    VectorField("embedding", "HNSW", {
-        "TYPE": "FLOAT32",
-        "DIM": 384,
-        "DISTANCE_METRIC":"L2"
-    })
-)
-
-r.ft("vector_idx").create_index(
-    schema,
-    definition=IndexDefinition(
-        prefix=["doc:"], index_type=IndexType.HASH
-    )
-)
-```
+{{< clients-example set="home_query_vec" step="create_index" >}}
+{{< /clients-example >}}
 
 ## Add data
 
@@ -144,31 +113,8 @@ Use the binary string representation when you are indexing hashes
 or running a query (but use a list of `float` for
 [JSON documents](#differences-with-json-documents)).
 
-```python
-content = "That is a very happy person"
-
-r.hset("doc:0", mapping={
-    "content": content,
-    "genre": "persons",
-    "embedding": model.encode(content).astype(np.float32).tobytes(),
-})
-
-content = "That is a happy dog"
-
-r.hset("doc:1", mapping={
-    "content": content,
-    "genre": "pets",
-    "embedding": model.encode(content).astype(np.float32).tobytes(),
-})
-
-content = "Today is a sunny day"
-
-r.hset("doc:2", mapping={
-    "content": content,
-    "genre": "weather",
-    "embedding": model.encode(content).astype(np.float32).tobytes(),
-})
-```
+{{< clients-example set="home_query_vec" step="add_data" >}}
+{{< /clients-example >}}
 
 ## Run a query
 
@@ -184,21 +130,8 @@ the indexing, and passes it as a parameter when the query executes
 [Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
 for more information about using query parameters with embeddings).
 
-```python
-q = Query(
-    "*=>[KNN 3 @embedding $vec AS vector_distance]"
-).return_field("score").dialect(2)
-
-query_text = "That is a happy person"
-
-res = r.ft("vector_idx").search(
-    q, query_params={
-        "vec": model.encode(query_text).astype(np.float32).tobytes()
-    }
-)
-
-print(res)
-```
+{{< clients-example set="home_query_vec" step="query" >}}
+{{< /clients-example >}}
 
 The code is now ready to run, but note that it may take a while to complete when
 you run it for the first time (which happens because RedisVL must download the
@@ -250,27 +183,8 @@ every query. Also, you must specify `IndexType.JSON` when you create the index.
 The code below shows these differences, but the index is otherwise very similar to
 the one created previously for hashes:
 
-```py
-schema = (
-    TextField("$.content", as_name="content"),
-    TagField("$.genre", as_name="genre"),
-    VectorField(
-        "$.embedding", "HNSW", {
-            "TYPE": "FLOAT32",
-            "DIM": 384,
-            "DISTANCE_METRIC": "L2"
-        },
-        as_name="embedding"
-    )
-)
-
-r.ft("vector_json_idx").create_index(
-    schema,
-    definition=IndexDefinition(
-        prefix=["jdoc:"], index_type=IndexType.JSON
-    )
-)
-```
+{{< clients-example set="home_query_vec" step="json_index" >}}
+{{< /clients-example >}}
 
 Use [`json().set()`]({{< relref "/commands/json.set" >}}) to add the data
 instead of [`hset()`]({{< relref "/commands/hset" >}}). The dictionaries
@@ -283,31 +197,8 @@ specified using lists instead of binary strings. Generate the list
 using the `tolist()` method instead of `tobytes()` as you would with a
 hash.
 
-```py
-content = "That is a very happy person"
-
-r.json().set("jdoc:0", Path.root_path(), {
-    "content": content,
-    "genre": "persons",
-    "embedding": model.encode(content).astype(np.float32).tolist(),
-})
-
-content = "That is a happy dog"
-
-r.json().set("jdoc:1", Path.root_path(), {
-    "content": content,
-    "genre": "pets",
-    "embedding": model.encode(content).astype(np.float32).tolist(),
-})
-
-content = "Today is a sunny day"
-
-r.json().set("jdoc:2", Path.root_path(), {
-    "content": content,
-    "genre": "weather",
-    "embedding": model.encode(content).astype(np.float32).tolist(),
-})
-```
+{{< clients-example set="home_query_vec" step="json_data" >}}
+{{< /clients-example >}}
 
 The query is almost identical to the one for the hash documents. This
 demonstrates how the right choice of aliases for the JSON paths can
@@ -316,19 +207,8 @@ is that the vector parameter for the query is still specified as a
 binary string (using the `tobytes()` method), even though the data for
 the `embedding` field of the JSON was specified as a list.
 
-```py
-q = Query(
-    "*=>[KNN 3 @embedding $vec AS vector_distance]"
-).return_field("vector_distance").return_field("content").dialect(2)
-
-query_text = "That is a happy person"
-
-res = r.ft("vector_json_idx").search(
-    q, query_params={
-        "vec": model.encode(query_text).astype(np.float32).tobytes()
-    }
-)
-```
+{{< clients-example set="home_query_vec" step="json_query" >}}
+{{< /clients-example >}}
 
 Apart from the `jdoc:` prefixes for the keys, the result from the JSON
 query is the same as for hash:

--- a/content/develop/clients/redis-py/vecsets.md
+++ b/content/develop/clients/redis-py/vecsets.md
@@ -47,12 +47,8 @@ pip install sentence-transformers
 
 In a new Python file, import the required classes:
 
-```python
-from sentence_transformers import SentenceTransformer
-
-import redis
-import numpy as np
-```
+{{< clients-example set="home_vecsets" step="import" >}}
+{{< /clients-example >}}
 
 The first of these imports is the
 `SentenceTransformer` class, which generates an embedding from a section of text.
@@ -65,77 +61,16 @@ tokens (see
 at the [Hugging Face](https://huggingface.co/) docs to learn more about the way tokens
 are related to the original text).
 
-```python
-model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
-```
+{{< clients-example set="home_vecsets" step="model" >}}
+{{< /clients-example >}}
 
 ## Create the data
 
 The example data is contained a dictionary with some brief
 descriptions of famous people:
 
-```python
-peopleData = {
-    "Marie Curie": {
-        "born": 1867, "died": 1934,
-        "description": """
-        Polish-French chemist and physicist. The only person ever to win
-        two Nobel prizes for two different sciences.
-        """
-    },
-    "Linus Pauling": {
-        "born": 1901, "died": 1994,
-        "description": """
-        American chemist and peace activist. One of only two people to win two
-        Nobel prizes in different fields (chemistry and peace).
-        """
-    },
-    "Freddie Mercury": {
-        "born": 1946, "died": 1991,
-        "description": """
-        British musician, best known as the lead singer of the rock band
-        Queen.
-        """
-    },
-    "Marie Fredriksson": {
-        "born": 1958, "died": 2019,
-        "description": """
-        Swedish multi-instrumentalist, mainly known as the lead singer and
-        keyboardist of the band Roxette.
-        """
-    },
-    "Paul Erdos": {
-        "born": 1913, "died": 1996,
-        "description": """
-        Hungarian mathematician, known for his eccentric personality almost
-        as much as his contributions to many different fields of mathematics.
-        """
-    },
-    "Maryam Mirzakhani": {
-        "born": 1977, "died": 2017,
-        "description": """
-        Iranian mathematician. The first woman ever to win the Fields medal
-        for her contributions to mathematics.
-        """
-    },
-    "Masako Natsume": {
-        "born": 1957, "died": 1985,
-        "description": """
-        Japanese actress. She was very famous in Japan but was primarily
-        known elsewhere in the world for her portrayal of Tripitaka in the
-        TV series Monkey.
-        """
-    },
-    "Chaim Topol": {
-        "born": 1935, "died": 2023,
-        "description": """
-        Israeli actor and singer, usually credited simply as 'Topol'. He was
-        best known for his many appearances as Tevye in the musical Fiddler
-        on the Roof.
-        """
-    }
-}
-```
+{{< clients-example set="home_vecsets" step="data" >}}
+{{< /clients-example >}}
 
 ## Add the data to a vector set
 
@@ -164,22 +99,8 @@ The call to `vadd()` also adds the `born` and `died` values from the
 original dictionary as attribute data. You can access this during a query
 or by using the [`vgetattr()`]({{< relref "/commands/vgetattr" >}}) method.
 
-```py
-r = redis.Redis(decode_responses=True)
-
-for name, details in peopleData.items():
-    emb = model.encode(details["description"]).astype(np.float32).tobytes()
-
-    r.vset().vadd(
-        "famousPeople",
-        emb,
-        name,
-        attributes={
-            "born": details["born"],
-            "died": details["died"]
-        }
-    )
-```
+{{< clients-example set="home_vecsets" step="add_data" >}}
+{{< /clients-example >}}
 
 ## Query the vector set
 
@@ -191,16 +112,8 @@ of the set, ranked in order of similarity to the query.
 
 Start with a simple query for "actors":
 
-```py
-query_value = "actors"
-
-actors_results = r.vset().vsim(
-    "famousPeople",
-    model.encode(query_value).astype(np.float32).tobytes(),
-)
-
-print(f"'actors': {actors_results}")
-```
+{{< clients-example set="home_vecsets" step="basic_query" >}}
+{{< /clients-example >}}
 
 This returns the following list of elements (formatted slightly for clarity):
 
@@ -218,18 +131,8 @@ on the information contained in the embedding model.
 You can use the `count` parameter of `vsim()` to limit the list of elements
 to just the most relevant few items:
 
-```py
-query_value = "actors"
-
-two_actors_results = r.vset().vsim(
-    "famousPeople",
-    model.encode(query_value).astype(np.float32).tobytes(),
-    count=2
-)
-
-print(f"'actors (2)': {two_actors_results}")
-# >>> 'actors (2)': ['Masako Natsume', 'Chaim Topol']
-```
+{{< clients-example set="home_vecsets" step="limited_query" >}}
+{{< /clients-example >}}
 
 The reason for using text embeddings rather than simple text search
 is that the embeddings represent semantic information. This allows a query
@@ -238,19 +141,8 @@ different. For example, the word "entertainer" doesn't appear in any of the
 descriptions but if you use it as a query, the actors and musicians are ranked
 highest in the results list:
 
-```py
-query_value = "entertainer"
-
-entertainer_results = r.vset().vsim(
-    "famousPeople",
-    model.encode(query_value).astype(np.float32).tobytes()
-)
-
-print(f"'entertainer': {entertainer_results}")
-# >>> 'entertainer': ['Chaim Topol', 'Freddie Mercury',
-# >>> 'Marie Fredriksson', 'Masako Natsume', 'Linus Pauling',
-# 'Paul Erdos', 'Maryam Mirzakhani', 'Marie Curie']
-```
+{{< clients-example set="home_vecsets" step="entertainer_query" >}}
+{{< /clients-example >}}
 
 Similarly, if you use "science" as a query, you get the following results:
 
@@ -270,19 +162,8 @@ with `vsim()` to restrict the search further. For example,
 repeat the "science" query, but this time limit the results to people
 who died before the year 2000:
 
-```py
-query_value = "science"
-
-science2000_results = r.vset().vsim(
-    "famousPeople",
-    model.encode(query_value).astype(np.float32).tobytes(),
-    filter=".died < 2000"
-)
-
-print(f"'science2000': {science2000_results}")
-# >>> 'science2000': ['Marie Curie', 'Linus Pauling',
-# 'Paul Erdos', 'Freddie Mercury', 'Masako Natsume']
-```
+{{< clients-example set="home_vecsets" step="filtered_query" >}}
+{{< /clients-example >}}
 
 Note that the boolean filter expression is applied to items in the list
 before the vector distance calculation is performed. Items that don't

--- a/local_examples/client-specific/HomeQueryVec.java
+++ b/local_examples/client-specific/HomeQueryVec.java
@@ -1,0 +1,249 @@
+// EXAMPLE: HomeQueryVec
+// STEP_START import
+// Jedis client and query engine classes.
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.search.*;
+import redis.clients.jedis.search.schemafields.*;
+import redis.clients.jedis.search.schemafields.VectorField.VectorAlgorithm;
+import redis.clients.jedis.exceptions.JedisDataException;
+
+// Data manipulation.
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Map;
+import java.util.List;
+import org.json.JSONObject;
+import redis.clients.jedis.json.Path2;
+
+// Tokenizer to generate the vector embeddings.
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+// STEP_END
+
+public class HomeQueryVec {
+    // STEP_START helper_method
+    public static byte[] longsToFloatsByteString(long[] input) {
+        float[] floats = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            floats[i] = input[i];
+        }
+
+        byte[] bytes = new byte[Float.BYTES * floats.length];
+        ByteBuffer
+            .wrap(bytes)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .asFloatBuffer()
+            .put(floats);
+        return bytes;
+    }
+    // STEP_END
+
+    // STEP_START json_helper_method
+    public static float[] longArrayToFloatArray(long[] input) {
+        float[] floats = new float[input.length];
+        for (int i = 0; i < input.length; i++) {
+            floats[i] = input[i];
+        }
+        return floats;
+    }
+    // STEP_END
+
+    public static void main(String[] args) throws Exception {
+        // STEP_START tokenizer
+        HuggingFaceTokenizer sentenceTokenizer = HuggingFaceTokenizer.newInstance(
+            "sentence-transformers/all-mpnet-base-v2",
+            Map.of("maxLength", "768",  "modelMaxLength", "768")
+        );
+        // STEP_END
+
+        // STEP_START connect
+        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+
+        try {jedis.ftDropIndex("vector_idx");} catch (JedisDataException j){}
+        // STEP_END
+
+        // STEP_START create_index
+        SchemaField[] schema = {
+            TextField.of("content"),
+            TagField.of("genre"),
+            VectorField.builder()
+                .fieldName("embedding")
+                .algorithm(VectorAlgorithm.HNSW)
+                .attributes(
+                    Map.of(
+                        "TYPE", "FLOAT32",
+                        "DIM", 768,
+                        "DISTANCE_METRIC", "L2"
+                    )
+                )
+                .build()
+        };
+
+        jedis.ftCreate("vector_idx",
+            FTCreateParams.createParams()
+                .addPrefix("doc:")
+                .on(IndexDataType.HASH),
+                schema
+        );
+        // STEP_END
+
+        // STEP_START add_data
+        String sentence1 = "That is a very happy person";
+        jedis.hset("doc:1", Map.of("content", sentence1, "genre", "persons"));
+        jedis.hset(
+            "doc:1".getBytes(),
+            "embedding".getBytes(),
+            longsToFloatsByteString(sentenceTokenizer.encode(sentence1).getIds())
+        );
+
+        String sentence2 = "That is a happy dog";
+        jedis.hset("doc:2", Map.of("content", sentence2, "genre", "pets"));
+        jedis.hset(
+            "doc:2".getBytes(),
+            "embedding".getBytes(),
+            longsToFloatsByteString(sentenceTokenizer.encode(sentence2).getIds())
+        );
+
+        String sentence3 = "Today is a sunny day";
+        jedis.hset("doc:3", Map.of("content", sentence3, "genre", "weather"));
+        jedis.hset(
+            "doc:3".getBytes(),
+            "embedding".getBytes(),
+            longsToFloatsByteString(sentenceTokenizer.encode(sentence3).getIds())
+        );
+        // STEP_END
+
+        // STEP_START query
+        String sentence = "That is a happy person";
+
+        int K = 3;
+        Query q = new Query("*=>[KNN $K @embedding $BLOB AS distance]")
+                        .returnFields("content", "distance")
+                        .addParam("K", K)
+                        .addParam(
+                            "BLOB",
+                            longsToFloatsByteString(
+                                sentenceTokenizer.encode(sentence).getIds()
+                            )
+                        )
+                        .setSortBy("distance", true)
+                        .dialect(2);
+
+        List<Document> docs = jedis.ftSearch("vector_idx", q).getDocuments();
+
+        for (Document doc: docs) {
+            System.out.println(
+                String.format(
+                    "ID: %s, Distance: %s, Content: %s",
+                    doc.getId(),
+                    doc.get("distance"),
+                    doc.get("content")
+                )
+            );
+        }
+        // STEP_END
+
+        // STEP_START json_schema
+        SchemaField[] jsonSchema = {
+            TextField.of("$.content").as("content"),
+            TagField.of("$.genre").as("genre"),
+            VectorField.builder()
+                .fieldName("$.embedding").as("embedding")
+                .algorithm(VectorAlgorithm.HNSW)
+                .attributes(
+                    Map.of(
+                        "TYPE", "FLOAT32",
+                        "DIM", 768,
+                        "DISTANCE_METRIC", "L2"
+                    )
+                )
+                .build()
+        };
+
+        jedis.ftCreate("vector_json_idx",
+            FTCreateParams.createParams()
+                .addPrefix("jdoc:")
+                .on(IndexDataType.JSON),
+                jsonSchema
+        );
+        // STEP_END
+
+        // STEP_START json_data
+        String jSentence1 = "That is a very happy person";
+
+        JSONObject jdoc1 = new JSONObject()
+                .put("content", jSentence1)
+                .put("genre", "persons")
+                .put(
+                    "embedding",
+                    longArrayToFloatArray(
+                        sentenceTokenizer.encode(jSentence1).getIds()
+                    )
+                );
+
+        jedis.jsonSet("jdoc:1", Path2.ROOT_PATH, jdoc1);
+
+        String jSentence2 = "That is a happy dog";
+
+        JSONObject jdoc2 = new JSONObject()
+                .put("content", jSentence2)
+                .put("genre", "pets")
+                .put(
+                    "embedding",
+                    longArrayToFloatArray(
+                        sentenceTokenizer.encode(jSentence2).getIds()
+                    )
+                );
+
+        jedis.jsonSet("jdoc:2", Path2.ROOT_PATH, jdoc2);
+
+        String jSentence3 = "Today is a sunny day";
+
+        JSONObject jdoc3 = new JSONObject()
+                .put("content", jSentence3)
+                .put("genre", "weather")
+                .put(
+                    "embedding",
+                    longArrayToFloatArray(
+                        sentenceTokenizer.encode(jSentence3).getIds()
+                    )
+                );
+
+        jedis.jsonSet("jdoc:3", Path2.ROOT_PATH, jdoc3);
+        // STEP_END
+
+        // STEP_START json_query
+        String jSentence = "That is a happy person";
+
+        int jK = 3;
+        Query jq = new Query("*=>[KNN $K @embedding $BLOB AS distance]")
+                        .returnFields("content", "distance")
+                        .addParam("K", jK)
+                        .addParam(
+                            "BLOB",
+                            longsToFloatsByteString(
+                                sentenceTokenizer.encode(jSentence).getIds()
+                            )
+                        )
+                        .setSortBy("distance", true)
+                        .dialect(2);
+
+        // Execute the query
+        List<Document> jDocs = jedis
+                .ftSearch("vector_json_idx", jq)
+                .getDocuments();
+
+        for (Document doc: jDocs) {
+            System.out.println(
+                String.format(
+                    "ID: %s, Distance: %s, Content: %s",
+                    doc.getId(),
+                    doc.get("distance"),
+                    doc.get("content")
+                )
+            );
+        }
+        // STEP_END
+
+        jedis.close();
+    }
+}

--- a/local_examples/client-specific/home_query_vec.go
+++ b/local_examples/client-specific/home_query_vec.go
@@ -73,7 +73,6 @@ func main() {
 			},
 		},
 	).Result()
-
 	if err != nil {
 		panic(err)
 	}
@@ -97,14 +96,12 @@ func main() {
 	}
 
 	embeddings, err := hf.Embed(ctx, sentences)
-
 	if err != nil {
 		panic(err)
 	}
 
 	for i, emb := range embeddings {
 		buffer := floatsToBytes(emb.ToFloat32())
-
 		if err != nil {
 			panic(err)
 		}
@@ -117,7 +114,6 @@ func main() {
 				"embedding": buffer,
 			},
 		).Result()
-
 		if err != nil {
 			panic(err)
 		}
@@ -128,13 +124,11 @@ func main() {
 	queryEmbedding, err := hf.Embed(ctx, []string{
 		"That is a happy person",
 	})
-
 	if err != nil {
 		panic(err)
 	}
 
 	buffer := floatsToBytes(queryEmbedding[0].ToFloat32())
-
 	if err != nil {
 		panic(err)
 	}
@@ -153,7 +147,6 @@ func main() {
 			},
 		},
 	).Result()
-
 	if err != nil {
 		panic(err)
 	}
@@ -196,7 +189,6 @@ func main() {
 			},
 		},
 	).Result()
-
 	if err != nil {
 		panic(err)
 	}
@@ -213,7 +205,6 @@ func main() {
 				"embedding": emb.ToFloat32(),
 			},
 		).Result()
-
 		if err != nil {
 			panic(err)
 		}
@@ -224,7 +215,6 @@ func main() {
 	jsonQueryEmbedding, err := hf.Embed(ctx, []string{
 		"That is a happy person",
 	})
-
 	if err != nil {
 		panic(err)
 	}
@@ -245,14 +235,13 @@ func main() {
 			},
 		},
 	).Result()
-
 	if err != nil {
 		panic(err)
 	}
 
 	for _, doc := range jsonResults.Docs {
 		fmt.Printf(
-			"JSON ID: %v, Distance:%v, Content:'%v'\n",
+			"ID: %v, Distance:%v, Content:'%v'\n",
 			doc.ID, doc.Fields["vector_distance"], doc.Fields["content"],
 		)
 	}

--- a/local_examples/client-specific/home_query_vec.go
+++ b/local_examples/client-specific/home_query_vec.go
@@ -1,0 +1,260 @@
+// EXAMPLE: home_query_vec
+// STEP_START import
+package main
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	huggingfaceembedder "github.com/henomis/lingoose/embedder/huggingface"
+	"github.com/redis/go-redis/v9"
+)
+
+// STEP_END
+
+// STEP_START helper
+func floatsToBytes(fs []float32) []byte {
+	buf := make([]byte, len(fs)*4)
+
+	for i, f := range fs {
+		u := math.Float32bits(f)
+		binary.NativeEndian.PutUint32(buf[i*4:], u)
+	}
+
+	return buf
+}
+
+// STEP_END
+
+func main() {
+	// STEP_START connect
+	ctx := context.Background()
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password docs
+		DB:       0,  // use default DB
+		Protocol: 2,
+	})
+
+	rdb.FTDropIndexWithArgs(ctx,
+		"vector_idx",
+		&redis.FTDropIndexOptions{
+			DeleteDocs: true,
+		},
+	)
+	// STEP_END
+
+	// STEP_START create_index
+	_, err := rdb.FTCreate(ctx,
+		"vector_idx",
+		&redis.FTCreateOptions{
+			OnHash: true,
+			Prefix: []any{"doc:"},
+		},
+		&redis.FieldSchema{
+			FieldName: "content",
+			FieldType: redis.SearchFieldTypeText,
+		},
+		&redis.FieldSchema{
+			FieldName: "genre",
+			FieldType: redis.SearchFieldTypeTag,
+		},
+		&redis.FieldSchema{
+			FieldName: "embedding",
+			FieldType: redis.SearchFieldTypeVector,
+			VectorArgs: &redis.FTVectorArgs{
+				HNSWOptions: &redis.FTHNSWOptions{
+					Dim:            384,
+					DistanceMetric: "L2",
+					Type:           "FLOAT32",
+				},
+			},
+		},
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+	// STEP_END
+
+	// STEP_START embedder
+	hf := huggingfaceembedder.New().
+		WithToken("<your-access-token>").
+		WithModel("sentence-transformers/all-MiniLM-L6-v2")
+	// STEP_END
+
+	// STEP_START add_data
+	sentences := []string{
+		"That is a very happy person",
+		"That is a happy dog",
+		"Today is a sunny day",
+	}
+
+	tags := []string{
+		"persons", "pets", "weather",
+	}
+
+	embeddings, err := hf.Embed(ctx, sentences)
+
+	if err != nil {
+		panic(err)
+	}
+
+	for i, emb := range embeddings {
+		buffer := floatsToBytes(emb.ToFloat32())
+
+		if err != nil {
+			panic(err)
+		}
+
+		_, err = rdb.HSet(ctx,
+			fmt.Sprintf("doc:%v", i),
+			map[string]any{
+				"content":   sentences[i],
+				"genre":     tags[i],
+				"embedding": buffer,
+			},
+		).Result()
+
+		if err != nil {
+			panic(err)
+		}
+	}
+	// STEP_END
+
+	// STEP_START query
+	queryEmbedding, err := hf.Embed(ctx, []string{
+		"That is a happy person",
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	buffer := floatsToBytes(queryEmbedding[0].ToFloat32())
+
+	if err != nil {
+		panic(err)
+	}
+
+	results, err := rdb.FTSearchWithArgs(ctx,
+		"vector_idx",
+		"*=>[KNN 3 @embedding $vec AS vector_distance]",
+		&redis.FTSearchOptions{
+			Return: []redis.FTSearchReturn{
+				{FieldName: "vector_distance"},
+				{FieldName: "content"},
+			},
+			DialectVersion: 2,
+			Params: map[string]any{
+				"vec": buffer,
+			},
+		},
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	for _, doc := range results.Docs {
+		fmt.Printf(
+			"ID: %v, Distance:%v, Content:'%v'\n",
+			doc.ID, doc.Fields["vector_distance"], doc.Fields["content"],
+		)
+	}
+	// STEP_END
+
+	// STEP_START json_index
+	_, err = rdb.FTCreate(ctx,
+		"vector_json_idx",
+		&redis.FTCreateOptions{
+			OnJSON: true,
+			Prefix: []any{"jdoc:"},
+		},
+		&redis.FieldSchema{
+			FieldName: "$.content",
+			As:        "content",
+			FieldType: redis.SearchFieldTypeText,
+		},
+		&redis.FieldSchema{
+			FieldName: "$.genre",
+			As:        "genre",
+			FieldType: redis.SearchFieldTypeTag,
+		},
+		&redis.FieldSchema{
+			FieldName: "$.embedding",
+			As:        "embedding",
+			FieldType: redis.SearchFieldTypeVector,
+			VectorArgs: &redis.FTVectorArgs{
+				HNSWOptions: &redis.FTHNSWOptions{
+					Dim:            384,
+					DistanceMetric: "L2",
+					Type:           "FLOAT32",
+				},
+			},
+		},
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+	// STEP_END
+
+	// STEP_START json_data
+	for i, emb := range embeddings {
+		_, err = rdb.JSONSet(ctx,
+			fmt.Sprintf("jdoc:%v", i),
+			"$",
+			map[string]any{
+				"content":   sentences[i],
+				"genre":     tags[i],
+				"embedding": emb.ToFloat32(),
+			},
+		).Result()
+
+		if err != nil {
+			panic(err)
+		}
+	}
+	// STEP_END
+
+	// STEP_START json_query
+	jsonQueryEmbedding, err := hf.Embed(ctx, []string{
+		"That is a happy person",
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
+	jsonBuffer := floatsToBytes(jsonQueryEmbedding[0].ToFloat32())
+
+	jsonResults, err := rdb.FTSearchWithArgs(ctx,
+		"vector_json_idx",
+		"*=>[KNN 3 @embedding $vec AS vector_distance]",
+		&redis.FTSearchOptions{
+			Return: []redis.FTSearchReturn{
+				{FieldName: "vector_distance"},
+				{FieldName: "content"},
+			},
+			DialectVersion: 2,
+			Params: map[string]any{
+				"vec": jsonBuffer,
+			},
+		},
+	).Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	for _, doc := range jsonResults.Docs {
+		fmt.Printf(
+			"JSON ID: %v, Distance:%v, Content:'%v'\n",
+			doc.ID, doc.Fields["vector_distance"], doc.Fields["content"],
+		)
+	}
+	// STEP_END
+}

--- a/local_examples/client-specific/home_query_vec.js
+++ b/local_examples/client-specific/home_query_vec.js
@@ -1,0 +1,184 @@
+// EXAMPLE: home_query_vec
+// STEP_START import
+import * as transformers from '@xenova/transformers';
+import {
+    VectorAlgorithms,
+    createClient,
+    SchemaFieldTypes,
+} from 'redis';
+// STEP_END
+
+// STEP_START pipeline
+let pipe = await transformers.pipeline(
+    'feature-extraction', 'Xenova/all-distilroberta-v1'
+);
+
+const pipeOptions = {
+    pooling: 'mean',
+    normalize: true,
+};
+// STEP_END
+
+// STEP_START connect
+const client = createClient({url: 'redis://localhost:6379'});
+await client.connect();
+
+try { 
+    await client.ft.dropIndex('vector_idx'); 
+} catch (e) {
+    // Index doesn't exist, which is fine
+}
+// STEP_END
+
+// STEP_START create_index
+await client.ft.create('vector_idx', {
+    'content': {
+        type: SchemaFieldTypes.TEXT,
+    },
+    'genre': {
+        type: SchemaFieldTypes.TAG,
+    },
+    'embedding': {
+        type: SchemaFieldTypes.VECTOR,
+        TYPE: 'FLOAT32',
+        ALGORITHM: VectorAlgorithms.HNSW,
+        DISTANCE_METRIC: 'L2',
+        DIM: 768,
+    }
+}, {
+    ON: 'HASH',
+    PREFIX: 'doc:'
+});
+// STEP_END
+
+// STEP_START add_data
+const sentence1 = 'That is a very happy person';
+const doc1 = {
+    'content': sentence1, 
+    'genre': 'persons', 
+    'embedding': Buffer.from(
+        (await pipe(sentence1, pipeOptions)).data.buffer
+    ),
+};
+
+const sentence2 = 'That is a happy dog';
+const doc2 = {
+    'content': sentence2, 
+    'genre': 'pets', 
+    'embedding': Buffer.from(
+        (await pipe(sentence2, pipeOptions)).data.buffer
+    )
+};
+
+const sentence3 = 'Today is a sunny day';
+const doc3 = {
+    'content': sentence3, 
+    'genre': 'weather', 
+    'embedding': Buffer.from(
+        (await pipe(sentence3, pipeOptions)).data.buffer
+    )
+};
+
+await Promise.all([
+    client.hSet('doc:1', doc1),
+    client.hSet('doc:2', doc2),
+    client.hSet('doc:3', doc3)
+]);
+// STEP_END
+
+// STEP_START query
+const similar = await client.ft.search(
+    'vector_idx',
+    '*=>[KNN 3 @embedding $B AS score]',
+    {
+        'PARAMS': {
+            B: Buffer.from(
+                (await pipe('That is a happy person', pipeOptions)).data.buffer
+            ),
+        },
+        'RETURN': ['score', 'content'],
+        'DIALECT': '2'
+    },
+);
+
+for (const doc of similar.documents) {
+    console.log(`${doc.id}: '${doc.value.content}', Score: ${doc.value.score}`);
+}
+// STEP_END
+
+try { 
+    await client.ft.dropIndex('vector_json_idx'); 
+} catch (e) {
+    // Index doesn't exist, which is fine
+}
+
+// STEP_START json_index
+await client.ft.create('vector_json_idx', {
+    '$.content': {
+        type: SchemaFieldTypes.TEXT,
+        AS: 'content',
+    },
+    '$.genre': {
+        type: SchemaFieldTypes.TAG,
+        AS: 'genre',
+    },
+    '$.embedding': {
+        type: SchemaFieldTypes.VECTOR,
+        TYPE: 'FLOAT32',
+        ALGORITHM: VectorAlgorithms.HNSW,
+        DISTANCE_METRIC: 'L2',
+        DIM: 768,
+        AS: 'embedding',
+    }
+}, {
+    ON: 'JSON',
+    PREFIX: 'jdoc:'
+});
+// STEP_END
+
+// STEP_START json_data
+const jSentence1 = 'That is a very happy person';
+const jdoc1 = {
+    'content': jSentence1,
+    'genre': 'persons',
+    'embedding': [...(await pipe(jSentence1, pipeOptions)).data],
+};
+
+const jSentence2 = 'That is a happy dog';
+const jdoc2 = {
+    'content': jSentence2,
+    'genre': 'pets',
+    'embedding': [...(await pipe(jSentence2, pipeOptions)).data],
+};
+
+const jSentence3 = 'Today is a sunny day';
+const jdoc3 = {
+    'content': jSentence3,
+    'genre': 'weather',
+    'embedding': [...(await pipe(jSentence3, pipeOptions)).data],
+};
+
+await Promise.all([
+    client.json.set('jdoc:1', '$', jdoc1),
+    client.json.set('jdoc:2', '$', jdoc2),
+    client.json.set('jdoc:3', '$', jdoc3)
+]);
+// STEP_END
+
+// STEP_START json_query
+const jsons = await client.ft.search(
+    'vector_json_idx',
+    '*=>[KNN 3 @embedding $B AS score]',
+    {
+        "PARAMS": {
+            B: Buffer.from(
+                (await pipe('That is a happy person', pipeOptions)).data.buffer
+            ),
+        },
+        'RETURN': ['score', 'content'],
+        'DIALECT': '2'
+    },
+);
+// STEP_END
+
+await client.quit();

--- a/local_examples/client-specific/home_query_vec.py
+++ b/local_examples/client-specific/home_query_vec.py
@@ -1,0 +1,154 @@
+# EXAMPLE: home_query_vec
+# STEP_START import
+from sentence_transformers import SentenceTransformer
+from redis.commands.search.query import Query
+from redis.commands.search.field import TextField, TagField, VectorField
+from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+from redis.commands.json.path import Path
+
+import numpy as np
+import redis
+# STEP_END
+
+# STEP_START model
+model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+# STEP_END
+
+# STEP_START connect
+r = redis.Redis(decode_responses=True)
+
+try:
+    r.ft("vector_idx").dropindex(True)
+except redis.exceptions.ResponseError:
+    pass
+# STEP_END
+
+# STEP_START create_index
+schema = (
+    TextField("content"),
+    TagField("genre"),
+    VectorField("embedding", "HNSW", {
+        "TYPE": "FLOAT32",
+        "DIM": 384,
+        "DISTANCE_METRIC":"L2"
+    })
+)
+
+r.ft("vector_idx").create_index(
+    schema,
+    definition=IndexDefinition(
+        prefix=["doc:"], index_type=IndexType.HASH
+    )
+)
+# STEP_END
+
+# STEP_START add_data
+content = "That is a very happy person"
+
+r.hset("doc:0", mapping={
+    "content": content,
+    "genre": "persons",
+    "embedding": model.encode(content).astype(np.float32).tobytes(),
+})
+
+content = "That is a happy dog"
+
+r.hset("doc:1", mapping={
+    "content": content,
+    "genre": "pets",
+    "embedding": model.encode(content).astype(np.float32).tobytes(),
+})
+
+content = "Today is a sunny day"
+
+r.hset("doc:2", mapping={
+    "content": content,
+    "genre": "weather",
+    "embedding": model.encode(content).astype(np.float32).tobytes(),
+})
+# STEP_END
+
+# STEP_START query
+q = Query(
+    "*=>[KNN 3 @embedding $vec AS vector_distance]"
+).return_field("vector_distance").return_field("content").dialect(2)
+
+query_text = "That is a happy person"
+
+res = r.ft("vector_idx").search(
+    q, query_params={
+        "vec": model.encode(query_text).astype(np.float32).tobytes()
+    }
+)
+
+print(res)
+# STEP_END
+
+try:
+    r.ft("vector_json_idx").dropindex(True)
+except redis.exceptions.ResponseError:
+    pass
+
+# STEP_START json_index
+schema = (
+    TextField("$.content", as_name="content"),
+    TagField("$.genre", as_name="genre"),
+    VectorField(
+        "$.embedding", "HNSW", {
+            "TYPE": "FLOAT32",
+            "DIM": 384,
+            "DISTANCE_METRIC": "L2"
+        },
+        as_name="embedding"
+    )
+)
+
+r.ft("vector_json_idx").create_index(
+    schema,
+    definition=IndexDefinition(
+        prefix=["jdoc:"], index_type=IndexType.JSON
+    )
+)
+# STEP_END
+
+# STEP_START json_data
+content = "That is a very happy person"
+
+r.json().set("jdoc:0", Path.root_path(), {
+    "content": content,
+    "genre": "persons",
+    "embedding": model.encode(content).astype(np.float32).tolist(),
+})
+
+content = "That is a happy dog"
+
+r.json().set("jdoc:1", Path.root_path(), {
+    "content": content,
+    "genre": "pets",
+    "embedding": model.encode(content).astype(np.float32).tolist(),
+})
+
+content = "Today is a sunny day"
+
+r.json().set("jdoc:2", Path.root_path(), {
+    "content": content,
+    "genre": "weather",
+    "embedding": model.encode(content).astype(np.float32).tolist(),
+})
+# STEP_END
+
+# STEP_START json_query
+q = Query(
+    "*=>[KNN 3 @embedding $vec AS vector_distance]"
+).return_field("vector_distance").return_field("content").dialect(2)
+
+query_text = "That is a happy person"
+
+res = r.ft("vector_json_idx").search(
+    q, query_params={
+        "vec": model.encode(query_text).astype(np.float32).tobytes()
+    }
+)
+
+print(repr(res))
+# STEP_END

--- a/local_examples/client-specific/home_vecsets.py
+++ b/local_examples/client-specific/home_vecsets.py
@@ -1,0 +1,155 @@
+# EXAMPLE: home_vecsets
+# STEP_START import
+from sentence_transformers import SentenceTransformer
+
+import redis
+import numpy as np
+# STEP_END
+
+# STEP_START model
+model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+# STEP_END
+
+# STEP_START data
+peopleData = {
+    "Marie Curie": {
+        "born": 1867, "died": 1934,
+        "description": """
+        Polish-French chemist and physicist. The only person ever to win
+        two Nobel prizes for two different sciences.
+        """
+    },
+    "Linus Pauling": {
+        "born": 1901, "died": 1994,
+        "description": """
+        American chemist and peace activist. One of only two people to win two
+        Nobel prizes in different fields (chemistry and peace).
+        """
+    },
+    "Freddie Mercury": {
+        "born": 1946, "died": 1991,
+        "description": """
+        British musician, best known as the lead singer of the rock band
+        Queen.
+        """
+    },
+    "Marie Fredriksson": {
+        "born": 1958, "died": 2019,
+        "description": """
+        Swedish multi-instrumentalist, mainly known as the lead singer and
+        keyboardist of the band Roxette.
+        """
+    },
+    "Paul Erdos": {
+        "born": 1913, "died": 1996,
+        "description": """
+        Hungarian mathematician, known for his eccentric personality almost
+        as much as his contributions to many different fields of mathematics.
+        """
+    },
+    "Maryam Mirzakhani": {
+        "born": 1977, "died": 2017,
+        "description": """
+        Iranian mathematician. The first woman ever to win the Fields medal
+        for her contributions to mathematics.
+        """
+    },
+    "Masako Natsume": {
+        "born": 1957, "died": 1985,
+        "description": """
+        Japanese actress. She was very famous in Japan but was primarily
+        known elsewhere in the world for her portrayal of Tripitaka in the
+        TV series Monkey.
+        """
+    },
+    "Chaim Topol": {
+        "born": 1935, "died": 2023,
+        "description": """
+        Israeli actor and singer, usually credited simply as 'Topol'. He was
+        best known for his many appearances as Tevye in the musical Fiddler
+        on the Roof.
+        """
+    }
+}
+# STEP_END
+
+# STEP_START add_data
+r = redis.Redis(decode_responses=True)
+
+for name, details in peopleData.items():
+    emb = model.encode(details["description"]).astype(np.float32).tobytes()
+
+    r.vset().vadd(
+        "famousPeople",
+        emb,
+        name,
+        attributes={
+            "born": details["born"],
+            "died": details["died"]
+        }
+    )
+# STEP_END
+
+# STEP_START basic_query
+query_value = "actors"
+
+actors_results = r.vset().vsim(
+    "famousPeople",
+    model.encode(query_value).astype(np.float32).tobytes(),
+)
+
+print(f"'actors': {actors_results}")
+# STEP_END
+
+# STEP_START limited_query
+query_value = "actors"
+
+two_actors_results = r.vset().vsim(
+    "famousPeople",
+    model.encode(query_value).astype(np.float32).tobytes(),
+    count=2
+)
+
+print(f"'actors (2)': {two_actors_results}")
+# >>> 'actors (2)': ['Masako Natsume', 'Chaim Topol']
+# STEP_END
+
+# STEP_START entertainer_query
+query_value = "entertainer"
+
+entertainer_results = r.vset().vsim(
+    "famousPeople",
+    model.encode(query_value).astype(np.float32).tobytes()
+)
+
+print(f"'entertainer': {entertainer_results}")
+# >>> 'entertainer': ['Chaim Topol', 'Freddie Mercury',
+# 'Marie Fredriksson', 'Masako Natsume', 'Linus Pauling',
+# 'Paul Erdos', 'Maryam Mirzakhani', 'Marie Curie']
+# STEP_END
+
+query_value = "science"
+
+science_results = r.vset().vsim(
+    "famousPeople",
+    model.encode(query_value).astype(np.float32).tobytes()
+)
+
+print(f"'science': {science_results}")
+# >>> 'science': ['Marie Curie', 'Linus Pauling',
+# 'Maryam Mirzakhani', 'Paul Erdos', 'Marie Fredriksson',
+# 'Freddie Mercury', 'Masako Natsume', 'Chaim Topol']
+
+# STEP_START filtered_query
+query_value = "science"
+
+science2000_results = r.vset().vsim(
+    "famousPeople",
+    model.encode(query_value).astype(np.float32).tobytes(),
+    filter=".died < 2000"
+)
+
+print(f"'science2000': {science2000_results}")
+# >>> 'science2000': ['Marie Curie', 'Linus Pauling',
+# 'Paul Erdos', 'Freddie Mercury', 'Masako Natsume']
+# STEP_END


### PR DESCRIPTION
Updated the client-specific vector RQE and vector set examples to use the new local example file feature. This presents the examples a bit better, but it will also make it easier to use AI to create derived examples from the files.