### PR TITLE
DOC-6048 updated Jedis examples with new connection API

### DIFF
--- a/content/develop/clients/jedis/_index.md
+++ b/content/develop/clients/jedis/_index.md
@@ -22,6 +22,17 @@ a more advanced Java client that also supports asynchronous and reactive connect
 The sections below explain how to install `Jedis` and connect your application
 to a Redis database.
 
+{{< note >}}Jedis 7.2.0 introduced a new client connection API:
+
+| New API class | Replaces | Use case |
+| :-- | :-- | :-- |
+| `RedisClient` | `UnifiedJedis`, `JedisPool`, `JedisPooled` | Single connection (with connection pooling) |
+| `RedisClusterClient` | `JedisCluster` | Redis Cluster connections |
+| `RedisSentinelClient` | `JedisSentinelPool` | Redis Sentinel connections |
+
+The old client classes are now considered deprecated.
+{{< /note >}}
+
 `Jedis` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
 
 ## Install
@@ -34,7 +45,7 @@ To include `Jedis` as a dependency in your application, edit the dependency file
   <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>7.0.0</version>
+      <version>7.2.0</version>
   </dependency>
   ```
 
@@ -46,7 +57,7 @@ To include `Jedis` as a dependency in your application, edit the dependency file
   }
   //...
   dependencies {
-      implementation 'redis.clients:jedis:7.0.0'
+      implementation 'redis.clients:jedis:7.2.0'
       //...
   }
   ```

--- a/content/develop/clients/jedis/amr.md
+++ b/content/develop/clients/jedis/amr.md
@@ -133,7 +133,7 @@ TokenAuthConfig authConfig = EntraIDTokenAuthConfigBuilder.builder()
 When you have created your `TokenAuthConfig` instance, you are ready to
 connect to AMR.
 The example below shows how to include the `TokenAuthConfig` details in a
-`JedisClientConfig` instance and use it with the `UnifiedJedis` connection.
+`JedisClientConfig` instance and use it with the `RedisClient` connection.
 The connection uses
 [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security),
 which is recommended and enabled by default for managed identities. See
@@ -159,7 +159,7 @@ JedisClientConfig config = DefaultJedisClientConfig.builder()
         .ssl(true).sslSocketFactory(sslFactory)
         .build();
 
-UnifiedJedis jedis = new UnifiedJedis(
+RedisClient jedis = new RedisClient(
     new HostAndPort("<host>", <port>),
     config
 );

--- a/content/develop/clients/jedis/connect.md
+++ b/content/develop/clients/jedis/connect.md
@@ -15,17 +15,28 @@ title: Connect to the server
 weight: 2
 ---
 
+{{< note >}}Jedis 7.2.0 introduced a new client connection API:
+
+| New API class | Replaces | Use case |
+| :-- | :-- | :-- |
+| `RedisClient` | `UnifiedJedis`, `JedisPool`, `JedisPooled` | Single connection (with connection pooling) |
+| `RedisClusterClient` | `JedisCluster` | Redis Cluster connections |
+| `RedisSentinelClient` | `JedisSentinelPool` | Redis Sentinel connections |
+
+The old client classes are now considered deprecated.
+{{< /note >}}
+
 ## Basic connection
 
 The following code opens a basic connection to a local Redis server:
 
 ```java
 package org.example;
-import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.RedisClient;
 
 public class Main {
     public static void main(String[] args) {
-        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+        RedisClient jedis = new RedisClient("redis://localhost:6379");
 
         // Code that interacts with Redis...
 
@@ -51,10 +62,10 @@ System.out.println(res2); // Deimos
 
 ### Connect to a Redis cluster
 
-To connect to a Redis cluster, use `JedisCluster`. 
+To connect to a Redis cluster, use `RedisClusterClient`. 
 
 ```java
-import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.RedisClusterClient;
 import redis.clients.jedis.HostAndPort;
 
 //...
@@ -62,7 +73,7 @@ import redis.clients.jedis.HostAndPort;
 Set<HostAndPort> jedisClusterNodes = new HashSet<HostAndPort>();
 jedisClusterNodes.add(new HostAndPort("127.0.0.1", 7379));
 jedisClusterNodes.add(new HostAndPort("127.0.0.1", 7380));
-JedisCluster jedis = new JedisCluster(jedisClusterNodes);
+RedisClusterClient jedis = new RedisClusterClient(jedisClusterNodes);
 ```
 
 ### Connect to your production Redis with TLS
@@ -118,7 +129,7 @@ public class Main {
                 .password("secret!") // use your Redis password
                 .build();
 
-        JedisPooled jedis = new JedisPooled(address, config);
+        RedisClient jedis = new RedisClient(address, config);
         jedis.set("foo", "bar");
         System.out.println(jedis.get("foo")); // prints bar
     }
@@ -184,7 +195,7 @@ DefaultJedisClientConfig config = DefaultJedisClientConfig
 
 CacheConfig cacheConfig = CacheConfig.builder().maxSize(1000).build();
 
-UnifiedJedis client = new UnifiedJedis(endpoint, config, cacheConfig);
+RedisClient client = new RedisClient(endpoint, config, cacheConfig);
 ```
 
 Once you have connected, the usual Redis commands will work transparently
@@ -269,10 +280,8 @@ The client will also flush the cache automatically
 if any connection (including one from a connection pool)
 is disconnected.
 
-## Connect with a connection pool
+## Configure a connection pool
 
-For production usage, you should use a connection pool to manage
-connections rather than opening and closing connections individually.
 A connection pool maintains several open connections and reuses them
 efficiently. When you open a connection from a pool, the pool allocates
 one of its open connections. When you subsequently close the same connection,
@@ -282,49 +291,9 @@ See
 [Connection pools and multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}})
 for more information.
 
