### PR TITLE
RS/K8s: update that flex tiers keys and values

### DIFF
--- a/content/operate/kubernetes/architecture/_index.md
+++ b/content/operate/kubernetes/architecture/_index.md
@@ -114,7 +114,7 @@ PVCs are created with a specific size and [can be expanded](https://kubernetes.i
 
 ### Redis Flex
 
-Redis Enterprise Software for Kubernetes supports [Redis Flex]({{<relref "/operate/kubernetes/re-clusters/redis-flex">}}) (previously known as Redis on Flash), which extends your node memory to use both RAM and flash storage. SSDs (solid state drives) can store infrequently used (warm) values while your keys and frequently used (hot) values are still stored in RAM. This improves performance and lowers costs for large datasets.
+Redis Enterprise Software for Kubernetes supports [Redis Flex]({{<relref "/operate/kubernetes/re-clusters/redis-flex">}}) (previously known as Redis on Flash), which extends your node memory to use both RAM and flash storage. SSDs (solid state drives) can store infrequently used (warm) keys and values while frequently used (hot) keys and values are stored in RAM. This improves performance and lowers costs for large datasets.
 
 NVMe (non-volatile memory express) SSDs are strongly recommended to achieve the best performance.
 

--- a/content/operate/kubernetes/re-clusters/redis-flex.md
+++ b/content/operate/kubernetes/re-clusters/redis-flex.md
@@ -16,7 +16,7 @@ This page applies to Redis Enterprise for Kubernetes version 8.0.2-2 and later. 
 
 ## Overview
 
-[Redis Flex]({{< relref "/operate/rs/databases/flash" >}}) (previously known as Redis on Flash) extends your node memory to use both RAM and flash storage. Solid state drives (SSDs) store infrequently used (warm) values, while RAM stores your keys and frequently used (hot) values. This approach improves performance and lowers costs for large datasets.
+[Redis Flex]({{< relref "/operate/rs/databases/flash" >}}) (previously known as Redis on Flash) extends your node memory to use both RAM and flash storage. Solid state drives (SSDs) store infrequently used (warm) keys and values, while RAM stores frequently used (hot) keys and values. This approach improves performance and lowers costs for large datasets.
 
 Redis Flex provides automatic RAM management and improved performance compared to Auto Tiering.
 

--- a/content/operate/rc/databases/create-database/create-flex-database.md
+++ b/content/operate/rc/databases/create-database/create-flex-database.md
@@ -24,12 +24,11 @@ The benefits associated with Redis Flex are dependent on the use case.
 Redis Flex is ideal when your:
 
 - working set is significantly smaller than your dataset (high RAM hit rate)
-- average key size is smaller than average value size (all key names are stored in RAM)
+- average key size is smaller than average value size
 - most recent data is the most frequently used (high RAM hit rate)
 
 Redis Flex is not recommended for:
 
-- Long key names (all key names are stored in RAM)
 - Broad access patterns (any value could be pulled into RAM)
 - Large working sets (working set is stored in RAM)
 - Frequently moved data (moving to and from RAM too often can impact performance)
@@ -39,14 +38,13 @@ Redis Flex is not intended to be used for persistent storage.
 ## Where is my data?
 
 When using Redis Flex, RAM storage holds:
-- All keys (names)
 - Key indexes
 - Dictionaries
-- Hot data (working set)
+- Hot data (working set), including frequently accessed keys and values
 
-All data is accessed through RAM. If a value in flash memory is accessed, it becomes part of the working set and is moved to RAM. These values are referred to as "hot data".
+All data is accessed through RAM. If a key or value in flash memory is accessed, it becomes part of the working set and is moved to RAM. This data is referred to as "hot data".
 
-Inactive or infrequently accessed data is referred to as "warm data" and stored in flash memory. When more space is needed in RAM, warm data is moved from RAM to flash storage.
+Inactive or infrequently accessed data is referred to as "warm data" and stored in flash memory. When more space is needed in RAM, warm keys and values are moved from RAM to flash storage.
 
 ## Create a Redis Flex database on Redis Cloud Essentials
 

--- a/content/operate/rs/databases/flash/_index.md
+++ b/content/operate/rs/databases/flash/_index.md
@@ -47,12 +47,11 @@ The benefits associated with Redis Flex are dependent on the use case.
 Redis Flex is ideal when your:
 
 - working set is significantly smaller than your dataset (high RAM hit rate)
-- average key size is smaller than average value size (all key names are stored in RAM)
+- average key size is smaller than average value size
 - most recent data is the most frequently used (high RAM hit rate)
 
 Redis Flex is not recommended for:
 
-- Long key names (all key names are stored in RAM)
 - Broad access patterns (any value could be pulled into RAM)
 - Large working sets (working set is stored in RAM)
 - Frequently moved data (moving to and from RAM too often can impact performance)
@@ -62,14 +61,13 @@ Redis Flex is not intended to be used for persistent storage. Redis Enterprise S
 ## Where is my data?
 
 When using Redis Flex, RAM storage holds:
-- All keys (names)
 - Key indexes
 - Dictionaries
-- Hot data (working set)
+- Hot data (working set), including frequently accessed keys and values
 
-All data is accessed through RAM. If a value in flash memory is accessed, it becomes part of the working set and is moved to RAM. These values are referred to as "hot data".
+All data is accessed through RAM. If a key or value in flash memory is accessed, it becomes part of the working set and is moved to RAM. This data is referred to as "hot data".
 
-Inactive or infrequently accessed data is referred to as "warm data" and stored in flash memory. When more space is needed in RAM, warm data is moved from RAM to flash storage.
+Inactive or infrequently accessed data is referred to as "warm data" and stored in flash memory. When more space is needed in RAM, warm keys and values are moved from RAM to flash storage.
 
 {{<note>}} When using Redis Flex with RediSearch, it’s important to note that RediSearch indexes are also stored in RAM.{{</note>}}
 

--- a/content/operate/rs/databases/memory-performance/_index.md
+++ b/content/operate/rs/databases/memory-performance/_index.md
@@ -44,7 +44,7 @@ For more info on data persistence see [Database persistence with Redis Enterpris
 
 ## Auto Tiering 
 
-By default, Redis Enterprise Software stores your data entirely in [RAM](https://en.wikipedia.org/wiki/Random-access_memory) for improved performance. [Redis Flex and Auto Tiering]({{< relref "/operate/rs/databases/flash/" >}}) enable your data to span both RAM and [SSD](https://en.wikipedia.org/wiki/Solid-state_drive) storage ([flash memory](https://en.wikipedia.org/wiki/Flash_memory)). Keys are always stored in RAM, but Auto Tiering manages the location of their values. Frequently used (hot) values are stored on RAM, but infrequently used (warm) values are moved to flash memory. This saves on expensive RAM space, which give you comparable performance at a lower cost for large datasets.
+By default, Redis Enterprise Software stores your data entirely in [RAM](https://en.wikipedia.org/wiki/Random-access_memory) for improved performance. [Redis Flex and Auto Tiering]({{< relref "/operate/rs/databases/flash/" >}}) enable your data to span both RAM and [SSD](https://en.wikipedia.org/wiki/Solid-state_drive) storage ([flash memory](https://en.wikipedia.org/wiki/Flash_memory)). Redis Flex tiers both keys and values to flash storage, ensuring that warm (infrequently accessed) data does not consume RAM. Auto Tiering stores keys in RAM but manages the location of their values. Frequently used (hot) data is stored in RAM, but infrequently used (warm) data is moved to flash memory. This saves on expensive RAM space, which gives you comparable performance at a lower cost for large datasets.
 
 For more info, see [Redis Flex and Auto Tiering]({{< relref "/operate/rs/databases/flash/" >}}).
 


### PR DESCRIPTION
Redis Flex tiers both keys and values now, where in Auto Tiering only values where tiered and keys were always stored in RAM. 