### PR TITLE
DEV: move query attributes to its own page

### DIFF
--- a/content/commands/ft.search.md
+++ b/content/commands/ft.search.md
@@ -682,7 +682,7 @@ Search for books with semantically similar title to _Planet Earth_. Return top 1
 <details open>
 <summary><b>Vector search with cluster optimization</b></summary>
 
-Search for books with titles that are semantically similar to _Planet Earth_ using cluster optimization. Each shard retrieves 60% of the requested results for improved performance in Redis cluster environments. See the [query attributes]({{< relref "/develop/ai/search-and-query/advanced-concepts/query_syntax#query-attributes" >}}) reference page for more information.
+Search for books with titles that are semantically similar to _Planet Earth_ using cluster optimization. Each shard retrieves 60% of the requested results for improved performance in Redis cluster environments. See the [query attributes]({{< relref "/develop/ai/search-and-query/advanced-concepts/query_attributes" >}}) reference page for more information.
 
 {{< highlight bash >}}
 127.0.0.1:6379> FT.SEARCH books-idx "*=>[KNN 100 @title_embedding $query_vec]=>{$SHARD_K_RATIO: 0.6; $YIELD_DISTANCE_AS: title_score}" PARAMS 2 query_vec <"Planet Earth" embedding BLOB> SORTBY title_score DIALECT 2

--- a/content/develop/ai/search-and-query/advanced-concepts/aggregations-syntax.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/aggregations-syntax.md
@@ -12,7 +12,7 @@ categories:
 description: Order of operations for the FT.AGGREGATE command
 linkTitle: Aggregation syntax
 title: FT.AGGREGATE order of operations
-weight: 2
+weight: 4
 ---
 
 ## Overview

--- a/content/develop/ai/search-and-query/advanced-concepts/autocomplete.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/autocomplete.md
@@ -14,7 +14,7 @@ categories:
 description: Learn how to use the autocomplete feature of Redis for efficient prefix-based suggestion retrieval.
 linkTitle: Autocomplete
 title: Autocomplete with Redis
-weight: 3
+weight: 7
 ---
 
 ## Overview

--- a/content/develop/ai/search-and-query/advanced-concepts/chinese.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/chinese.md
@@ -14,7 +14,7 @@ categories:
 description: Chinese support for searching and querying in Redis Open Source
 linkTitle: Chinese
 title: Chinese support
-weight: 15
+weight: 55
 ---
 
 Support for adding documents in Chinese is available starting at version 0.99.0.

--- a/content/develop/ai/search-and-query/advanced-concepts/dialects.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/dialects.md
@@ -14,7 +14,7 @@ categories:
 description: Learn how to use query dialects
 linkTitle: Query dialects
 title: Query dialects
-weight: 5
+weight: 16
 ---
 
 Redis Open Source currently supports four query dialects for use with the [`FT.SEARCH`]({{< relref "/commands/ft.search/" >}}), [`FT.AGGREGATE`]({{< relref "/commands/ft.aggregate/" >}}), and other Redis Query Engine commands.

--- a/content/develop/ai/search-and-query/advanced-concepts/escaping.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/escaping.md
@@ -14,7 +14,7 @@ categories:
 description: Controlling text tokenization and escaping
 linkTitle: Tokenization
 title: Tokenization
-weight: 4
+weight: 10
 ---
 
 Full-text search works by comparing words, URLs, numbers, and other elements of the query

--- a/content/develop/ai/search-and-query/advanced-concepts/expiration.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/expiration.md
@@ -12,7 +12,7 @@ categories:
 description: How the Redis Query Engine handles expiring keys and hash fields
 linkTitle: Key and field expiration
 title: Key and field expiration behavior
-weight: 8
+weight: 34
 ---
 
 The Redis Query Engine behavior with expiring keys and hash fields has been enhanced starting with Redis 8 to provide more consistent and predictable results.

--- a/content/develop/ai/search-and-query/advanced-concepts/geo.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/geo.md
@@ -16,7 +16,7 @@ description: Learn how to use geospatial fields and perform geospatial queries i
 linkTitle: Geospatial
 math: true
 title: Geospatial