-Use the following code to connect with a connection pool:
-
-```java
-package org.example;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.JedisPool;
-
-public class Main {
-    public static void main(String[] args) {
-        JedisPool pool = new JedisPool("localhost", 6379);
-
-        try (Jedis jedis = pool.getResource()) {
-            // Store & Retrieve a simple string
-            jedis.set("foo", "bar");
-            System.out.println(jedis.get("foo")); // prints bar
-            
-            // Store & Retrieve a HashMap
-            Map<String, String> hash = new HashMap<>();;
-            hash.put("name", "John");
-            hash.put("surname", "Smith");
-            hash.put("company", "Redis");
-            hash.put("age", "29");
-            jedis.hset("user-session:123", hash);
-            System.out.println(jedis.hgetAll("user-session:123"));
-            // Prints: {name=John, surname=Smith, company=Redis, age=29}
-        }
-    }
-}
-```
-
-Because adding a `try-with-resources` block for each command can be cumbersome, consider using `JedisPooled` as an easier way to pool connections. `JedisPooled`, added in Jedis version 4.0.0, provides capabilities similar to `JedisPool` but with a more straightforward API.
-
-```java
-import redis.clients.jedis.JedisPooled;
-
-//...
-
-JedisPooled jedis = new JedisPooled("localhost", 6379);
-jedis.set("foo", "bar");
-System.out.println(jedis.get("foo")); // prints "bar"
-```
-
-A connection pool holds a specified number of connections, creates more connections when necessary, and terminates them when they are no longer needed.
+From Jedis 7.2.0, the `RedisClient` class provides connection pooling automatically,
+but it's important to configure the connection pool correctly to get the best performance. 
+Each pool holds a specified number of connections, creates more connections when necessary, and terminates them when they are no longer needed.
 
 Here is a simplified connection lifecycle in a pool:
 
@@ -339,8 +308,8 @@ Here is a simplified connection lifecycle in a pool:
 7. The connection becomes evictable if the number of connections is greater than `minIdle`. 
 8. The connection is ready to be closed.
 
-It's important to configure the connection pool correctly. 
-Use `GenericObjectPoolConfig` from [Apache Commons Pool2](https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/GenericObjectPoolConfig.html).
+Pass a `ConnectionPoolConfig` object to the `RedisClient` constructor to configure the pool. 
+(`ConnectionPoolConfig` is a wrapper around `GenericObjectPoolConfig` from [Apache Commons Pool2](https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/GenericObjectPoolConfig.html)).
 
 ```java
 ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
@@ -364,9 +333,7 @@ poolConfig.setTestWhileIdle(true);
 // controls the period between checks for idle connections in the pool
 poolConfig.setTimeBetweenEvictionRuns(Duration.ofSeconds(1));
 
-// JedisPooled does all hard work on fetching and releasing connection to the pool
-// to prevent connection starvation
-JedisPooled jedis = new JedisPooled(poolConfig, "localhost", 6379);
+RedisClient jedis = new RedisClient(poolConfig, "localhost", 6379);
 ```
 
 ### Retrying a command after a connection failure
@@ -380,7 +347,7 @@ shows a retry loop that uses a simple
 strategy:
 
 ```java
-JedisPooled jedis = new JedisPooled(
+RedisClient jedis = new RedisClient(
     new HostAndPort("localhost", 6379),
     clientConfig,
     poolConfig

--- a/content/develop/clients/jedis/error-handling.md
+++ b/content/develop/clients/jedis/error-handling.md
@@ -67,7 +67,7 @@ Catch specific exceptions that represent unrecoverable errors and re-throw them 
 for a full description):
 
 ```java
