### PR TITLE
Add traditional search button to home page banner

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -16,20 +16,14 @@
       {{ with .Params.description }}
       <p class="text-xl md:text-2xl">{{ . | markdownify }}</p>
       {{ end }}
-      <div class="flex flex-row items-center gap-4 w-full md:w-4/5">
-        <form class="flex flex-row items-center border border-white rounded-md px-6 gap-6 w-full bg-redis-ink-900" action="/chat">
-          <label class="" for="search-home" id="search-label-home">
-            {{ partial "icons/search.html" }}
-          </label>
-          <input id="seach-home" name="q" class="appearance-none bg-transparent text-base sm:text-lg text-white placeholder-white w-full h-16 focus:outline-none"
-                 autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-                 placeholder="Ask our AI-powered Redis copilot a question…" maxlength="500" type="text" value="" tabindex=""/>
-          <!--<input type="submit" class="hover:text-redis-pen-300" value="&#x23CE;"/>-->
-          <input class="invisible" type="submit" class="hover:text-redis-pen-300" value=""/>
-        </form>
-        <button id="search-button-home" type="button" class="flex-shrink-0 p-3 border border-white rounded-md bg-redis-ink-900 hover:bg-white hover:text-redis-ink-900 transition-colors" title="Search documentation (Ctrl+K)">
+      <div class="flex flex-row items-center border border-white rounded-md px-6 gap-6 w-full md:w-4/5 bg-redis-ink-900 cursor-pointer" id="search-trigger-home">
+        <label class="" for="search-home" id="search-label-home">
           {{ partial "icons/search.html" }}
-        </button>
+        </label>
+        <div class="appearance-none bg-transparent text-base sm:text-lg text-white placeholder-white w-full h-16 flex items-center"
+             autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+          Search Redis documentation…
+        </div>
       </div>
     </div>
   </header>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -16,16 +16,21 @@
       {{ with .Params.description }}
       <p class="text-xl md:text-2xl">{{ . | markdownify }}</p>
       {{ end }}
-      <form class="flex flex-row items-center border border-white rounded-md px-6 gap-6 w-full md:w-4/5 bg-redis-ink-900" action="/chat">
-        <label class="" for="search-home" id="search-label-home">
+      <div class="flex flex-row items-center gap-4 w-full md:w-4/5">
+        <form class="flex flex-row items-center border border-white rounded-md px-6 gap-6 w-full bg-redis-ink-900" action="/chat">
+          <label class="" for="search-home" id="search-label-home">
+            {{ partial "icons/search.html" }}
+          </label>
+          <input id="seach-home" name="q" class="appearance-none bg-transparent text-base sm:text-lg text-white placeholder-white w-full h-16 focus:outline-none"
+                 autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+                 placeholder="Ask our AI-powered Redis copilot a question…" maxlength="500" type="text" value="" tabindex=""/>
+          <!--<input type="submit" class="hover:text-redis-pen-300" value="&#x23CE;"/>-->
+          <input class="invisible" type="submit" class="hover:text-redis-pen-300" value=""/>
+        </form>
+        <button id="search-button-home" type="button" class="flex-shrink-0 p-3 border border-white rounded-md bg-redis-ink-900 hover:bg-white hover:text-redis-ink-900 transition-colors" title="Search documentation (Ctrl+K)">
           {{ partial "icons/search.html" }}
-        </label>
-        <input id="seach-home" name="q" class="appearance-none bg-transparent text-base sm:text-lg text-white placeholder-white w-full h-16 focus:outline-none" 
-               autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
-               placeholder="Ask our AI-powered Redis copilot a question…" maxlength="500" type="text" value="" tabindex=""/>
-        <!--<input type="submit" class="hover:text-redis-pen-300" value="&#x23CE;"/>-->
-        <input class="invisible" type="submit" class="hover:text-redis-pen-300" value=""/>
-      </form>
+        </button>
+      </div>
     </div>
   </header>
   {{ partial "second-header.html" "disabled" }}

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -23,12 +23,12 @@
           <path d="M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z" stroke="currentColor" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
       </button>
-      <button id="ai-copilot-toggle" type="button" style="height: calc(3rem - 2px);" class="px-3 border border-redis-pen-800 rounded-md bg-white hover:bg-redis-yellow-100 transition-colors flex items-center gap-2" title="Switch to AI chat">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+      <button id="ai-copilot-toggle" type="button" style="height: calc(3rem - 2px);" class="group px-3 border border-redis-pen-800 rounded-md bg-white flex items-center gap-2" title="Switch to AI chat">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
           <!-- Larger plus in top left -->
-          <path d="M3 2h2v2h2v2h-2v2h-2v-2h-2v-2h2v-2z"/>
+          <path class="transform origin-center transition-transform duration-300 group-hover:scale-50" d="M3 2h2v2h2v2h-2v2h-2v-2h-2v-2h2v-2z" fill="#FF4438"/>
           <!-- Smaller plus in bottom right -->
-          <path d="M11 9h1v1h1v1h-1v1h-1v-1h-1v-1h1v-1z"/>
+          <path class="transform origin-center transition-transform duration-300 group-hover:scale-150" d="M11 9h1v1h1v1h-1v1h-1v-1h-1v-1h1v-1z" fill="#FF4438"/>
         </svg>
         <span class="text-sm">AI</span>
       </button>

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -24,7 +24,11 @@
         </svg>
       </button>
       <button id="ai-copilot-toggle" type="button" style="height: calc(3rem - 2px);" class="px-3 border border-redis-pen-800 rounded-md bg-white hover:bg-redis-yellow-100 transition-colors flex items-center gap-2" title="Switch to AI Copilot">
