### PR TITLE
DOC-6097 rename failover to Client-side geographic failover

### DIFF
--- a/content/develop/clients/failover.md
+++ b/content/develop/clients/failover.md
@@ -10,8 +10,8 @@ categories:
 - kubernetes
 - clients
 description: Improve reliability using the failover/failback features of client libraries.
-linkTitle: Failover/failback
-title: Failover and failback
+linkTitle: Geographic failover
+title: Client-side geographic failover
 topics:
 - failover
 - failback
@@ -25,7 +25,7 @@ weight: 50
 ---
 
 Some Redis client libraries support
-[failover and failback](https://en.wikipedia.org/wiki/Failover)
+[Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. Use this page
 to get a general overview of the concepts and then see the documentation for
 your client library to learn how to configure it for failover and failback:

--- a/content/develop/clients/jedis/failover.md
+++ b/content/develop/clients/jedis/failover.md
@@ -9,9 +9,9 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Improve reliability using the failover/failback features of Jedis.
-linkTitle: Failover/failback
-title: Failover and failback
+description: Improve reliability using the failover features of Jedis.
+linkTitle: Geographic failover
+title: Client-side geographic failover
 topics:
 - failover
 - failback
@@ -24,10 +24,10 @@ scope: [client-specific, implementation]
 weight: 50
 ---
 
-Jedis supports [failover and failback](https://en.wikipedia.org/wiki/Failover)
+Jedis supports [Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. This page explains
-how to configure Jedis for failover and failback. For an overview of the concepts,
-see the main [Failover/failback]({{< relref "/develop/clients/failover" >}}) page.
+how to configure Jedis for failover. For an overview of the concepts,
+see the main [Client-side geographic failover]({{< relref "/develop/clients/failover" >}}) page.
 
 ## Failover configuration
 

--- a/content/develop/clients/redis-py/failover.md
+++ b/content/develop/clients/redis-py/failover.md
@@ -9,9 +9,9 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Improve reliability using the failover/failback features of redis-py.
-linkTitle: Failover/failback
-title: Failover and failback
+description: Improve reliability using the failover features of redis-py.
+linkTitle: Geographic failover
+title: Client-side geographic failover
 topics:
 - failover
 - failback
@@ -25,10 +25,10 @@ weight: 65
 bannerText: This feature is currently in preview and may be subject to change.
 ---
 
-redis-py supports [failover and failback](https://en.wikipedia.org/wiki/Failover)
+redis-py supports [Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. This page explains
-how to configure redis-py for failover and failback. For an overview of the concepts,
-see the main [Failover/failback]({{< relref "/develop/clients/failover" >}}) page.
+how to configure redis-py for failover. For an overview of the concepts,
+see the main [Client-side geographic failover]({{< relref "/develop/clients/failover" >}}) page.
 
 ## Failover configuration
 


### PR DESCRIPTION
A new name has been chosen for this feature, so this simply updates the titles and link titles (generally, referring to it just as "failover" in the text makes more sense).