### PR TITLE
RS: Added bundled x.y DB versions to release notes index tables (part 1)

### DIFF
--- a/content/operate/rs/release-notes/rs-6-2-10-february-2022.md
+++ b/content/operate/rs/release-notes/rs-6-2-10-february-2022.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.5
+compatibleOSSVersion: Redis 6.2.5, 6.0
 description: Python 3 support.  RHEL 8.5 support.
 linkTitle: 6.2.10 (February 2022)
 weight: 75

--- a/content/operate/rs/release-notes/rs-6-2-12.md
+++ b/content/operate/rs/release-notes/rs-6-2-12.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.6
+compatibleOSSVersion: Redis 6.2.6, 6.0
 description: OCSP Support.  Password & session configuration changes.  RHEL 8.6 support.
 linkTitle: 6.2.12 (August 2022)
 weight: 74

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/_index.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.6
+compatibleOSSVersion: Redis 6.2, 6.0
 description: Database auditing. Private key encryption. Active-Active database support
   for MEMORY USAGE command.
 headerRange: '[1-2]'

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-43.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-43.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.6
+compatibleOSSVersion: Redis 6.2.6, 6.0
 description: Database auditing. Private key encryption. Active-Active database support
   for MEMORY USAGE command. Improvements to crdb-cli.
 linkTitle: 6.2.18-43 (September 2022)

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-49.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-49.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.6
+compatibleOSSVersion: Redis 6.2.6, 6.0
 description: New REST API endpoint to check whether a node is a primary or a replica.
   Added metrics to track certificate expiration time.
 linkTitle: 6.2.18-49 (October 2022)

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-58.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-58.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.6
+compatibleOSSVersion: Redis 6.2.6, 6.0
 description: UI support for custom REST API port. Added info level for troubleshooting
   redis_mgr.
 linkTitle: 6.2.18-58 (November 2022)

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-65.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-65.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.6
+compatibleOSSVersion: Redis 6.2.6, 6.0
 description: Added To field to test email server alerts. New flag to skip cluster
   resource validation during imports. Improved error messages.
 linkTitle: 6.2.18-65 (December 2022)

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-70.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/rs-6-2-18-70.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.6
+compatibleOSSVersion: Redis 6.2.6, 6.0
 description: New script to generate new self-signed certificates for renewal. Improved
   logs. Deactivate alert_mgr using rladmin.
 linkTitle: 6.2.18-70 (January 2023)

--- a/content/operate/rs/release-notes/rs-6-2-4-august-2021.md
+++ b/content/operate/rs/release-notes/rs-6-2-4-august-2021.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2
+compatibleOSSVersion: Redis 6.2, 6.0
 description: Internode encryption. Nginx replaced by envoy.  New upgrade policies/behavior.
 linkTitle: 6.2.4 (August 2021)
 weight: 76

