### PR TITLE
DOC-5654 changed namespace name highlighting

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -701,7 +701,7 @@ html {
 
 /* Names - Red (NameNamespace) */
 .chroma .nn {
-  @apply text-red-400;
+  @apply text-blue-400;
 }
 
 /* Names - Green (NameTag) */


### PR DESCRIPTION
Open to all suggestions about the colour to use for the namespaces, but it should probably not be the same as the surrounding keywords :-) 

Staging: [Python](https://redis.io/docs/staging/DOC-5654-python-import-css/develop/clients/redis-py/amr/), [Java](https://redis.io/docs/staging/DOC-5654-python-import-css/develop/clients/jedis/queryjson/#initialize), [C#](https://redis.io/docs/staging/DOC-5654-python-import-css/develop/clients/dotnet/queryjson/#initialize). Other languages already look OK.