### PR TITLE
Update ubuntu-jammy.md

### DIFF
--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-jammy.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-jammy.md
@@ -46,7 +46,21 @@ sudo apt-get install -y --no-install-recommends \
     libtool
 ```
 
-## 2. Download and extract the Redis source
+## 2. Install CMake
+
+Install CMake using `pip3` and link it for system-wide access.
+
+{{< warning >}}
+CMake version 3.31.6 is the latest supported version. Newer versions cannot be used.
+{{< /warning>}}
+
+```bash
+pip3 install cmake==3.31.6
+sudo ln -sf /usr/local/bin/cmake /usr/bin/cmake
+cmake --version
+```
+
+## 3. Download and extract the Redis source
 
 The Redis source code is available from [the Redis GitHub site](https://github.com/redis/redis/releases). Select the release you want to build and then select the .tar.gz file from the **Assets** drop down menu. You can verify the integrity of these downloads by checking them against the digests in the [redis-hashes GitHub repository](https://github.com/redis/redis-hashes).
 
@@ -69,7 +83,7 @@ tar xvf redis-<version>.tar.gz
 rm redis-<version>.tar.gz
 ```
 
-## 3. Build Redis
+## 4. Build Redis
 
 Set the appropriate environment variables to enable TLS, modules, and other build options, then compile and install Redis:
 
@@ -85,7 +99,7 @@ make -j "$(nproc)" all
 
 This builds the Redis server, CLI, and any included modules.
 
-## 4. (Optional) Verify the installation
+## 5. (Optional) Verify the installation
 
 You can confirm that Redis has been built and installed successfully by checking the version:
 
@@ -94,7 +108,7 @@ You can confirm that Redis has been built and installed successfully by checking
 ./src/redis-cli --version
 ```
 
-## 5. Start Redis
+## 6. Start Redis
 
 To start Redis, use the following command:
 
@@ -117,7 +131,7 @@ module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
 ...
 ```
 
-## 6. (Optional) Install Redis to its default location
+## 7. (Optional) Install Redis to its default location
 
 ```
 cd /usr/src/redis-<version>


### PR DESCRIPTION
Starting with 8.2, the cmake step is required in Ubuntu 22.04 as well (copied from Ubuntu 20.04 instructions)