### PR TITLE
RS: Added limitation for HA for replica shards

### DIFF
--- a/content/operate/rs/databases/configure/replica-ha.md
+++ b/content/operate/rs/databases/configure/replica-ha.md
@@ -169,3 +169,11 @@ The following alerts are sent during replica HA activation:
 - Shard migration begins after the grace period.
 - Shard migration fails because there is no available node (sent hourly).
 - Shard migration is delayed because of the cooldown period.
+
+## Limitations
+
+- If two nodes that host a primary shard and its corresponding replica shard go down at the same time, both shards will be lost and replica high availability will not be able to create a new replica shard for any primary shard still running.
+
+    {{< note >}}
+This limitation applies only when cluster quorum is maintained after two nodes fail, such as clusters with at least five nodes. If two nodes fail simultaneously in a cluster with only three nodes, the entire cluster is lost and must be recovered.
+    {{< /note >}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or behavior is modified.
> 
> **Overview**
> Adds a new **Limitations** section to `replica-ha.md` clarifying that replica HA cannot recover a shard pair if the nodes hosting a primary shard and its replica fail at the same time, and notes this scenario is relevant only when quorum is still maintained (for example, 5+ node clusters).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40479465aff635659dd75a450b3b3885ecd883c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->