--- a/content/operate/rs/release-notes/rs-6-2-8-october-2021.md
+++ b/content/operate/rs/release-notes/rs-6-2-8-october-2021.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.3
+compatibleOSSVersion: Redis 6.2.3, 6.0
 description: RHEL 8 support. Set backup start time.
 linkTitle: 6.2.8 (October 2021)
 weight: 75

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/_index.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2, 6.0
 description: Pub/sub ACLs & default permissions. Validate client certificates by subject
   attributes. Ubuntu 20.04 support.
 headerRange: '[1-2]'

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-103.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: RHEL 8.8 support. RediSearch v2.6.12. RedisGraph v2.10.12. RedisTimeSeries
   v1.8.11 Log when CCS schema changes. Bug fixes.
 linkTitle: 6.4.2-103 (October 2023)

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-110.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-110.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: RedisGraph v2.10.15. RedisBloom v2.4.8. Bug fixes.
 linkTitle: 6.4.2-110 (May 2024)
 weight: 65

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-115.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-115.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: RediSearch v2.6.23. RedisBloom v2.4.12. RedisTimeSeries v1.8.15.
 linkTitle: 6.4.2-115 (Oct 2024)
 weight: 64

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-121.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-121.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Internal fixes and improvements.
 linkTitle: 6.4.2-121 (March 2025)
 weight: 63

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-127.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-127.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Internal fixes and improvements.
 linkTitle: 6.4.2-127 (June 2025)
 weight: 62

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-131.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-131.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Internal fixes and improvements.
 linkTitle: 6.4.2-131 (September 2025)
 weight: 61

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-30.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-30.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.7
+compatibleOSSVersion: Redis 6.2.7, 6.0
 description: Pub/sub ACLs & default permissions. Validate client certificates by subject
   attributes.
 linkTitle: 6.4.2-30 (February 2023)

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-43.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-43.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Ubuntu 20.04 support. Safe node removal. Allow gossip_envoy port configuration.
 linkTitle: 6.4.2-43 (March 2023)
 weight: 71

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-61.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Amazon Linux 2 support. Fixed known limitations for custom installation
   on RHEL 7 and RHEL 8, running rl_rdbconvert manually, and resharding rack-aware
   databases with no replication.

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-69.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-69.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Amazon Linux 2 support. Configure envoy ports using rladmin. Added option
   to avoid specific nodes when using the optimized shards placement API. Added failure_detection_sensitivity
   to replace watchdog_profile.

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-81.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-81.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Email alerts for database backup failures and replica high availability
   shard relocation failures.
 linkTitle: 6.4.2-81 (June 2023)

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-94.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/rs-6-4-2-94.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 6.2.10
+compatibleOSSVersion: Redis 6.2.10, 6.0
 description: Look-ahead mechanism for planner attempts. Package OS compatibility validation.
 linkTitle: 6.4.2-94 (July 2023)
 toc: 'true'

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2, 6.2, 6.0
 description: Redis 7.0 and 7.2 features. Auto Tiering (enhanced successor to Redis
   on Flash). RESP3 support. Sharded pub/sub. Preview of the new Cluster Manager UI.
   Redis Stack 7.2 features. Three Redis database versions. License file structure

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-105.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-105.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: LDAP authentication timeout is configurable using the REST API. RHEL
   8.9 support.
 linkTitle: 7.2.4-105 (February 2024)

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-109.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-109.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Bug fixes.
 linkTitle: 7.2.4-109 (May 2024)
 weight: 67

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-122.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-122.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Internal fixes and improvements.
 linkTitle: 7.2.4-122 (March 2025)
 weight: 66

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-130.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-130.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Retry mechanism for listener creation on database ports. Bug fix for Lua out-of-memory errors preventing scripts from running Redis commands.
 linkTitle: 7.2.4-130 (May 2025)
 weight: 65

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-132.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-132.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Bug fix for mismatched key counts in Active-Active databases after cluster recovery.
 linkTitle: 7.2.4-132 (June 2025)
 weight: 64

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-138.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-138.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Internal fixes and improvements.
 linkTitle: 7.2.4-138 (September 2025)
 weight: 63

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-52.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Redis 7.0 and 7.2 features. Auto Tiering (enhanced successor to Redis
   on Flash). RESP3 support. Sharded pub/sub. Preview of the new Cluster Manager UI.
   Redis Stack 7.2 features. Three Redis database versions. License file structure

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-64.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Improved cluster recovery with manually uploaded modules. Support package
   contains supervisorctl status. Configure port range using rladmin and REST API.
   License API returns the number of used shards (RAM & flash).

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-72.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: New Cluster Manager UI enhancements - database upgrade configuration,
   database defaults, user lockout parameters, and TLS configuration improvements.
 linkTitle: 7.2.4-72 (October 2023)

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-92.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: New Cluster Manager UI enhancements - LDAP configuration improvements.
   New `capability_name` field added to module REST API object. Automatic removal of
   deprecated, predefined roles and ACLs upon cluster upgrade, unless they are associated

