### PR TITLE
Release notes - Redis Insight v3.2.0

### DIFF
--- a/content/develop/tools/insight/release-notes/v.3.2.0.md
+++ b/content/develop/tools/insight/release-notes/v.3.2.0.md
@@ -8,20 +8,20 @@ weight: 1
 
 ## 3.2.0 (February 2026)
 
-This is the General Availability (GA) release of Redis Insight 3.2.0. Includes new features, build updates and bug fixes.
+This is the General Availability (GA) release of Redis Insight 3.2.0, which includes new features, build updates, and bug fixes.
 
 ### Headlines
 
-• Connect to Azure Managed Redis with ease. Auto-discover databases across subscriptions with one-click import and connect using Entra ID, Azure passwordless (OAuth) authentication.
+Connect to Azure Managed Redis with ease. Auto-discover databases across subscriptions with one-click import and connect using Entra ID and Azure passwordless (OAuth) authentication.
 
 ### Details
 
-• Added support for Azure Managed Redis and Azure Cache for Redis tiers. Includes auto-discovery of databases across subscriptions with one-click import. Supports Microsoft Entra ID (OAuth) authentication with automatic background token refresh. Multi-account support to easily switch between different Azure accounts.
-• Simplified build process by removing Webpack dependency, using Vite for both development and production builds.
+- Added support for Azure Managed Redis and Azure Cache for Redis tiers. This support includes auto-discovery of databases across subscriptions with one-click import, Microsoft Entra ID (OAuth) authentication with automatic background token refresh, and multi-account support to switch easily between different Azure accounts.
+- Simplified the build process by removing the Webpack dependency. Vite is used now for both development and production builds.
 
 ### Bug fixes
 
-- https://github.com/redis/RedisInsight/pull/5504 Fixed critical security vulnerabilities CVE-2025-55130 (Node.js) and CVE-2025-15467 (OpenSSL) by upgrading Node version and Alpine base image in Docker.
+- https://github.com/redis/RedisInsight/pull/5504 Fixed critical security vulnerabilities CVE-2025-55130 (Node.js) and CVE-2025-15467 (OpenSSL) by upgrading the Node.js version and the Alpine base image in Docker.
 
 **SHA-512 Checksums**
 


### PR DESCRIPTION
Introduces notes for Redis Insight 3.2.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a new documentation page with release notes and checksums, with no runtime code changes.
> 
> **Overview**
> Adds a new release-notes page for **Redis Insight v3.2.0 (GA, Feb 2026)**.
> 
> Documents Azure Managed Redis/Azure Cache for Redis support (discovery + Entra ID OAuth), a build tooling shift from Webpack to Vite, and a security fix note referencing Node.js/OpenSSL CVEs, plus published SHA-512 package checksums.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48432e8427cf0cd345f7e6327c57befd21130f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->