-weight: 14
+weight: 49
 ---
 
 Redis Query Engine supports geospatial data. This feature

--- a/content/develop/ai/search-and-query/advanced-concepts/highlight.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/highlight.md
@@ -14,7 +14,7 @@ categories:
 description: Highlighting full-text results
 linkTitle: Highlighting
 title: Highlighting
-weight: 7
+weight: 31
 ---
 
 Redis Open Source uses advanced algorithms for highlighting and summarizing, which enable only the relevant portions of a document to appear in response to a search query. This feature allows users to immediately understand the relevance of a document to their search criteria, typically highlighting the matching terms in bold text.

--- a/content/develop/ai/search-and-query/advanced-concepts/phonetic_matching.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/phonetic_matching.md
@@ -14,7 +14,7 @@ categories:
 description: Details about phonetic matching capabilities
 linkTitle: Phonetic
 title: Phonetic matching
-weight: 14
+weight: 52
 ---
 
 Phonetic matching, for example "Jon" vs. "John", allows searching for terms based on their pronunciation. This capability can be a useful tool when searching for names of people.
@@ -23,7 +23,7 @@ Phonetic matching is based on the use of a phonetic algorithm. A phonetic algori
 
 As of v1.4, Redis Query Engine, which is included in Redis Open Source, provides phonetic matching of text fields specified with the `PHONETIC` attribute. This causes the terms in such fields to be indexed both by their textual value as well as their phonetic approximation.
 
-Performing a search on `PHONETIC` fields will, by default, also return results for phonetically similar terms. This behavior can be controlled with the [`$phonetic` query attribute]({{< relref "/develop/ai/search-and-query/query/#query-attributes" >}}).
+Performing a search on `PHONETIC` fields will, by default, also return results for phonetically similar terms. This behavior can be controlled with the [`$phonetic` query attribute]({{< relref "/develop/ai/search-and-query/advanced-concepts/query_attributes" >}}).
 
 ## Phonetic algorithms support
 

--- a/content/develop/ai/search-and-query/advanced-concepts/query_attributes.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/query_attributes.md
@@ -1,0 +1,40 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Learn how to use query attributes
+linkTitle: Query attributes
+title: Query attributes
+weight: 22
+---
+
+## Query attributes
+
+As of v1.2.0, you can apply specific query modifying attributes to specific clauses of the query.
+
+The syntax is `(foo bar) => { $attribute: value; $attribute:value; ...}`:
+
+```
+(foo bar) => { $weight: 2.0; $slop: 1; $inorder: true; }
+~(bar baz) => { $weight: 0.5; }
+```
+
+The supported attributes are:
+
+1. **$weight**: determines the weight of the sub-query or token in the overall ranking on the result (default: 1.0).
+2. **$slop**: determines the maximum allowed slop (space between terms) in the query clause (default: 0).
+3. **$inorder**: whether or not the terms in a query clause must appear in the same order as in the query. This is usually set alongside with `$slop` (default: false).
+4. **$phonetic**: whether or not to perform phonetic matching (default: true). Note: setting this attribute to true for fields which were not created as `PHONETIC` will produce an error.
+
+As of v2.6.1, the query attributes syntax supports these additional attributes:
+
+* **$yield_distance_as**: specifies the distance field name for clauses that yield some distance metric. This is used for later sorting and/or returning. It is currently supported for vector queries only (both KNN and range).
+* **$shard_k_ratio**: controls how many results each shard retrieves relative to the requested top_k in cluster setups. Value range: 0.1 - 1.0 (default: 1.0). Only applicable to vector KNN queries in Redis cluster environments. See [Cluster-specific query parameters]({{< relref "develop/ai/search-and-query/vectors#cluster-specific-query-parameters" >}}) for detailed information.
+* **vector query params**: pass optional parameters for [vector queries]({{< relref "develop/ai/search-and-query/vectors#querying-vector-fields" >}}) in key-value format.

