### PR TITLE
Fix names of the cnm_ctl program.

### DIFF
--- a/content/operate/rs/7.4/references/cli-utilities/_index.md
+++ b/content/operate/rs/7.4/references/cli-utilities/_index.md
@@ -32,7 +32,7 @@ Do not use these tools for normal operations.
 |---------|-------------|
 | bdb-cli | `redis-cli` connected to a database. |
 | ccs-cli | Inspect Cluster Configuration Store. |
-| cnm-ctl | Manages services for provisioning, migration, monitoring, <br />resharding, rebalancing, deprovisioning, and autoscaling. |
+| cnm_ctl | Manages services for provisioning, migration, monitoring, <br />resharding, rebalancing, deprovisioning, and autoscaling. |
 | consistency_checker | Checks the consistency of Redis instances. |
 | crdbtop | Monitor Active-Active databases. |
 | debug_mode | Enables debug mode. |

--- a/content/operate/rs/7.8/references/cli-utilities/_index.md
+++ b/content/operate/rs/7.8/references/cli-utilities/_index.md
@@ -32,7 +32,7 @@ Do not use these tools for normal operations.
 |---------|-------------|
 | bdb-cli | `redis-cli` connected to a database. |
 | ccs-cli | Inspect Cluster Configuration Store. |
-| cnm-ctl | Manages services for provisioning, migration, monitoring, <br />resharding, rebalancing, deprovisioning, and autoscaling. |
+| cnm_ctl | Manages services for provisioning, migration, monitoring, <br />resharding, rebalancing, deprovisioning, and autoscaling. |
 | consistency_checker | Checks the consistency of Redis instances. |
 | crdbtop | Monitor Active-Active databases. |
 | debug_mode | Enables debug mode. |

--- a/content/operate/rs/references/cli-utilities/_index.md
+++ b/content/operate/rs/references/cli-utilities/_index.md
@@ -31,7 +31,7 @@ Do not use these tools for normal operations.
 |---------|-------------|
 | bdb-cli | `redis-cli` connected to a database. |
 | ccs-cli | Inspect Cluster Configuration Store. |
-| cnm-ctl | Manages services for provisioning, migration, monitoring, <br />resharding, rebalancing, deprovisioning, and autoscaling. |
+| cnm_ctl | Manages services for provisioning, migration, monitoring, <br />resharding, rebalancing, deprovisioning, and autoscaling. |
 | consistency_checker | Checks the consistency of Redis instances. |
 | crdbtop | Monitor Active-Active databases. |
 | debug_mode | Enables debug mode. |


### PR DESCRIPTION
The documentation references is cnm-ctl which is a typo of cnm_ctl.