### PR TITLE
RS: Add --eviction-policy option to crdb-cli update usage

### DIFF
--- a/content/operate/rs/7.4/references/cli-utilities/crdb-cli/crdb/update.md
+++ b/content/operate/rs/7.4/references/cli-utilities/crdb-cli/crdb/update.md
@@ -27,6 +27,7 @@ crdb-cli crdb update --crdb-guid <guid>
          [--featureset-version { true | false } ]
          [--memory-size <maximum_memory>]
          [--bigstore-ram-size <maximum_memory>]
+         [--eviction-policy { noeviction | allkeys-lru | allkeys-lfu | allkeys-random | volatile-lru | volatile-lfu | volatile-random | volatile-ttl }]
          [--update-module name=<name>,featureset_version=<version>]
 ```
 

--- a/content/operate/rs/7.8/references/cli-utilities/crdb-cli/crdb/update.md
+++ b/content/operate/rs/7.8/references/cli-utilities/crdb-cli/crdb/update.md
@@ -27,6 +27,7 @@ crdb-cli crdb update --crdb-guid <guid>
          [--featureset-version { true | false } ]
          [--memory-size <maximum_memory>]
          [--bigstore-ram-size <maximum_memory>]
+         [--eviction-policy { noeviction | allkeys-lru | allkeys-lfu | allkeys-random | volatile-lru | volatile-lfu | volatile-random | volatile-ttl }]
          [--update-module name=<name>,featureset_version=<version>]
 ```
 

--- a/content/operate/rs/references/cli-utilities/crdb-cli/crdb/update.md
+++ b/content/operate/rs/references/cli-utilities/crdb-cli/crdb/update.md
@@ -26,6 +26,7 @@ crdb-cli crdb update --crdb-guid <guid>
          [--featureset-version { true | false } ]
          [--memory-size <maximum_memory>]
          [--bigstore-ram-size <maximum_memory>]
+         [--eviction-policy { noeviction | allkeys-lru | allkeys-lfu | allkeys-random | volatile-lru | volatile-lfu | volatile-random | volatile-ttl }]
          [--update-module name=<name>,featureset_version=<version>]
 ```
 


### PR DESCRIPTION
The `--eviction-policy` option was described correctly in the `Parameters` section, but seems to have been forgotten in the command-line usage section. This PR adds it.