### PR TITLE
Update docs-nav to dynamically create version dropdown for products

### DIFF
--- a/.github/workflows/main-staging.yml
+++ b/.github/workflows/main-staging.yml
@@ -66,6 +66,10 @@ jobs:
         rs_versions=($(find content/operate/rs/ -maxdepth 1 -type d -regex ".*[0-9-]" | awk -F/ '{print $NF}'))
         rdi_versions=($(find content/integrate/redis-data-integration/ -maxdepth 1 -type d -regex ".*[0-9-]" | awk -F/ '{print $NF}'))
 
+        printf "%s\n" "${kubernetes_versions[@]}" > kubernetes-versions
+        printf "%s\n" "${rs_versions[@]}" > rs-versions
+        printf "%s\n" "${rdi_versions[@]}" > rdi-versions
+
         # build latest
         for version in "${kubernetes_versions[@]}"; do
           rm -r "content/operate/kubernetes/${version}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,10 @@ jobs:
         rs_versions=($(find content/operate/rs/ -maxdepth 1 -type d -regex ".*[0-9-]" | awk -F/ '{print $NF}'))
         rdi_versions=($(find content/integrate/redis-data-integration/ -maxdepth 1 -type d -regex ".*[0-9-]" | awk -F/ '{print $NF}'))
 
+        printf "%s\n" "${kubernetes_versions[@]}" > kubernetes-versions
+        printf "%s\n" "${rs_versions[@]}" > rs-versions
+        printf "%s\n" "${rdi_versions[@]}" > rdi-versions
+
         # build latest
         for version in "${kubernetes_versions[@]}"; do
           rm -r "content/operate/kubernetes/${version}"

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -23,25 +23,41 @@
             <span class="menu__version-selector__toggler opener version-selector-control">&#x25BC;</span>
             <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
         </button>
-        {{- $entries := readDir "content/operate/kubernetes" -}}
         {{- $vers := slice -}}
+        {{- $lines := slice -}}
 
-        {{- range $e := $entries -}}
-          {{- if and $e.IsDir (findRE `^\d+\.\d+\.\d+$` $e.Name) -}}
-            {{- $p := split $e.Name "." -}}
-            {{- $maj := int (index $p 0) -}}
-            {{- $min := int (index $p 1) -}}
-            {{- $pat := int (index $p 2) -}}
-            {{- $key := printf "%03d.%03d.%03d" $maj $min $pat -}} {{/* for sorting */}}
-            {{- $vers = $vers | append (dict "v" $e.Name "key" $key) -}}
+        {{ if fileExists "kubernetes-versions" }}
+          {{- $txt := readFile "kubernetes-versions" -}}
+          {{- $lines = split $txt "\n" -}}
+
+          {{- range $lines }}
+          {{- $v := strings.TrimSpace . -}}
+          {{- if and (ne $v "") (findRE `^\d+\.\d+\.\d+$` $v) -}}
+            {{- $p := split $v "." -}}
+            {{- $key := printf "%03d.%03d.%03d" (int (index $p 0)) (int (index $p 1)) (int (index $p 2)) -}}
+            {{- $vers = $vers | append (dict "v" $v "key" $key) -}}
           {{- end -}}
         {{- end -}}
+        {{ else }}
+          {{- $entries := readDir "content/operate/kubernetes" -}}
+          {{- range $e := $entries -}}
+            {{- if and $e.IsDir (findRE `^\d+\.\d+\.\d+$` $e.Name) -}}
+              {{- $p := split $e.Name "." -}}
+              {{- $maj := int (index $p 0) -}}
+              {{- $min := int (index $p 1) -}}
+              {{- $pat := int (index $p 2) -}}
+              {{- $key := printf "%03d.%03d.%03d" $maj $min $pat -}} {{/* for sorting */}}
+              {{- $vers = $vers | append (dict "v" $e.Name "key" $key) -}}
+            {{- end -}}
+          {{- end -}}
+        {{ end}}
+
         {{- $vers = sort $vers "key" "desc" -}}
 
         <div id="versionDropdownKubernetes" class="menu__version-selector__list version-selector-control">
           <a href="{{ absURL "operate/kubernetes/" }}" id="kubernetes-version-select-latest" onclick="_setSelectedVersion('kubernetes', 'latest')">latest</a>
           {{- range $vers }}
