### PR TITLE
DOC-6280 added alias to old Redis Insight link

### DIFF
--- a/content/develop/tools/insight/_index.md
+++ b/content/develop/tools/insight/_index.md
@@ -1,5 +1,7 @@
 ---
-aliases: /develop/connect/insight
+aliases:
+- /develop/connect/insight
+- /ui/insight/
 categories:
 - docs
 - develop


### PR DESCRIPTION
Alias for an obsolete link in the Redis Insight UI, reported by an RI developer on Slack.