### PR TITLE
DOC-5643 added close/quit details to client landing pages

### DIFF
--- a/content/develop/clients/go/_index.md
+++ b/content/develop/clients/go/_index.md
@@ -156,6 +156,21 @@ fmt.Printf("Model: %v, Brand: %v, Type: %v, Price: $%v\n",
 // >>> Model: Deimos, Brand: Ergonom, Type: Enduro bikes, Price: $4972
  ```
 
+Close the connection when you're done using `client.Close()`. In the
+common case where you want to close the connection at the end of the
+function where you opened it, you may find it convenient to use a `defer`
+statement right after connecting:
+
+```go
+func main() {    
+    client := redis.NewClient(&redis.Options{
+        ...
+    })
+    defer client.Close()
+    ...
+}
+```
+
 ## Observability
 
 `go-redis` supports [OpenTelemetry](https://opentelemetry.io/) instrumentation.

--- a/content/develop/clients/jedis/_index.md
+++ b/content/develop/clients/jedis/_index.md
@@ -58,7 +58,8 @@ To include `Jedis` as a dependency in your application, edit the dependency file
 
 ## Connect and test
 
-The following code opens a basic connection to a local Redis server:
+The following code opens a basic connection to a local Redis server
+and closes it after use.
 
 ```java
 package org.example;

--- a/content/develop/clients/lettuce/_index.md
+++ b/content/develop/clients/lettuce/_index.md
@@ -55,7 +55,8 @@ To build from source, see the instructions on the [Lettuce source code GitHub re
 ## Connect and test
 
 Connect to a local server using the following code. This example
-also stores and retrieves a simple string value to test the connection.
+also stores and retrieves a simple string value to test the connection
+and closes the connection after use.
 
 ```java
 import io.lettuce.core.*;

--- a/content/develop/clients/nodejs/_index.md
+++ b/content/develop/clients/nodejs/_index.md
@@ -86,6 +86,12 @@ createClient({
 ```
 To check if the client is connected and ready to send commands, use `client.isReady`, which returns a Boolean. `client.isOpen` is also available. This returns `true` when the client's underlying socket is open, and `false` when it isn't (for example, when the client is still connecting or reconnecting after a network error).
 
+When you have finished using a connection, close it with `client.quit()`.
+
+```js
+await client.quit();
+```
+
 ## More information
 
 The [`node-redis` website](https://redis.js.org/) has more examples.

--- a/content/develop/clients/redis-py/_index.md
+++ b/content/develop/clients/redis-py/_index.md
@@ -82,6 +82,12 @@ r.hgetall('user-session:123')
 # {'surname': 'Smith', 'name': 'John', 'company': 'Redis', 'age': '29'}
 ```
 
+Close the connection when you're done.
+
+```python
+r.close()
+```
+
 ## More information
 
 The [`redis-py`](https://redis.readthedocs.io/en/stable/index.html) website


### PR DESCRIPTION
The call to close the connection after use is now explicitly mentioned in the client pages where it's relevant.

Closes #2020 
