### PR TITLE
RDSC-3996 Add RDI 1.14.1 release notes. Update the Google Spanner documentation wrt new default option for using the service account

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/spanner.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/spanner.md
@@ -60,9 +60,10 @@ for more details, including additional configuration options and dialect-specifi
 
 ## 3. Create a service account
 
-To allow RDI to access the Spanner instance, you'll need to create a service account with the 
-appropriate permissions. This service account will then be provided to RDI as a secret for 
-authentication.
+To allow RDI to access the Spanner instance, you'll need to create a service account with the
+appropriate permissions. By default, RDI uses Google Cloud Workload Identity authentication
+when the service account is assigned to the GKE cluster. Alternatively, you can provide the
+service account credentials as a Kubernetes secret (see step 4 for details).
 
 1. Create the service account
 
@@ -109,15 +110,27 @@ authentication.
         --project=YOUR_PROJECT_ID
     ```
 
-## 4. Set up secrets for Kubernetes deployment
+### Authentication methods
 
-Before deploying the RDI pipeline, you need to configure the necessary secrets for both the source 
-and target databases. Instructions for setting up the target database secrets are available in the 
+RDI supports two authentication methods for accessing Spanner:
+
+1. **Workload Identity (default)**: The service account is assigned to the GKE cluster, and RDI
+   automatically uses the cluster's identity to authenticate. This is the recommended approach
+   as it's more secure and doesn't require managing credential files.
+
+2. **Service account credentials file**: You provide the service account key file as a Kubernetes
+   secret. This method requires setting `use_credentials_file: true` in your RDI configuration.
+
+## 4. Set up secrets for Kubernetes deployment (optional)
+
+Before deploying the RDI pipeline, you need to configure the necessary secrets for the target
+database. Instructions for setting up the target database secrets are available in the
 [RDI deployment guide]({{< relref "/integrate/redis-data-integration/data-pipelines/deploy#set-secrets-for-k8shelm-deployment-using-kubectl-command" >}}).
 
-In addition to the target database secrets, you'll also need to create a Spanner-specific secret 
-named `source-db-credentials`. This secret should contain the service account key file generated 
-during the Spanner setup phase. Use the command below to create it:
+**Optional**: If you prefer to use service account credentials file instead of Workload Identity
+authentication, you'll need to create a Spanner-specific secret named `source-db-credentials`.
+This secret should contain the service account key file generated during the Spanner setup phase.
+Use the command below to create it:
 
 ```bash
 kubectl create secret generic source-db-credentials --namespace=rdi \
@@ -125,8 +138,13 @@ kubectl create secret generic source-db-credentials --namespace=rdi \
 --save-config --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-Be sure to adjust the file path (`~/spanner-reader-account.json`) if your service account key is 
+Be sure to adjust the file path (`~/spanner-reader-account.json`) if your service account key is
 stored elsewhere.
+
+{{< note >}}
+If you create the `source-db-credentials` secret, you must also set `use_credentials_file: true`
+in your RDI configuration to use the credentials file instead of Workload Identity authentication.
+{{< /note >}}
 
 ## 5. Configure RDI for Spanner
 
@@ -142,6 +160,7 @@ sources:
       project_id: your-project-id
       instance_id: your-spanner-instance
       database_id: your-spanner-database
+      # use_credentials_file: false  # Set to true if using service account credentials file instead of Workload Identity
       change_streams:
         change_stream_all:
           {}

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-14-1.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-14-1.md
@@ -1,0 +1,36 @@
+---
+Title: Redis Data Integration release notes 1.14.1 (August 2025)
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: |
+  New RDI API v2 with enhanced pipeline management.
+  Improved Oracle RAC support with configuration scaffolding.
+  Enhanced metrics and monitoring capabilities.
+  Better TLS/mTLS support across components.
+linkTitle: 1.14.1 (August 2025)
+toc: 'true'
+weight: 978
+---
+
+{{< note >}}This maintenance release replaces the 1.14.0 release.{{< /note >}}
+
+RDI’s mission is to help Redis customers sync Redis Enterprise with live data from their slow disk-based databases to:
+
+- Meet the required speed and scale of read queries and provide an excellent and predictable user experience.
+- Save resources and time when building pipelines and coding data transformations.
+- Reduce the total cost of ownership by saving money on expensive database read replicas.
+
+RDI keeps the Redis cache up to date with changes in the primary database, using a [_Change Data Capture (CDC)_](https://en.wikipedia.org/wiki/Change_data_capture) mechanism.
+It also lets you _transform_ the data from relational tables into convenient and fast data structures that match your app's requirements. You specify the transformations using a configuration system, so no coding is required.
+
+## What's New in 1.14.1
+
+- Support for Google Cloud Workload Identity authentication when a service account is assigned to the GKE cluster
+- Fixed RDI API job validation that was incorrectly failing when schemas are not explicitly specified in source configuration, even though the configuration was valid
+
+## Limitations
+
+RDI can write data to a Redis Active-Active database. However, it doesn't support writing data to two or more Active-Active replicas. Writing data from RDI to several Active-Active replicas could easily harm data integrity as RDI is not synchronous with the source database commits.


### PR DESCRIPTION
1. RDI 1.14.1 release notes
2. Update Google Spanner documentation wrt new way of setting the GCP service account