### PR TITLE
DOC-6227 added small section about failback configuration

### DIFF
--- a/content/develop/clients/jedis/failover.md
+++ b/content/develop/clients/jedis/failover.md
@@ -220,6 +220,15 @@ MultiDbClient client = MultiDbClient.builder()
         .build();
 ```
 
+## Failback configuration
+
+The `MultiDbConfig` builder lets you configure the failback behavior using the following options:
+
+| Builder method | Default value | Description|
+| --- | --- | --- |
+| `failbackSupported()` | `true` | Enable/disable failback (it is enabled by default). |
+| `failbackCheckInterval()` | `120000` | Interval in milliseconds to check if the unhealthy database has recovered. |
+
 ## Health check configuration
 
 Each health check consists of one or more separate "probes", each of which is a simple


### PR DESCRIPTION
The settings are easy to infer from the code example but they are important enough to be called out explicitly.