--- a/content/operate/rs/release-notes/rs-7-22-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/_index.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4, 7.2, 6.2
 description: Diagnostic logging service. Call home client to send daily usage statistics to Redis. Usage reports in support packages. Revamp database API. Migration status API. Two-dimensional rack awareness. New version for actions API. Additional REST API enhancements.
 hideListLinks: true
 linkTitle: 7.22.x releases

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-216.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-216.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: license_expiration_days metric for monitoring. Bug fixes for user password management REST API requests, cluster setup in the Cluster Manager UI, cluster upgrades, maintenance mode snapshot cleanup, database availability API performance, Active-Active syncing, and more.
 linkTitle: 7.22.0-216 (June 2025)
 weight: 89

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-241.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-241.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fixes for LDAP authentication, Active-Active databases, database recovery, support package generation, memory leaks, and the Cluster Manager UI.
 linkTitle: 7.22.0-241 (July 2025)
 weight: 88

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-250.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-250.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fix for LDAPS port configuration in the Cluster Manager UI. Internal fixes and improvements.
 linkTitle: 7.22.0-250 (August 2025)
 weight: 87

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-95.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-95.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Diagnostic logging service. Call home client to send daily usage statistics to Redis. Usage reports in support packages. Revamp database API. Migration status API. Two-dimensional rack awareness. New version for actions API. Additional REST API enhancements.
 linkTitle: 7.22.0-95 (May 2025)
 weight: 90

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-14.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-14.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Customer-managed certificates for internode encryption. Cluster Manager UI bug fixes for viewing shard memory usage metrics and editing Active-Active databases that have participating clusters with empty ports.
 linkTitle: 7.22.2-14 (September 2025)
 weight: 86

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-20.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-20.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Cluster Manager UI bug fixes for issues with S3 periodic backups configuration and connection issues. API bug fixes for omitted default values in responses and Active-Active database creation failures.
 linkTitle: 7.22.2-20 (October 2025)
 weight: 85

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2, 6.2, 6.0
 description: New Cluster Manager UI enhancements, including Active-Active database
   management. Full TLS 1.3 support. Automatic recovery configuration. Full IPv6 support,
   including for internal traffic. Maintenance mode enhancements. Module management

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-104.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-104.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: New Cluster Manager UI enhancements to change passwords from the sign-in
   screen, view locked user accounts, and unlock user accounts with password reset.
 linkTitle: 7.4.2-104 (March 2024)

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-126.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-126.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Redis database version selection during database creation in the Cluster Manager UI. New Redis logo.
 linkTitle: 7.4.2-126 (April 2024)
 weight: 70

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-129.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-129.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Fixes for bugs and known limitations that affect Redis Enterprise Software v7.4.2-126.
 linkTitle: 7.4.2-129 (April 2024)
 weight: 69

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-169.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-169.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: Configuration options for cluster management API workers and threads. Reduced Cluster Configuration Store CPU usage.
 linkTitle: 7.4.2-169 (May 2024)
 weight: 68

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-216.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-216.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: region_name field for new AWS S3 regions. Bug fixes.
 linkTitle: 7.4.2-216 (July 2024)
 weight: 67

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-54.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.0
+compatibleOSSVersion: Redis 7.2.0, 6.2, 6.0
 description: New Cluster Manager UI enhancements, including Active-Active database
   management. Full TLS 1.3 support. Automatic recovery configuration. Full IPv6 support,
   including for internal traffic. Maintenance mode enhancements. Module management

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-102.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-102.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.4
+compatibleOSSVersion: Redis 7.2.4, 6.2, 6.0
 description: Updated module feature sets with later versions of RediSearch and RedisTimeSeries.
 linkTitle: 7.4.6-102 (October 2024)
 weight: 64

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-188.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-188.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.4
+compatibleOSSVersion: Redis 7.2.4, 6.2, 6.0
 description: Bug fix for a memory leak in the DMC proxy process.
 linkTitle: 7.4.6-188 (January 2025)
 weight: 63

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-22.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-22.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.4
+compatibleOSSVersion: Redis 7.2.4, 6.2, 6.0
 description: Support for SHA-384 certificates in client authentication. New parameters for optimize_shard_placement and recover database REST API requests.
 linkTitle: 7.4.6-22 (July 2024)
 weight: 66

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-232.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-232.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.4
+compatibleOSSVersion: Redis 7.2.4, 6.2, 6.0
 description: Internal fixes and improvements.
 linkTitle: 7.4.6-232 (March 2025)
 weight: 62

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-268.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-268.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.4
+compatibleOSSVersion: Redis 7.2.4, 6.2, 6.0
 description: Internal fixes and improvements.
 linkTitle: 7.4.6-268 (June 2025)
 weight: 61

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-272.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-272.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.4
+compatibleOSSVersion: Redis 7.2.4, 6.2, 6.0
 description: Internal fixes and improvements.
 linkTitle: 7.4.6-272 (September 2025)
 weight: 60

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-77.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-77.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.2.4
+compatibleOSSVersion: Redis 7.2.4, 6.2, 6.0
 description: Updated module feature sets. Bug fixes.
 linkTitle: 7.4.6-77 (September 2024)
 weight: 65

