### PR TITLE
DOC-5544 enable PHP tabbed code examples

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ tagManagerId = "GTM-TKZ6J9R"
 gitHubRepo = "https://github.com/redis/docs"
 
 # Display and sort order for client examples
-clientsExamples = ["Python", "Node.js", "Java-Sync", "Java-Async", "Java-Reactive", "Go", "C#", "RedisVL"]
+clientsExamples = ["Python", "Node.js", "Java-Sync", "Java-Async", "Java-Reactive", "Go", "C#", "RedisVL", "PHP"]
 searchService = "/convai/api/search-service"
 ratingsService = "/docusight/api/rate"
 
@@ -66,6 +66,7 @@ rdi_current_version = "1.12.3"
 "Go"={quickstartSlug="go"}
 "C#"={quickstartSlug="dotnet"}
 "RedisVL"={quickstartSlug="redis-vl"}
+"PHP"={quickstartSlug="php"}
 
 # Markup
 [markup]

--- a/data/components/index.json
+++ b/data/components/index.json
@@ -10,6 +10,7 @@
         "nredisstack",
         "go_redis",
         "node_redis",
+        "php",
         "redis_py",
         "jedis",
         "lettuce_async",

--- a/data/components/php.json
+++ b/data/components/php.json
@@ -1,0 +1,15 @@
+{
+    "id": "php",
+    "type": "client",
+    "name": "Predis",
+    "language": "PHP",
+    "label": "PHP",
+    "repository": {
+        "git_uri": "https://github.com/predis/predis"
+    },
+    "examples": {
+        "git_uri": "https://github.com/predis/predis",
+        "path": "examples",
+        "pattern": "*.php"
+    }
+}

--- a/layouts/partials/tabs/wrapper.html
+++ b/layouts/partials/tabs/wrapper.html
@@ -17,7 +17,7 @@
         <input tabindex="1" type="radio" name="{{ $id }}" id="{{ $tid }}" data-lang="{{ $dataLang }}" class="radiotab w-0 h-0"
                {{ if eq $i 0 }}checked{{ end }}
         />
-        <label class="justify-left label ml-1.5 pt-3.5 px-1 pb-1 cursor-pointer text-sm text-center bg-redis-ink-900
+        <label class="justify-left label ml-0.5 pt-3.5 px-1 pb-1 cursor-pointer text-sm text-center bg-redis-ink-900
         hover:text-redis-red-600  rounded rounded-mx transition duration-150 ease-in-out"
                title="Open example" for="{{ $tid }}">
             {{ if eq (index $tab "title") "redis-cli" }}

--- a/local_examples/php/DtStringTest.php
+++ b/local_examples/php/DtStringTest.php
@@ -1,0 +1,88 @@
+// EXAMPLE: set_tutorial
+<?php
+
+require 'vendor/autoload.php';
+
+use Predis\Client as PredisClient;
+
+class DtStringTest
+// REMOVE_START
+extends PredisTestCase
+// REMOVE_END
+{
+    public function testDtString() {
+        $r = new PredisClient([
+            'scheme'   => 'tcp',
+            'host'     => '127.0.0.1',
+            'port'     => 6379,
+            'password' => '',
+            'database' => 0,
+        ]);
+        // REMOVE_START
+        $r->flushall();
+        // REMOVE_END
+
+        // STEP_START set_get
+        $res1 = $r->set('bike:1', 'Deimos');
+        echo "$res1" . PHP_EOL;
+        // >>> OK
+
+        $res2 = $r->get('bike:1');
+        echo "$res2" . PHP_EOL;
+        // >>> Deimos
+        // STEP_END
+        // REMOVE_START
+        $this->assertEquals('OK', $res1);
+        $this->assertEquals('Deimos', $res2);
+        // REMOVE_END
+
+        // STEP_START setnx_xx
+        $res3 = $r->set('bike:1', 'bike', 'nx');
+        echo "$res3" . PHP_EOL;
+        // >>> (null)
+        
+        echo $r->get('bike:1') . PHP_EOL;
+        // >>> Deimos
+
+        $res4 = $r->set('bike:1', 'bike', 'xx');
+        echo "$res4" . PHP_EOL;
+        // >>> OK
+        // STEP_END
+        // REMOVE_START
+        $this->assertEquals(null, $res3);
+        $this->assertEquals('OK', $res4);
+        $this->assertEquals('bike', $r->get('bike:1'));
+        // REMOVE_END
+
+        // STEP_START mset
+        $res5 = $r->mset([
+            'bike:1' => 'Deimos', 'bike:2' => 'Ares', 'bike:3' => 'Vanth'
+        ]);
+        echo "$res5" . PHP_EOL;
+        // >>> OK
+
+        $res6 = $r->mget(['bike:1', 'bike:2', 'bike:3']);
+        echo json_encode($res6) . PHP_EOL;
+        // >>> ["Deimos","Ares","Vanth"]
+        // STEP_END
+        // REMOVE_START
+        $this->assertEquals('OK', $res5);
+        $this->assertEquals(['Deimos', 'Ares', 'Vanth'],  $res6);
+        // REMOVE_END
+
+        // STEP_START incr
+        $r->set('total_crashes', 0);
+        $res7 = $r->incr('total_crashes');
+        echo "$res7" . PHP_EOL;
+        // >>> 1
+
+        $res8 = $r->incrby('total_crashes', 10);
+        echo "$res8" . PHP_EOL;
+        // >>> 11
+        // STEP_END
+        // REMOVE_START
+        $this->assertEquals(1, $res7);
+        $this->assertEquals(11, $res8);
+        // REMOVE_END
+    }
+}


### PR DESCRIPTION
This:
- Enables the config for PHP examples
- Squeezes the tab buttons a bit closer together to make room for the PHP button
- Adds a first PHP example (strings datatype page)
