### PR TITLE
Update streams.md with XREADGROUP behavior details

### DIFF
--- a/content/operate/rs/databases/active-active/develop/data-types/streams.md
+++ b/content/operate/rs/databases/active-active/develop/data-types/streams.md
@@ -300,8 +300,8 @@ Unlike XREAD, XREADGOUP will never skip stream entries.
 
 In traffic redirection, XREADGROUP may return entries that have been read but not acknowledged. It may also even return entries that have already been acknowledged.
 
-When entries are added from multiple regions, Redis guarantees ordered entries in the reply of a single read command (`XREAD`, `XREADGROUP`, `XRANGE`). However, ordered IDs are not guaranteed for a sequence of read commands.
-For example, two subsequent `XREADGROUP GROUP group consumer COUNT 1 STREAMS key >` may reply with descreasing IDs.
+When entries are added from multiple regions, Redis guarantees ordered entries in the reply of a single read command (`XREAD`, `XREADGROUP`, or `XRANGE`). However, ordered IDs are not guaranteed for a sequence of read commands.
+For example, two subsequent `XREADGROUP GROUP group consumer COUNT 1 STREAMS key >` commands may reply with decreasing IDs.
 
 ## Summary
 


### PR DESCRIPTION
Clarify the behavior of XREADGROUP in Active-Active streams, including message order guarantees.