### PR TITLE
DOC-6192 updated AMR examples to connect withe cluster client

### DIFF
--- a/content/develop/clients/go/amr.md
+++ b/content/develop/clients/go/amr.md
@@ -200,7 +200,7 @@ The fields of `TokenManagerOptions` are explained below:
 When you have created your `StreamingCredentialsProvider` instance, you are ready to
 connect to AMR.
 The example below shows how to pass the instance as a parameter to the standard
-`NewClient()` connection method. It also illustrates how to use
+`NewClusterClient()` connection method. It also illustrates how to use
 [`os.Getenv()`](https://pkg.go.dev/os#Getenv) to get the connection details
 from environment variables rather than include their values in the code.
 
@@ -240,7 +240,8 @@ func main() {
     }
 
     // Create Redis client
-    client := redis.NewClient(&redis.Options{
+    // Note: AMR databases have clustering enabled by default.
+    client := redis.NewClusterClient(&redis.Options{
         Addr: redisEndpoint,
         StreamingCredentialsProvider: provider,
     })

--- a/content/develop/clients/jedis/amr.md
+++ b/content/develop/clients/jedis/amr.md
@@ -133,7 +133,7 @@ TokenAuthConfig authConfig = EntraIDTokenAuthConfigBuilder.builder()
 When you have created your `TokenAuthConfig` instance, you are ready to
 connect to AMR.
 The example below shows how to include the `TokenAuthConfig` details in a
-`JedisClientConfig` instance and use it with the `RedisClient` connection.
+`JedisClientConfig` instance and use it with the `RedisClusterClient` connection.
 The connection uses
 [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security),
 which is recommended and enabled by default for managed identities. See
@@ -159,7 +159,8 @@ JedisClientConfig config = DefaultJedisClientConfig.builder()
         .ssl(true).sslSocketFactory(sslFactory)
         .build();
 
-RedisClient jedis = RedisClient.builder()
+// AMR databases have clustering enabled by default.
+RedisClusterClient jedis = RedisClusterClient.builder()
         .hostAndPort(new HostAndPort("<host>", <port>))
         .clientConfig(config)
         .build();

--- a/content/develop/clients/lettuce/amr.md
+++ b/content/develop/clients/lettuce/amr.md
@@ -204,8 +204,9 @@ RedisURI redisURI = RedisURI.builder()
         .withSsl(true)
         .build();
 
-// Create the RedisClient and set the re-authentication options.
-RedisClient redisClient = RedisClient.create(redisURI);
+// Create the RedisClusterClient and set the re-authentication options.
+// Note: AMR databases have clustering enabled by default.
+RedisClusterClient redisClient = RedisClusterClient.create(redisURI);
 redisClient.setOptions(clientOptions);
 
 // Connect with the credentials provider.

--- a/content/develop/clients/nodejs/amr.md
+++ b/content/develop/clients/nodejs/amr.md
@@ -315,16 +315,16 @@ Note that when you use `createForDefaultAzureCredential()`, you must:
 When you have created your credential provider instance, you are ready to
 connect to AMR.
 The example below shows how to pass the instance as a parameter to the standard
-`createClient()` connection method.
+`createCluster()` connection method.
 
 ```js
-import { createClient } from '@redis/client';
+import { createCluster } from '@redis/client';
 import { EntraIdCredentialsProviderFactory }
     from '@redis/entraid';
     
 // Create credentials provider instance...
-
-const client = createClient({
+// Note: AMR databases have clustering enabled by default.
+const client = createCluster({
   url: 'redis://localhost',
   credentialsProvider: provider
 });

--- a/content/develop/clients/redis-py/amr.md
+++ b/content/develop/clients/redis-py/amr.md
@@ -59,7 +59,6 @@ The example below shows how to import the required modules and call
 `create_from_service_principal()`:
 
 ```python
-from redis import Redis
 from redis_entraid.cred_provider import *
 
 credential_provider = create_from_service_principal(
@@ -102,7 +101,6 @@ Pass `ManagedIdentityType.USER_ASSIGNED` or `ManagedIdentityType.SYSTEM_ASSIGNED
 as the `identity_type` parameter.
 
 ```python
-from redis import Redis
 from redis_entraid.cred_provider import *
 
 credential_provider = create_from_managed_identity(
@@ -135,7 +133,7 @@ credential_provider = create_from_managed_identity(
 When you have created your `CredentialProvider` instance, you are ready to
 connect to AMR.
 The example below shows how to pass the instance as a parameter to the standard
-`Redis()` connection method.
+`RedisCluster()` connection method.
 {{< note >}} Azure requires you to use
 [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security)
 when you connect (see
@@ -143,7 +141,11 @@ when you connect (see
 {{< /note >}}
 
 ```python
-r = Redis(
+from redis import RedisCluster
+# ...
+
+# AMR databases have clustering enabled by default.
+r = RedisCluster(
     host=<HOST>, port=<PORT>,
     credential_provider=credential_provider,
     ssl=True,


### PR DESCRIPTION
We've had a suggestion from Microsoft to use the cluster connection for our AMR examples (AMR has cluster enabled by default).