### PR TITLE
MOD-5752: Clarify limitations on HIGHLIGHT, SUMMARIZE, and multi-values

### DIFF
--- a/content/develop/ai/search-and-query/indexing/_index.md
+++ b/content/develop/ai/search-and-query/indexing/_index.md
@@ -676,7 +676,7 @@ FT.CREATE idx ON JSON PREFIX 1 key: SCHEMA $.propA AS propA TAG $.propB AS propB
 
 ### HIGHLIGHT and SUMMARIZE
 
-No `HIGHLIGHT` and `SUMMARIZE` support for JSON documents.
+There is no `HIGHLIGHT` and `SUMMARIZE` support for JSON documents.
 
 ### Schema mapping
 


### PR DESCRIPTION
Clarify limitations on HIGHLIGHT, SUMMARIZE, and multi-values as general limitations
Not specific only to array of TEXT, etc.