### PR TITLE
DOC-5589: update RS/RC compat. info. for new cmds

### DIFF
--- a/content/commands/cluster-migration.md
+++ b/content/commands/cluster-migration.md
@@ -121,6 +121,12 @@ Cancel all migration tasks:
 CLUSTER MIGRATION CANCEL ALL
 ```
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Enterprise | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/delex.md
+++ b/content/commands/delex.md
@@ -87,6 +87,13 @@ Only one of the options can be specified.
 
 In 8.4, keys must be of type string when using one of the options above. If no options are specified, the key is removed regardless of its type.
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Enterprise | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/digest.md
+++ b/content/commands/digest.md
@@ -53,6 +53,12 @@ Get the hash digest for the value stored in the specified key as a hexadecimal s
 
 A hash digest is a fixed-size numerical representation of a string value, computed using the XXH3 hash algorithm. Redis uses this hash digest for efficient comparison operations without needing to compare the full string content. You can use these hash digests with the [SET]({{< relref "/commands/set" >}}) command's `IFDEQ` and `IFDNE` options, and also the [DELEX]({{< relref "/commands/delex" >}}) command's `IFDEQ` and `IFDNE` options.
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Enterprise | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/msetex.md
+++ b/content/commands/msetex.md
@@ -135,6 +135,12 @@ The `MSETEX` command supports a set of options that modify its behavior:
 
 </details>
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Enterprise | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"


### PR DESCRIPTION
New commands introduced in 8.4:

- CLUSTER MIGRATION
- DELEX
- DIGEST
- FT.HYBRID (added to [existing PR](https://github.com/redis/docs/pull/2210))
- MSETEX