### PR TITLE
K8s: RN weight fix

### DIFF
--- a/content/operate/kubernetes/release-notes/7-2-4-releases/7-2-4-12-june25.md
+++ b/content/operate/kubernetes/release-notes/7-2-4-releases/7-2-4-12-june25.md
@@ -7,7 +7,7 @@ categories:
 description: This is a maintenance release to support Redis Enterprise Software version 7.2.4-130.
 linkTitle: 7.2.4-12 (June 2025)
 title: Redis Enterprise for Kubernetes 7.2.4-12 (June 2025) release notes
-weight: 1
+weight: 2
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-2-4-releases/7-2-4-12-mar25.md
+++ b/content/operate/kubernetes/release-notes/7-2-4-releases/7-2-4-12-mar25.md
@@ -7,7 +7,7 @@ categories:
 description: This is a maintenance release to support Redis Enterprise Software version 7.2.4-118.
 linkTitle: 7.2.4-12 (March 2025)
 title: Redis Enterprise for Kubernetes 7.2.4-12 (March 2025) release notes
-weight: 2
+weight: 3
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-2-4-releases/7-2-4-15-sep25.md
+++ b/content/operate/kubernetes/release-notes/7-2-4-releases/7-2-4-15-sep25.md
@@ -7,7 +7,7 @@ categories:
 description: This is a maintenance release to support Redis Enterprise Software version 7.2.4-138. RHEL7 support has been removed.
 linkTitle: 7.2.4-15 (September 2025)
 title: Redis Enterprise for Kubernetes 7.2.4-15 (September 2025) release notes
-weight: 0
+weight: 1
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-11-june2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-11-june2025.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.22.0-11 (June 2025)
 title: Redis Enterprise for Kubernetes 7.22.0-11 (June 2025) release notes
-weight: 3
+weight: 4
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-15-july2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-15-july2025.md
@@ -8,7 +8,7 @@ description: Feature release with Helm chart general availability, Kubernetes 1.
 hideListLinks: true
 linkTitle: 7.22.0-15 (July 2025)
 title: Redis Enterprise for Kubernetes 7.22.0-15 (July 2025) release notes
-weight: 2
+weight: 3
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-16-august2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-16-august2025.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.22.0-16 (August 2025)
 title: Redis Enterprise for Kubernetes 7.22.0-16 (August 2025) release notes
-weight: 1
+weight: 2
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.22.0-17 (September 2025)
 title: Redis Enterprise for Kubernetes 7.22.0-17 (September 2025) release notes
-weight: 0
+weight: 1
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-7-april2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-7-april2025.md
@@ -8,7 +8,7 @@ description: Feature release with Redis Software 7.22.0-28 support, enhancements
 hideListLinks: true
 linkTitle: 7.22.0-7 (April 2025)
 title: Redis Enterprise for Kubernetes 7.22.0-7 (April 2025) release notes
-weight: 4
+weight: 5
 ---
 ## New in the release
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-21-october2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-21-october2025.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.22.2-21 (October 2025)
 title: Redis Enterprise for Kubernetes 7.22.2-21 (October 2025) release notes
-weight: 0
+weight: 1
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2-oct24.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2-oct24.md
@@ -7,7 +7,7 @@ categories:
 description: This is a maintenance release with a new version of Redis Enterprise Software 7.4.6.
 linkTitle: 7.4.6-2 (October 2024)
 title: Redis Enterprise for Kubernetes 7.4.6-2 (October 2024) release notes
-weight: 4 
+weight: 5
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2-october24.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2-october24.md
@@ -7,7 +7,7 @@ categories:
 description: This is a maintenance release with a new version of Redis Enterprise Software 7.4.6.
 linkTitle: 7.4.6-2 (October 2024)
 title: Redis Enterprise for Kubernetes 7.4.6-2 (October 2024) release notes
-weight: 4
+weight: 6
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2.md
@@ -8,7 +8,7 @@ description: This is a feature release with a new version of Redis Enterprise So
   7.4.6.
 linkTitle: 7.4.6-2 (July 2024)
 title: Redis Enterprise for Kubernetes 7.4.6-2 (July 2024) release notes
-weight: 5
+weight: 7
 aliases: /operate/kubernetes/release-notes/7-4-6-2, 
 ---
 

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-6-dec24.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-6-dec24.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.4.6-6 (Dec 2024)
 title: Redis Enterprise for Kubernetes 7.4.6-6 (Dec 2024) release notes
-weight: 3
+weight: 4
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-6-june25.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-6-june25.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.4.6-6 (June 2025)
 title: Redis Enterprise for Kubernetes 7.4.6-6 (June 2025) release notes
-weight: 1
+weight: 2
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-6-mar25.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-6-mar25.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.4.6-6 (March 2025)
 title: Redis Enterprise for Kubernetes 7.4.6-6 (March 2025) release notes
-weight: 2
+weight: 3
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-7-sep25.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-7-sep25.md
@@ -8,7 +8,7 @@ description: This is a maintenance release to support Redis Enterprise Software 
 hideListLinks: true
 linkTitle: 7.4.6-7 (September 2025)
 title: Redis Enterprise for Kubernetes 7.4.6-7 (September 2025) release notes
