### PR TITLE
DOC-5738 note about RDI being unsupported on Redis Enterprise v8 and above

### DIFF
--- a/content/embeds/rdi-db-reqs.md
+++ b/content/embeds/rdi-db-reqs.md
@@ -1,4 +1,4 @@
-* Redis Enterprise v6.4 or greater for the cluster.
+* Redis Enterprise >= v6.4 and < v8.0 for the cluster. Note that Redis Enterprise may suggest v8.0 or above by default for new databases, but you must select a version in the 6.4 to 7.4 range.
 * For production, 250MB RAM with one primary and one replica is recommended, but for the
   quickstart or for development, 125MB and a single shard is sufficient.
 * If you are deploying RDI for a production environment then secure this database with a password

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -44,7 +44,7 @@ traffic from a relational database.
 ## Can RDI work with any Redis database?
 
 No. RDI is designed and tested to work only with Redis Enterprise. The staging database can
-only use version 6.4 or above. The target Redis database can be of any version and can be a
+only use versions greater than or equal to 6.4 and strictly less than 8.0. The target Redis database can be of any version and can be a
 replica of an Active-Active replication setup or an Auto tiering database.
 
 ## Can RDI automatically track changes to the source database schema?

--- a/content/integrate/redis-data-integration/quick-start-guide.md
+++ b/content/integrate/redis-data-integration/quick-start-guide.md
@@ -14,7 +14,7 @@ In this tutorial you will learn how to install RDI and set up a pipeline to inge
 
 - A Redis Enterprise database that will serve as the pipeline target. The dataset that will be ingested is
   quite small in size, so a single shard database should be enough. RDI also needs to maintain its
-  own database on the cluster to store state information. *This requires Redis Enterprise v6.4 or greater*.
+  own database on the cluster to store state information. *This requires Redis Enterprise >= v6.4 and < v8.0*.
 - [Redis Insight]({{< relref "/develop/tools/insight" >}})
   to edit your pipeline
 - A virtual machine (VM) with one of the following operating systems:  


### PR DESCRIPTION
RDI hasn't been tested on v8+ yet and problems have been reported.