### PR TITLE
Redis Employee - Update yamls for ## Enable the admission controller part

### DIFF
--- a/content/operate/kubernetes/deployment/quick-start.md
+++ b/content/operate/kubernetes/deployment/quick-start.md
@@ -218,9 +218,9 @@ The operator bundle includes a webhook file. The webhook will intercept requests
     apiVersion: v1
     kind: Namespace
     metadata:
-       labels:
+      name: example-ns
+      labels:
         namespace-name: example-ns
-    name: example-ns
     ```
 
 1. Patch the webhook to add the `namespaceSelector` section.
@@ -231,7 +231,7 @@ The operator bundle includes a webhook file. The webhook will intercept requests
     - name: redisenterprise.admission.redislabs
       namespaceSelector:
         matchLabels:
-          namespace-name: staging
+          namespace-name: example-ns
     EOF
     ```
 


### PR DESCRIPTION
The YAMLs were badly identified, and also the second step was using `staging` as the namespace, not  `example-ns`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that corrects YAML structure and aligns the webhook `namespaceSelector` example with the intended `example-ns` namespace label.
> 
> **Overview**
> Fixes the *Enable the admission controller* quick-start snippet by correcting the Namespace YAML ordering/indentation and updating the webhook `namespaceSelector.matchLabels` example from `staging` to `example-ns`, so the admission webhook targeting instructions are consistent and copy/pasteable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3b1c119a70efef64255b8b37ec3344d963c1a34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->