--- a/content/operate/rs/release-notes/rs-7-8-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/_index.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4, 7.2, 6.2
 description: Redis Community Edition 7.4 features. Hash field expiration. Client-side caching support. Metrics stream engine preview. New APIs to check database availability, rebalance shards, fail over shards, and control database traffic. Cluster Manager UI enhancements for node actions, database tags, and database configuration. User manager role. Log rotation based on both size and time. Module management enhancements. Configurable minimum password length. Configurable license expiration alert threshold.
 hideListLinks: true
 linkTitle: 7.8.x releases

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-34.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Redis Community Edition 7.4 features. Hash field expiration. Client-side caching support. Metrics stream engine preview. New APIs to check database availability, rebalance shards, fail over shards, and control database traffic. Cluster Manager UI enhancements for node actions, database tags, and database configuration. User manager role. Log rotation based on both size and time. Module management enhancements. Configurable minimum password length. Configurable license expiration alert threshold.
 linkTitle: 7.8.2-34 (November 2024)
 weight: 90

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-60.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-2-60.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fixes, including a fix for a RHEL 8 OpenSSL dependency issue that caused frequent restarts of the `cm_server` and prevented access to the Redis Software Cluster Manager UI after upgrading to Redis Software version 7.8.2-34.
 linkTitle: 7.8.2-60 (December 2024)
 weight: 89

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-18.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-18.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Certificate-based authentication for the REST API. Dry run option to validate Redis ACL REST API requests.
 linkTitle: 7.8.4-18 (December 2024)
 weight: 88

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-66.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-66.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Ubuntu 22 support. Bug fixes for crashes, unexpected restarts, and incorrect type for the automatically calculated replica buffer.
 linkTitle: 7.8.4-66 (February 2025)
 weight: 87

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-95.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-95.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fixes for server restart failures during upgrades, connectivity checks for optional services, swapped shard status and watchdog status values in `rladmin`, process exporter crashes, and a syncer issue for Active-Active databases that have the OSS Cluster API enabled.
 linkTitle: 7.8.4-95 (March 2025)
 weight: 86

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-119.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-119.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fixes for user password management REST API requests, maintenance mode snapshot cleanup, and rlec_supervisor file permissions.
 linkTitle: 7.8.6-119 (June 2025)
 weight: 81

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-13.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-13.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Configurable hashing algorithm for user passwords. Dry run option to validate REST API requests for users and roles.
 linkTitle: 7.8.6-13 (March 2025)
 weight: 85

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-152.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-152.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fixes for Active-Active syncing, event log entries for configuration changes made by LDAP users, LDAP mapping visibility in the Cluster Manager UI, database max_connections setting, and memory leaks when using Active-Active databases in Kubernetes.
 linkTitle: 7.8.6-152 (August 2025)
 weight: 80

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-207.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-207.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Enhanced timeout diagnostics and logging when restarting shards. Bug fix for viewing shard memory usage metrics in the Cluster Manager UI. Internal fixes and improvements.
 linkTitle: 7.8.6-207 (September 2025)
 weight: 79

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-36.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-36.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fixes, including a fix for an issue where new workers might use an outdated certificate after a certificate update.
 linkTitle: 7.8.6-36 (April 2025)
 weight: 84

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-60.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-60.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Bug fixes for an LDAP connection issue caused by setting LDAP bind credentials that include `<` in the Cluster Manager UI and an issue where migrated shards can appear stuck on multiple nodes. Deprecated required_version in the bootstrap cluster API.
 linkTitle: 7.8.6-60 (April 2025)
 weight: 83

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-95.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-95.md
@@ -5,7 +5,7 @@ categories:
 - docs
 - operate
 - rs
-compatibleOSSVersion: Redis 7.4.0
+compatibleOSSVersion: Redis 7.4.0, 7.2, 6.2
 description: Performance improvements for the Cluster Manager UI's nodes screen. Bug fix for slowness and intermittent failures in the Cluster Manager UI, `rladmin`, and `rlcheck` after upgrading large clusters to version 7.8.4. Bug fix for an issue that could cause inconsistent memory settings across shards and out-of-memory errors. Bug fix for an issue where certain processes might not terminate as expected during cluster upgrades due to timeouts.
 linkTitle: 7.8.6-95 (May 2025)
 weight: 82


### PR DESCRIPTION
This PR is just part 1 to add the missing x.y DB versions to the release notes tables. I will update them to x.y.z versions in a future PR since it will probably take a while to collect and confirm the exact DB versions bundled with each release.

Staged previews:
1. https://redis.io/docs/staging/DOC-5975/operate/rs/release-notes/
2. https://redis.io/docs/staging/DOC-5975/operate/rs/release-notes/rs-7-22-releases/#detailed-release-notes
3. https://redis.io/docs/staging/DOC-5975/operate/rs/release-notes/rs-7-8-releases/#detailed-release-notes
4. https://redis.io/docs/staging/DOC-5975/operate/rs/release-notes/rs-7-4-2-releases/#detailed-release-notes
5. https://redis.io/docs/staging/DOC-5975/operate/rs/release-notes/rs-7-2-4-releases/#detailed-release-notes
6. https://redis.io/docs/staging/DOC-5975/operate/rs/release-notes/rs-6-4-2-releases/#detailed-release-notes
7. https://redis.io/docs/staging/DOC-5975/operate/rs/release-notes/rs-6-2-18-releases/#detailed-release-notes