### PR TITLE
RS: Copied storage engine description/link fixes to 7.8 and 7.4 versions

### DIFF
--- a/content/operate/rs/7.4/databases/auto-tiering/storage-engine.md
+++ b/content/operate/rs/7.4/databases/auto-tiering/storage-engine.md
@@ -15,8 +15,9 @@ url: '/operate/rs/7.4/databases/auto-tiering/storage-engine/'
 
 Redis Enterprise Auto Tiering supports two storage engines:
 
-* [Speedb](https://www.speedb.io/) (default, recommended)
-* [RocksDB](https://rocksdb.org/)
+- Speedb: Redis proprietary storage engine. The default and recommended storage engine as of Redis Enterprise Software version 7.2.4.
+
+- [RocksDB](https://rocksdb.org/): Used up to Redis version 6.2. Deprecated for later Redis versions.
 
 {{<warning>}}Switching between storage engines requires guidance by Redis Support or your Account Manager.{{</warning>}}
 

--- a/content/operate/rs/7.8/databases/auto-tiering/storage-engine.md
+++ b/content/operate/rs/7.8/databases/auto-tiering/storage-engine.md
@@ -15,8 +15,9 @@ url: '/operate/rs/7.8/databases/auto-tiering/storage-engine/'
 
 Redis Enterprise Auto Tiering supports two storage engines:
 
-* [Speedb](https://www.speedb.io/) (default, recommended)
-* [RocksDB](https://rocksdb.org/)
+- Speedb: Redis proprietary storage engine. The default and recommended storage engine as of Redis Enterprise Software version 7.2.4.
+
+- [RocksDB](https://rocksdb.org/): Used up to Redis version 6.2. Deprecated for later Redis versions.
 
 {{<warning>}}Switching between storage engines requires guidance by Redis Support or your Account Manager.{{</warning>}}
 


### PR DESCRIPTION
Copies the fixes from #2087 to the RS 7.8 and 7.4 versions.