### PR TITLE
DOC-5742 hide Jedis failover page for now

### DIFF
--- a/content/develop/clients/jedis/failover.md
+++ b/content/develop/clients/jedis/failover.md
@@ -13,6 +13,7 @@ description: Improve reliability using the failover/failback features of Jedis.
 linkTitle: Failover/failback
 title: Failover and failback
 weight: 50
+draft: true
 ---
 
 Jedis supports [failover and failback](https://en.wikipedia.org/wiki/Failover)


### PR DESCRIPTION
The feature isn't quite ready to go, so we should hide the docs page with `draft: true` for now.