### PR TITLE
refactor focus on feature not the techniques svs-compression.md

### DIFF
--- a/content/develop/ai/search-and-query/vectors/_index.md
+++ b/content/develop/ai/search-and-query/vectors/_index.md
@@ -161,7 +161,7 @@ Choose the `SVS-VAMANA` index type when all of the following requirements apply:
 | `LEANVEC_DIM`              | The dimension used when using `LeanVec4x8` or `LeanVec8x8` compression for dimensionality reduction. If a value is provided, it should be less than `DIM`. Lowering it can speed up search and reduce memory use. | `DIM / 2` |
 
 {{< warning >}}
-Intel's proprietary LVQ and LeanVec optimizations are not available on Redis Open Source. On non-Intel platforms and Redis Open Source platforms, `SVS-VAMANA` with `COMPRESSION` will fall back to Intel’s basic, 8-bit scalar quantization implementation: all values in a vector are scaled using the global minimum and maximum, and then each dimension is quantized independently into 256 levels using 8-bit precision.
+Some advanced vector compression features may depend on hardware or Intel's proprietary optimizations. Intel's proprietary LVQ and LeanVec optimizations are not available in Redis Open Source. On non-Intel platforms and Redis Open Source platforms, `SVS-VAMANA` with `COMPRESSION` will fall back to basic, 8-bit scalar quantization implementation: all values in a vector are scaled using the global minimum and maximum, and then each dimension is quantized independently into 256 levels using 8-bit precision.
 {{< /warning >}}
 
 **Example**

--- a/content/develop/ai/search-and-query/vectors/svs-compression.md
+++ b/content/develop/ai/search-and-query/vectors/svs-compression.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+
 categories:
 - docs
 - develop
@@ -9,23 +11,23 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Vector compression and quantization for efficient memory usage and search performance
-linkTitle: Vector Compression & Quantization
-title: Vector Compression and Quantization
+description: Vector quantization and compression for efficient memory usage and search performance
+linkTitle: Quantization and compression
+title: Vector quantization and compression
 weight: 2
 ---
 
-Efficient management of high-dimensional vector data is crucial for scalable search and retrieval. Advanced methods for vector compression and quantization—such as LVQ (Locally-Adaptive Vector Quantization) and LeanVec—can dramatically optimize memory usage and improve search speed, without sacrificing too much accuracy. This page describes practical approaches to compressing and quantizing vectors for scalable search.
+Efficient management of high-dimensional vector data is crucial for scalable search and retrieval. Advanced methods for vector quantization and compression, such as LVQ (Locally-adaptive Vector Quantization) and LeanVec, can dramatically optimize memory usage and improve search speed, without sacrificing much accuracy. This page describes practical approaches to quantizing and compressing vectors for scalable search.
 
 {{< warning >}}
-Some advanced vector compression features may depend on hardware or Intel's proprietary optimizations. Intel's proprietary LVQ and LeanVec optimizations are not available on Redis Open Source. On non-Intel platforms and Redis Open Source platforms, `SVS-VAMANA` with `COMPRESSION` will fall back to basic, 8-bit scalar quantization implementation: all values in a vector are scaled using the global minimum and maximum, and then each dimension is quantized independently into 256 levels using 8-bit precision.
+Some advanced vector compression features may depend on hardware or Intel's proprietary optimizations. Intel's proprietary LVQ and LeanVec optimizations are not available in Redis Open Source. On non-Intel platforms and Redis Open Source platforms, `SVS-VAMANA` with `COMPRESSION` will fall back to basic, 8-bit scalar quantization implementation: all values in a vector are scaled using the global minimum and maximum, and then each dimension is quantized independently into 256 levels using 8-bit precision.
 {{< /warning >}}
 
-## Compression and Quantization Techniques
+## Quantization and compression techniques
 
-### LVQ (Locally-Adaptive Vector Quantization)
+### LVQ (Locally-adaptive Vector Quantization)
 
-* **Method:** Applies per-vector normalization and scalar quantization, learning parameters directly from the data.
+* **Method:** Applies per-vector normalization and scalar quantization; learns parameters directly from the data.
 * **Advantages:**
     * Enables fast, on-the-fly distance computations.
     * SIMD-optimized layout for efficient search.