-          <a href="{{ absURL (printf "operate/kubernetes/%s" .v) }}" id="kubernetes-version-select-{{ .v }}" onclick="_setSelectedVersion('kubernetes', 'v{{ .v }}')">v{{ .v }}</a>
+          <a href="{{ (absURL "operate/kubernetes/{{ .v }}/") }}" id="kubernetes-version-select-{{ .v }}" onclick="_setSelectedVersion('kubernetes', 'v{{ .v }}')">v{{ .v }}</a>
           {{- end }}
         </div>
       </div>
@@ -52,25 +68,40 @@
             <span class="menu__version-selector__toggler opener version-selector-control">&#x25BC;</span>
             <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
         </button>
-        {{- $entries := readDir "content/operate/rs" -}}
         {{- $vers := slice -}}
+        {{- $lines := slice -}}
 
-        {{- range $e := $entries -}}
-          {{- if and $e.IsDir (findRE `^\d+\.\d+$` $e.Name) -}}
-            {{- $p := split $e.Name "." -}}
-            {{- $maj := int (index $p 0) -}}
-            {{- $min := int (index $p 1) -}}
-            {{- $pat := int (index $p 2) -}}
-            {{- $key := printf "%03d.%03d.%03d" $maj $min $pat -}} {{/* for sorting */}}
-            {{- $vers = $vers | append (dict "v" $e.Name "key" $key) -}}
+        {{ if fileExists "rs-versions" }}
+          {{- $txt := readFile "rs-versions" -}}
+          {{- $lines = split $txt "\n" -}}
+
+          {{- range $lines }}
+          {{- $v := strings.TrimSpace . -}}
+          {{- if and (ne $v "") (findRE `^\d+\.\d+$` $v) -}}
+            {{- $p := split $v "." -}}
+            {{- $key := printf "%03d.%03d" (int (index $p 0)) (int (index $p 1)) -}}
+            {{- $vers = $vers | append (dict "v" $v "key" $key) -}}
           {{- end -}}
         {{- end -}}
+        {{ else }}
+          {{- $entries := readDir "content/operate/rs" -}}
+          {{- range $e := $entries -}}
+            {{- if and $e.IsDir (findRE `^\d+\.\d+$` $e.Name) -}}
+              {{- $p := split $e.Name "." -}}
+              {{- $maj := int (index $p 0) -}}
+              {{- $min := int (index $p 1) -}}
+              {{- $key := printf "%03d.%03d" $maj $min -}} {{/* for sorting */}}
+              {{- $vers = $vers | append (dict "v" $e.Name "key" $key) -}}
+            {{- end -}}
+          {{- end -}}
+        {{ end}}
+
         {{- $vers = sort $vers "key" "desc" -}}
 
         <div id="versionDropdownRs" class="menu__version-selector__list version-selector-control">
           <a href="{{ absURL "operate/rs/" }}" id="rs-version-select-latest" onclick="_setSelectedVersion('rs', 'latest')">latest</a>
           {{- range $vers }}
-          <a href="{{ absURL (printf "operate/rs/%s" .v) }}" id="rs-version-select-{{ .v }}" onclick="_setSelectedVersion('rs', 'v{{ .v }}')">v{{ .v }}</a>
+          <a href="{{ (absURL "operate/rs/{{ .v }}/") }}" id="rs-version-select-{{ .v }}" onclick="_setSelectedVersion('rs', 'v{{ .v }}')">v{{ .v }}</a>
           {{- end }}
         </div>
       </div>

--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -23,11 +23,26 @@
             <span class="menu__version-selector__toggler opener version-selector-control">&#x25BC;</span>
             <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
         </button>
