### PR TITLE
Remove note on producing pretty-formatted JSON

### DIFF
--- a/content/commands/json.get.md
+++ b/content/commands/json.get.md
@@ -92,8 +92,6 @@ sets the string that's printed at the end of each line.
 
 sets the string that's put between a key and a value.
 </details>
-
-{{% alert title="Note" color="warning" %}}
  
 Produce pretty-formatted JSON with `redis-cli` by following this example:
 
@@ -101,8 +99,6 @@ Produce pretty-formatted JSON with `redis-cli` by following this example:
 ~/$ redis-cli --raw
 redis> JSON.GET myjsonkey INDENT "\t" NEWLINE "\n" SPACE " " path.to.value[1]
 {{< / highlight >}}
-
-{{% /alert %}}
 
 ## Examples
 


### PR DESCRIPTION
Removed alert note about pretty-formatted JSON usage because it falls off the right margin when viewing on a laptop-sized screen.