### PR TITLE
DOC-6225 add underscore to embeds folder to prevent publication

### DIFF
--- a/content/embeds/_index.md
+++ b/content/embeds/_index.md
@@ -1,0 +1,7 @@
+---
+_build:
+  render: never
+cascade:
+  _build:
+    render: never
+---


### PR DESCRIPTION
Although it's not in the navigation, the `embeds` folder was being published. This stuff doesn't make sense by itself and could easily contain obsolete material, so it seems best not to publish it. The easiest way to do this was to rename `embeds` to `_embeds` (underscore prevents publication).

I've checked a few examples of embedded content to make sure they still work following this change (no need to change pathnames or shortcodes for this, btw). It looks OK to me, but if there are any places where things could go wrong because of this change, then please let me know :-) 