--- a/content/develop/ai/search-and-query/advanced-concepts/query_syntax.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/query_syntax.md
@@ -11,12 +11,10 @@ categories:
 - oss
 - kubernetes
 - clients
-description: 'Learn how to use query syntax
-
-  '
+description: Learn how to use query syntax
 linkTitle: Query syntax
 title: Query syntax
-weight: 5
+weight: 19
 ---
 
 {{< note >}}The query syntax that RediSearch uses has improved over time,
@@ -368,30 +366,6 @@ The maximum LD for fuzzy matching is 3.
 As of v1.1.0, you can use a special query to retrieve all the documents in an index. This is meant mostly for the aggregation engine. You can call it by specifying only a single star sign as the query string, in other words, `FT.SEARCH myIndex *`.
 
 You can't combine this with any other filters, field modifiers, or anything inside the query. It is technically possible to use the deprecated `FILTER` and `GEOFILTER` request parameters outside the query string in conjunction with a wildcard, but this makes the wildcard meaningless and only hurts performance.
-
-## Query attributes
-
-As of v1.2.0, you can apply specific query modifying attributes to specific clauses of the query.
-
-The syntax is `(foo bar) => { $attribute: value; $attribute:value; ...}`:
-
-```
-(foo bar) => { $weight: 2.0; $slop: 1; $inorder: true; }
-~(bar baz) => { $weight: 0.5; }
-```
-
-The supported attributes are:
-
-1. **$weight**: determines the weight of the sub-query or token in the overall ranking on the result (default: 1.0).
-2. **$slop**: determines the maximum allowed slop (space between terms) in the query clause (default: 0).
-3. **$inorder**: whether or not the terms in a query clause must appear in the same order as in the query. This is usually set alongside with `$slop` (default: false).
-4. **$phonetic**: whether or not to perform phonetic matching (default: true). Note: setting this attribute to true for fields which were not created as `PHONETIC` will produce an error.
-
-As of v2.6.1, the query attributes syntax supports these additional attributes:
-
-* **$yield_distance_as**: specifies the distance field name for clauses that yield some distance metric. This is used for later sorting and/or returning. It is currently supported for vector queries only (both KNN and range).
-* **$shard_k_ratio**: controls how many results each shard retrieves relative to the requested top_k in cluster setups. Value range: 0.1 - 1.0 (default: 1.0). Only applicable to vector KNN queries in Redis cluster environments. See [Cluster-specific query parameters]({{< relref "develop/ai/search-and-query/vectors#cluster-specific-query-parameters" >}}) for detailed information.
-* **vector query params**: pass optional parameters for [vector queries]({{< relref "develop/ai/search-and-query/vectors#querying-vector-fields" >}}) in key-value format.
 
 ## A few query examples
 

--- a/content/develop/ai/search-and-query/advanced-concepts/scoring.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/scoring.md
@@ -14,7 +14,7 @@ categories:
 description: Full-text scoring functions
 linkTitle: Scoring
 title: Scoring documents
-weight: 8
+weight: 37
 ---
 
 When searching, documents are scored based on their relevance to the query. The score is a floating point number between 0.0 and 1.0, where 1.0 is the highest score. The score is returned as part of the search results and can be used to sort the results.

--- a/content/develop/ai/search-and-query/advanced-concepts/sorting.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/sorting.md
@@ -14,7 +14,7 @@ categories:
 description: Support for sorting query results
 linkTitle: Sorting
 title: Sorting by indexed fields
-weight: 5
+weight: 25
 ---
 
 As of RediSearch 0.15, you can bypass the scoring function mechanism and order search results by the value of different document attributes (fields) directly, even if the sorting field is not used by the query. For example, you can search for first name and sort by last name.

--- a/content/develop/ai/search-and-query/advanced-concepts/spellcheck.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/spellcheck.md
@@ -14,7 +14,7 @@ categories:
 description: Query spelling correction support
 linkTitle: Spellchecking
 title: Spellchecking
