### PR TITLE
Refactor certificate loading to use helper methods

### DIFF
--- a/content/develop/clients/dotnet/connect.md
+++ b/content/develop/clients/dotnet/connect.md
@@ -95,7 +95,7 @@ ConfigurationOptions options = new ConfigurationOptions
 
 options.CertificateSelection += delegate
 {
-    return new X509Certificate2("redis.pfx", "secret"); // use the password you specified for pfx file
+    return X509CertificateLoader.LoadPkcs12FromFile("redis.pfx", "secret"); // use the password you specified for pfx file
 };
 options.CertificateValidation += ValidateServerCertificate;
 
@@ -109,7 +109,7 @@ bool ValidateServerCertificate(
         return false;       
     }
 
-    var ca = new X509Certificate2("redis_ca.pem");
+    var ca = X509CertificateLoader.LoadCertificateFromFile("redis_ca.pem");
     bool verdict = (certificate.Issuer == ca.Subject);
     if (verdict) {
         return true;


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/fundamentals/syslib-diagnostics/syslib0057

SYSLIB0057: X509Certificate2 and X509Certificate constructors for binary and file content are obsolete

Reason for obsoletion

The affected APIs supported loading certificates in multiple formats. For example, new X509Certificate2(data) loaded a certificate from a byte[] called data. data could be one of any supported format, including X.509, PKCS7, or PKCS12/PFX.

While this method was easy to use, it created issues where user-supplied data was passed with a different format than intended. This might allow loading PKCS12 where only X.509 content was intended to be loaded. Or it might create interoperability issues from handling the data in different ways.