### PR TITLE
Update to accurate description of total_indexing_time from ft.info

### DIFF
--- a/content/commands/ft.info.md
+++ b/content/commands/ft.info.md
@@ -79,7 +79,7 @@ is the name of the given index. You must first create the index using [`FT.CREAT
 | Statistic | Definition |
 |:---       |:---        |
 | `hash_indexing_failures` | The number of failures encountered during indexing. |
-| `total_indexing_time` | The total time taken for indexing in seconds. |
+| `total_indexing_time` | The cumulative wall-clock time spent indexing documents in ms. |
 | `indexing` | Indicates whether the index is currently being generated. |
 | `percent_indexed` | The percentage of the index that has been successfully generated (1 means 100%). |
 | `number_of_uses` | The number of times the index has been used. |


### PR DESCRIPTION
Bug: total indexing time is in ms not seconds as current docs show.

Current:
<img width="664" height="192" alt="image" src="https://github.com/user-attachments/assets/6293cdb0-844f-40df-949a-25fc16119ccb" />

Basic test:

(didn't actually take 107/60 ~ 2 minutes to index this data which would be the case if this field were seconds)

<img width="589" height="553" alt="image" src="https://github.com/user-attachments/assets/25147b04-b28d-447e-abe4-9becf9d45cb9" />

From source code this field is cumulative wall-clock time in ms:
<img width="626" height="1666" alt="image" src="https://github.com/user-attachments/assets/fd83c1c4-a26c-49f1-a1de-1125a7f20c8a" />


