### PR TITLE
Add examples for fuzzy search on specific attributes

### DIFF
--- a/content/develop/ai/search-and-query/query/full-text.md
+++ b/content/develop/ai/search-and-query/query/full-text.md
@@ -123,14 +123,14 @@ FT.SEARCH idx:bicycle "%%optamised%%"
 
 ### Fuzzy search on a specific attribute
 
-To perform a fuzzy search on a specific text field, use the `@field:(...)` syntax with the fuzzy term inside parentheses. Do **not** wrap the fuzzy term in quotes, as this changes the search behavior.
+To perform a fuzzy search on a specific text field, use the `@field:(...)` syntax with the fuzzy term inside parentheses.
 
 ```
 FT.SEARCH index "@field:(%word%)"
 ```
 
-{{% alert title="Important" color="warning" %}}
-Do not use quotes around the fuzzy term when targeting a specific field. Wrapping the term in quotes (e.g., `@field:("%word%")`) converts the query into an exact phrase search, and the `%` characters are treated as literal characters rather than fuzzy operators.
+{{% alert title="Important" %}}
+Do not use quotes around the fuzzy term when targeting a specific field. Wrapping the term in quotes (for example, `@field:("%word%")`) converts the query into an exact match search, and the `%` characters are treated as literal characters rather than fuzzy operators.
 {{% /alert  %}}
 
 The following example shows the correct way to perform a fuzzy search with distance one on the `description` field:


### PR DESCRIPTION
Clarify that fuzzy search terms should NOT be wrapped in quotes when targeting a specific field. Using quotes (e.g., @field:("%word%")) converts the query to an exact phrase search instead of a fuzzy search.

Added:
- New subsection 'Fuzzy search on a specific attribute'
- Correct syntax: @field:(%word%) using parentheses without quotes
- Warning alert explaining the quotes pitfall
- Examples for single field fuzzy search with distance 1 and 2
- Example combining fuzzy searches on multiple fields with OR