### PR TITLE
Document 'search-on-oom' configuration parameter

### DIFF
--- a/content/develop/ai/search-and-query/administration/configuration.md
+++ b/content/develop/ai/search-and-query/administration/configuration.md
@@ -547,7 +547,7 @@ Specifies the response policy for queries when the server's current memory usage
 
 * `IGNORE`: Execute the query regardless of current memory usage.
 * `RETURN`: In cluster mode, the query returns partial results from shards that did not exceed the memory limit. Shards that exceed the limit will not contribute results.
-* `FAIL`: Will return an error if memory usage exceeds memory limit.
+* `FAIL`: Will return an error if memory usage exceeds the memory limit.
 
 Type: string
 
@@ -556,7 +556,7 @@ Valid values: `IGNORE`, `RETURN`, `FAIL`
 Default: `IGNORE`
 
 {{% alert title="Notes" color="info" %}}
-To prevent potential out-of-memory conditions, it is recommended to set this parameter to FAIL or RETURN rather than IGNORE.
+To prevent potential out-of-memory conditions, it is recommended that you set this parameter to FAIL or RETURN rather than IGNORE.
 {{% /alert %}}
 
 ## Set configuration parameters at module load-time (deprecated)


### PR DESCRIPTION
Added documentation for the 'search-on-oom' configuration parameter, including its valid values and default setting.