### PR TITLE
DOC-5750 clearer pointers about using RDI in Redis Insight

### DIFF
--- a/content/integrate/redis-data-integration/installation/install-k8s.md
+++ b/content/integrate/redis-data-integration/installation/install-k8s.md
@@ -323,10 +323,12 @@ section to learn how to do this.
 
 When the Helm installation is complete and you have prepared the source database for CDC,
 you are ready to start using RDI.
-Use [Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}}) to
+Use [Redis Insight]({{< relref "/develop/tools/insight" >}}) to
 [configure]({{< relref "/integrate/redis-data-integration/data-pipelines" >}}) and
 [deploy]({{< relref "/integrate/redis-data-integration/data-pipelines/deploy" >}})
-your pipeline.
+your pipeline (see
+[RDI in Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}})
+for full details on how to do this).
 
 ## Uninstall RDI
 

--- a/content/integrate/redis-data-integration/installation/install-vm.md
+++ b/content/integrate/redis-data-integration/installation/install-vm.md
@@ -266,7 +266,9 @@ you are ready to start using RDI. See the guides on how to
 [configure]({{< relref "/integrate/redis-data-integration/data-pipelines" >}}) and
 [deploy]({{< relref "/integrate/redis-data-integration/data-pipelines/deploy" >}})
 RDI pipelines for more information. You can also configure and deploy a pipeline
-using [Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}}).
+using [Redis Insight]({{< relref "/develop/tools/insight" >}}). See
+[RDI in Redis Insight]({{< relref "/develop/tools/insight/rdi-connector" >}})
+for full details on how to connect to RDI and deploy pipelines.
 
 ## Uninstall RDI
 


### PR DESCRIPTION
We've had some feedback saying that the [RDI K8s install page](https://redis.io/docs/latest/integrate/redis-data-integration/installation/install-k8s/#deploy-a-pipeline) mentions using Redis Insight to deploy but doesn't explain how to do this. We have a [RDI in Redis Insight page](https://redis.io/docs/latest/develop/tools/insight/rdi-connector/) (which seems to have the relevant info), and links to it from the installer pages, but the text around the links doesn't emphasise that this is where you should go if you want to use Redis Insight.

I've improved the text on the installer pages to suggest following the links to the RDI/RI page. However, if any more detail would be helpful here, then let me know and I'll add it.