### PR TITLE
DOC-5709 fixed dodgy note formatting

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/deploy.md
+++ b/content/integrate/redis-data-integration/data-pipelines/deploy.md
@@ -52,7 +52,9 @@ secrets are only relevant for TLS/mTLS connections.
 {{< note >}}When creating secrets for TLS or mTLS, ensure that all certificates and keys are in `PEM` format. The only exception to this is that for PostgreSQL, the private key `SOURCE_DB_KEY` secret must be in `DER` format. If you have a key in `PEM` format, you must convert it to `DER` before creating the `SOURCE_DB_KEY` secret using the command:
 
 ```bash
-openssl pkcs8 -topk8 -inform PEM -outform DER -in /path/to/myclient.pem -out /path/to/myclient.pk8 -nocrypt
+openssl pkcs8 -topk8 -inform PEM -outform DER \
+    -in /path/to/myclient.pem \
+    -out /path/to/myclient.pk8 -nocrypt
 ```
 
 This command assumes that the private key is not encrypted. See the [`openssl` documentation](https://docs.openssl.org/master/) to learn how to convert an encrypted private key.


### PR DESCRIPTION
A long command line example inside a `{{< note >}}` shortcode was causing the rest of the text in the note to overflow. Fixed by wrapping the command line with backslashes.