-try (Jedis jedis = jedisPool.getResource()) {
+try (RedisClient jedis = new RedisClient()) {
     String result = jedis.get(key);
 } catch (JedisDataException e) {
     // This indicates a bug in our code
@@ -82,7 +82,7 @@ Catch specific errors and fall back to an alternative, where possible (see
 for a full description):
 
 ```java
-try (Jedis jedis = jedisPool.getResource()) {
+try (RedisClient jedis = new RedisClient()) {
     String cachedValue = jedis.get(key);
     if (cachedValue != null) {
         return cachedValue;
@@ -107,7 +107,7 @@ int maxRetries = 3;
 int retryDelay = 100;
 
 for (int attempt = 0; attempt < maxRetries; attempt++) {
-    try (Jedis jedis = jedisPool.getResource()) {
+    try (RedisClient jedis = new RedisClient()) {
         return jedis.get(key);
     } catch (JedisConnectionException e) {
         if (attempt < maxRetries - 1) {
@@ -132,7 +132,7 @@ Log non-critical errors and continue (see
 for a full description):
 
 ```java
-try (Jedis jedis = jedisPool.getResource()) {
+try (RedisClient jedis = new RedisClient()) {
     jedis.setex(key, 3600, value);
 } catch (JedisConnectionException e) {
     logger.warn("Failed to cache " + key + ", continuing without cache");

--- a/content/develop/clients/jedis/produsage.md
+++ b/content/develop/clients/jedis/produsage.md
@@ -49,7 +49,7 @@ and closing connections has a performance overhead.
 Use [connection pooling]({{< relref "/develop/clients/pools-and-muxing" >}})
 to avoid the overhead of opening and closing connections without having to
 write your own code to cache and reuse open connections. See
-[Connect with a connection pool]({{< relref "/develop/clients/jedis/connect#connect-with-a-connection-pool" >}})
+[Configure a connection pool]({{< relref "/develop/clients/jedis/connect#configure-a-connection-pool" >}})
 to learn how to use this technique with Jedis.
 
 ### Connection retries
@@ -76,14 +76,14 @@ connection or issuing a command, it can end up hanging indefinitely.
 You can prevent this from happening by setting timeouts for socket
 reads and writes and for opening connections.
 
-To set a timeout for a connection, use the `JedisPooled` or `JedisPool` constructor with the `timeout` parameter, or use `JedisClientConfig` with the `socketTimeout` and `connectionTimeout` parameters.
+To set a timeout for a connection, use the `RedisClient` constructor with the `timeout` parameter, or use `JedisClientConfig` with the `socketTimeout` and `connectionTimeout` parameters.
 (The socket timeout is the maximum time allowed for reading or writing data while executing a
 command. The connection timeout is the maximum time allowed for establishing a new connection.)
 
 ```java
 HostAndPort hostAndPort = new HostAndPort("localhost", 6379);
 
-JedisPooled jedisWithTimeout = new JedisPooled(hostAndPort,
+RedisClient jedisWithTimeout = new RedisClient(hostAndPort,
     DefaultJedisClientConfig.builder()
         .socketTimeoutMillis(5000)  // set timeout to 5 seconds
         .connectionTimeoutMillis(5000) // set connection timeout to 5 seconds
@@ -100,7 +100,7 @@ every few seconds). You can do this using a simple
 [`PING`]({{< relref "/commands/ping" >}}) command:
 
 ```java
-try (Jedis jedis = jedisPool.getResource()) {
+try (RedisClient jedis = new RedisClient()) {
   if (! "PONG".equals(jedis.ping())) {
     // Report problem.
   }
@@ -120,20 +120,22 @@ The Jedis exception hierarchy is rooted on `JedisException`, which implements
 `RuntimeException`. All exceptions in the hierarchy are therefore unchecked
 exceptions.
 
-```
-JedisException
-├── JedisDataException
-│   ├── JedisRedirectionException
-│   │   ├── JedisMovedDataException
-│   │   └── JedisAskDataException
-│   ├── AbortedTransactionException
-│   ├── JedisAccessControlException
-│   └── JedisNoScriptException
-├── JedisClusterException
-│   ├── JedisClusterOperationException
-│   ├── JedisConnectionException
-│   └── JedisValidationException
-└── InvalidURIException
+```hierarchy {type="exception"}
+"JedisException":
+    _meta:
+        description: "Base class for all Jedis exceptions"
+    "JedisDataException":
+        "JedisRedirectionException":
+            "JedisMovedDataException":
+            "JedisAskDataException":
+        "AbortedTransactionException":
+        "JedisAccessControlException":
+        "JedisNoScriptException":
+    "JedisClusterException":
+        "JedisClusterOperationException":
+        "JedisConnectionException":
+        "JedisValidationException":
+    "InvalidURIException":
 ```
 
 #### General exceptions

--- a/content/develop/clients/jedis/vecsearch.md
+++ b/content/develop/clients/jedis/vecsearch.md
@@ -63,7 +63,7 @@ dependencies to your `pom.xml` file:
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>6.1.0</version>
+    <version>7.2.0</version>
 </dependency>
 <dependency>
     <groupId>ai.djl.huggingface</groupId>
@@ -86,7 +86,7 @@ If you are using [Gradle](https://gradle.org/), add the following
 dependencies to your `build.gradle` file:
 
 ```bash
-implementation 'redis.clients:jedis:6.1.0'
+implementation 'redis.clients:jedis:7.2.0'
 implementation 'ai.djl.huggingface:tokenizers:0.33.0'
 implementation 'ai.djl.pytorch:pytorch-model-zoo:0.33.0'
 implementation 'ai.djl:api:0.33.0'

--- a/content/develop/clients/jedis/vecsets.md
+++ b/content/develop/clients/jedis/vecsets.md
@@ -44,7 +44,7 @@ dependencies to your `pom.xml` file
 <dependency>
     <groupId>redis.clients</groupId>
     <artifactId>jedis</artifactId>
-    <version>6.2.0</version>
+    <version>7.2.0</version>
 </dependency>
 
 <dependency>
@@ -70,7 +70,7 @@ If you are using [Gradle](https://gradle.org/), add the following
 dependencies to your `build.gradle` file:
 
 ```bash
-compileOnly 'redis.clients:jedis:6.2.0'
+compileOnly 'redis.clients:jedis:7.2.0'
 compileOnly 'ai.djl.huggingface:tokenizers:0.33.0'
 compileOnly 'ai.djl.pytorch:pytorch-model-zoo:0.33.0'
 compileOnly 'ai.djl:api:0.33.0'

--- a/local_examples/client-specific/jedis/HomeJsonExample.java
+++ b/local_examples/client-specific/jedis/HomeJsonExample.java
@@ -8,7 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 // REMOVE_END
 // STEP_START import
-import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.json.Path2;
 import redis.clients.jedis.search.*;
@@ -47,7 +47,7 @@ public class HomeJsonExample {
         // STEP_END
 
         // STEP_START connect
-        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+        RedisClient jedis = new RedisClient("redis://localhost:6379");
         // STEP_END
 
         // STEP_START cleanup_json

--- a/local_examples/client-specific/jedis/HomeQueryVec.java
+++ b/local_examples/client-specific/jedis/HomeQueryVec.java
@@ -3,7 +3,7 @@
 package com.redis.app;
 // REMOVE_END
 // STEP_START import
-import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.search.*;
 import redis.clients.jedis.search.schemafields.*;
 import redis.clients.jedis.search.schemafields.VectorField.VectorAlgorithm;
@@ -54,7 +54,7 @@ public class HomeQueryVec {
         // STEP_END
 
         // STEP_START connect
-        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+        RedisClient jedis = new RedisClient("redis://localhost:6379");
         // REMOVE_START
         jedis.del(
             "doc:1", "doc:2", "doc:3",

--- a/local_examples/client-specific/jedis/HomeVecSets.java
+++ b/local_examples/client-specific/jedis/HomeVecSets.java
@@ -3,7 +3,7 @@
 package com.redis.app;
 // REMOVE_END
 // STEP_START import
-import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.RedisClient;
 import redis.clients.jedis.params.VAddParams;
 import redis.clients.jedis.params.VSimParams;
 
@@ -101,7 +101,7 @@ public class HomeVecSets {
     // STEP_END
 
     // STEP_START add_data
-        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+        RedisClient jedis = new RedisClient("redis://localhost:6379");
         // REMOVE_START
         jedis.del("famousPeople");
         // REMOVE_END

--- a/local_examples/client-specific/jedis/LandingExample.java
+++ b/local_examples/client-specific/jedis/LandingExample.java
@@ -1,7 +1,7 @@
 // EXAMPLE: landing
 // BINDER_ID jedis-landing
 // STEP_START import
-import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.RedisClient;
 import java.util.HashMap;
 import java.util.Map;
 // STEP_END
@@ -11,7 +11,7 @@ public class LandingExample {
     @Test
     public void run() {
         // STEP_START connect
-        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+        RedisClient jedis = new RedisClient("redis://localhost:6379");
         // STEP_END
 
         // STEP_START set_get_string


### PR DESCRIPTION
Several old connection classes are now replaced with a new, simpler API.

Note: the notebooks will need to be updated separately with the new API (however, they still work fine).