### PR TITLE
DOC-5728 improve RDI stub page directions

### DIFF
--- a/content/operate/rdi.md
+++ b/content/operate/rdi.md
@@ -11,4 +11,5 @@ weight: 60
 
 Redis Data Integration (RDI) is a [change data capture](https://en.wikipedia.org/wiki/Change_data_capture) (CDC) system that tracks changes to the data in a non-Redis source database and makes corresponding changes to a Redis target database. You can use the target as a cache to improve performance because it will typically handle read queries much faster than the source.
 
-See [Redis Data Integration]({{< relref "/integrate/redis-data-integration" >}}) for more information.
+See the main [RDI docs section]({{< relref "/integrate/redis-data-integration" >}})
+under [Libraries and tools]({{< relref "/integrate" >}}) for full documentation.


### PR DESCRIPTION
Someone mentioned that the existing page looks like it's going to be a docs page but then it just says "see RDI for more information". The new description makes it more obvious that it's just a stub.