### PR TITLE
RS: Added tombstone explanation to Active-Active docs

### DIFF
--- a/content/operate/rs/databases/active-active/develop/develop-for-aa.md
+++ b/content/operate/rs/databases/active-active/develop/develop-for-aa.md
@@ -135,7 +135,7 @@ TTL on key1 to an infinite time.
 
 The replica responsible for the winning expire value is also
 responsible for expiring the key and propagating a DEL effect when this
-happens. A losing replica is from this point on not responsible
+happens. From this point on, a losing replica is not responsible
 for expiring the key, unless another `EXPIRE` command resets the TTL.
 Furthermore, a replica that is not the owner of the expired value:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no product or runtime behavior impact. Main risk is minor doc inaccuracies/typos (e.g., link/wording changes) affecting reader guidance.
> 
> **Overview**
> Adds a new **`Tombstones`** section to the Active-Active development guide explaining why deletions are retained, how garbage collection removes tombstones, and how to monitor them via `INFO crdt`/Grafana.
> 
> Also improves clarity/consistency across the page (adds external links for MMR/CRDT, updates the `Replica Of` and Auto Tiering references, and tightens wording/formatting in the expiration, OOM, key counts, and `INFO` sections).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85f0763344625cc73cf805fb1c7bf00a0d40d422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->