### PR TITLE
Add OOM indexing failures count metric

### DIFF
--- a/content/commands/info.md
+++ b/content/commands/info.md
@@ -570,7 +570,7 @@ _Redis Query Engine fields_
 *   `search_total_active_queries`: The total number of background queries currently being executed in the shard, excluding `FT.CURSOR READ`. <sup>[1](#tnote-1)</sup>
 *   `search_errors_indexing_failures`: The total number of indexing failures recorded across all indexes in the shard. <sup>[1](#tnote-1)</sup>
 *   `search_errors_for_index_with_max_failures`: The number of indexing failures in the index with the highest count of failures. <sup>[1](#tnote-1)</sup>
-*   `search_OOM_indexing_failures_indexes_count`: The number of indexes whose background indexing process failed due to out-of-memory (OOM) conditions. <sup>[1](#tnote-1)</sup>
+*   `search_OOM_indexing_failures_indexes_count`: The number of indexes whose background indexing process failed due to out-of-memory (OOM) conditions. <sup>[2](#tnote-2)</sup>
 
 1. <a name="tnote-1"></a> Available in RediSearch 2.6.
 2. <a name="tnote-2"></a> Available in RediSearch 2.8.


### PR DESCRIPTION
* Added `search_OOM_indexing_failures_indexes_count` to `content/commands/info.md`, documenting the number of indexes with background indexing failures due to out-of-memory (OOM) conditions.