### PR TITLE
RC: Fix Jan. 2026 changelog weight

### DIFF
--- a/content/operate/rc/changelog/january-2026.md
+++ b/content/operate/rc/changelog/january-2026.md
@@ -9,7 +9,7 @@ description: New features, enhancements, and other changes added to Redis Cloud 
   January 2026.
 highlights: Redis 8.4 on Redis Cloud Essentials
 linktitle: January 2026
-weight: 55
+weight: 54
 tags:
 - changelog
 ---


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line docs metadata change that only affects site navigation/sorting order, with no code or runtime behavior impact.
> 
> **Overview**
> Adjusts the frontmatter `weight` in `content/operate/rc/changelog/january-2026.md` (from `55` to `54`) to correct the January 2026 Redis Cloud changelog’s ordering in the docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e70abc029ca4a099d71b2f31dc608aabd5d3f56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->