### PR TITLE
RS 7.22.2-93 maintenance release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-93.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-93.md
@@ -91,11 +91,11 @@ The following table shows the SHA256 checksums for the available packages:
 
 | Package | SHA256 checksum (7.22.2-93 March release) |
 |---------|---------------------------------------|
-| Ubuntu 20 | <span class="break-all"></span> |
-| Ubuntu 22 | <span class="break-all"></span> |
-| Red Hat Enterprise Linux (RHEL) 8 | <span class="break-all"></span> |
-| Red Hat Enterprise Linux (RHEL) 9 | <span class="break-all"></span> |
-| Amazon Linux 2 | <span class="break-all"></span> |
+| Ubuntu 20 | <span class="break-all">08fe22b8ccb2e06c7e960fa15880e1f0ef421a3f43e63823155637b84220c866</span> |
+| Ubuntu 22 | <span class="break-all">efdc33d7c5566e4ecb0f4f0715f55cdcfcb56f8c187fcfc52a4a7397dec999fa</span> |
+| Red Hat Enterprise Linux (RHEL) 8 | <span class="break-all">92d60a4405638b049706f939499b13298f31504b7bd647c03e4ebbf112bcb2d4</span> |
+| Red Hat Enterprise Linux (RHEL) 9 | <span class="break-all">0d99ce90b9d4891304aa5c98663ab0d1a040bf6b3aa2e7ec0e577551727174a2</span> |
+| Amazon Linux 2 | <span class="break-all">90e732ed482d4243057464a89812afbabbfcbbf8a0df1a9c0765fa5dd27f7220</span> |
 
 ## Known issues
 


### PR DESCRIPTION
TODO:

- Add checksums when they are available

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new release notes markdown page and does not affect product code or runtime behavior.
> 
> **Overview**
> Introduces a new release-notes page, `rs-7-22-2-93.md`, for Redis Software **7.22.2-93 (March 2026)**.
> 
> The page documents highlighted fixes (post-upgrade `node_mgr` crashes and incorrect flash DB capacity >100% in Cluster Manager UI), lists bundled Redis versions/module compatibility, provides platform support and package SHA256 checksums, and includes updated known-issues/limitations and CVE/security-fix compatibility details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf159093e47d0a998a665ae3b91763f4d4e1a320. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->