### PR TITLE
DEV: add Rust TCEs to existing 3QFY2026 hash commands

### DIFF
--- a/local_examples/cmds_hash/rust-async/cmds_hash.rs
+++ b/local_examples/cmds_hash/rust-async/cmds_hash.rs
@@ -138,10 +138,9 @@ mod cmds_hash_tests {
             ("field3", "World"),
         ];
 
-        if let Ok(res) = r.hset_multiple::<&str, &str, &str, String>("myhash", &hash_fields).await {
+        if let Ok(res) = r.hset_multiple("myhash", &hash_fields).await {
             let res: String = res;
-            println!("{res}");    // >>> OK (but we'll print 2 to match Python)
-            println!("2");    // >>> 2
+            println!("{res}");    // >>> OK
             // REMOVE_START
             assert_eq!(res, "OK");
             // REMOVE_END

--- a/local_examples/cmds_hash/rust-sync/cmds_hash.rs
+++ b/local_examples/cmds_hash/rust-sync/cmds_hash.rs
@@ -138,10 +138,9 @@ mod cmds_hash_tests {
             ("field3", "World"),
         ];
 
-        if let Ok(res) = r.hset_multiple::<&str, &str, &str, String>("myhash", &hash_fields) {
+        if let Ok(res) = r.hset_multiple("myhash", &hash_fields) {
             let res: String = res;
-            println!("{res}");    // >>> OK (but we'll print 2 to match Python)
-            println!("2");    // >>> 2
+            println!("{res}");    // >>> OK
             // REMOVE_START
             assert_eq!(res, "OK");
             // REMOVE_END


### PR DESCRIPTION
Added Rust sync and async examples for cmds_hash commands (cf. local_examples/cmds_hash/rust*/*).