+        {{- $entries := readDir "content/operate/kubernetes" -}}
+        {{- $vers := slice -}}
+
+        {{- range $e := $entries -}}
+          {{- if and $e.IsDir (findRE `^\d+\.\d+\.\d+$` $e.Name) -}}
+            {{- $p := split $e.Name "." -}}
+            {{- $maj := int (index $p 0) -}}
+            {{- $min := int (index $p 1) -}}
+            {{- $pat := int (index $p 2) -}}
+            {{- $key := printf "%03d.%03d.%03d" $maj $min $pat -}} {{/* for sorting */}}
+            {{- $vers = $vers | append (dict "v" $e.Name "key" $key) -}}
+          {{- end -}}
+        {{- end -}}
+        {{- $vers = sort $vers "key" "desc" -}}
+
         <div id="versionDropdownKubernetes" class="menu__version-selector__list version-selector-control">
-            <a href="{{ absURL "operate/kubernetes/" }}" id="kubernetes-version-select-latest" onclick="_setSelectedVersion('kubernetes', 'latest')">latest</a>
-            <a href="{{ absURL "operate/kubernetes/7.8.4/" }}" id="kubernetes-version-select-7.8.6" onclick="_setSelectedVersion('kubernetes', 'v7.8.6')">v7.8.6</a>
-            <a href="{{ absURL "operate/kubernetes/7.8.4/" }}" id="kubernetes-version-select-7.8.4" onclick="_setSelectedVersion('kubernetes', 'v7.8.4')">v7.8.4</a>
-            <a href="{{ absURL "operate/kubernetes/7.4.6/" }}" id="kubernetes-version-select-7.4.6" onclick="_setSelectedVersion('kubernetes', 'v7.4.6')">v7.4.6</a> 
+          <a href="{{ absURL "operate/kubernetes/" }}" id="kubernetes-version-select-latest" onclick="_setSelectedVersion('kubernetes', 'latest')">latest</a>
+          {{- range $vers }}
+          <a href="{{ absURL (printf "operate/kubernetes/%s" .v) }}" id="kubernetes-version-select-{{ .v }}" onclick="_setSelectedVersion('kubernetes', 'v{{ .v }}')">v{{ .v }}</a>
+          {{- end }}
         </div>
       </div>
       {{else if (eq (.Params.linkTitle) "Redis Software")}}
@@ -37,10 +52,26 @@
             <span class="menu__version-selector__toggler opener version-selector-control">&#x25BC;</span>
             <span class="menu__version-selector__toggler closer version-selector-control">&#x25B2;</span>
         </button>
+        {{- $entries := readDir "content/operate/rs" -}}
+        {{- $vers := slice -}}
+
+        {{- range $e := $entries -}}
+          {{- if and $e.IsDir (findRE `^\d+\.\d+$` $e.Name) -}}
+            {{- $p := split $e.Name "." -}}
+            {{- $maj := int (index $p 0) -}}
+            {{- $min := int (index $p 1) -}}
+            {{- $pat := int (index $p 2) -}}
+            {{- $key := printf "%03d.%03d.%03d" $maj $min $pat -}} {{/* for sorting */}}
+            {{- $vers = $vers | append (dict "v" $e.Name "key" $key) -}}
+          {{- end -}}
+        {{- end -}}
+        {{- $vers = sort $vers "key" "desc" -}}
+
         <div id="versionDropdownRs" class="menu__version-selector__list version-selector-control">
-            <a href="{{ absURL "operate/rs/" }}" id="rs-version-select-latest" onclick="_setSelectedVersion('rs', 'latest')">latest</a>
-            <a href="{{ absURL "operate/rs/7.8/" }}" id="rs-version-select-7.8" onclick="_setSelectedVersion('rs', 'v7.8')">v7.8</a>  
-            <a href="{{ absURL "operate/rs/7.4/" }}" id="rs-version-select-7.4" onclick="_setSelectedVersion('rs', 'v7.4')">v7.4</a>  
+          <a href="{{ absURL "operate/rs/" }}" id="rs-version-select-latest" onclick="_setSelectedVersion('rs', 'latest')">latest</a>
+          {{- range $vers }}
+          <a href="{{ absURL (printf "operate/rs/%s" .v) }}" id="rs-version-select-{{ .v }}" onclick="_setSelectedVersion('rs', 'v{{ .v }}')">v{{ .v }}</a>
+          {{- end }}
         </div>
       </div>
     </li>


### PR DESCRIPTION
This change removes the need to manually update the version picker. The content of the picker is based on the versioned folders on the filesystem.