### PR TITLE
RS 7.8.6-256 maintenance release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-256.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-256.md
@@ -85,11 +85,11 @@ The following table shows the SHA256 checksums for the available packages:
 
 | Package | SHA256 checksum (7.8.6-256 March release) |
 |---------|---------------------------------------|
-| Ubuntu 20 | <span class="break-all"></span> |
-| Ubuntu 22 | <span class="break-all"></span> |
-| Red Hat Enterprise Linux (RHEL) 8 | <span class="break-all"></span> |
-| Red Hat Enterprise Linux (RHEL) 9 | <span class="break-all"></span> |
-| Amazon Linux 2 | <span class="break-all"></span> |
+| Ubuntu 20 | <span class="break-all">69fa9e70d9718e2646c46ee7a09285c4e47febcc556a9728ac6e747c7c75f499</span> |
+| Ubuntu 22 | <span class="break-all">bf624bfe54b2e80a608ec97aad8d902e70445175a4cf4b2c0acfba47b4b95f2f</span> |
+| Red Hat Enterprise Linux (RHEL) 8 | <span class="break-all">7565de90080cf80729aeed7134b248c1c46e911d37df83cd5fc1a97448df9a46</span> |
+| Red Hat Enterprise Linux (RHEL) 9 | <span class="break-all">5cf42bf8cc35420b87bd3124142eebb95c97dd3721e767c41b5f9977ce2f3aa5</span> |
+| Amazon Linux 2 | <span class="break-all">1873daa09d9e17f09a456a17ee46f7415e40ac360d8fc919bcebe2630d979710</span> |
 
 ## Known issues
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a new release-notes markdown page; no product code or configuration logic is modified.
> 
> **Overview**
> Adds a new release notes document for **Redis Software `7.8.6-256` (March 2026)** under `rs-7-8-releases`, covering highlights, bundled Redis DB versions and module compatibility, and the supported-platforms snapshot.
> 
> Includes sections for downloads (with checksum placeholders), known issues/limitations, and an updated *Security* section enumerating included open-source Redis fixes and CVEs across supported Redis versions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98604834baec537bdd72a0c8dd5f2685bdb4b902. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->