-weight: 0
+weight: 1
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-8-4-releases/7-8-4-8-feb25.md
+++ b/content/operate/kubernetes/release-notes/7-8-4-releases/7-8-4-8-feb25.md
@@ -8,7 +8,7 @@ description: Maintenance release to support Redis Enterprise Software version 7.
 hideListLinks: true
 linkTitle: 7.8.4-8 (Feb 2025)
 title: Redis Enterprise for Kubernetes 7.8.4-8 (Feb 2025) release notes
-weight: 1
+weight: 2
 ---
 
 This release includes bug fixes, enhancements, and support for [Redis Enterprise Software version 7.8.4-66]({{<relref "/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-66">}}).

--- a/content/operate/kubernetes/release-notes/7-8-4-releases/7-8-4-9-mar25.md
+++ b/content/operate/kubernetes/release-notes/7-8-4-releases/7-8-4-9-mar25.md
@@ -8,7 +8,7 @@ description: Maintenance release to support Redis Enterprise Software version 7.
 hideListLinks: true
 linkTitle: 7.8.4-9 (March 2025)
 title: Redis Enterprise for Kubernetes 7.8.4-9 (March 2025) release notes
-weight: 0
+weight: 1
 ---
 
 This is a maintenance release to support [Redis Enterprise Software version 7.8.4-95]({{<relref "/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-95/">}}) and OpenShift 4.17 and 4.18.

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-april2025.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-april2025.md
@@ -8,7 +8,7 @@ description: A maintenance release that includes support for Redis Software 7.8.
 hideListLinks: true
 linkTitle: 7.8.6-1 (April 2025)
 title: Redis Enterprise for Kubernetes 7.8.6-1 (April 2025) release notes
-weight: 5
+weight: 6
 ---
 
 ## New in the release

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-march2025.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-march2025.md
@@ -8,7 +8,7 @@ description: Feature release including enhancements, bug fixes, platform updates
 hideListLinks: true
 linkTitle: 7.8.6-1 (March 2025)
 title: Redis Enterprise for Kubernetes 7.8.6-1 (March 2025) release notes
-weight: 6
+weight: 7
 ---
 
 ## New in the release

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-may2025.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-may2025.md
@@ -8,7 +8,7 @@ description: A maintenance release that includes support for Redis Software 7.8.
 hideListLinks: true
 linkTitle: 7.8.6-1 (May 2025)
 title: Redis Enterprise for Kubernetes 7.8.6-1 (May 2025) release notes
-weight: 4
+weight: 5
 ---
 
 Redis Enterprise for Kubernetes 7.8.6-1 (May 2025) is a maintenance release that includes support for [Redis Software 7.8.6-60]({{<relref "/operate/rs/release-notes/rs-7-8-releases/">}}).

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-2-june2025.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-2-june2025.md
@@ -8,7 +8,7 @@ description: A maintenance release that includes support for Redis Software 7.8.
 hideListLinks: true
 linkTitle: 7.8.6-2 (June 2025)
 title: Redis Enterprise for Kubernetes 7.8.6-2 (June 2025) release notes
-weight: 3
+weight: 4
 ---
 
 Redis Enterprise for Kubernetes 7.8.6-2 (June 2025) is a maintenance release that includes support for [Redis Software 7.8.6-95]({{<relref "/operate/rs/release-notes/rs-7-8-releases/">}}).

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-3-june2025.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-3-june2025.md
@@ -8,7 +8,7 @@ description: A maintenance release that includes support for Redis Software 7.8.
 hideListLinks: true
 linkTitle: 7.8.6-3 (June 2025)
 title: Redis Enterprise for Kubernetes 7.8.6-3 (June 2025) release notes
-weight: 2
+weight: 3
 ---
 
 Redis Enterprise for Kubernetes 7.8.6-3 (June 2025) is a maintenance release that includes support for [Redis Software 7.8.6-119]({{<relref "/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-119">}}).

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-5-august2025.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-5-august2025.md
@@ -8,7 +8,7 @@ description: A maintenance release that includes support for Redis Software 7.8.
 hideListLinks: true
 linkTitle: 7.8.6-5 (August 2025)
 title: Redis Enterprise for Kubernetes 7.8.6-5 (August 2025) release notes
-weight: 1
+weight: 2
 ---
 
 Redis Enterprise for Kubernetes 7.8.6-5 (August 2025) is a maintenance release that includes support for [Redis Software 7.8.6-152]({{<relref "/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-152" >}}).

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-8-october2025.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-8-october2025.md
@@ -8,7 +8,7 @@ description: A maintenance release that includes support for Redis Software 7.8.
 hideListLinks: true
 linkTitle: 7.8.6-8 (October 2025)
 title: Redis Enterprise for Kubernetes 7.8.6-8 (October 2025) release notes
-weight: 0
+weight: 1
 ---
 
 Redis Enterprise for Kubernetes 7.8.6-8 (October 2025) is a maintenance release that includes support for [Redis Software 7.8.6-207]({{<relref "/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-207" >}}).


### PR DESCRIPTION
Augment set weight: 0 in several release notes, which put them at the end of the list, not the beginning. This adjusts them so they are all 1 or higher. 