### PR TITLE
DOC-5953 added stdlib.h to hiredis examples with includes

### DIFF
--- a/content/develop/clients/hiredis/_index.md
+++ b/content/develop/clients/hiredis/_index.md
@@ -40,6 +40,7 @@ connection. An explanation of the code follows the example.
 
 ```c
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <hiredis/hiredis.h>
 

--- a/content/develop/clients/hiredis/connect.md
+++ b/content/develop/clients/hiredis/connect.md
@@ -24,6 +24,7 @@ and port as its arguments, and returns a context object.
 
 ```c
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <hiredis/hiredis.h>
     .
@@ -77,6 +78,7 @@ sets the context callbacks. Note that you must also include the
 
 ```c
 #include <stdio.h>
+#include <stdlib.h>
 
 #include <hiredis/hiredis.h>
 #include <hiredis/async.h>


### PR DESCRIPTION
The hiredis examples need `stdlib.h` but it was strangely missing until now.