### PR TITLE
DOC-6208 mention that SCH is the default for redis-py and Lettuce

### DIFF
--- a/content/develop/clients/lettuce/connect.md
+++ b/content/develop/clients/lettuce/connect.md
@@ -264,9 +264,9 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
-To enable SCH on the client, create a `MaintNotificationsConfig` object
-and/or a `TimeoutOptions` object
-and pass them to the `ClientOptions` builder as shown in the example below.
+SCH is enabled on the client by default. However, you can configure it
+explicitly by creating a `MaintNotificationsConfig` object and/or a `TimeoutOptions`
+object and passing them to the `ClientOptions` builder as shown in the example below.
 Note that SCH also requires the
 [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
 protocol. Lettuce uses this by default, but make sure you don't set
@@ -317,11 +317,22 @@ ClientOptions clientOptions = ClientOptions.builder()
 redisClient.setOptions(clientOptions);
 ```
 
+To disable SCH, use `MaintNotificationsConfig.disabled()` and pass the instance it
+returns to the `ClientOptions` builder:
+
+```java
+ClientOptions clientOptions = ClientOptions.builder()
+        .maintNotificationsConfig(MaintNotificationsConfig.disabled())
+        .build();
+
+redisClient.setOptions(clientOptions);
+```
+
 The `MaintNotificationsConfig` builder accepts the following options:
 
 | Method | Description |
 |--------|-------------|
-| `enableMaintNotifications()` | Enable SCH. |
+| `enableMaintNotifications(boolean enabled)` | Enable/disable SCH. The default is `true` (enabled). |
 | `endpointType(EndpointType type)` | Set the type of endpoint to use for the connection. The options are `EndpointType.EXTERNAL_IP`, `EndpointType.INTERNAL_IP`, `EndpointType.EXTERNAL_FQDN`, `EndpointType.INTERNAL_FQDN`, and `EndpointType.NONE`. Use the separate `autoResolveEndpointType()` method to auto-detect based on the connection (this is the default behavior). |
 | `autoResolveEndpointType()` | Auto-detect the type of endpoint to use for the connection. This is the default behavior. Use `endpointType()` to set a specific endpoint type. |
 

--- a/content/develop/clients/redis-py/connect.md
+++ b/content/develop/clients/redis-py/connect.md
@@ -262,8 +262,9 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
-To enable SCH on the client, pass a `MaintNotificationsConfig` object
-during the connection, as shown in the following example:
+SCH is enabled on the client by default, but you can configure it
+explicitly by passing a `MaintNotificationsConfig` object during the connection,
+as shown in the following example:
 
 ```py
 import redis
@@ -273,10 +274,20 @@ r = redis.Redis(
     decode_responses=True,
     protocol=3,
     maint_notifications_config=MaintNotificationsConfig(
-        enabled=True,
         proactive_reconnect=True,
         relaxed_timeout=10,
         endpoint_type=EndpointType.EXTERNAL_IP
+    ),
+    ...
+)
+```
+
+To disable SCH, pass `enabled=False` in the `MaintNotificationsConfig` object:
+
+```python
+r = redis.Redis(
+    maint_notifications_config=MaintNotificationsConfig(
+        enabled=False,
     ),
     ...
 )
@@ -290,7 +301,7 @@ The `MaintNotificationsConfig` constructor accepts the following parameters:
 
 | Name | Type | Default | Description |
 |------|------|---------|-------------|
-| `enabled` | `bool` | `False` | Whether or not to enable SCH. |
+| `enabled` | `bool` | `True` | Whether or not to enable SCH. |
 | `proactive_reconnect` | `bool` | `True` | Whether or not to automatically reconnect when a node is replaced. |
 | `endpoint_type` | `EndpointType` | Auto-detect | The type of endpoint to use for the connection. The options are `EndpointType.EXTERNAL_IP`, `EndpointType.INTERNAL_IP`, `EndpointType.EXTERNAL_FQDN`, `EndpointType.INTERNAL_FQDN`, and `EndpointType.NONE`. |
 | `relaxed_timeout` | `int` | `20` | The timeout (in seconds) to use while the server is performing maintenance. A value of `-1` disables the relax timeout and just uses the normal timeout during maintenance. |


### PR DESCRIPTION
The existing docs suggest that you have to enable SCH explicitly. The examples now talk about configuring the feature and showing how to *disable* it if you don't want it.