### PR TITLE
RS: Added that 7.22.0 uses RHEL 9.6 to the RHEL version vs. Redis Enterprise version table

### DIFF
--- a/content/embeds/supported-platforms-embed.md
+++ b/content/embeds/supported-platforms-embed.md
@@ -47,6 +47,7 @@ The following table shows which Redis Enterprise Software version first tested a
 | 8.9 | 7.2.4 |
 | 9.3 | 7.4.2 |
 | 9.5 | 7.8.2 |
+| 9.6 | 7.22.0 |
 
 ## Operating system compatibility policy
 


### PR DESCRIPTION
DOC-5549 and fixes https://github.com/redis/docs/issues/1933

Staged preview: https://redis.io/docs/staging/DOC-5549/operate/rs/references/supported-platforms/