-weight: 13
+weight: 46
 ---
 
 Query spelling correction provides suggestions for misspelled search terms. For example, the term 'reids' may be a misspelled version of 'redis'.

--- a/content/develop/ai/search-and-query/advanced-concepts/stemming.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/stemming.md
@@ -14,7 +14,7 @@ categories:
 description: Stemming support
 linkTitle: Stemming
 title: Stemming
-weight: 10
+weight: 40
 ---
 
 RediSearch supports stemming - that is adding the base form of a word to the index. This allows the query for "`hiring`" to also return results for "`hire`" and "`hired`", for example.

--- a/content/develop/ai/search-and-query/advanced-concepts/stopwords.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/stopwords.md
@@ -15,7 +15,7 @@ categories:
 description: Stop words support
 linkTitle: Stop words
 title: Stop words
-weight: 4
+weight: 13
 ---
 
 Redis Open Source has a default list of [stop words](https://en.wikipedia.org/wiki/Stop_words). These are words that are usually so common that they do not add much information to search, but take up a lot of space and CPU time in the index. 

--- a/content/develop/ai/search-and-query/advanced-concepts/synonyms.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/synonyms.md
@@ -14,7 +14,7 @@ categories:
 description: Details on synonym support with Redis Open Source
 linkTitle: Synonym
 title: Synonym support
-weight: 11
+weight: 43
 ---
 
 Redis Open Source supports synonyms. That is, searching for synonym words defined by the synonym data structure.

--- a/content/develop/ai/search-and-query/advanced-concepts/tags.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/tags.md
@@ -15,7 +15,7 @@ categories:
 description: How to use tag fields for exact match searches and high-performance filtering
 linkTitle: Tag fields
 title: Tag fields
-weight: 6
+weight: 28
 ---
 
 Tag fields provide exact match search capabilities with high performance and memory efficiency. Use tag fields when you need to filter documents by specific values without the complexity of full-text search tokenization.

--- a/content/develop/ai/search-and-query/vectors/_index.md
+++ b/content/develop/ai/search-and-query/vectors/_index.md
@@ -303,7 +303,7 @@ FT.SEARCH documents "*=>[KNN 10 @doc_embedding $BLOB]" PARAMS 2 BLOB "\x12\xa9\x
 **Use query attributes**
 
 Alternatively, as of v2.6, `<vector_query_params>` and `<distance_field>` name can be specified in runtime
-[query attributes]({{< relref "/develop/ai/search-and-query/advanced-concepts/query_syntax" >}}#query-attributes) as shown below.
+[query attributes]({{< relref "/develop/ai/search-and-query/advanced-concepts/query_attributes" >}}) as shown below.
 
 ```
 [KNN <top_k> @<vector_field> $<vector_blob_param>]=>{$yield_distance_as: <distance_field>}
@@ -497,7 +497,7 @@ Assign a custom name to the distance field (`vector_distance`) and then sort usi
 FT.SEARCH documents "*=>[KNN 10 @doc_embedding $BLOB AS vector_distance]" PARAMS 2 BLOB "\x12\xa9\xf5\x6c" SORTBY vector_distance DIALECT 2
 ```
 
-Use [query attributes]({{< relref "develop/ai/search-and-query/advanced-concepts/query_syntax#query-attributes" >}}) syntax to specify optional parameters and the distance field name:
+Use [query attributes]({{< relref "develop/ai/search-and-query/advanced-concepts/query_attributes" >}}) syntax to specify optional parameters and the distance field name:
 
 ```
 FT.SEARCH documents "*=>[KNN 10 @doc_embedding $BLOB]=>{$EF_RUNTIME: $EF; $YIELD_DISTANCE_AS: vector_distance}" PARAMS 4 EF 150 BLOB "\x12\xa9\xf5\x6c" SORTBY vector_distance DIALECT 2


### PR DESCRIPTION
This PR does not contain new content. It simply moves the query attributes section of the **Search concepts** page to its own page. It also fixes links to that section and rejiggers the weights to leave some space for future content.