### PR TITLE
DOC-5785 added Rust examples in updated format

### DIFF
--- a/build/components/example.py
+++ b/build/components/example.py
@@ -16,7 +16,8 @@ TEST_MARKER = {
     'java-reactive': '@Test',
     'c#': r'\[Fact]|\[SkipIfRedis\(.*\)]',
     'c#-sync': r'\[Fact]|\[SkipIfRedis\(.*\)]',
-    'c#-async': r'\[Fact]|\[SkipIfRedis\(.*\)]'
+    'c#-async': r'\[Fact]|\[SkipIfRedis\(.*\)]',
+    'rust': r'#\[test]|#\[cfg\(test\)]|#\[tokio::test]'
 }
 PREFIXES = {
     'python': '#',

--- a/local_examples/client-specific/rust-async/landing.rs
+++ b/local_examples/client-specific/rust-async/landing.rs
@@ -1,100 +1,130 @@
 // EXAMPLE: landing
-// STEP_START import
-use redis::AsyncCommands;
-// STEP_END
+#[cfg(test)]
+mod tests {
+    // STEP_START import
+    use redis::AsyncCommands;
+    // STEP_END
 
-#[tokio::main]
-async fn main() {
-    // STEP_START connect
-    let mut r = match redis::Client::open("redis://127.0.0.1") {
-        Ok(client) => {
-            match client.get_multiplexed_async_connection().await {
-                Ok(conn) => conn,
-                Err(e) => {
-                    println!("Failed to connect to Redis: {e}");
-                    return;
+    #[tokio::test]
+    async fn run() {
+        // STEP_START connect
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => {
+                match client.get_multiplexed_async_connection().await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        println!("Failed to connect to Redis: {e}");
+                        return;
+                    }
                 }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
             }
-        },
-        Err(e) => {
-            println!("Failed to create Redis client: {e}");
-            return;
-        }
-    };
-    // STEP_END
-
-    // STEP_START set_get_string
-    if let Ok(res) = r.set("foo", "bar").await {
-        let res: String = res;
-        println!("{res}"); // >>> OK
-    } else {
-        println!("Error setting foo");
-    }
-
-    match r.get("foo").await {
-        Ok(res) => {
-            let res: String = res;
-            println!("{res}"); // >>> bar
-        },
-        Err(e) => {
-            println!("Error getting foo: {e}");
-            return;
-        }
-    };
-    // STEP_END
-
-    // STEP_START set_get_hash
-    let hash_fields = [
-        ("model", "Deimos"),
-        ("brand", "Ergonom"),
-        ("type", "Enduro bikes"),
-        ("price", "4972"),
-    ];
-
-    if let Ok(res) = r.hset_multiple("bike:1", &hash_fields).await {
-        let res: String = res;
-        println!("{res}"); // >>> OK
-    } else {
-        println!("Error setting bike:1");
-    }
-
-    match r.hget("bike:1", "model").await {
-        Ok(res) => {
-            let res: String = res;
-            println!("{res}"); // >>> Deimos
-        },
-        Err(e) => {
-            println!("Error getting bike:1 model: {e}");
-            return;
-        }
-    }
-
-    match r.hget("bike:1", "price").await {
-        Ok(res) => {
-            let res: String = res;
-            println!("{res}"); // >>> 4972
-        },
-        Err(e) => {
-            println!("Error getting bike:1 price: {e}");
-            return;
-        }
-    }
-
-    match r.hgetall("bike:1").await {
-        Ok(res) => {
-            let res: Vec<(String, String)> = res;
-            for (key, value) in res {
-                println!("{key}: {value}");
-            }
-            // >>> model: Deimos
-            // >>> brand: Ergonom
-            // >>> type: Enduro bikes
-            // >>> price: 4972
-        },
-        Err(e) => {
-            println!("Error getting bike:1: {e}");
-            return;
-        }
+        };
         // STEP_END
+
+        // STEP_START set_get_string
+        if let Ok(res) = r.set("foo", "bar").await {
+            let res: String = res;
+            println!("{res}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        } else {
+            println!("Error setting foo");
+        }
+
+        match r.get("foo").await {
+            Ok(res) => {
+                let res: String = res;
+                println!("{res}"); // >>> bar
+                // REMOVE_START
+                assert_eq!(res, "bar");
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting foo: {e}");
+                return;
+            }
+        };
+        // STEP_END
+
+        // STEP_START set_get_hash
+        let hash_fields = [
+            ("model", "Deimos"),
+            ("brand", "Ergonom"),
+            ("type", "Enduro bikes"),
+            ("price", "4972"),
+        ];
+
+        if let Ok(res) = r.hset_multiple("bike:1", &hash_fields).await {
+            let res: String = res;
+            println!("{res}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        } else {
+            println!("Error setting bike:1");
+        }
+
+        match r.hget("bike:1", "model").await {
+            Ok(res) => {
+                let res: String = res;
+                println!("{res}"); // >>> Deimos
+                // REMOVE_START
+                assert_eq!(res, "Deimos");
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting bike:1 model: {e}");
+                return;
+            }
+        }
+
+        match r.hget("bike:1", "price").await {
+            Ok(res) => {
+                let res: String = res;
+                println!("{res}"); // >>> 4972
+                // REMOVE_START
+                assert_eq!(res, "4972");
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting bike:1 price: {e}");
+                return;
+            }
+        }
+
+        match r.hgetall("bike:1").await {
+            Ok(res) => {
+                let res: Vec<(String, String)> = res;
+                // REMOVE_START
+                assert_eq!(res.len(), 4);
+                assert_eq!(res[0].0, "model");
+                assert_eq!(res[0].1, "Deimos");
+                assert_eq!(res[1].0, "brand");
+                assert_eq!(res[1].1, "Ergonom");
+                assert_eq!(res[2].0, "type");
+                assert_eq!(res[2].1, "Enduro bikes");
+                assert_eq!(res[3].0, "price");
+                assert_eq!(res[3].1, "4972");
+                // REMOVE_END
+
+                for (key, value) in res {
+                    println!("{key}: {value}");
+                }
+                // >>> model: Deimos
+                // >>> brand: Ergonom
+                // >>> type: Enduro bikes
+                // >>> price: 4972
+            },
+            Err(e) => {
+                println!("Error getting bike:1: {e}");
+                return;
+            }
+            // STEP_END
+        }
     }
 }

--- a/local_examples/client-specific/rust-sync/landing.rs
+++ b/local_examples/client-specific/rust-sync/landing.rs
@@ -1,99 +1,126 @@
 // EXAMPLE: landing
-// STEP_START import
-use redis::Commands;
-// STEP_END
+#[cfg(test)]
+mod landing_tests {
+    // STEP_START import
+    use redis::Commands;
+    // STEP_END
 
-fn main() {
-    // STEP_START connect
-    let mut r = match redis::Client::open("redis://127.0.0.1") {
-        Ok(client) => {
-            match client.get_connection() {
-                Ok(conn) => conn,
-                Err(e) => {
-                    println!("Failed to connect to Redis: {e}");
-                    return;
+    #[test]
+    fn run() {
+        // STEP_START connect
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => {
+                match client.get_connection() {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        println!("Failed to connect to Redis: {e}");
+                        return;
+                    }
                 }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
             }
-        },
-        Err(e) => {
-            println!("Failed to create Redis client: {e}");
-            return;
-        }
-    };
-    // STEP_END
+        };
+        // STEP_END
 
-    // STEP_START set_get_string
-    if let Ok(res) = r.set("foo", "bar") {
-        let res: String = res;
-        println!("{res}"); // >>> OK
-    } else {
-        println!("Error setting foo");
-    }
+        // STEP_START set_get_string
+        if let Ok(res) = r.set("foo", "bar") {
+            let res: String = res;
+            println!("{res}");    // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        } else {
+            println!("Error setting foo");
+        }
+        
+        match r.get("foo") {
+            Ok(res) => {
+                let res: String = res;
+                println!("{res}");   // >>> bar
+                // REMOVE_START
+                assert_eq!(res, "bar");
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting foo: {e}");
+                return;
+            }
+        };
+        // STEP_END
     
-    match r.get("foo") {
-        Ok(res) => {
+        // STEP_START set_get_hash
+        let hash_fields = [
+            ("model", "Deimos"),
+            ("brand", "Ergonom"),
+            ("type", "Enduro bikes"),
+            ("price", "4972"),
+        ];
+    
+        if let Ok(res) = r.hset_multiple("bike:1", &hash_fields) {
             let res: String = res;
-            println!("{res}"); // >>> bar
-        },
-        Err(e) => {
-            println!("Error getting foo: {e}");
-            return;
+            println!("{res}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        } else {
+            println!("Error setting bike:1");
         }
-    };
-    // STEP_END
-
-    // STEP_START set_get_hash
-    let hash_fields = [
-        ("model", "Deimos"),
-        ("brand", "Ergonom"),
-        ("type", "Enduro bikes"),
-        ("price", "4972"),
-    ];
-
-    if let Ok(res) = r.hset_multiple("bike:1", &hash_fields) {
-        let res: String = res;
-        println!("{res}"); // >>> OK
-    } else {
-        println!("Error setting bike:1");
+    
+        match r.hget("bike:1", "model") {
+            Ok(res) => {
+                let res: String = res;
+                println!("{res}"); // >>> Deimos
+                // REMOVE_START
+                assert_eq!(res, "Deimos");
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting bike:1 model: {e}");
+                return;
+            }   
+        }
+    
+        match r.hget("bike:1", "price") {
+            Ok(res) => {
+                let res: String = res;
+                println!("{res}"); // >>> 4972
+                // REMOVE_START
+                assert_eq!(res, "4972");
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting bike:1 price: {e}");
+                return;
+            }   
+        }
+    
+        match r.hgetall("bike:1") {
+            Ok(res) => {
+                let res: Vec<(String, String)> = res;
+                // REMOVE_START
+                assert_eq!(res.len(), 4);
+                assert_eq!(res[0].0, "model");
+                assert_eq!(res[0].1, "Deimos");
+                assert_eq!(res[1].0, "brand");
+                assert_eq!(res[1].1, "Ergonom");
+                // REMOVE_END
+                
+                for (key, value) in res {
+                    println!("{key}: {value}");
+                }
+                // >>> model: Deimos
+                // >>> brand: Ergonom
+                // >>> type: Enduro bikes
+                // >>> price: 4972
+            },
+            Err(e) => {
+                println!("Error getting bike:1: {e}");
+                return;
+            }   
+        }
+        // STEP_END
     }
-
-    match r.hget("bike:1", "model") {
-        Ok(res) => {
-            let res: String = res;
-            println!("{res}"); // >>> Deimos
-        },
-        Err(e) => {
-            println!("Error getting bike:1 model: {e}");
-            return;
-        }   
-    }
-
-    match r.hget("bike:1", "price") {
-        Ok(res) => {
-            let res: String = res;
-            println!("{res}"); // >>> 4972
-        },
-        Err(e) => {
-            println!("Error getting bike:1 price: {e}");
-            return;
-        }   
-    }
-
-    match r.hgetall("bike:1") {
-        Ok(res) => {
-            let res: Vec<(String, String)> = res;
-            for (key, value) in res {
-                println!("{key}: {value}");
-            }
-            // >>> model: Deimos
-            // >>> brand: Ergonom
-            // >>> type: Enduro bikes
-            // >>> price: 4972
-        },
-        Err(e) => {
-            println!("Error getting bike:1: {e}");
-            return;
-        }   
-    }
-    // STEP_END
 }


### PR DESCRIPTION
Proposed improvement is to structure Rust example files as [test modules](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) so that we can add the usual asserts and run them with the standard Rust testing system. Also, if you enable the "Test Explorer" option in the rust-analyzer extension in VSCode, you get the usual test arrows, etc, in the editor for test modules.

Staging: https://redis.io/docs/staging/DOC-5785-rust-example-format/develop/clients/rust/