### PR TITLE
RS: Added skip-updating-env-path install.sh parameter as a breaking change in 7.22.x release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-7-22-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/_index.md
@@ -47,6 +47,14 @@ For more detailed release notes, select a build version from the following table
 
 - The fully qualified domain name is now validated using the FQDN library instead of a regex during cluster creation.
 
+### Breaking changes
+
+- Redis Software installation script changes:
+
+    - Added `--skip-updating-env-path` option to [`install.sh`]({{<relref "/operate/rs/installing-upgrading/install/install-script">}}).
+
+    - Added `skip_updating_env_path` parameter to the [installation answers file]({{<relref "/operate/rs/installing-upgrading/install/manage-installation-questions#configure-file-to-answer">}}).
+
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-95.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-0-95.md
@@ -212,6 +212,14 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 - The fully qualified domain name is now validated using the FQDN library instead of a regex during cluster creation.
 
+### Breaking changes
+
+- Redis Software installation script changes:
+
+    - Added `--skip-updating-env-path` option to [`install.sh`]({{<relref "/operate/rs/installing-upgrading/install/install-script">}}).
+
+    - Added `skip_updating_env_path` parameter to the [installation answers file]({{<relref "/operate/rs/installing-upgrading/install/manage-installation-questions#configure-file-to-answer">}}).
+
 ### Deprecations
 
 #### API deprecations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it just updates release notes to call out an installation script option as a breaking change.
> 
> **Overview**
> Documents a new **Breaking change** in Redis Software 7.22.x release notes.
> 
> Both the 7.22.x index and the `7.22.0-95` notes now call out installation-script changes, specifically the new `--skip-updating-env-path` flag for `install.sh` and the corresponding `skip_updating_env_path` answers-file parameter (with links to the install docs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79667d04ab5fa6bd0da0168d10face4621452106. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->