### PR TITLE
INT: fix RDI build error

### DIFF
--- a/content/integrate/redis-data-integration/release-notes/rdi-1-15-1.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-15-1.md
@@ -6,9 +6,9 @@ categories:
 - operate
 - rs
 description: |
-	  Fixes support package generation and masking to simplify troubleshooting and log collection.
-	  Improves processor throughput during initial sync via parallel processing and new stream tuning parameters.
-	  Adds an advanced configuration option to pass custom Java options to the Debezium collector.
+    Fixes support package generation and masking to simplify troubleshooting and log collection.
+    Improves processor throughput during initial sync via parallel processing and new stream tuning parameters.
+    Adds an advanced configuration option to pass custom Java options to the Debezium collector.
 linkTitle: 1.15.1 (November 2025)
 toc: 'true'
 weight: 975


### PR DESCRIPTION
There were tab characters in the frontmatter, which caused build to fail. This PR fixes the issue.