### PR TITLE
Fix sortby arg typo

### DIFF
--- a/content/commands/ft.aggregate.md
+++ b/content/commands/ft.aggregate.md
@@ -401,7 +401,7 @@ FT.AGGREGATE idx "@url:\"about.html\""
     APPLY "day(@timestamp)" AS day
     GROUPBY 2 @day @country
       REDUCE count 0 AS num_visits
-    SORTBY 4 @day
+    SORTBY 1 @day
 {{< /highlight >}}
 </details>
 


### PR DESCRIPTION
The `sortby` count looks from in the `about.html` example.