### PR TITLE
Update S&Q _index.md with another alias

### DIFF
--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /develop/interact/search-and-query
 - /develop/interact/search-and-query/
+- /interact/search-and-query/
 categories:
 - docs
 - develop


### PR DESCRIPTION
There is an in-product link that refers to https://redis.io/docs/latest/interact/search-and-query/, so I've added an alias for that.