### PR TITLE
DOC-5582 RDI: remove write-behind from index

### DIFF
--- a/content/integrate/redis-data-integration/rdi-archive.md
+++ b/content/integrate/redis-data-integration/rdi-archive.md
@@ -14,7 +14,3 @@ RDI is now in general availability but you can still access an
 [archived version of the docs for the preview version](https://docs.redis.com/rdi-preview/rdi/)
 if you need to refer to them. Note that these docs will not be updated and
 information in the current docs supersedes the content of the preview docs.
-
-There is also another RDI product, **Write-behind**, that is still in preview.
-See the [Write-behind]({{< relref "/integrate/write-behind" >}}) docs for
-more information.

--- a/content/integrate/write-behind/_index.md
+++ b/content/integrate/write-behind/_index.md
@@ -15,5 +15,5 @@ summary: Redis Data Integration keeps Redis in sync with the primary database in
   real time.
 type: integration
 weight: 2
+draft: true
 ---
-


### PR DESCRIPTION
The content will stay in the docs repo for now, in case we want to archive it or whatever.