### PR TITLE
RDSC-4666 Documenting how to modify the Debezium heap size

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
+++ b/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
@@ -110,7 +110,7 @@ sources:
     #   quarkus:
     #     banner.enabled: "false"
 
-    #   `java_options` controls the JAVA_OPTS environment variable. Use it to modify the default values for
+    #   `java_options` (for RDI 1.15.1 and above) controls the JAVA_OPTS environment variable. Use it to modify the default values for
     #       Java heap size and other Java options for the Debezium server.
     #   java_options: "-Xmx2g -Xms512m"
 
@@ -230,7 +230,7 @@ configuration contains the following data:
   - `quarkus`: Properties for the Debezium server, such as the log level. See the
     Quarkus [Configuration options](https://quarkus.io/guides/all-config)
     docs for the full set of available properties.
-  - `java_options`: controls the JAVA_OPTS environment variable. Use it to modify the default values for Java heap size and other Java options for the Debezium server.
+  - `java_options`: controls the JAVA_OPTS environment variable (for RDI 1.15.1 and above). Use it to modify the default values for Java heap size and other Java options for the Debezium server.
     For example, set it to `"-Xmx2g -Xms512m"` to set the maximum heap size to 2 GB and the initial heap size to 512 MB.
 
 ### Targets


### PR DESCRIPTION
Ticket: https://redislabs.atlassian.net/browse/RDSC-4666

Describes how the user can modify the JAVA_OPTS environment variable and use it to change the Debezium heap size default.