### PR TITLE
K8s: correct enable sso

### DIFF
--- a/content/operate/kubernetes/security/sso.md
+++ b/content/operate/kubernetes/security/sso.md
@@ -79,6 +79,8 @@ The Service Provider certificate is used by the cluster to sign SAML requests an
       certificates:
         ssoServiceCertificateSecretName: sso-service-cert
       sso:
+        enabled: false  # SSO not yet active - set to true in Step 7 after completing configuration
+        enforceSSO: false  # Optional: set to true to disable local authentication for non-admin users
         saml:
           spMetadataSecretName: sp-metadata  # Optional: store SP metadata in a secret
           serviceProvider:
@@ -238,6 +240,8 @@ Using IdP metadata XML is the recommended approach as it's less error-prone.
         ssoServiceCertificateSecretName: sso-service-cert
         ssoIssuerCertificateSecretName: sso-issuer-cert
       sso:
+        enabled: false  # SSO not yet active - set to true in Step 7 after completing configuration
+        enforceSSO: false  # Optional: set to true to disable local authentication for non-admin users
         saml:
           idpMetadataSecretName: idp-metadata
           spMetadataSecretName: sp-metadata
@@ -263,6 +267,8 @@ If IdP metadata XML is unavailable, you can manually configure the issuer settin
         ssoServiceCertificateSecretName: sso-service-cert
         ssoIssuerCertificateSecretName: sso-issuer-cert
       sso:
+        enabled: false  # SSO not yet active - set to true in Step 7 after completing configuration
+        enforceSSO: false  # Optional: set to true to disable local authentication for non-admin users
         saml:
           issuer:
             entityID: "urn:sso:example:idp"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk docs-only change updating YAML examples; risk is limited to potential user confusion if the new `enabled`/`enforceSSO` guidance is incorrect.
> 
> **Overview**
> Updates the Kubernetes SSO documentation (`content/operate/kubernetes/security/sso.md`) to explicitly include `sso.enabled: false` and `sso.enforceSSO: false` in the intermediate configuration examples, clarifying that SSO should remain disabled until the final activation step and that `enforceSSO` is optional for disabling local auth.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0db51892dccfd2d5e7bf126adf444b0e799780bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->