-        <span class="text-sm">🤖 AI</span>
+        <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor">
+          <path d="M6 2.5L7.5 6.5L11.5 7L8.5 9.5L9.5 13.5L6 11.5L2.5 13.5L3.5 9.5L0.5 7L4.5 6.5L6 2.5Z"></path>
+          <path d="M14 6.5L15.5 10.5L19.5 11L16.5 13.5L17.5 17.5L14 15.5L10.5 17.5L11.5 13.5L8.5 11L12.5 10.5L14 6.5Z"></path>
+        </svg>
+        <span class="text-sm">AI</span>
       </button>
       <select id="search-select" style="height: calc(3rem - 2px);" class="w-2/5 pl-3 grow-0 border border-redis-pen-800 rounded-md search-filter bg-white text-left pr-8 appearance-none hidden md:block" autocomplete="off">
         <option value="all" selected>All products</option>

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -23,6 +23,9 @@
           <path d="M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z" stroke="currentColor" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
       </button>
+      <button id="ai-copilot-toggle" type="button" style="height: calc(3rem - 2px);" class="px-3 border border-redis-pen-800 rounded-md bg-white hover:bg-redis-yellow-100 transition-colors flex items-center gap-2" title="Switch to AI Copilot">
+        <span class="text-sm">🤖 AI</span>
+      </button>
       <select id="search-select" style="height: calc(3rem - 2px);" class="w-2/5 pl-3 grow-0 border border-redis-pen-800 rounded-md search-filter bg-white text-left pr-8 appearance-none hidden md:block" autocomplete="off">
         <option value="all" selected>All products</option>
         <option value="rs">Redis Enterprise</option>
@@ -369,10 +372,19 @@
   
     // Click handler function
     function clickHandler(event) {
-      if (event.target.closest('#search-button') || event.target.closest('#search-button-home')) {
+      if (event.target.closest('#search-button') || event.target.closest('#search-trigger-home')) {
         startSearch()
       } else if (event.target.closest('#search-cancel') || event.target.matches('#search-container')) {
         stopSearch()
+      } else if (event.target.closest('#ai-copilot-toggle')) {
+        // Get the current search query
+        const searchQuery = searchInput.value.trim()
+        // Redirect to chat with the query
+        if (searchQuery) {
+          window.location.href = `/chat?q=${encodeURIComponent(searchQuery)}`
+        } else {
+          window.location.href = '/chat'
+        }
       }
     }
   

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -23,10 +23,12 @@
           <path d="M10 10l5.09-5.09L10 10l5.09 5.09L10 10zm0 0L4.91 4.91 10 10l-5.09 5.09L10 10z" stroke="currentColor" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round" />
         </svg>
       </button>
-      <button id="ai-copilot-toggle" type="button" style="height: calc(3rem - 2px);" class="px-3 border border-redis-pen-800 rounded-md bg-white hover:bg-redis-yellow-100 transition-colors flex items-center gap-2" title="Switch to AI Copilot">
-        <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor">
-          <path d="M6 2.5L7.5 6.5L11.5 7L8.5 9.5L9.5 13.5L6 11.5L2.5 13.5L3.5 9.5L0.5 7L4.5 6.5L6 2.5Z"></path>
-          <path d="M14 6.5L15.5 10.5L19.5 11L16.5 13.5L17.5 17.5L14 15.5L10.5 17.5L11.5 13.5L8.5 11L12.5 10.5L14 6.5Z"></path>
+      <button id="ai-copilot-toggle" type="button" style="height: calc(3rem - 2px);" class="px-3 border border-redis-pen-800 rounded-md bg-white hover:bg-redis-yellow-100 transition-colors flex items-center gap-2" title="Switch to AI chat">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+          <!-- Larger plus in top left -->
+          <path d="M3 2h2v2h2v2h-2v2h-2v-2h-2v-2h2v-2z"/>
+          <!-- Smaller plus in bottom right -->
+          <path d="M11 9h1v1h1v1h-1v1h-1v-1h-1v-1h1v-1z"/>
         </svg>
         <span class="text-sm">AI</span>
       </button>

--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -369,7 +369,7 @@
   
     // Click handler function
     function clickHandler(event) {
-      if (event.target.closest('#search-button')) {
+      if (event.target.closest('#search-button') || event.target.closest('#search-button-home')) {
         startSearch()
       } else if (event.target.closest('#search-cancel') || event.target.matches('#search-container')) {
         stopSearch()


### PR DESCRIPTION
https://redis.io/docs/staging/DOC-5587/

- Add dedicated search button next to chat entry field on home page
- Maintains existing chat functionality while providing traditional search access
- Button opens existing search modal with full documentation search capabilities
- Styled consistently with chat form (white border, dark background, hover effects)
- Includes tooltip showing keyboard shortcut (Ctrl+K)
- Updated search modal click handler to support new button
- Provides clear distinction between AI chat and traditional search options
- Leverages existing search infrastructure and keyboard shortcuts

This enhancement gives users immediate access to both AI-powered chat and traditional documentation search directly from the home page, improving discoverability and user experience.