### PR TITLE
Revise node_available_memory_bytes metric description

### DIFF
--- a/content/embeds/rs-prometheus-metrics-v2.md
+++ b/content/embeds/rs-prometheus-metrics-v2.md
@@ -50,7 +50,7 @@
 | :-------- | :--- | :---------- |
 | node_available_flash_bytes | gauge | Available flash in the node (bytes) |
 | <span class="break-all">node_available_flash_no_overbooking_bytes</span> | gauge | Available flash in the node (bytes), without taking into account overbooking |
-| <span class="break-all">node_available_memory_bytes</span> | gauge | Amount of free memory in the node (bytes) that is available for database provisioning |
+| <span class="break-all">node_available_memory_bytes</span> | gauge | Amount of free memory in the node (bytes) |
 | <span class="break-all">node_available_memory_no_overbooking_bytes</span> | gauge | Available RAM in the node (bytes) without taking into account overbooking |
 | node_bigstore_free_bytes | gauge | Sum of free space of back-end flash (used by flash database's [BigRedis]) on all cluster nodes (bytes); returned only when BigRedis is enabled |
 | <span class="break-all">node_cert_expires_in_seconds</span> | gauge | Certificate expiration (in seconds) per given node; read more about [certificates in Redis Enterprise]({{< relref "/operate/rs/security/certificates" >}}) and [monitoring certificates]({{< relref "/operate/rs/security/certificates/monitor-certificates" >}}) |


### PR DESCRIPTION
Updated description for node_available_memory_bytes metric.
•    node_available_memory_bytes is closer to current free OS memory that Redis can use.
•    node_provisional_memory_bytes is a scheduler/capacity metric: “given existing shards, growth headroom, thresholds, and policies, how much more database RAM can I safely place here?”