### PR TITLE
K8s: babylon maint 2 RN

### DIFF
--- a/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
@@ -1,0 +1,29 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: This is a maintenance release to support Redis Enterprise Software version 8.0.10-81.
+hideListLinks: true
+linkTitle: 8.0.10-23 (February 2026)
+title: Redis Enterprise for Kubernetes 8.0.10-23 (February 2026) release notes
+weight: 29
+---
+
+## Highlights
+
+This is a maintenance release to support Redis Enterprise Software version 8.0.10-81. For version changes, supported distributions, and known limitations, see the [release notes for 8.0.10-21 (February 2026)]({{<relref "/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-21-feb2026">}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:8.0.10-81`
+- **Operator**: `redislabs/operator:8.0.10-23`
+- **Services Rigger**: `redislabs/k8s-controller:8.0.10-23`
+- **Callhome client**: `redislabs/re-call-home-client:8.0.10-23`
+- **Redis Enterprise operator bundle**: `8.0.10-23.0`
+
+## Known limitations
+
+See [8.0.10 releases]({{<relref "/operate/kubernetes/release-notes/8-0-10-releases/">}}) for information on known limitations.
+

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 8.0.10 release notes
 weight: 1
 ---
 
-Redis Enterprise for Kubernetes 8.0.10 includes bug fixes, enhancements, and support for Redis Enterprise Software 8.0.10. The latest release is 8.0.10-22 with support for Redis Enterprise Software version 8.0.10-76.
+Redis Enterprise for Kubernetes 8.0.10 includes bug fixes, enhancements, and support for Redis Enterprise Software 8.0.10. The latest release is 8.0.10-23 with support for Redis Enterprise Software version 8.0.10-81.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new release-note page and updates the 8.0.10 index to point to the new latest build/version tags.
> 
> **Overview**
> Adds release notes for **Redis Enterprise for Kubernetes `8.0.10-23` (Feb 2026)**, documenting it as a maintenance release supporting Redis Enterprise Software `8.0.10-81` and listing updated image/bundle tags.
> 
> Updates the `8.0.10` release-notes index to mark `8.0.10-23` (RES `8.0.10-81`) as the latest release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ad2855608593aab44c0b1e974026d077955ba04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->