### PR TITLE
docs: fix typo in ZRANK command description

### DIFF
--- a/content/develop/data-types/sorted-sets.md
+++ b/content/develop/data-types/sorted-sets.md
@@ -231,7 +231,7 @@ You'll see that [`ZADD`]({{< relref "/commands/zadd" >}}) returns 0 when the mem
 
 * [`ZADD`]({{< relref "/commands/zadd" >}}) adds a new member and associated score to a sorted set. If the member already exists, the score is updated.
 * [`ZRANGE`]({{< relref "/commands/zrange" >}}) returns members of a sorted set, sorted within a given range.
-* [`ZRANK`]({{< relref "/commands/zrank" >}}) returns the rank of the provided member, assuming the sorted is in ascending order.
+* [`ZRANK`]({{< relref "/commands/zrank" >}}) returns the rank of the provided member, assuming the sorted set is in ascending order.
 * [`ZREVRANK`]({{< relref "/commands/zrevrank" >}}) returns the rank of the provided member, assuming the sorted set is in descending order.
  
 See the [complete list of sorted set commands]({{< relref "/commands/" >}}?group=sorted-set).


### PR DESCRIPTION
Simple fix of a minor typo in the "Basic commands" section of the "Sorted sets" page (see https://redis.io/docs/latest/develop/data-types/sorted-sets/):
> [ZRANK](https://redis.io/docs/latest/commands/zrank/) returns the rank of the provided member, assuming the sorted is in ascending order

to

> [ZRANK](https://redis.io/docs/latest/commands/zrank/) returns the rank of the provided member, assuming the sorted **set** is in ascending order