### PR TITLE
Update note on 'attribute' in JSON index creation

### DIFF
--- a/content/develop/ai/search-and-query/indexing/_index.md
+++ b/content/develop/ai/search-and-query/indexing/_index.md
@@ -29,7 +29,7 @@ The result of each JSONPath expression is indexed and associated with a logical 
 You can use these attributes in queries.
 
 {{% alert title="Note" color="info" %}}
-Note: `attribute` is optional for [`FT.CREATE`]({{< relref "commands/ft.create/" >}}).
+`attribute` is optional for [`FT.CREATE`]({{< relref "commands/ft.create/" >}}).
 {{% /alert %}}
 
 Use the following syntax to create a JSON index:


### PR DESCRIPTION
Deleted word "Note:" as it is being displayed twice, because the alert title already includes "Note:"

You can check this on https://redis.io/docs/latest/develop/ai/search-and-query/indexing/

<img width="1145" height="116" alt="image" src="https://github.com/user-attachments/assets/74b43311-ea32-4b61-9497-f6453468c795" />
