### PR TITLE
[RDSC-4241] Improving observability documentation

### DIFF
--- a/content/integrate/redis-data-integration/observability.md
+++ b/content/integrate/redis-data-integration/observability.md
@@ -213,7 +213,7 @@ The endpoint for operator metrics is `https://<RDI_HOST>/operator/metrics` (or t
 ### Operator metric types
 
 Most of the metrics exposed by the RDI operator are standard controller-runtime [metrics](https://book.kubebuilder.io/reference/metrics-reference).
-Those important for RDI operations are listed in the table below:
+The metrics that are relevant for RDI operations are listed in the table below:
 
 | Metric Name | Metric Type | Metric Description | Alerting Recommendations |
 |-------------|-------------|-------------------|-------------------------|


### PR DESCRIPTION
Ticket: https://redislabs.atlassian.net/browse/RDSC-4241

IMPORTANT: Do not merge or delete before the merge of https://github.com/RedisLabs/redis-data-integration/pull/2288 and the release of the respectful RDI version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that change how users are instructed to access RDI metrics endpoints; no product code or runtime behavior is modified.
> 
> **Overview**
> Adds a new **“Accessing the metrics”** section that distinguishes VM vs Helm installs, documents the correct metrics endpoints for each component, and provides Helm `values.yaml` examples to enable Prometheus ServiceMonitors (with a note about discovery delays and a pre-`1.16.0` collector caveat).
> 
> Removes the old per-section endpoint callouts for collector/stream processor, and updates the operator metrics section to note most metrics are standard controller-runtime metrics while highlighting the RDI-specific ones.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99540b613dd46ba344c57fff881cfb35b5bf5ee4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->