### PR TITLE
Revise service types table for database connectivity

### DIFF
--- a/content/operate/kubernetes/networking/database-connectivity.md
+++ b/content/operate/kubernetes/networking/database-connectivity.md
@@ -29,13 +29,18 @@ Both services are created in the same namespace as your database and follow pred
 
 Redis Enterprise supports three service types for database access:
 
-| Service Type | Access Scope | Use Case |
-|--------------|--------------|----------|
-| `ClusterIP` | Cluster-internal only | Applications running within the same Kubernetes cluster |
-| `headless` | Cluster-internal only | Direct pod access, service discovery, StatefulSet scenarios |
-| `LoadBalancer` | External access | Applications outside the Kubernetes cluster |
+| Service Type | Rigger Spec Exact Name | Access Scope | Use Case |
+|--------------|--------------|--------------|----------|
+| `ClusterIP` | `cluster_ip` | Cluster-internal only | Applications running within the same Kubernetes cluster |
+| `headless` | `headless` | Cluster-internal only | Direct pod access, service discovery, StatefulSet scenarios |
+| `LoadBalancer` | `load_balancer` | External access | Applications outside the Kubernetes cluster |
 
 To configure the service type, use the `databaseServiceType` field in your REC's `servicesRiggerSpec`.
+
+For example, to enable the three Service options, you may use:
+```
+  {"spec":{"servicesRiggerSpec":{"databaseServiceType":"cluster_ip,headless,load_balancer"}}}
+```
 
 ## In-cluster database access
 


### PR DESCRIPTION
A good example of how to fix the servicesRiggerSpec for other service kinds would be helpful. Also, we don't properly document the exact databaseServiceType case-sensitive options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies configuration values for `servicesRiggerSpec.databaseServiceType`; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the Kubernetes database connectivity docs to **explicitly document the exact, case-sensitive `databaseServiceType` values** (`cluster_ip`, `headless`, `load_balancer`) by adding a new column to the service types table.
> 
> Adds a concrete `servicesRiggerSpec` example showing how to enable all three service options via a comma-separated `databaseServiceType` value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc093ebe5291685a27500088787aed5c3be7f00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->