### PR TITLE
DOC-6252 sections about failover behaviour when all endpoints are unhealthy

### DIFF
--- a/content/develop/clients/failover.md
+++ b/content/develop/clients/failover.md
@@ -32,6 +32,7 @@ your client library to learn how to configure it for failover and failback:
 
 - [Jedis]({{< relref "/develop/clients/jedis/failover" >}})
 - [redis-py]({{< relref "/develop/clients/redis-py/failover" >}}) (preview)
+- [Lettuce]({{< relref "/develop/clients/lettuce/failover" >}}) (preview)
 
 ## Concepts
 
@@ -93,10 +94,20 @@ still better than the current failover target, so it might be worth
 failing back to that server even if it is not optimal.
 
 Clients periodically run a "health check" on each server to see if it has recovered.
-The health check can be as simple as sending a Redis
-[`PING`]({{< relref "/commands/ping" >}}) or
-[ECHO]({{< relref "/commands/echo" >}}) command and ensuring that it gives the
-expected response.
+Several health check strategies are implemented in all clients:
+
+-   **Ping**: This is the default strategy, which just sends a
+    [`PING`]({{< relref "/commands/ping" >}}) command and ensures that it gives the
+    expected response.
+-   **Lag aware** (Redis Software only): This strategy uses the
+    [REST API]({{< relref "/operate/rs/references/rest-api" >}}) to check the
+    synchronization lag between a specific database and the others in the Active-Active
+    setup. If the lag is within a specified tolerance, the server is considered healthy.
+-   **Custom**: You can implement your own health check strategy to use information
+    or take action that is specific to your application.
+
+See the documentation for your client library for more information on how to
+configure health checks.
 
 You can also configure the client to run health checks on the current target
 server during periods of inactivity, even if no failover has occurred. This can

--- a/content/develop/clients/jedis/failover.md
+++ b/content/develop/clients/jedis/failover.md
@@ -419,10 +419,10 @@ a healthy endpoint.
 
 You can still keep retrying commands after a `JedisTemporarilyNotAvailableException` is thrown (for example,
 you could add this exception to the `includedExceptionList`, as described
-in the [Retry configuration]({{< relref "#retry-configuration" >}}) section). However, if the client exhausts
-all the available failover attempts before any endpoint becomes healthy again, commands will throw a `JedisPermanentlyNotAvailableException`. The client won't recover automatically from this situation, so you
-should handle it by reconnecting with the `MultiDBClient` builder after a suitable delay (see
-[Failover configuration](#failover-configuration) for a connection example).
+in the [Retry configuration]({{< relref "#retry-configuration" >}}) section). However, if the number of
+failover attempts exceeds the value set by `maxNumFailoverAttempts()`, commands will throw a `JedisPermanentlyNotAvailableException`. Note that this is intended to notify your app
+that the problem is likely to be persistent, but it *doesn't* mean that Jedis will stop trying
+to connect to a healthy endpoint if one becomes available.
 
 ## Troubleshooting
 

--- a/content/develop/clients/redis-py/failover.md
+++ b/content/develop/clients/redis-py/failover.md
@@ -215,13 +215,11 @@ a database that is already unhealthy.
 | `health_check` | Custom list of `HealthCheck` objects to specify how to perform each probe during a health check. This defaults to just the simple [`PingHealthCheck`](#pinghealthcheck-default). |
 | `initial_health_check_policy` | `InitialHealthCheck` enum value to specify the policy to use during the initial health check. The options are `InitialHealthCheck.ALL_HEALTHY` (all probes must succeed), `InitialHealthCheck.ANY_HEALTHY` (at least one probe must succeed), and `InitialHealthCheck.MAJORITY_HEALTHY` (more than half the probes must succeed). The default policy is `InitialHealthCheck.ALL_HEALTHY`. |
 
-### Health check strategies
-
 There are several strategies available for health checks that you can configure using the
 `MultiClusterClientConfig` builder. The sections below explain these strategies
 in more detail.
 
-#### `PingHealthCheck` (default)
+### `PingHealthCheck` (default)
 
 The default strategy, `PingHealthCheck`, periodically sends a Redis
 [`PING`]({{< relref "/commands/ping" >}}) command
@@ -229,7 +227,7 @@ and checks that it gives the expected response. Any unexpected response
 or exception indicates an unhealthy server. Although `PingHealthCheck` is
 very simple, it is a good basic approach for most Redis deployments.
 
-#### `LagAwareHealthCheck` (Redis Software only) {#lag-aware-health-check}
+### `LagAwareHealthCheck` (Redis Software only) {#lag-aware-health-check}
 
 `LagAwareHealthCheck` is designed specifically for
 Redis Software [Active-Active]({{< relref "/operate/rs/databases/active-active" >}})
@@ -294,7 +292,7 @@ The `LagAwareHealthCheck` constructor accepts the following options:
 | `client_key_file` | Path to client private key file for mutual TLS. |
 | `client_key_password` | Password for encrypted client private key |
 
-#### Custom health check strategy
+### Custom health check strategy
 
 You can supply your own custom health check strategy by
 deriving a new class from the `AbstractHealthCheck` class.
@@ -415,12 +413,19 @@ This section lists some common problems and their solutions.
 
 If all health checks fail, you should first rule out authentication
 problems with the Redis server and also make sure there are no persistent
-network connectivity problems. If you are using
+network connectivity problems.
+
+If you are using [`PingHealthCheck`](#pinghealthcheck-default) or a
+[custom health check strategy](#custom-health-check-strategy),
+check that the `socket_timeout` is not too low for your network conditions
+(see [Timeouts]({{< relref "/develop/clients/redis-py/produsage#timeouts" >}}) for more information).
+
+For
 [`LagAwareHealthCheck`](#lag-aware-health-check), check that the `health_check_url`
-is set correctly for each endpoint. You can also try increasing the timeout
-for health checks and the interval between them. See
-[Health check configuration](#health-check-configuration) and
-[Endpoint configuration](#endpoint-configuration) for more information about these options.
+is set correctly for each endpoint. Note that health checks might be taking longer to
+execute than you anticipated, so make sure your `timeout` setting is not too low.
+
+
 
 ### Slow failback after recovery
 


### PR DESCRIPTION
Added info about this based on customer feedback. The corresponding section for the Lettuce geo failover page will be added in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes; the main risk is incorrect exception/option naming that could mislead users configuring failover.
> 
> **Overview**
> Expands the client-side geographic failover docs to better describe **health check strategies** (ping, lag-aware via REST API, and custom) in the main overview.
> 
> Adds new guidance for Jedis and redis-py on **what happens when all endpoints are unhealthy**, including the exceptions thrown, how long the client keeps probing based on failover attempt/delay settings, and suggested retry/reconnect handling. Also clarifies redis-py troubleshooting advice around timeouts and `LagAwareHealthCheck` configuration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 817863f6099575255e64030a6b58a0c5816fbc67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->