### PR TITLE
DEV/RI: add additional documentation link in Redis Insight 3.2.0 release notes

### DIFF
--- a/content/develop/tools/insight/release-notes/v.3.2.0.md
+++ b/content/develop/tools/insight/release-notes/v.3.2.0.md
@@ -12,7 +12,7 @@ This is the General Availability (GA) release of Redis Insight 3.2.0, which incl
 
 ### Headlines
 
-Connect to Azure Managed Redis with ease. Auto-discover databases across subscriptions with one-click import and connect using Entra ID and Azure passwordless (OAuth) authentication.
+Connect to Azure Managed Redis with ease. Auto-discover databases across subscriptions with one-click import and connect using Entra ID and Azure passwordless (OAuth) authentication. To get started, follow the [Azure setup guide](https://github.com/RedisInsight/RedisInsight/blob/main/docs/azure-setup.md) to configure the required permissions.
 
 ### Details
 


### PR DESCRIPTION
Not sure if this is how it's done, but we need to add an additional link in the release notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a link to external setup instructions; no runtime or behavioral impact.
> 
> **Overview**
> Updates the Redis Insight `v.3.2.0` release notes to include a direct link to the Azure setup guide in the Azure Managed Redis headline, pointing readers to required permission configuration steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2dfb30597e68158ee4ef6c7c70ad9caaf41c4bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->