### PR TITLE
DEV: ACL LIST command doc under oss needs an update

### DIFF
--- a/content/commands/acl-list.md
+++ b/content/commands/acl-list.md
@@ -44,6 +44,10 @@ configuration file if you wish (but make sure to check [`ACL SAVE`]({{< relref "
 2) "user default on nopass ~* &* +@all"
 ```
 
+{{< note >}}
+In some cases, you might see `allchannels` instead of `&*` and `allkeys` instead of `~*` in the output. This is because `allchannels` and `allkeys` are aliases for `&*` and `~*` respectively.
+{{< /note>}}
+
 ## Return information
 
 {{< multitabs id="acl-list-return-info" 


### PR DESCRIPTION
RC seems to have different behavior ACL LIST output than ROS:

ROS: 1) "user default on nopass sanitize-payload ~* &* +@all"

RC: 1) "user default on allkeys +@all allchannels"
