### PR TITLE
De-emphasize RDS Proxy in RDI setup documentation

### DIFF
--- a/content/operate/rc/databases/rdi/rds-proxy.md
+++ b/content/operate/rc/databases/rdi/rds-proxy.md
@@ -1,0 +1,112 @@
+---
+Title: RDS Proxy setup for RDI
+alwaysopen: false
+categories:
+- docs
+- operate
+- rc
+description: Set up RDS Proxy for Redis Data Integration (not recommended).
+hidden: true
+hideListLinks: true
+weight: 99
+---
+
+{{<warning>}}
+We do not recommend using RDS Proxy for RDI connections. The [Lambda function approach]({{< relref "/operate/rc/databases/rdi/setup#setup-lambda-function" >}}) provides better failover handling and is the recommended solution for production environments.
+
+Additionally, RDS Proxy does not work with RDS PostgreSQL and Aurora PostgreSQL because it does not support PostgreSQL logical replication.
+
+Only use RDS Proxy if you have specific requirements that necessitate it.
+{{</warning>}}
+
+## Overview
+
+RDS Proxy is a fully managed, highly available database proxy for Amazon RDS. While it can be used with RDI, we recommend the Lambda function approach instead for the following reasons:
+
+- **PostgreSQL incompatibility**: RDS Proxy does not support PostgreSQL logical replication, which is required for CDC (Change Data Capture).
+- **Added complexity**: RDS Proxy adds an additional layer between RDI and your database.
+- **Lambda provides better failover**: The Lambda function approach handles failover scenarios more efficiently.
+
+If you still need to use RDS Proxy, follow the instructions below.
+
+## Prerequisites
+
+Before setting up RDS Proxy, ensure you have:
+
+- An RDS or Aurora database (MySQL or SQL Server only)
+- AWS Secrets Manager secret containing your database credentials
+- AWS KMS encryption key for the secret
+- Appropriate IAM permissions
+
+## Create RDS Proxy
+
+Follow the AWS documentation to create an RDS Proxy:
+
+- [Creating an RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html) (AWS documentation)
+- [How RDS Proxy works](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.howitworks.html) (AWS documentation)
+- [RDS Proxy TLS/SSL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.howitworks.html#rds-proxy-security.tls) (AWS documentation)
+
+### IAM permissions
+
+The Proxy's IAM role must have the following permissions to access the database using the credentials secret and encryption key:
+
+- `secretsmanager:GetSecretValue`
+- `secretsmanager:DescribeSecret`
+- `kms:Decrypt`
+
+Example IAM policy:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret"
+            ],
+            "Resource": "arn:aws:secretsmanager:region:account-id:secret:secret-name"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "kms:Decrypt",
+            "Resource": "arn:aws:kms:region:account-id:key/key-id"
+        }
+    ]
+}
+```
+
+## Get the RDS Proxy IP address
+
+After creating the RDS Proxy, you need to get its static IP address to use when configuring the Network Load Balancer.
+
+To get the static IP address of your RDS Proxy, run the following command on an EC2 instance in the same VPC as the Proxy:
+
+```sh
+$ nslookup <proxy-endpoint>
+```
+
+Replace `<proxy-endpoint>` with the endpoint of your RDS Proxy. Save this IP address for use in the Network Load Balancer configuration.
+
+## Configure the Network Load Balancer
+
+When you [create the Network Load Balancer]({{< relref "/operate/rc/databases/rdi/setup#create-network-load-balancer-rds" >}}), use the RDS Proxy IP address instead of the database IP address:
+
+1. In **Register targets**, enter the static IP address of your RDS Proxy (obtained in the previous step).
+2. Enter the port number where your RDS Proxy is exposed.
+3. Select **Include as pending below**.
+4. Complete the remaining Network Load Balancer setup as described in the [main setup guide]({{< relref "/operate/rc/databases/rdi/setup#create-network-load-balancer-rds" >}}).
+
+## Next steps
+
+After setting up RDS Proxy and the Network Load Balancer:
+
+1. [Create an endpoint service]({{< relref "/operate/rc/databases/rdi/setup#create-endpoint-service-rds" >}}) through AWS PrivateLink.
+2. [Share your source database credentials]({{< relref "/operate/rc/databases/rdi/setup#share-source-database-credentials" >}}) with Redis Cloud.
+3. Continue with the [RDI pipeline configuration]({{< relref "/operate/rc/databases/rdi/define" >}}).
+
+{{<note>}}
+When using RDS Proxy, you do not need to set up the Lambda function for failover handling, as the proxy provides a static endpoint.
+{{</note>}}
+

--- a/content/operate/rc/databases/rdi/setup.md
+++ b/content/operate/rc/databases/rdi/setup.md
@@ -132,42 +132,13 @@ To set up PrivateLink for a database hosted on AWS RDS or AWS Aurora:
 
 To connect to your RDS or Aurora database, we recommend using a Lambda function approach. This provides a reliable and secure connection method for all database types.
 
-1. (Optional) [Create an RDS Proxy](#create-rds-proxy) - Not recommended, but available if required.
 1. [Create a network load balancer](#create-network-load-balancer-rds) that will route incoming requests to your database.
 1. [Create an endpoint service](#create-endpoint-service-rds) through AWS PrivateLink.
 1. [Set up Lambda function connectivity](#setup-lambda-function) to route requests to your database.
 
-### Create RDS Proxy (Optional - Not Recommended) {#create-rds-proxy}
-
-<details>
-<summary>Click to expand RDS Proxy setup instructions</summary>
-
-{{<warning>}}
-We do not recommend using RDS Proxy for RDI connections. The Lambda function approach (described later in this guide) provides better failover handling and is the recommended solution for production environments.
-
-Additionally, RDS Proxy does not work with RDS PostgreSQL and Aurora PostgreSQL because it does not support PostgreSQL logical replication.
-
-Only use RDS Proxy if you have specific requirements that necessitate it.
-{{</warning>}}
-
-If you need to use an RDS Proxy, follow the AWS documentation to set it up:
-
-- [How RDS Proxy works](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.howitworks.html#rds-proxy-security.tls) (AWS documentation)
-
-The Proxy's IAM role must have the following permissions to access the database using the credentials secret and encryption key:
-- `secretsmanager:GetSecretValue`
-- `secretsmanager:DescribeSecret`
-- `kms:Decrypt`
-
-After creating the RDS Proxy, you will need to get its static IP address to use when configuring the Network Load Balancer in the next step. To get the static IP address of your RDS Proxy, run the following command on an EC2 instance in the same VPC as the Proxy:
-
-```sh
-$ nslookup <proxy-endpoint>
-```
-
-Replace `<proxy-endpoint>` with the endpoint of your RDS Proxy. Save this IP address for use in the Network Load Balancer configuration.
-
-</details>
+{{<note>}}
+If you have specific requirements that necessitate using RDS Proxy instead of the recommended Lambda function approach, see the [RDS Proxy setup guide]({{< relref "/operate/rc/databases/rdi/rds-proxy" >}}). Note that RDS Proxy is not recommended and does not work with PostgreSQL.
+{{</note>}}
 
 ### Create network load balancer {#create-network-load-balancer-rds}
 
@@ -184,11 +155,9 @@ In the [AWS Management Console](https://console.aws.amazon.com/), use the **Serv
             - **Target type**: Select **IP Addresses**.
             - **Protocol : Port**: Select **TCP**, and then enter the port number where your database is exposed.
             - The **IP address type** and **VPC** should be selected already and match the VPC you selected earlier.
-        1. In **Register targets**, enter the static IP address of your database (or RDS Proxy if you created one), enter the port, and select **Include as pending below**. Then, select **Create target group** to create your target group. Return to **Listeners and routing** in the Network Load Balancer setup.
+        1. In **Register targets**, enter the static IP address of your database, enter the port, and select **Include as pending below**. Then, select **Create target group** to create your target group. Return to **Listeners and routing** in the Network Load Balancer setup.
 
-            **If you created an RDS Proxy:** Use the IP address you obtained in the [Create RDS Proxy](#create-rds-proxy) step.
-
-            **If connecting directly to the database:** To get the static IP address of your database, run the following command on an EC2 instance in the same VPC as the database:
+            To get the static IP address of your database, run the following command on an EC2 instance in the same VPC as the database:
             ```sh
             $ nslookup <database-endpoint>
             ```


### PR DESCRIPTION
## Summary

This PR updates the RDI setup documentation to de-emphasize RDS Proxy and recommend the Lambda function approach instead.

## Changes

- **Move RDS Proxy to optional collapsible section**: RDS Proxy setup is now hidden in a `<details>` section with a clear warning that it's not recommended
- **Add Lambda function recommendation**: Recommend using a Lambda function approach for all database types (MySQL, SQL Server, PostgreSQL)
- **Update documentation links**: 
  - Link to AWS documentation on RDS Proxy: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.howitworks.html#rds-proxy-security.tls
  - Link to AWS Lambda approach: https://aws.amazon.com/blogs/database/access-amazon-rds-across-vpcs-using-aws-privatelink-and-network-load-balancer/
  - Link to Redis Terraform solution: https://github.com/redis/rdi-cloud-automation/tree/main/examples/aws-rds-privatelink-failover
- **Reorder setup steps**: Lambda function setup is now last so customers have the necessary ARNs from NLB and Endpoint Service
- **Update NLB instructions**: Added conditional guidance for using RDS Proxy IP vs. database IP

## Rationale

- RDS Proxy is not recommended for RDI connections
- Lambda function approach provides better failover handling
- RDS Proxy doesn't work with PostgreSQL due to logical replication incompatibility
- Some customers may still require RDS Proxy for specific use cases, so we keep it available but hidden

## Related

Jira: RDSC-4604

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this PR only changes documentation content and links, with no product or infrastructure code changes.
> 
> **Overview**
> **RDI setup docs now steer users away from RDS Proxy** by removing it from the main RDS/Aurora PrivateLink steps, updating the NLB target guidance to register the database IP, and adding a note that RDS Proxy is *not recommended* and does not work with PostgreSQL.
> 
> Adds a new hidden `rds-proxy.md` page that documents RDS Proxy setup (with strong warnings), and adds a new `#setup-lambda-function` section describing the recommended Lambda-based failover approach, including a Redis-provided Terraform module and related deployment/verification guidance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3bfef7b073ce44ddb236a6b8c030569e91ed2fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->