### PR TITLE
Lettuce: Add example on enabling keep-alive in SDR

### DIFF
--- a/content/develop/clients/lettuce/produsage.md
+++ b/content/develop/clients/lettuce/produsage.md
@@ -114,7 +114,7 @@ try (RedisClient client = RedisClient.create(redisURI)) {
 
 ### Setting timeouts in Spring Data Redis
 
-If you are using Spring Data Redis, you can set timeouts and keepalive settings using `LettuceClientConfigurationCustomizer`:
+If you are using Spring Data Redis, you can set timeouts and keepalive settings using `LettuceClientConfigurationBuilderCustomizer`:
 
 ```java
 @Bean


### PR DESCRIPTION
Currently, we lack an example of how to apply recommended settings in Spring Data Redis. This PR fixes that.