### PR TITLE
DEV: FP32 (vectorsets) should explicitly document endianness

### DIFF
--- a/content/commands/vadd.md
+++ b/content/commands/vadd.md
@@ -38,7 +38,7 @@ is the name of the key that will hold the vector set data.
 <details open>
 <summary><code>FP32 vector or VALUES num vector</code></summary>
 
-either a 32-bit floating point (FP32) blob of values or `num` floating point numbers as strings.
+either a 32-bit floating point (FP32) blob of values or `num` floating point numbers as strings. When using the FP32 format, the blob must use little-endian encoding. On platforms with different endianness, you should either manually adjust the byte order or use the VALUES syntax instead.
 </details>
 
 <details open>

--- a/content/commands/vemb.md
+++ b/content/commands/vemb.md
@@ -82,7 +82,7 @@ One of the following:
 * [Array reply](../../develop/reference/protocol-spec#arrays): consisting of the following elements:
     1. The quantization type as a [simple string](../../develop/reference/protocol-spec#simple-strings): `fp32`, `bin`, or `q8`.
     1. A [bulk string](../../develop/reference/protocol-spec#bulk-strings) blob with the following raw data:
-        * 4-byte floats for fp32
+        * 4-byte floats for fp32 (little-endian encoding)
         * A bitmap for binary quantization
         * A byte array for q8
     1. The L2 norm, as a [simple string](../../develop/reference/protocol-spec#simple-strings), of the vector before normalization.
@@ -95,7 +95,7 @@ One of the following:
 * [Array reply](../../develop/reference/protocol-spec#arrays): consisting of the following elements:
     1. The quantization type as a [simple string](../../develop/reference/protocol-spec#simple-strings): `fp32`, `bin`, or `q8`.
     1. A [bulk string](../../develop/reference/protocol-spec#bulk-strings) blob with the following raw data:
-        * 4-byte floats for fp32
+        * 4-byte floats for fp32 (little-endian encoding)
         * A bitmap for binary quantization
         * A byte array for q8
     1. The [double](../../develop/reference/protocol-spec#doubles) L2 norm of the vector before normalization.

--- a/content/commands/vlinks.md
+++ b/content/commands/vlinks.md
@@ -66,14 +66,16 @@ includes similarity scores for each neighbor.
     tab2="RESP3" >}}
 
 One of the following:
-* [Array reply](../../develop/reference/protocol-spec#arrays) containing the names of adjacent elements as [strings](../../develop/reference/protocol-spec#simple-strings); interleved with scores when using the WITHSCORES option.
+* An [array](../../develop/reference/protocol-spec#arrays) of [array replies](../../develop/reference/protocol-spec#arrays) containing the names of adjacent elements as [bulk strings](../../develop/reference/protocol-spec#bulk-strings); interleaved with scores as [bulk strings](../../develop/reference/protocol-spec#bulk-strings) when used with the `WITHSCORES` option.
+* [Simple error reply](../../develop/reference/protocol-spec/#simple-errors) for incorrect syntax.
 * [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings) (null bulk string) for unknown keys and/or elements.
 
 -tab-sep-
 
 One of the following:
-* [Array reply](../../develop/reference/protocol-spec#arrays) containing the names of adjacent elements as [strings](../../develop/reference/protocol-spec#simple-strings) when used without the WITHSCORES option.
-* [Map reply](../../develop/reference/protocol-spec#maps) containing the names of adjecent elements as [strings](../../develop/reference/protocol-spec#simple-strings), together with their scores as [doubles](../../develop/reference/protocol-spec#doubles) when used with the WITHSCORES option.
+* An [array](../../develop/reference/protocol-spec#arrays) of [array replies](../../develop/reference/protocol-spec#arrays) containing the names of adjacent elements as [bulk strings](../../develop/reference/protocol-spec#bulk-strings) when used without the `WITHSCORES` option.
+* An [array](../../develop/reference/protocol-spec#arrays) of [map replies](../../develop/reference/protocol-spec#maps) containing the names of adjecent elements as [bulk strings](../../develop/reference/protocol-spec#bulk-strings), together with their scores as [doubles](../../develop/reference/protocol-spec#doubles) when used with the `WITHSCORES` option.
+* [Simple error reply](../../develop/reference/protocol-spec/#simple-errors) for incorrect syntax.
 * [Null reply](../../develop/reference/protocol-spec#nulls) for unknown keys and/or elements.
 
 {{< /multitabs >}}

--- a/content/commands/vsim.md
+++ b/content/commands/vsim.md
@@ -70,7 +70,7 @@ is the name of the key that holds the vector set data.
 <details open>
 <summary><code>ELE | FP32 | VALUES num</code></summary>
 
-specifies how the input vector is provided. Use `ELE` to refer to an existing element, `FP32` for binary float format, or `VALUES num` for a list of stringified float values.
+specifies how the input vector is provided. Use `ELE` to refer to an existing element, `FP32` for binary float format (little-endian encoding required), or `VALUES num` for a list of stringified float values.
 </details>
 
 <details open>

--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -40,6 +40,14 @@ The following commands are available for vector sets:
 - [VSETATTR]({{< relref "/commands/vsetattr" >}}) - set or replace attributes on a vector set element.
 - [VSIM]({{< relref "/commands/vsim" >}}) - retrieve elements similar to a given vector or element with optional filtering.
 
+## Endianness considerations for FP32 format
+
+When using the FP32 blob format with vector set commands like [`VADD`]({{< relref "/commands/vadd" >}}) and [`VSIM`]({{< relref "/commands/vsim" >}}), the binary data must be encoded in little-endian byte order. This is important for cross-platform compatibility, as some ARM variants and other architectures may use different endianness.
+
+If your platform uses big-endian or mixed-endian encoding, you have two options:
+- Manually convert the byte order to little-endian before passing the blob to Redis.
+- Use the `VALUES` syntax instead, which accepts floating-point numbers as strings and is platform-independent.
+
 ## Examples
 
 The following examples give an overview of how to use vector sets. For clarity,


### PR DESCRIPTION
Fixes #1967.
Fixes #1972.

Also includes updates to the return information for the VLINKS command page.

Tests used to confirm the correct return information for the VLINKS command:

```
RESP2

vlinks vs element1
*1
*2
$8
element2
$8
element3
vlinks vs element1 withscores
*1
*4
$8
element2
$17
0.996941864490509
$8
element3
$3
0.5
vlinks foo
-ERR wrong number of arguments for 'VLINKS' command
vlinks vs foo
$-1
vlinks foo bar
$-1

RESP3

vlinks vs element1
*1
*2
$8
element2
$8
element3
vlinks vs element1 withscores
*1
%2
$8
element2
,0.996941864490509
$8
element3
,0.5
vlinks foo
-ERR wrong number of arguments for 'VLINKS' command
vlinks vs foo
_
vlinks foo bar
_
```