### PR TITLE
Add blocklist to prevent tailwind from generating incorrect css

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ const plugin = require('tailwindcss/plugin');
 
 module.exports = {
   content: ["content/**/*.md", "layouts/**/*.html", "./tailwindcss.whitelist.txt"],
+  blocklist: ['[username:password@]'],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
Tailwind is currently generating css from this comment on this [page](https://github.com/redis/docs/blob/main/content/develop/ai/redisvl/0.9.0/overview/installation.md#redis-sentinel):

```
# Format: redis+sentinel://[username:password@]host1:port1,host2:port2/service_name[/db]
```

into

```
.\[username\:password\@\] {
  username: password@;
}
```
The comment doesn't exist for versions earlier than 0.9.0, which is why the css generated for those versions has a different hash. 

The fix is to prevent tailwind from generating unwanted css.