### PR TITLE
RS: Certificate-based authentication doc improvements

### DIFF
--- a/content/operate/rs/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/security/certificates/certificate-based-authentication.md
@@ -12,21 +12,17 @@ weight: 70
 
 You can set up certificate-based authentication for specific users to enable secure, passwordless access to the Redis Software [REST API]({{<relref "/operate/rs/references/rest-api">}}) and databases.
 
-## Set up certificate-based authentication
+## Certificate-based authentication for the REST API
+
+### Set up certificate-based authentication for the REST API
 
 To set up certificate-based authentication:
 
-1. [Add the `mtls_trusted_ca` certificate.](#add-cert) 
+1. Add a trusted CA certificate `mtls_trusted_ca` to the cluster using an [update cluster certificates]({{<relref "/operate/rs/references/rest-api/requests/cluster/certificates">}}) request:
 
-1. [Configure cluster settings.](#config-cluster)
-
-1. If you want to enable certificate-based authentication for databases, you must [enable mutual TLS for the relevant databases](#enable-mtls-dbs). Otherwise, you can skip this step.
-
-1. [Create certificate auth_method users.](#create-cert-users)
-
-### Add mtls_trusted_ca certificate {#add-cert}
-
-To add a trusted CA certificate `mtls_trusted_ca` to the cluster, use an [update cluster certificates]({{<relref "/operate/rs/references/rest-api/requests/cluster/certificates">}}) request.
+    {{< multitabs id="add-mtls_trusted_ca-cert"
+          tab1="Redis Software v7.22.2 and later"
+          tab2="Redis Software v7.22.0 and earlier" >}}
 
 For Redis Software versions 7.22.2 and later, use:
 
@@ -42,6 +38,8 @@ PUT /v1/cluster/certificates
 }
 ```
 
+-tab-sep-
+
 For Redis Software versions 7.22.0 and earlier, use:
 
 ```sh
@@ -52,17 +50,14 @@ PUT /v1/cluster/update_cert
 }
 ```
 
-### Configure cluster settings {#config-cluster}
+    {{< /multitabs >}}
 
-[Update cluster settings]({{<relref "/operate/rs/references/rest-api/requests/cluster#put-cluster">}}) with mutual TLS (mTLS) configuration using one of the following options:
+1. [Update cluster settings]({{<relref "/operate/rs/references/rest-api/requests/cluster#put-cluster">}}) with mutual TLS (mTLS) configuration using one of the following options:
 
-- [Enable mTLS without subject validation](#enable-mtls-without-subject-validation).
-
-- [Enable mTLS with SAN validation](#enable-mtls-with-san-validation).
-
-- [Enable mTLS with Full Subject Name validation](#enable-mtls-with-full-subject-name-validation).
-
-#### Enable mTLS without subject validation
+    {{< multitabs id="enable-mTLS"
+          tab1="Without subject validation"
+          tab2="With SAN validation"
+          tab3="With Full Subject Name validation" >}}
 
 Additional certificate validation is optional. To enable mutual TLS without subject validation, use:
 
@@ -74,7 +69,7 @@ PUT /v1/cluster
 }
 ```
 
-#### Enable mTLS with SAN validation
+-tab-sep-
 
 For certificate validation by Subject Alternative Name (SAN), use:
 
@@ -91,29 +86,7 @@ PUT /v1/cluster
 
 Replace the placeholder value `<>` with your client certificate's Subject Common Name or SAN DNS entry.
 
-#### Enable mTLS with Full Subject Name validation
-
-For certificate validation by full Subject Name, use:
-
-```sh
-PUT /v1/cluster
-{
-  "mtls_certificate_authentication": true,
-  "mtls_client_cert_subject_validation_type": "full_subject",
-  "mtls_authorized_subjects": [{
-    "CN": "<Common Name>",
-    "OU": [<array of Organizational Unit strings>],
-    "O": "<Organization>",
-    "C": "<2-letter country code>",
-    "L": "<Locality (city)>",
-    "ST": "<State/Province>"
-  }]
-}
-```
-
-Replace the placeholder values `<>` with your client certificate's subject values.
-
-#### Example certificate and mTLS settings
+**Example certificate and mTLS settings**
 
 If a client certificate has:
 
@@ -136,25 +109,66 @@ PUT /v1/cluster
 }
 ```
 
-### Enable mutual TLS for databases {#enable-mtls-dbs}
+-tab-sep-
 
-Before you can connect to a database using certificate-based authentication, you must enable mutual TLS (mTLS). See [Enable TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls">}}) for detailed instructions.
-
-### Create certificate auth_method users {#create-cert-users}
-
-When you [create new users]({{<relref "/operate/rs/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body :
+For certificate validation by full Subject Name, use:
 
 ```sh
-POST /v1/users
+PUT /v1/cluster
 {
-  "auth_method": "certificate",
-  "certificate_subject_line": "CN=<Common Name>, OU=<Organization Unit>, O=<Organization>, L=<Locality>, ST=<State/Province>, C=<Country>"
+  "mtls_certificate_authentication": true,
+  "mtls_client_cert_subject_validation_type": "full_subject",
+  "mtls_authorized_subjects": [{
+    "CN": "<Common Name>",
+    "OU": [<array of Organizational Unit strings>],
+    "O": "<Organization>",
+    "C": "<2-letter country code>",
+    "L": "<Locality (city)>",
+    "ST": "<State/Province>"
+  }]
 }
 ```
 
 Replace the placeholder values `<>` with your client certificate's subject values.
 
-## Authenticate REST API requests
+**Example certificate and mTLS settings**
+
+If a client certificate has:
+
+- Subject: `CN=client.example.com`
+
+- SAN: `DNS:app1.example.com, DNS:client.example.com, DNS:app1-prod.example.com`
+
+You can use any of these values for the CN in `mtls_authorized_subjects`:
+
+```sh
+PUT /v1/cluster
+{
+  "mtls_certificate_authentication": true,
+  "mtls_client_cert_subject_validation_type": "san_cn",
+  "mtls_authorized_subjects": [
+    {"CN": "client.example.com"},   // Subject CN
+    {"CN": "app1.example.com"},     // SAN DNS entry
+    {"CN": "app1-prod.example.com"} // Another SAN DNS entry
+  ]
+}
+```
+
+    {{< /multitabs >}}
+
+1. When you [create new users]({{<relref "/operate/rs/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body:
+
+    ```sh
+    POST /v1/users
+    {
+      "auth_method": "certificate",
+      "certificate_subject_line": "CN=<Common Name>, OU=<Organization Unit>, O=<Organization>, L=<Locality>, ST=<State/Province>, C=<Country>"
+    }
+    ```
+
+    Replace the placeholder values `<>` with your client certificate's subject values.
+
+### Authenticate REST API requests
 
 To use the REST API with certificate-based authentication, you must provide a client certificate, signed by the trusted CA `mtls_trusted_ca`, and a private key.
 
@@ -164,7 +178,27 @@ The following example uses [cURL](https://curl.se/) to send a [REST API request]
 curl --request <METHOD> --url https://<hostname-or-IP-address>:9443/<API-version>/<API-path> --cert client.pem --key client.key
 ```
 
-## Authenticate database connections
+## Certificate-based authentication for databases
+
+### Set up certificate-based authentication for databases
+
+To set up certificate-based authentication for databases:
+
+1. Enable mutual TLS for the relevant databases. See [Enable TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls">}}) for detailed instructions.
+
+1. When you [create new users]({{<relref "/operate/rs/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body :
+
+    ```sh
+    POST /v1/users
+    {
+      "auth_method": "certificate",
+      "certificate_subject_line": "CN=<Common Name>, OU=<Organization Unit>, O=<Organization>, L=<Locality>, ST=<State/Province>, C=<Country>"
+    }
+    ```
+
+    Replace the placeholder values `<>` with your client certificate's subject values.
+
+### Authenticate database connections
 
 To connect to a database with certificate-based authentication, you must provide a client certificate, signed by the trusted CA `mtls_trusted_ca`, and a private key.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes that restructure and clarify mTLS/certificate-auth configuration; no runtime or security logic is modified.
> 
> **Overview**
> Reworks the `certificate-based-authentication` doc to clearly separate **REST API** vs **database** certificate-auth setup steps.
> 
> Adds version-specific REST API examples for uploading `mtls_trusted_ca` (newer `PUT /v1/cluster/certificates` vs older `PUT /v1/cluster/update_cert`), expands cluster mTLS configuration guidance with tabs for *no validation*, *SAN validation*, and *full subject validation*, and includes clearer SAN/CN placeholder guidance plus an explicit example mapping certificate Subject/SAN values to `mtls_authorized_subjects`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cd5a8f7e6cd0bebfcb48302369f6963518c4a52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->