@@ -35,7 +37,7 @@ Some advanced vector compression features may depend on hardware or Intel's prop
     * **LVQ8:** Faster ingestion, slower search.
     * **LVQ4x8:** Two-level quantization for improved recall.
 
-### LeanVec
+### LeanVec (LVQ with dimensionality reduction)
 
 * **Method:** Combines dimensionality reduction with LVQ, applying quantization after reducing vector dimensions.
 * **Advantages:**
@@ -44,11 +46,11 @@ Some advanced vector compression features may depend on hardware or Intel's prop
 * **Variants:**
     * **LeanVec4x8:** Recommended for high-dimensional datasets, fastest search and ingestion.
     * **LeanVec8x8:** Improved recall when more granularity is needed.
-* **LeanVec Dimension:** For faster search and lower memory usage, reduce the dimension further by using the optional `REDUCE` argument. The default is typically `input dimension / 2`, but more aggressive reduction (such as `dimension / 4`) is possible for greater efficiency.
+* **LeanVec Dimension:** For faster search and lower memory usage, reduce the dimension further by using the optional `REDUCE` argument. The default is typically `input dimension / 2`, but more aggressive reduction (such as `input dimension / 4`) is possible for greater efficiency.
 
-## Choosing a Compression Type
+## Choosing a compression type
 
-| Compression type      | Best for                                        | Observations                                            |
+| Compression type     | Best for                                         | Observations                                            |
 |----------------------|--------------------------------------------------|---------------------------------------------------------|
 | LVQ4x4               | Fast search and low memory use                   | Consider LeanVec for even faster search                 |
 | LeanVec4x8           | Fastest search and ingestion                     | LeanVec dimensionality reduction might reduce recall    |

--- a/content/develop/ai/search-and-query/vectors/svs-compression.md
+++ b/content/develop/ai/search-and-query/vectors/svs-compression.md
@@ -9,16 +9,16 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Intel scalable vector search (SVS) LVQ and LeanVec compression
-linkTitle: Intel SVS compression
-title: Intel scalable vector search (SVS) compression
+description: Vector compression and quantization for efficient memory usage and search performance
+linkTitle: Vector Compression & Quantization
+title: Vector Compression and Quantization
 weight: 2
 ---
 
-Intel's SVS (Scalable Vector Search) introduces two advanced vector compression techniques&mdash;LVQ and LeanVec&mdash;designed to optimize memory usage and search performance. These methods compress high-dimensional vectors while preserving the geometric relationships essential for accurate similarity search.
+Efficient management of high-dimensional vector data is crucial for scalable search and retrieval. Advanced methods for vector compression and quantization—such as LVQ (Locally-Adaptive Vector Quantization) and LeanVec—can dramatically optimize memory usage and improve search speed, without sacrificing too much accuracy. This page describes practical approaches to compressing and quantizing vectors for scalable search.
 
 {{< warning >}}
-Intel's proprietary LVQ and LeanVec optimizations are not available on Redis Open Source. On non-Intel platforms and Redis Open Source platforms, `SVS-VAMANA` with `COMPRESSION` will fall back to Intel’s basic, 8-bit scalar quantization implementation: all values in a vector are scaled using the global minimum and maximum, and then each dimension is quantized independently into 256 levels using 8-bit precision.
+Some advanced vector compression features may depend on hardware or Intel's proprietary optimizations. Intel's proprietary LVQ and LeanVec optimizations are not available on Redis Open Source. On non-Intel platforms and Redis Open Source platforms, `SVS-VAMANA` with `COMPRESSION` will fall back to basic, 8-bit scalar quantization implementation: all values in a vector are scaled using the global minimum and maximum, and then each dimension is quantized independently into 256 levels using 8-bit precision.
 {{< /warning >}}
 
 ## Compression and Quantization Techniques


### PR DESCRIPTION
Update the SVS compression documentation to focus on the feature of compression and quantization, using the technique names LVQ and LeanVec, as these are directly reflected in the API and implementation. Remove generic references and ensure all sections and examples use LVQ and LeanVec terminology, as well as their respective naming conventions for configuration. The rewritten content should clarify the function and benefit of each variant, the role of multi-level compression, and practical considerations for parameter learning and data drift, while maintaining warning about hardware dependency and proprietary optimizations.