### PR TITLE
AI: add canonical code examples to for-ais-only

### DIFF
--- a/for-ais-only/examples/go-redis/GO_REDIS_TEST_PATTERNS.md
+++ b/for-ais-only/examples/go-redis/GO_REDIS_TEST_PATTERNS.md
@@ -1,0 +1,192 @@
+# go-redis Test File Patterns
+
+This document describes the conventions used in go-redis documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable Go tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/go-redis/doctests/*_test.go`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/go-redis/sample_test.go`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template (Testable Examples)
+
+Go uses "Testable Examples" with `// Output:` comments for verification:
+
+```go
+// EXAMPLE: example_name
+// HIDE_START
+package example_commands_test
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/redis/go-redis/v9"
+)
+// HIDE_END
+
+func ExampleClient_operation_name() {
+    ctx := context.Background()
+
+    rdb := redis.NewClient(&redis.Options{
+        Addr:     "localhost:6379",
+        Password: "",
+        DB:       0,
+    })
+
+    // REMOVE_START
+    rdb.Del(ctx, "mykey")
+    // REMOVE_END
+
+    // STEP_START operation_name
+    res, err := rdb.Set(ctx, "mykey", "Hello", 0).Result()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(res) // >>> OK
+
+    value, err := rdb.Get(ctx, "mykey").Result()
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(value) // >>> Hello
+    // STEP_END
+
+    // Output:
+    // OK
+    // Hello
+}
+```
+
+## Key Patterns
+
+### 1. Package and Imports (in HIDE block)
+```go
+// HIDE_START
+package example_commands_test
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/redis/go-redis/v9"
+)
+// HIDE_END
+```
+
+### 2. Client Setup
+```go
+ctx := context.Background()
+
+rdb := redis.NewClient(&redis.Options{
+    Addr:     "localhost:6379",
+    Password: "",
+    DB:       0,
+})
+```
+
+### 3. Testable Example Function Naming
+```go
+// Function name format: Example<Type>_<method>
+func ExampleClient_hset() { ... }
+func ExampleClient_hget() { ... }
+func ExampleClient_string_ops() { ... }
+```
+
+### 4. Output Verification
+```go
+fmt.Println(res) // >>> OK
+
+// Output:
+// OK
+// Hello
+// value1
+```
+
+### 5. Hash Operations
+```go
+// Single field
+rdb.HSet(ctx, "myhash", "field1", "value1")
+
+// Multiple fields
+rdb.HSet(ctx, "myhash",
+    "field2", "value2",
+    "field3", "value3",
+)
+
+// Map
+bike := map[string]interface{}{
+    "model": "Deimos",
+    "brand": "Ergonom",
+}
+rdb.HSet(ctx, "bike:1", bike)
+
+// Get operations
+value, _ := rdb.HGet(ctx, "myhash", "field1").Result()
+all, _ := rdb.HGetAll(ctx, "myhash").Result()
+```
+
+### 6. Error Handling
+```go
+res, err := rdb.Set(ctx, "key", "value", 0).Result()
+if err != nil {
+    panic(err)
+}
+```
+
+## Setup
+
+```bash
+cd examples/go-redis
+go mod tidy
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+go test -v
+
+# Run specific example
+go test -v -run ExampleClient_hset
+
+# Run with race detection
+go test -race -v
+```
+
+## go.mod
+
+```go
+module redis_examples
+
+go 1.21
+
+require github.com/redis/go-redis/v9 v9.7.0
+```
+
+## API Notes
+
+- All methods require `context.Context` as first parameter
+- Methods return `*redis.StatusCmd`, `*redis.StringCmd`, etc.
+- Use `.Result()` to get value and error
+- Expiration: use `0` for no expiration, or `time.Duration`
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/go-redis/sample_test.go`
+- Hash commands: `/path/to/go-redis/doctests/cmds_hash_test.go`
+- String commands: `/path/to/go-redis/doctests/cmds_string_test.go`

--- a/for-ais-only/examples/go-redis/go.mod
+++ b/for-ais-only/examples/go-redis/go.mod
@@ -1,0 +1,10 @@
+module redis_examples
+
+go 1.21
+
+require github.com/redis/go-redis/v9 v9.7.0
+
+require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)

--- a/for-ais-only/examples/go-redis/sample_test.go
+++ b/for-ais-only/examples/go-redis/sample_test.go
@@ -1,0 +1,159 @@
+// =============================================================================
+// CANONICAL GO-REDIS TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for go-redis
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// Go uses "Testable Examples" with // Output: comments for verification
+// RUN: go test -v sample_test.go
+// =============================================================================
+
+// EXAMPLE: sample_example
+// HIDE_START
+package example_commands_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// HIDE_END
+
+func ExampleClient_string_ops() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "",
+		DB:       0,
+	})
+
+	// REMOVE_START
+	rdb.Del(ctx, "mykey")
+	// REMOVE_END
+
+	// STEP_START string_ops
+	res1, err := rdb.Set(ctx, "mykey", "Hello", 0).Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res1) // >>> OK
+
+	res2, err := rdb.Get(ctx, "mykey").Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res2) // >>> Hello
+	// STEP_END
+
+	// Output:
+	// OK
+	// Hello
+}
+
+func ExampleClient_hash_ops() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "",
+		DB:       0,
+	})
+
+	// REMOVE_START
+	rdb.Del(ctx, "myhash")
+	// REMOVE_END
+
+	// STEP_START hash_ops
+	res1, err := rdb.HSet(ctx, "myhash", "field1", "value1").Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res1) // >>> 1
+
+	res2, err := rdb.HSet(ctx, "myhash",
+		"field2", "value2",
+		"field3", "value3",
+	).Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res2) // >>> 2
+
+	res3, err := rdb.HGet(ctx, "myhash", "field1").Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res3) // >>> value1
+
+	res4, err := rdb.HGetAll(ctx, "myhash").Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res4["field1"]) // >>> value1
+	// STEP_END
+
+	// Output:
+	// 1
+	// 2
+	// value1
+	// value1
+}
+
+func ExampleClient_hash_tutorial() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "",
+		DB:       0,
+	})
+
+	// REMOVE_START
+	rdb.Del(ctx, "bike:1", "bike:1:stats")
+	// REMOVE_END
+
+	// STEP_START hash_tutorial
+	bike1 := map[string]interface{}{
+		"model": "Deimos",
+		"brand": "Ergonom",
+		"type":  "Enduro bikes",
+		"price": 4972,
+	}
+
+	res1, err := rdb.HSet(ctx, "bike:1", bike1).Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res1) // >>> 4
+
+	res2, err := rdb.HGet(ctx, "bike:1", "model").Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res2) // >>> Deimos
+
+	res3, err := rdb.HGet(ctx, "bike:1", "price").Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res3) // >>> 4972
+	// STEP_END
+
+	// Output:
+	// 4
+	// Deimos
+	// 4972
+}
+

--- a/for-ais-only/examples/hiredis/HIREDIS_TEST_PATTERNS.md
+++ b/for-ais-only/examples/hiredis/HIREDIS_TEST_PATTERNS.md
@@ -1,0 +1,204 @@
+# hiredis Test File Patterns
+
+This document describes the conventions used in hiredis (C) documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable C programs** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Sample template**: `/path/to/docs/for-ais-only/examples/hiredis/sample_test.c`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```c
+// EXAMPLE: example_name
+
+// STEP_START includes
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <hiredis/hiredis.h>
+// STEP_END
+
+int main(int argc, char **argv) {
+    // STEP_START connect
+    redisContext *c = redisConnect("127.0.0.1", 6379);
+
+    if (c == NULL || c->err) {
+        if (c) {
+            printf("Connection error: %s\n", c->errstr);
+            redisFree(c);
+        } else {
+            printf("Connection error: can't allocate redis context\n");
+        }
+        return 1;
+    }
+
+    printf("Connected to Redis\n");
+    // STEP_END
+
+    // REMOVE_START
+    redisCommand(c, "DEL mykey");
+    // REMOVE_END
+
+    // STEP_START string_ops
+    redisReply *reply;
+
+    reply = redisCommand(c, "SET %s %s", "mykey", "Hello");
+    printf("SET mykey Hello: %s\n", reply->str); // >>> OK
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "GET %s", "mykey");
+    printf("GET mykey: %s\n", reply->str); // >>> Hello
+    // REMOVE_START
+    if (strcmp(reply->str, "Hello") != 0) {
+        printf("ASSERTION FAILED\n");
+    }
+    // REMOVE_END
+    freeReplyObject(reply);
+    // STEP_END
+
+    // STEP_START disconnect
+    redisFree(c);
+    printf("Disconnected from Redis\n");
+    // STEP_END
+
+    return 0;
+}
+```
+
+## Key Patterns
+
+### 1. Includes
+```c
+// STEP_START includes
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <hiredis/hiredis.h>
+// STEP_END
+```
+
+### 2. Connection Setup
+```c
+// STEP_START connect
+redisContext *c = redisConnect("127.0.0.1", 6379);
+
+if (c == NULL || c->err) {
+    if (c) {
+        printf("Connection error: %s\n", c->errstr);
+        redisFree(c);
+    } else {
+        printf("Connection error: can't allocate redis context\n");
+    }
+    return 1;
+}
+// STEP_END
+```
+
+### 3. Executing Commands
+```c
+redisReply *reply;
+
+// String command with format specifiers
+reply = redisCommand(c, "SET %s %s", "mykey", "Hello");
+printf("Result: %s\n", reply->str);
+freeReplyObject(reply);
+
+// Integer result
+reply = redisCommand(c, "HSET %s %s %s", "myhash", "field1", "value1");
+printf("Fields added: %lld\n", reply->integer);
+freeReplyObject(reply);
+```
+
+### 4. Assertions (in REMOVE blocks)
+```c
+// REMOVE_START
+if (strcmp(reply->str, "Hello") != 0) {
+    printf("ASSERTION FAILED: Expected 'Hello', got '%s'\n", reply->str);
+}
+// REMOVE_END
+```
+
+### 5. Array Results (HGETALL)
+```c
+reply = redisCommand(c, "HGETALL %s", "myhash");
+printf("HGETALL myhash:\n");
+for (size_t i = 0; i < reply->elements; i += 2) {
+    printf("  %s: %s\n", reply->element[i]->str, reply->element[i+1]->str);
+}
+freeReplyObject(reply);
+```
+
+### 6. Cleanup
+```c
+// STEP_START disconnect
+redisFree(c);
+printf("Disconnected from Redis\n");
+// STEP_END
+```
+
+## Reply Types
+
+| Type | Field | Description |
+|------|-------|-------------|
+| `REDIS_REPLY_STRING` | `reply->str` | String value |
+| `REDIS_REPLY_INTEGER` | `reply->integer` | Integer value |
+| `REDIS_REPLY_ARRAY` | `reply->elements`, `reply->element[i]` | Array of replies |
+| `REDIS_REPLY_STATUS` | `reply->str` | Status string (OK) |
+| `REDIS_REPLY_NIL` | - | NULL value |
+
+## Building and Running
+
+```bash
+# Compile
+cc sample_test.c -L/usr/local/lib -lhiredis -o sample_test
+
+# Or with pkg-config
+cc sample_test.c $(pkg-config --cflags --libs hiredis) -o sample_test
+
+# Run
+./sample_test
+```
+
+## Memory Management
+
+**Important**: Always free reply objects to avoid memory leaks:
+```c
+redisReply *reply = redisCommand(c, "GET key");
+// ... use reply ...
+freeReplyObject(reply);  // Always free!
+```
+
+## Installing hiredis
+
+```bash
+# macOS
+brew install hiredis
+
+# Ubuntu/Debian
+apt-get install libhiredis-dev
+
+# From source
+git clone https://github.com/redis/hiredis.git
+cd hiredis
+make && sudo make install
+```
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/hiredis/sample_test.c`
+- hiredis repo: https://github.com/redis/hiredis

--- a/for-ais-only/examples/hiredis/sample_test.c
+++ b/for-ais-only/examples/hiredis/sample_test.c
@@ -1,0 +1,161 @@
+// =============================================================================
+// CANONICAL HIREDIS TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for hiredis
+// documentation test files. These tests serve dual purposes:
+// 1. Executable code that validates snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// BUILD: cc sample_test.c -L/usr/local/lib -lhiredis -o sample_test
+// RUN: ./sample_test
+// =============================================================================
+
+// EXAMPLE: sample_example
+
+// STEP_START includes
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <hiredis/hiredis.h>
+// STEP_END
+
+int main(int argc, char **argv) {
+    // STEP_START connect
+    // Connect to Redis server
+    redisContext *c = redisConnect("127.0.0.1", 6379);
+
+    if (c == NULL || c->err) {
+        if (c) {
+            printf("Connection error: %s\n", c->errstr);
+            redisFree(c);
+        } else {
+            printf("Connection error: can't allocate redis context\n");
+        }
+        return 1;
+    }
+
+    printf("Connected to Redis\n");
+    // STEP_END
+
+    // REMOVE_START
+    // Clean up any existing data before tests
+    redisCommand(c, "DEL mykey myhash bike:1 bike:1:stats");
+    // REMOVE_END
+
+    // STEP_START string_ops
+    // Basic string SET/GET operations
+    redisReply *reply;
+
+    reply = redisCommand(c, "SET %s %s", "mykey", "Hello");
+    printf("SET mykey Hello: %s\n", reply->str); // >>> OK
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "GET %s", "mykey");
+    printf("GET mykey: %s\n", reply->str); // >>> Hello
+    // REMOVE_START
+    if (strcmp(reply->str, "Hello") != 0) {
+        printf("ASSERTION FAILED: Expected 'Hello', got '%s'\n", reply->str);
+    }
+    // REMOVE_END
+    freeReplyObject(reply);
+    // STEP_END
+
+    // REMOVE_START
+    redisCommand(c, "DEL mykey");
+    // REMOVE_END
+
+    // STEP_START hash_ops
+    // Hash operations: HSET, HGET, HGETALL
+    reply = redisCommand(c, "HSET %s %s %s", "myhash", "field1", "value1");
+    printf("HSET myhash field1 value1: %lld\n", reply->integer); // >>> 1
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "HSET %s %s %s %s %s", 
+        "myhash", "field2", "value2", "field3", "value3");
+    printf("HSET myhash field2 value2 field3 value3: %lld\n", reply->integer); // >>> 2
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "HGET %s %s", "myhash", "field1");
+    printf("HGET myhash field1: %s\n", reply->str); // >>> value1
+    // REMOVE_START
+    if (strcmp(reply->str, "value1") != 0) {
+        printf("ASSERTION FAILED: Expected 'value1', got '%s'\n", reply->str);
+    }
+    // REMOVE_END
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "HGETALL %s", "myhash");
+    printf("HGETALL myhash:\n");
+    for (size_t i = 0; i < reply->elements; i += 2) {
+        printf("  %s: %s\n", reply->element[i]->str, reply->element[i+1]->str);
+    }
+    // >>> field1: value1
+    // >>> field2: value2
+    // >>> field3: value3
+    freeReplyObject(reply);
+    // STEP_END
+
+    // REMOVE_START
+    redisCommand(c, "DEL myhash");
+    // REMOVE_END
+
+    // STEP_START hash_tutorial
+    // Tutorial-style example with bike data
+    reply = redisCommand(c, "HSET %s %s %s %s %s %s %s %s %s",
+        "bike:1",
+        "model", "Deimos",
+        "brand", "Ergonom",
+        "type", "Enduro bikes",
+        "price", "4972");
+    printf("HSET bike:1 (4 fields): %lld\n", reply->integer); // >>> 4
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "HGET %s %s", "bike:1", "model");
+    printf("HGET bike:1 model: %s\n", reply->str); // >>> Deimos
+    // REMOVE_START
+    if (strcmp(reply->str, "Deimos") != 0) {
+        printf("ASSERTION FAILED: Expected 'Deimos', got '%s'\n", reply->str);
+    }
+    // REMOVE_END
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "HGET %s %s", "bike:1", "price");
+    printf("HGET bike:1 price: %s\n", reply->str); // >>> 4972
+    freeReplyObject(reply);
+    // STEP_END
+
+    // STEP_START hincrby
+    // Numeric operations on hash fields
+    reply = redisCommand(c, "HINCRBY %s %s %d", "bike:1:stats", "rides", 1);
+    printf("HINCRBY bike:1:stats rides 1: %lld\n", reply->integer); // >>> 1
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "HINCRBY %s %s %d", "bike:1:stats", "rides", 1);
+    printf("HINCRBY bike:1:stats rides 1: %lld\n", reply->integer); // >>> 2
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "HINCRBY %s %s %d", "bike:1:stats", "crashes", 1);
+    printf("HINCRBY bike:1:stats crashes 1: %lld\n", reply->integer); // >>> 1
+    freeReplyObject(reply);
+    // STEP_END
+
+    // REMOVE_START
+    redisCommand(c, "DEL bike:1 bike:1:stats");
+    // REMOVE_END
+
+    // STEP_START disconnect
+    // Disconnect from Redis
+    redisFree(c);
+    printf("Disconnected from Redis\n");
+    // STEP_END
+
+    return 0;
+}
+

--- a/for-ais-only/examples/ioredis/IOREDIS_TEST_PATTERNS.md
+++ b/for-ais-only/examples/ioredis/IOREDIS_TEST_PATTERNS.md
@@ -1,0 +1,172 @@
+# ioredis Test File Patterns
+
+This document describes the conventions used in ioredis documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable Node.js scripts** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/docs/local_examples/client-specific/ioredis/*.js`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/ioredis/sample_test.js`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```javascript
+// EXAMPLE: example_name
+// BINDER_ID ioredis-example
+
+// STEP_START connect
+import { Redis } from 'ioredis';
+
+const redis = new Redis();
+// STEP_END
+
+// REMOVE_START
+await redis.del('mykey');
+// REMOVE_END
+
+// STEP_START operation_name
+const res = await redis.set('mykey', 'Hello');
+console.log(res); // >>> OK
+
+const value = await redis.get('mykey');
+console.log(value); // >>> Hello
+// STEP_END
+
+// REMOVE_START
+if (res !== 'OK') throw new Error('Expected OK');
+if (value !== 'Hello') throw new Error('Expected Hello');
+await redis.del('mykey');
+// REMOVE_END
+
+// STEP_START close
+redis.disconnect();
+// STEP_END
+```
+
+## Key Patterns
+
+### 1. Connection Setup
+```javascript
+// STEP_START connect
+import { Redis } from 'ioredis';
+
+const redis = new Redis();
+// STEP_END
+
+// Or with options:
+const redis = new Redis({
+    host: 'localhost',
+    port: 6379,
+    password: ''
+});
+```
+
+### 2. Assertions (in REMOVE blocks)
+```javascript
+// REMOVE_START
+if (res !== 'OK') throw new Error('Expected OK');
+if (value !== 'Hello') throw new Error('Expected Hello');
+await redis.del('mykey');
+// REMOVE_END
+```
+
+### 3. Console Output Comments
+```javascript
+console.log(res); // >>> OK
+console.log(value); // >>> Hello
+
+// Multi-line output:
+console.log(JSON.stringify(data, null, 2));
+/* >>>
+{
+  "field1": "value1",
+  "field2": "value2"
+}
+*/
+```
+
+### 4. Hash Operations
+```javascript
+// Single field
+await redis.hset('myhash', 'field1', 'value1');
+
+// Multiple fields (object)
+await redis.hset('myhash', {
+    field2: 'value2',
+    field3: 'value3'
+});
+
+// Get operations
+const value = await redis.hget('myhash', 'field1');
+const all = await redis.hgetall('myhash');
+```
+
+### 5. Disconnect
+```javascript
+// STEP_START close
+redis.disconnect();
+// STEP_END
+```
+
+## ioredis vs node-redis API Differences
+
+| Operation | ioredis | node-redis |
+|-----------|---------|------------|
+| Import | `import { Redis } from 'ioredis'` | `import { createClient } from 'redis'` |
+| Create | `new Redis()` | `createClient()` |
+| Connect | Auto-connects | `await client.connect()` |
+| Methods | lowercase: `hset`, `hget` | camelCase: `hSet`, `hGet` |
+| Disconnect | `redis.disconnect()` | `await client.quit()` |
+
+## Setup
+
+```bash
+cd examples/ioredis
+npm install
+```
+
+## Running Tests
+
+```bash
+# Run directly
+node sample_test.js
+
+# Or use npm script
+npm test
+```
+
+## package.json
+
+```json
+{
+  "name": "ioredis-examples",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node sample_test.js"
+  },
+  "dependencies": {
+    "ioredis": "^5.4.0"
+  }
+}
+```
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/ioredis/sample_test.js`
+- Landing example: `/path/to/docs/local_examples/client-specific/ioredis/landing.js`

--- a/for-ais-only/examples/ioredis/package.json
+++ b/for-ais-only/examples/ioredis/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ioredis-examples",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node sample_test.js"
+  },
+  "dependencies": {
+    "ioredis": "^5.4.0"
+  }
+}

--- a/for-ais-only/examples/ioredis/sample_test.js
+++ b/for-ais-only/examples/ioredis/sample_test.js
@@ -1,0 +1,134 @@
+// =============================================================================
+// CANONICAL IOREDIS TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for ioredis
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// RUN: node sample_test.js
+// =============================================================================
+
+// EXAMPLE: sample_example
+// BINDER_ID ioredis-sample
+
+// STEP_START connect
+import { Redis } from 'ioredis';
+
+const redis = new Redis();
+// STEP_END
+
+// REMOVE_START
+// Clean up any existing data before tests
+await redis.del('mykey');
+await redis.del('myhash');
+await redis.del('bike:1');
+await redis.del('bike:1:stats');
+// REMOVE_END
+
+// STEP_START string_ops
+// Basic string SET/GET operations
+const res1 = await redis.set('mykey', 'Hello');
+console.log(res1); // >>> OK
+
+const res2 = await redis.get('mykey');
+console.log(res2); // >>> Hello
+// STEP_END
+
+// REMOVE_START
+if (res1 !== 'OK') throw new Error('Expected OK');
+if (res2 !== 'Hello') throw new Error('Expected Hello');
+await redis.del('mykey');
+// REMOVE_END
+
+// STEP_START hash_ops
+// Hash operations: HSET, HGET, HGETALL
+const res3 = await redis.hset('myhash', 'field1', 'value1');
+console.log(res3); // >>> 1
+
+const res4 = await redis.hset('myhash', {
+    'field2': 'value2',
+    'field3': 'value3'
+});
+console.log(res4); // >>> 2
+
+const res5 = await redis.hget('myhash', 'field1');
+console.log(res5); // >>> value1
+
+const res6 = await redis.hgetall('myhash');
+console.log(res6);
+// >>> { field1: 'value1', field2: 'value2', field3: 'value3' }
+// STEP_END
+
+// REMOVE_START
+if (res3 !== 1) throw new Error('Expected 1');
+if (res4 !== 2) throw new Error('Expected 2');
+if (res5 !== 'value1') throw new Error('Expected value1');
+await redis.del('myhash');
+// REMOVE_END
+
+// STEP_START hash_tutorial
+// Tutorial-style example with bike data
+await redis.hset('bike:1', {
+    model: 'Deimos',
+    brand: 'Ergonom',
+    type: 'Enduro bikes',
+    price: 4972
+});
+
+const res7 = await redis.hget('bike:1', 'model');
+console.log(res7); // >>> Deimos
+
+const res8 = await redis.hget('bike:1', 'price');
+console.log(res8); // >>> 4972
+
+const res9 = await redis.hgetall('bike:1');
+console.log(JSON.stringify(res9, null, 2));
+/* >>>
+{
+  "model": "Deimos",
+  "brand": "Ergonom",
+  "type": "Enduro bikes",
+  "price": "4972"
+}
+*/
+// STEP_END
+
+// REMOVE_START
+if (res7 !== 'Deimos') throw new Error('Expected Deimos');
+if (res8 !== '4972') throw new Error('Expected 4972');
+await redis.del('bike:1');
+// REMOVE_END
+
+// STEP_START hincrby
+// Numeric operations on hash fields
+await redis.hset('bike:1:stats', 'rides', 0);
+
+const res10 = await redis.hincrby('bike:1:stats', 'rides', 1);
+console.log(res10); // >>> 1
+
+const res11 = await redis.hincrby('bike:1:stats', 'rides', 1);
+console.log(res11); // >>> 2
+
+const res12 = await redis.hincrby('bike:1:stats', 'crashes', 1);
+console.log(res12); // >>> 1
+// STEP_END
+
+// REMOVE_START
+if (res10 !== 1) throw new Error('Expected 1');
+if (res11 !== 2) throw new Error('Expected 2');
+if (res12 !== 1) throw new Error('Expected 1');
+await redis.del('bike:1:stats');
+// REMOVE_END
+
+// STEP_START close
+redis.disconnect();
+// STEP_END
+

--- a/for-ais-only/examples/jedis/JEDIS_TEST_PATTERNS.md
+++ b/for-ais-only/examples/jedis/JEDIS_TEST_PATTERNS.md
@@ -1,0 +1,215 @@
+# Jedis Test File Patterns
+
+This document describes the conventions used in Jedis documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable JUnit 5 tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/jedis/src/test/java/io/redis/examples/*.java`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/jedis/SampleTest.java`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```java
+// EXAMPLE: example_name
+// REMOVE_START
+package io.redis.examples;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+// REMOVE_END
+
+// HIDE_START
+import redis.clients.jedis.UnifiedJedis;
+
+import java.util.HashMap;
+import java.util.Map;
+// HIDE_END
+
+public class SampleTest {
+
+    // REMOVE_START
+    @Test
+    // REMOVE_END
+    public void run() {
+        // HIDE_START
+        UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+        // HIDE_END
+
+        // REMOVE_START
+        jedis.del("mykey");
+        // REMOVE_END
+
+        // STEP_START operation_name
+        String res = jedis.set("mykey", "Hello");
+        System.out.println(res); // >>> OK
+
+        String value = jedis.get("mykey");
+        System.out.println(value); // >>> Hello
+        // STEP_END
+
+        // REMOVE_START
+        assertEquals("OK", res);
+        assertEquals("Hello", value);
+        jedis.del("mykey");
+        jedis.close();
+        // REMOVE_END
+    }
+}
+```
+
+## Key Patterns
+
+### 1. Package and Imports
+```java
+// REMOVE_START
+package io.redis.examples;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+// REMOVE_END
+
+// HIDE_START
+import redis.clients.jedis.UnifiedJedis;
+import java.util.HashMap;
+import java.util.Map;
+// HIDE_END
+```
+
+### 2. Connection Setup (in HIDE block)
+```java
+// HIDE_START
+UnifiedJedis jedis = new UnifiedJedis("redis://localhost:6379");
+// HIDE_END
+```
+
+### 3. Assertions (in REMOVE blocks)
+```java
+// REMOVE_START
+assertEquals("OK", res);
+assertEquals("Hello", value);
+assertEquals(3, map.size());
+jedis.del("mykey");
+jedis.close();
+// REMOVE_END
+```
+
+### 4. Console Output Comments
+```java
+System.out.println(res); // >>> OK
+System.out.println(value); // >>> Hello
+System.out.println(map);
+// >>> {field1=value1, field2=value2}
+```
+
+### 5. Hash Operations
+```java
+// Single field
+jedis.hset("myhash", "field1", "value1");
+
+// Multiple fields
+Map<String, String> fields = new HashMap<>();
+fields.put("field2", "value2");
+fields.put("field3", "value3");
+jedis.hset("myhash", fields);
+
+// Get operations
+String value = jedis.hget("myhash", "field1");
+Map<String, String> all = jedis.hgetAll("myhash");
+```
+
+## Directory Structure
+
+Maven requires test files to be in a specific directory structure:
+
+```
+examples/jedis/
+├── pom.xml
+├── JEDIS_TEST_PATTERNS.md
+└── src/
+    └── test/
+        └── java/
+            └── io/
+                └── redis/
+                    └── examples/
+                        └── SampleTest.java
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+mvn test
+
+# Run specific test class
+mvn test -Dtest=SampleTest
+
+# Run specific method
+mvn test -Dtest=SampleTest#run
+```
+
+## Maven pom.xml (Minimal)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.redis.examples</groupId>
+    <artifactId>jedis-examples</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>7.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/jedis/SampleTest.java`
+- Hash commands: `/path/to/jedis/src/test/java/io/redis/examples/CmdsHashExample.java`

--- a/for-ais-only/examples/jedis/pom.xml
+++ b/for-ais-only/examples/jedis/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.redis.examples</groupId>
+    <artifactId>jedis-examples</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>7.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/for-ais-only/examples/jedis/src/test/java/io/redis/examples/SampleTest.java
+++ b/for-ais-only/examples/jedis/src/test/java/io/redis/examples/SampleTest.java
@@ -1,0 +1,145 @@
+// =============================================================================
+// CANONICAL JEDIS TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for Jedis
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// RUN: mvn test -Dtest=SampleTest
+// =============================================================================
+
+// EXAMPLE: sample_example
+// REMOVE_START
+package io.redis.examples;
+
+import org.junit.jupiter.api.Test;
+// REMOVE_END
+
+import java.util.HashMap;
+import java.util.Map;
+
+// HIDE_START
+import redis.clients.jedis.RedisClient;
+// HIDE_END
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+// HIDE_START
+public class SampleTest {
+
+    @Test
+    public void run() {
+        RedisClient jedis = RedisClient.create("redis://localhost:6379");
+
+        // REMOVE_START
+        // Clean up any existing data before tests
+        jedis.del("mykey", "myhash", "bike:1", "bike:1:stats");
+        // REMOVE_END
+// HIDE_END
+
+        // STEP_START string_ops
+        // Basic string SET/GET operations
+        String res1 = jedis.set("mykey", "Hello");
+        System.out.println(res1);    // >>> OK
+
+        String res2 = jedis.get("mykey");
+        System.out.println(res2);    // >>> Hello
+        // STEP_END
+        // REMOVE_START
+        assertEquals("OK", res1);
+        assertEquals("Hello", res2);
+        jedis.del("mykey");
+        // REMOVE_END
+
+        // STEP_START hash_ops
+        // Hash operations: HSET, HGET, HGETALL
+        Map<String, String> hashFields = new HashMap<>();
+        hashFields.put("field1", "value1");
+
+        long res3 = jedis.hset("myhash", hashFields);
+        System.out.println(res3);    // >>> 1
+
+        hashFields.clear();
+        hashFields.put("field2", "value2");
+        hashFields.put("field3", "value3");
+
+        long res4 = jedis.hset("myhash", hashFields);
+        System.out.println(res4);    // >>> 2
+
+        String res5 = jedis.hget("myhash", "field1");
+        System.out.println(res5);    // >>> value1
+
+        Map<String, String> res6 = jedis.hgetAll("myhash");
+        System.out.println(res6.get("field1"));    // >>> value1
+        // STEP_END
+        // REMOVE_START
+        assertEquals(1, res3);
+        assertEquals(2, res4);
+        assertEquals("value1", res5);
+        assertEquals("value1", res6.get("field1"));
+        jedis.del("myhash");
+        // REMOVE_END
+
+        // STEP_START hash_tutorial
+        // Tutorial-style example with bike data
+        Map<String, String> bike1 = new HashMap<>();
+        bike1.put("model", "Deimos");
+        bike1.put("brand", "Ergonom");
+        bike1.put("type", "Enduro bikes");
+        bike1.put("price", "4972");
+
+        long res7 = jedis.hset("bike:1", bike1);
+        System.out.println(res7);    // >>> 4
+
+        String res8 = jedis.hget("bike:1", "model");
+        System.out.println(res8);    // >>> Deimos
+
+        String res9 = jedis.hget("bike:1", "price");
+        System.out.println(res9);    // >>> 4972
+
+        Map<String, String> res10 = jedis.hgetAll("bike:1");
+        System.out.println(res10.get("model"));    // >>> Deimos
+        // STEP_END
+        // REMOVE_START
+        assertEquals(4, res7);
+        assertEquals("Deimos", res8);
+        assertEquals("4972", res9);
+        assertEquals("Deimos", res10.get("model"));
+        jedis.del("bike:1");
+        // REMOVE_END
+
+        // STEP_START hincrby
+        // Numeric operations on hash fields
+        jedis.hset("bike:1:stats", "rides", "0");
+
+        long res11 = jedis.hincrBy("bike:1:stats", "rides", 1);
+        System.out.println(res11);    // >>> 1
+
+        long res12 = jedis.hincrBy("bike:1:stats", "rides", 1);
+        System.out.println(res12);    // >>> 2
+
+        long res13 = jedis.hincrBy("bike:1:stats", "crashes", 1);
+        System.out.println(res13);    // >>> 1
+        // STEP_END
+        // REMOVE_START
+        assertEquals(1, res11);
+        assertEquals(2, res12);
+        assertEquals(1, res13);
+        jedis.del("bike:1:stats");
+        // REMOVE_END
+
+// HIDE_START
+        jedis.close();
+    }
+}
+// HIDE_END
+

--- a/for-ais-only/examples/lettuce-async/LETTUCE_ASYNC_TEST_PATTERNS.md
+++ b/for-ais-only/examples/lettuce-async/LETTUCE_ASYNC_TEST_PATTERNS.md
@@ -1,0 +1,227 @@
+# Lettuce Async Test File Patterns
+
+This document describes the conventions used in Lettuce async documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable JUnit 5 tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/lettuce/src/test/java/io/redis/examples/async/*.java`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/lettuce-async/SampleTest.java`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```java
+// EXAMPLE: example_name
+package io.redis.examples.async;
+
+import io.lettuce.core.*;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.StatefulRedisConnection;
+
+// REMOVE_START
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+// REMOVE_END
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+public class SampleTest {
+
+    // REMOVE_START
+    @Test
+    // REMOVE_END
+    public void run() {
+        RedisClient redisClient = RedisClient.create("redis://localhost:6379");
+
+        try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+            RedisAsyncCommands<String, String> asyncCommands = connection.async();
+
+            // REMOVE_START
+            asyncCommands.del("mykey").get();
+            // REMOVE_END
+
+            // STEP_START operation_name
+            CompletableFuture<String> setFuture = asyncCommands.set("mykey", "Hello")
+                .toCompletableFuture();
+
+            CompletableFuture<String> result = setFuture
+                .thenCompose(res -> {
+                    System.out.println(res); // >>> OK
+                    return asyncCommands.get("mykey").toCompletableFuture();
+                })
+                .thenApply(value -> {
+                    System.out.println(value); // >>> Hello
+                    return value;
+                });
+
+            result.join();
+            // STEP_END
+
+            // REMOVE_START
+            assertThat(result.join()).isEqualTo("Hello");
+            // REMOVE_END
+        } finally {
+            redisClient.shutdown();
+        }
+    }
+}
+```
+
+## Key Patterns
+
+### 1. Connection Setup
+```java
+RedisClient redisClient = RedisClient.create("redis://localhost:6379");
+
+try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+    RedisAsyncCommands<String, String> asyncCommands = connection.async();
+    // ... operations
+} finally {
+    redisClient.shutdown();
+}
+```
+
+### 2. CompletableFuture Chaining
+```java
+CompletableFuture<Void> chain = asyncCommands.set("key", "value")
+    .toCompletableFuture()
+    .thenCompose(res -> asyncCommands.get("key").toCompletableFuture())
+    .thenAccept(value -> System.out.println(value));
+
+chain.join(); // Wait for completion
+```
+
+### 3. Assertions (in REMOVE blocks)
+```java
+// REMOVE_START
+assertThat(result.join()).isEqualTo("Hello");
+assertThat(map).hasSize(3);
+asyncCommands.del("mykey").get();
+// REMOVE_END
+```
+
+### 4. Hash Operations
+```java
+// Multiple fields
+Map<String, String> fields = new HashMap<>();
+fields.put("field1", "value1");
+fields.put("field2", "value2");
+
+CompletableFuture<Long> setHash = asyncCommands.hset("myhash", fields)
+    .toCompletableFuture();
+
+// Get operations
+CompletableFuture<String> getField = asyncCommands.hget("myhash", "field1")
+    .toCompletableFuture();
+
+CompletableFuture<Map<String, String>> getAll = asyncCommands.hgetall("myhash")
+    .toCompletableFuture();
+```
+
+### 5. Parallel Execution
+```java
+CompletableFuture.allOf(future1, future2, future3).join();
+```
+
+## Directory Structure
+
+Maven requires test files to be in a specific directory structure:
+
+```
+examples/lettuce-async/
+├── pom.xml
+├── LETTUCE_ASYNC_TEST_PATTERNS.md
+└── src/
+    └── test/
+        └── java/
+            └── io/
+                └── redis/
+                    └── examples/
+                        └── async/
+                            └── SampleTest.java
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+mvn test
+
+# Run specific test class
+mvn test -Dtest=SampleTest
+
+# Run specific method
+mvn test -Dtest=SampleTest#run
+```
+
+## Maven pom.xml (Minimal)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.redis.examples</groupId>
+    <artifactId>lettuce-async-examples</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>7.4.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/lettuce-async/SampleTest.java`
+- Hash commands: `/path/to/lettuce/src/test/java/io/redis/examples/async/HashExample.java`

--- a/for-ais-only/examples/lettuce-async/pom.xml
+++ b/for-ais-only/examples/lettuce-async/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.redis.examples</groupId>
+    <artifactId>lettuce-async-examples</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>7.4.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/for-ais-only/examples/lettuce-async/src/test/java/io/redis/examples/async/SampleTest.java
+++ b/for-ais-only/examples/lettuce-async/src/test/java/io/redis/examples/async/SampleTest.java
@@ -1,0 +1,169 @@
+// =============================================================================
+// CANONICAL LETTUCE ASYNC TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for Lettuce async
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// Lettuce async uses CompletableFuture chains with thenCompose()
+// RUN: mvn test -Dtest=SampleTest
+// =============================================================================
+
+// EXAMPLE: sample_example
+package io.redis.examples.async;
+
+import io.lettuce.core.*;
+import io.lettuce.core.api.async.RedisAsyncCommands;
+import io.lettuce.core.api.StatefulRedisConnection;
+
+// REMOVE_START
+import org.junit.jupiter.api.Test;
+// REMOVE_END
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+// REMOVE_START
+import static org.assertj.core.api.Assertions.assertThat;
+// REMOVE_END
+
+public class SampleTest {
+
+    @Test
+    public void run() {
+        RedisClient redisClient = RedisClient.create("redis://localhost:6379");
+
+        try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+            RedisAsyncCommands<String, String> asyncCommands = connection.async();
+
+            // REMOVE_START
+            CompletableFuture<Long> delResult = asyncCommands.del(
+                "mykey", "myhash", "bike:1", "bike:1:stats"
+            ).toCompletableFuture();
+            // REMOVE_END
+
+            // STEP_START string_ops
+            // Basic string SET/GET operations using CompletableFuture chains
+            CompletableFuture<Void> stringOps = asyncCommands.set("mykey", "Hello")
+                .thenCompose(res1 -> {
+                    System.out.println(res1); // >>> OK
+                    // REMOVE_START
+                    assertThat(res1).isEqualTo("OK");
+                    // REMOVE_END
+                    return asyncCommands.get("mykey");
+                })
+                .thenAccept(res2 -> {
+                    System.out.println(res2); // >>> Hello
+                    // REMOVE_START
+                    assertThat(res2).isEqualTo("Hello");
+                    // REMOVE_END
+                })
+                .toCompletableFuture();
+            // STEP_END
+
+            // STEP_START hash_ops
+            // Hash operations using async commands
+            Map<String, String> hashFields = new HashMap<>();
+            hashFields.put("field1", "value1");
+            hashFields.put("field2", "value2");
+            hashFields.put("field3", "value3");
+
+            CompletableFuture<Void> hashOps = stringOps.thenCompose(v ->
+                asyncCommands.hset("myhash", hashFields)
+            ).thenCompose(res3 -> {
+                System.out.println(res3); // >>> 3
+                // REMOVE_START
+                assertThat(res3).isEqualTo(3);
+                // REMOVE_END
+                return asyncCommands.hget("myhash", "field1");
+            }).thenCompose(res4 -> {
+                System.out.println(res4); // >>> value1
+                // REMOVE_START
+                assertThat(res4).isEqualTo("value1");
+                // REMOVE_END
+                return asyncCommands.hgetall("myhash");
+            })
+            // REMOVE_START
+            .thenApply(res -> {
+                assertThat(res.get("field1")).isEqualTo("value1");
+                return res;
+            })
+            // REMOVE_END
+            .thenAccept(System.out::println)
+            // >>> {field1=value1, field2=value2, field3=value3}
+            .toCompletableFuture();
+            // STEP_END
+
+            // STEP_START hash_tutorial
+            // Tutorial-style example with bike data
+            Map<String, String> bike1 = new HashMap<>();
+            bike1.put("model", "Deimos");
+            bike1.put("brand", "Ergonom");
+            bike1.put("type", "Enduro bikes");
+            bike1.put("price", "4972");
+
+            CompletableFuture<Void> bikeTutorial = hashOps.thenCompose(v ->
+                asyncCommands.hset("bike:1", bike1)
+            ).thenCompose(res5 -> {
+                System.out.println(res5); // >>> 4
+                // REMOVE_START
+                assertThat(res5).isEqualTo(4);
+                // REMOVE_END
+                return asyncCommands.hget("bike:1", "model");
+            }).thenCompose(res6 -> {
+                System.out.println(res6); // >>> Deimos
+                // REMOVE_START
+                assertThat(res6).isEqualTo("Deimos");
+                // REMOVE_END
+                return asyncCommands.hget("bike:1", "price");
+            }).thenAccept(res7 -> {
+                System.out.println(res7); // >>> 4972
+                // REMOVE_START
+                assertThat(res7).isEqualTo("4972");
+                // REMOVE_END
+            }).toCompletableFuture();
+            // STEP_END
+
+            // STEP_START hincrby
+            // Numeric operations on hash fields
+            CompletableFuture<Void> incrOps = bikeTutorial.thenCompose(v ->
+                asyncCommands.hincrby("bike:1:stats", "rides", 1)
+            ).thenCompose(res8 -> {
+                System.out.println(res8); // >>> 1
+                // REMOVE_START
+                assertThat(res8).isEqualTo(1L);
+                // REMOVE_END
+                return asyncCommands.hincrby("bike:1:stats", "rides", 1);
+            }).thenCompose(res9 -> {
+                System.out.println(res9); // >>> 2
+                // REMOVE_START
+                assertThat(res9).isEqualTo(2L);
+                // REMOVE_END
+                return asyncCommands.hincrby("bike:1:stats", "crashes", 1);
+            }).thenAccept(res10 -> {
+                System.out.println(res10); // >>> 1
+                // REMOVE_START
+                assertThat(res10).isEqualTo(1L);
+                // REMOVE_END
+            }).toCompletableFuture();
+            // STEP_END
+
+            CompletableFuture.allOf(
+                // REMOVE_START
+                delResult,
+                // REMOVE_END
+                incrOps
+            ).join();
+
+        } finally {
+            redisClient.shutdown();
+        }
+    }
+}
+

--- a/for-ais-only/examples/lettuce-reactive/LETTUCE_REACTIVE_TEST_PATTERNS.md
+++ b/for-ais-only/examples/lettuce-reactive/LETTUCE_REACTIVE_TEST_PATTERNS.md
@@ -1,0 +1,248 @@
+# Lettuce Reactive Test File Patterns
+
+This document describes the conventions used in Lettuce reactive documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable JUnit 5 tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/lettuce/src/test/java/io/redis/examples/reactive/*.java`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/lettuce-reactive/SampleTest.java`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```java
+// EXAMPLE: example_name
+package io.redis.examples.reactive;
+
+import io.lettuce.core.*;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.api.StatefulRedisConnection;
+
+// REMOVE_START
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+// REMOVE_END
+
+import reactor.core.publisher.Mono;
+
+import java.util.*;
+
+public class SampleTest {
+
+    // REMOVE_START
+    @Test
+    // REMOVE_END
+    public void run() {
+        RedisClient redisClient = RedisClient.create("redis://localhost:6379");
+
+        try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+
+            // REMOVE_START
+            reactiveCommands.del("mykey").block();
+            // REMOVE_END
+
+            // STEP_START operation_name
+            Mono<String> setKey = reactiveCommands.set("mykey", "Hello").doOnNext(res -> {
+                System.out.println(res); // >>> OK
+            });
+
+            setKey.block();
+
+            Mono<String> getKey = reactiveCommands.get("mykey").doOnNext(value -> {
+                System.out.println(value); // >>> Hello
+                // REMOVE_START
+                assertThat(value).isEqualTo("Hello");
+                // REMOVE_END
+            });
+
+            getKey.block();
+            // STEP_END
+        } finally {
+            redisClient.shutdown();
+        }
+    }
+}
+```
+
+## Key Patterns
+
+### 1. Connection Setup
+```java
+RedisClient redisClient = RedisClient.create("redis://localhost:6379");
+
+try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+    RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+    // ... operations
+} finally {
+    redisClient.shutdown();
+}
+```
+
+### 2. Mono with doOnNext
+```java
+Mono<String> operation = reactiveCommands.set("key", "value").doOnNext(result -> {
+    System.out.println(result); // >>> OK
+});
+
+operation.block(); // Execute and wait
+```
+
+### 3. flatMap Chaining
+```java
+Mono<Void> chain = reactiveCommands.hincrby("stats", "count", 1)
+    .doOnNext(result -> System.out.println(result)) // >>> 1
+    .flatMap(v -> reactiveCommands.hincrby("stats", "count", 1))
+    .doOnNext(result -> System.out.println(result)) // >>> 2
+    .then();
+
+chain.block();
+```
+
+### 4. Parallel Execution
+```java
+Mono.when(mono1, mono2, mono3).block();
+```
+
+### 5. Collecting Results
+```java
+Mono<List<KeyValue<String, String>>> getAll = reactiveCommands.hgetall("myhash")
+    .collectList()
+    .doOnNext(result -> {
+        System.out.println(result);
+        // >>> [KeyValue[field1, value1], KeyValue[field2, value2]]
+    });
+
+getAll.block();
+```
+
+### 6. Hash Operations
+```java
+Map<String, String> fields = new HashMap<>();
+fields.put("field1", "value1");
+fields.put("field2", "value2");
+
+Mono<Long> setHash = reactiveCommands.hset("myhash", fields).doOnNext(result -> {
+    System.out.println(result); // >>> 2
+});
+
+setHash.block();
+```
+
+## Project Reactor Types
+
+| Type | Description |
+|------|-------------|
+| `Mono<T>` | 0 or 1 element |
+| `Flux<T>` | 0 to N elements |
+| `doOnNext()` | Side effect on each element |
+| `flatMap()` | Transform and flatten |
+| `then()` | Complete without value |
+| `block()` | Subscribe and wait |
+
+## Directory Structure
+
+Maven requires test files to be in a specific directory structure:
+
+```
+examples/lettuce-reactive/
+├── pom.xml
+├── LETTUCE_REACTIVE_TEST_PATTERNS.md
+└── src/
+    └── test/
+        └── java/
+            └── io/
+                └── redis/
+                    └── examples/
+                        └── reactive/
+                            └── SampleTest.java
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+mvn test
+
+# Run specific test class
+mvn test -Dtest=SampleTest
+
+# Run specific method
+mvn test -Dtest=SampleTest#run
+```
+
+## Maven pom.xml (Minimal)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.redis.examples</groupId>
+    <artifactId>lettuce-reactive-examples</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>7.4.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+```
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/lettuce-reactive/SampleTest.java`
+- Hash commands: `/path/to/lettuce/src/test/java/io/redis/examples/reactive/HashExample.java`

--- a/for-ais-only/examples/lettuce-reactive/pom.xml
+++ b/for-ais-only/examples/lettuce-reactive/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.redis.examples</groupId>
+    <artifactId>lettuce-reactive-examples</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>7.4.0.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/for-ais-only/examples/lettuce-reactive/src/test/java/io/redis/examples/reactive/SampleTest.java
+++ b/for-ais-only/examples/lettuce-reactive/src/test/java/io/redis/examples/reactive/SampleTest.java
@@ -1,0 +1,176 @@
+// =============================================================================
+// CANONICAL LETTUCE REACTIVE TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for Lettuce reactive
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// Lettuce reactive uses Project Reactor's Mono/Flux with doOnNext(), flatMap(), block()
+// RUN: mvn test -Dtest=SampleTest
+// =============================================================================
+
+// EXAMPLE: sample_example
+package io.redis.examples.reactive;
+
+import io.lettuce.core.*;
+import io.lettuce.core.api.reactive.RedisReactiveCommands;
+import io.lettuce.core.api.StatefulRedisConnection;
+
+// REMOVE_START
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+// REMOVE_END
+
+import reactor.core.publisher.Mono;
+
+import java.util.*;
+
+public class SampleTest {
+
+    // REMOVE_START
+    @Test
+    // REMOVE_END
+    public void run() {
+        RedisClient redisClient = RedisClient.create("redis://localhost:6379");
+
+        try (StatefulRedisConnection<String, String> connection = redisClient.connect()) {
+            RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
+
+            // REMOVE_START
+            // Clean up any existing data
+            Mono<Void> cleanup = reactiveCommands.del(
+                "mykey", "myhash", "bike:1", "bike:1:stats"
+            ).then();
+            cleanup.block();
+            // REMOVE_END
+
+            // STEP_START string_ops
+            // Basic string SET/GET operations using reactive streams
+            Mono<String> setKey = reactiveCommands.set("mykey", "Hello").doOnNext(result -> {
+                System.out.println(result); // >>> OK
+                // REMOVE_START
+                assertThat(result).isEqualTo("OK");
+                // REMOVE_END
+            });
+
+            setKey.block();
+
+            Mono<String> getKey = reactiveCommands.get("mykey").doOnNext(result -> {
+                System.out.println(result); // >>> Hello
+                // REMOVE_START
+                assertThat(result).isEqualTo("Hello");
+                // REMOVE_END
+            });
+
+            getKey.block();
+            // STEP_END
+
+            // STEP_START hash_ops
+            // Hash operations using reactive commands
+            Map<String, String> hashFields = new HashMap<>();
+            hashFields.put("field1", "value1");
+            hashFields.put("field2", "value2");
+            hashFields.put("field3", "value3");
+
+            Mono<Long> setHash = reactiveCommands.hset("myhash", hashFields).doOnNext(result -> {
+                System.out.println(result); // >>> 3
+                // REMOVE_START
+                assertThat(result).isEqualTo(3L);
+                // REMOVE_END
+            });
+
+            setHash.block();
+
+            Mono<String> getField = reactiveCommands.hget("myhash", "field1").doOnNext(result -> {
+                System.out.println(result); // >>> value1
+                // REMOVE_START
+                assertThat(result).isEqualTo("value1");
+                // REMOVE_END
+            });
+
+            Mono<List<KeyValue<String, String>>> getAll = reactiveCommands.hgetall("myhash")
+                .collectList()
+                .doOnNext(result -> {
+                    System.out.println(result);
+                    // >>> [KeyValue[field1, value1], KeyValue[field2, value2], KeyValue[field3, value3]]
+                });
+
+            Mono.when(getField, getAll).block();
+            // STEP_END
+
+            // STEP_START hash_tutorial
+            // Tutorial-style example with bike data
+            Map<String, String> bike1 = new HashMap<>();
+            bike1.put("model", "Deimos");
+            bike1.put("brand", "Ergonom");
+            bike1.put("type", "Enduro bikes");
+            bike1.put("price", "4972");
+
+            Mono<Long> setBike = reactiveCommands.hset("bike:1", bike1).doOnNext(result -> {
+                System.out.println(result); // >>> 4
+                // REMOVE_START
+                assertThat(result).isEqualTo(4L);
+                // REMOVE_END
+            });
+
+            setBike.block();
+
+            Mono<String> getModel = reactiveCommands.hget("bike:1", "model").doOnNext(result -> {
+                System.out.println(result); // >>> Deimos
+                // REMOVE_START
+                assertThat(result).isEqualTo("Deimos");
+                // REMOVE_END
+            });
+
+            Mono<String> getPrice = reactiveCommands.hget("bike:1", "price").doOnNext(result -> {
+                System.out.println(result); // >>> 4972
+                // REMOVE_START
+                assertThat(result).isEqualTo("4972");
+                // REMOVE_END
+            });
+
+            Mono.when(getModel, getPrice).block();
+            // STEP_END
+
+            // STEP_START hincrby
+            // Numeric operations on hash fields using flatMap chains
+            Mono<Void> incrOps = reactiveCommands.hincrby("bike:1:stats", "rides", 1)
+                .doOnNext(result -> {
+                    System.out.println(result); // >>> 1
+                    // REMOVE_START
+                    assertThat(result).isEqualTo(1L);
+                    // REMOVE_END
+                })
+                .flatMap(v -> reactiveCommands.hincrby("bike:1:stats", "rides", 1))
+                .doOnNext(result -> {
+                    System.out.println(result); // >>> 2
+                    // REMOVE_START
+                    assertThat(result).isEqualTo(2L);
+                    // REMOVE_END
+                })
+                .flatMap(v -> reactiveCommands.hincrby("bike:1:stats", "crashes", 1))
+                .doOnNext(result -> {
+                    System.out.println(result); // >>> 1
+                    // REMOVE_START
+                    assertThat(result).isEqualTo(1L);
+                    // REMOVE_END
+                })
+                .then();
+
+            incrOps.block();
+            // STEP_END
+
+        } finally {
+            redisClient.shutdown();
+        }
+    }
+}
+

--- a/for-ais-only/examples/node-redis/NODE_REDIS_TEST_PATTERNS.md
+++ b/for-ais-only/examples/node-redis/NODE_REDIS_TEST_PATTERNS.md
@@ -1,0 +1,168 @@
+# node-redis Test File Patterns
+
+This document describes the conventions used in node-redis documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable Node.js scripts** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/node-redis/doctests/*.js`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/node-redis/sample_test.js`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```javascript
+// EXAMPLE: example_name
+// BINDER_ID nodejs-example
+
+// HIDE_START
+import assert from 'node:assert';
+import { createClient } from 'redis';
+
+const client = createClient();
+await client.connect().catch(console.error);
+// HIDE_END
+
+// REMOVE_START
+await client.del('mykey');
+// REMOVE_END
+
+// STEP_START operation_name
+const res = await client.set('mykey', 'Hello');
+console.log(res); // >>> OK
+
+const value = await client.get('mykey');
+console.log(value); // >>> Hello
+// STEP_END
+
+// REMOVE_START
+assert.equal(res, 'OK');
+assert.equal(value, 'Hello');
+await client.del('mykey');
+// REMOVE_END
+
+// HIDE_START
+await client.quit();
+// HIDE_END
+```
+
+## Key Patterns
+
+### 1. Connection Setup (in HIDE block)
+```javascript
+// HIDE_START
+import assert from 'node:assert';
+import { createClient } from 'redis';
+
+const client = createClient();
+await client.connect().catch(console.error);
+// HIDE_END
+```
+
+### 2. Assertions (Always in REMOVE blocks)
+```javascript
+// REMOVE_START
+assert.equal(res, 1);
+assert.equal(value, 'Hello');
+assert.deepEqual(data, { field1: 'value1', field2: 'value2' });
+await client.del('mykey');
+// REMOVE_END
+```
+
+### 3. Console Output Comments
+```javascript
+console.log(res); // >>> OK
+console.log(value); // >>> Hello
+console.log(data);
+// >>> { field1: 'value1', field2: 'value2' }
+```
+
+### 4. Hash Operations
+```javascript
+// Single field
+await client.hSet('myhash', 'field1', 'value1');
+
+// Multiple fields (object)
+await client.hSet('myhash', {
+    field2: 'value2',
+    field3: 'value3'
+});
+
+// Get operations
+const value = await client.hGet('myhash', 'field1');
+const all = await client.hGetAll('myhash');
+```
+
+### 5. Connection Cleanup (in HIDE block)
+```javascript
+// HIDE_START
+await client.quit();
+// HIDE_END
+```
+
+## Common Imports
+
+```javascript
+import assert from 'node:assert';
+import { createClient } from 'redis';
+import { SchemaFieldTypes, AggregateSteps } from 'redis';
+```
+
+## Setup
+
+```bash
+cd examples/node-redis
+npm install
+```
+
+## Running Tests
+
+```bash
+# Run directly
+node sample_test.js
+
+# Or use npm script
+npm test
+```
+
+## package.json
+
+```json
+{
+  "name": "node-redis-examples",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node sample_test.js"
+  },
+  "dependencies": {
+    "redis": "^5.0.0"
+  }
+}
+```
+
+## API Notes
+
+- node-redis uses **camelCase** method names: `hSet`, `hGet`, `hGetAll`
+- All operations return Promises (use `await`)
+- Connection requires explicit `connect()` call
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/node-redis/sample_test.js`
+- Hash commands: `/path/to/node-redis/doctests/cmds-hash.js`
+- String commands: `/path/to/node-redis/doctests/cmds-string.js`

--- a/for-ais-only/examples/node-redis/package.json
+++ b/for-ais-only/examples/node-redis/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "node-redis-examples",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node sample_test.js"
+  },
+  "dependencies": {
+    "redis": "^5.0.0"
+  }
+}
+

--- a/for-ais-only/examples/node-redis/sample_test.js
+++ b/for-ais-only/examples/node-redis/sample_test.js
@@ -1,0 +1,134 @@
+// =============================================================================
+// CANONICAL NODE-REDIS TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for node-redis
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// RUN: node sample_test.js
+// =============================================================================
+
+// EXAMPLE: sample_example
+// BINDER_ID nodejs-sample
+
+// HIDE_START
+import assert from 'node:assert';
+import { createClient } from 'redis';
+
+const client = createClient();
+await client.connect().catch(console.error);
+// HIDE_END
+
+// REMOVE_START
+// Clean up any existing data before tests
+await client.del('mykey');
+await client.del('myhash');
+await client.del('bike:1');
+await client.del('bike:1:stats');
+// REMOVE_END
+
+// STEP_START string_ops
+// Basic string SET/GET operations
+const res1 = await client.set('mykey', 'Hello');
+console.log(res1); // >>> OK
+
+const res2 = await client.get('mykey');
+console.log(res2); // >>> Hello
+// STEP_END
+
+// REMOVE_START
+assert.equal(res1, 'OK');
+assert.equal(res2, 'Hello');
+await client.del('mykey');
+// REMOVE_END
+
+// STEP_START hash_ops
+// Hash operations: HSET, HGET, HGETALL
+const res3 = await client.hSet('myhash', 'field1', 'value1');
+console.log(res3); // >>> 1
+
+const res4 = await client.hSet('myhash', {
+    'field2': 'value2',
+    'field3': 'value3'
+});
+console.log(res4); // >>> 2
+
+const res5 = await client.hGet('myhash', 'field1');
+console.log(res5); // >>> value1
+
+const res6 = await client.hGetAll('myhash');
+console.log(res6); // >>> { field1: 'value1', field2: 'value2', field3: 'value3' }
+// STEP_END
+
+// REMOVE_START
+assert.equal(res3, 1);
+assert.equal(res4, 2);
+assert.equal(res5, 'value1');
+assert.deepEqual(res6, { field1: 'value1', field2: 'value2', field3: 'value3' });
+await client.del('myhash');
+// REMOVE_END
+
+// STEP_START hash_tutorial
+// Tutorial-style example with bike data
+const bike1 = {
+    model: 'Deimos',
+    brand: 'Ergonom',
+    type: 'Enduro bikes',
+    price: '4972'
+};
+
+const res7 = await client.hSet('bike:1', bike1);
+console.log(res7); // >>> 4
+
+const res8 = await client.hGet('bike:1', 'model');
+console.log(res8); // >>> Deimos
+
+const res9 = await client.hGet('bike:1', 'price');
+console.log(res9); // >>> 4972
+
+const res10 = await client.hGetAll('bike:1');
+console.log(res10);
+// >>> { model: 'Deimos', brand: 'Ergonom', type: 'Enduro bikes', price: '4972' }
+// STEP_END
+
+// REMOVE_START
+assert.equal(res7, 4);
+assert.equal(res8, 'Deimos');
+assert.equal(res9, '4972');
+assert.deepEqual(res10, { model: 'Deimos', brand: 'Ergonom', type: 'Enduro bikes', price: '4972' });
+await client.del('bike:1');
+// REMOVE_END
+
+// STEP_START hincrby
+// Numeric operations on hash fields
+await client.hSet('bike:1:stats', 'rides', 0);
+
+const res11 = await client.hIncrBy('bike:1:stats', 'rides', 1);
+console.log(res11); // >>> 1
+
+const res12 = await client.hIncrBy('bike:1:stats', 'rides', 1);
+console.log(res12); // >>> 2
+
+const res13 = await client.hIncrBy('bike:1:stats', 'crashes', 1);
+console.log(res13); // >>> 1
+// STEP_END
+
+// REMOVE_START
+assert.equal(res11, 1);
+assert.equal(res12, 2);
+assert.equal(res13, 1);
+await client.del('bike:1:stats');
+// REMOVE_END
+
+// HIDE_START
+await client.quit();
+// HIDE_END
+

--- a/for-ais-only/examples/nredisstack/NREDISSTACK_TEST_PATTERNS.md
+++ b/for-ais-only/examples/nredisstack/NREDISSTACK_TEST_PATTERNS.md
@@ -1,0 +1,238 @@
+# NRedisStack Test File Patterns
+
+This document describes the conventions used in NRedisStack documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable xUnit tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/NRedisStack/tests/Doc/*.cs`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/nredisstack/*.cs`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## Standalone Class Structure Template
+
+```csharp
+// EXAMPLE: example_name
+using NRedisStack;
+using NRedisStack.RedisStackCommands;
+using NRedisStack.Search;
+using NRedisStack.Search.Aggregation;
+using NRedisStack.Search.Literals.Enums;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Doc;
+
+public class ExampleName
+{
+    [Fact]
+    public void Run()
+    {
+        var muxer = ConnectionMultiplexer.Connect("localhost:6379");
+        var db = muxer.GetDatabase();
+
+        // Get module command interfaces
+        var ft = db.FT();      // Search/Query commands
+        var json = db.JSON();  // JSON commands
+
+        // Test setup/cleanup
+        db.KeyDelete(["mykey"]);
+        try { ft.DropIndex("idx:example"); } catch { }
+
+        // STEP_START operation_name
+        // Code that appears in documentation
+        bool result = db.StringSet("key", "value");
+        Console.WriteLine(result);  // >>> True
+        // STEP_END
+
+        // REMOVE_START
+        Assert.True(result);
+        // REMOVE_END
+    }
+}
+```
+
+## Module Command Interfaces
+
+```csharp
+var ft = db.FT();      // Search/Query (FT.* commands)
+var json = db.JSON();  // JSON (JSON.* commands)
+var bf = db.BF();      // Bloom filter
+var cms = db.CMS();    // Count-min sketch
+var cf = db.CF();      // Cuckoo filter
+var tdigest = db.TDIGEST();
+var ts = db.TS();      // Time series
+var topk = db.TOPK();
+```
+
+## Key Patterns
+
+### 1. Assertions (Always in REMOVE blocks)
+```csharp
+// REMOVE_START
+Assert.True(result);
+Assert.Equal("expected", actual);
+Assert.Equal(3, collection.Length);
+// REMOVE_END
+```
+
+### 2. Console Output Comments
+Always include expected output as comments:
+```csharp
+Console.WriteLine(result);  // >>> True
+Console.WriteLine(name);    // >>> Alice
+```
+
+### 3. Connection Setup
+```csharp
+var muxer = ConnectionMultiplexer.Connect("localhost:6379");
+var db = muxer.GetDatabase();
+```
+
+### 4. Cleanup Before Tests
+```csharp
+db.KeyDelete(["mykey", "user:1"]);
+try { ft.DropIndex("idx:users"); } catch { }
+```
+
+## Common Imports
+
+```csharp
+using NRedisStack;
+using NRedisStack.RedisStackCommands;
+using NRedisStack.Search;
+using NRedisStack.Search.Aggregation;
+using NRedisStack.Search.Literals.Enums;
+using StackExchange.Redis;
+using Xunit;
+```
+
+## Project Setup (csproj)
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="NRedisStack" Version="1.3.0" />
+        <PackageReference Include="StackExchange.Redis" Version="2.9.17" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>
+```
+
+## Directory Structure
+
+.NET requires test files to be in a project with a `.csproj` file:
+
+```
+examples/nredisstack/
+├── nredisstack-examples.csproj
+├── NREDISSTACK_TEST_PATTERNS.md
+└── SampleTest.cs
+```
+
+## Setup
+
+### Prerequisites
+
+- **.NET SDK 8.0+**: Download from [dotnet.microsoft.com](https://dotnet.microsoft.com/download)
+- **Redis Stack**: Running on `localhost:6379`
+
+### Quick Start
+
+The project includes a pre-configured `.csproj` with all dependencies:
+
+```bash
+cd examples/nredisstack
+dotnet restore
+dotnet test
+```
+
+### Starting From Scratch
+
+If creating a new standalone project:
+
+```bash
+# Create new xUnit test project
+dotnet new xunit -n nredisstack-examples -f net8.0
+
+# Add required packages
+dotnet add package NRedisStack
+dotnet add package StackExchange.Redis
+```
+
+## Running Tests
+
+```bash
+cd examples/nredisstack
+
+# Run all tests (restores packages automatically if needed)
+dotnet test
+
+# Run tests with verbose output
+dotnet test -v n
+
+# Run a specific test class
+dotnet test --filter "FullyQualifiedName~ExampleClassName"
+
+# Run a specific test method
+dotnet test --filter "FullyQualifiedName~ExampleClassName.Run"
+
+# Run and see console output
+dotnet test -v n --logger "console;verbosity=detailed"
+```
+
+### After Deleting bin/obj Directories
+
+Simply run:
+
+```bash
+dotnet test
+```
+
+This automatically restores packages and rebuilds before running tests.
+
+### Running Within the NRedisStack Repository
+
+If working within the main NRedisStack repository:
+
+```bash
+cd clients/NRedisStack
+
+# Run all doc tests
+dotnet test -f net8.0 --filter "FullyQualifiedName~Doc"
+
+# Run a specific example
+dotnet test -f net8.0 --filter "FullyQualifiedName~Doc.CmdsHashExample"
+```
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/nredisstack/SampleTest.cs`
+- Hash example: `/path/to/NRedisStack/tests/Doc/CmdsHashExample.cs`
+- String example: `/path/to/NRedisStack/tests/Doc/CmdsStringExample.cs`

--- a/for-ais-only/examples/nredisstack/nredisstack-examples.csproj
+++ b/for-ais-only/examples/nredisstack/nredisstack-examples.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="NRedisStack" Version="1.3.0" />
+        <PackageReference Include="StackExchange.Redis" Version="2.9.17" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/for-ais-only/examples/nredisstack/nredisstack_sample_test.cs
+++ b/for-ais-only/examples/nredisstack/nredisstack_sample_test.cs
@@ -1,0 +1,156 @@
+// =============================================================================
+// CANONICAL NREDISSTACK TEST FILE TEMPLATE (STANDALONE VERSION)
+// =============================================================================
+// This file demonstrates the structure and conventions used for NRedisStack
+// documentation test files. These tests serve dual purposes:
+// 1. Executable xUnit tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+// =============================================================================
+
+// EXAMPLE: example_name
+// BINDER_ID netsync-example_name
+
+// STEP_START import
+// Imports shown in documentation go here
+using NRedisStack;
+using NRedisStack.RedisStackCommands;
+using NRedisStack.Search;
+using NRedisStack.Search.Aggregation;
+using NRedisStack.Search.Literals.Enums;
+using StackExchange.Redis;
+// STEP_END
+
+// HIDE_START
+using Xunit;
+// HIDE_END
+
+// REMOVE_START
+namespace Doc;
+// REMOVE_END
+
+public class ExampleClassName
+{
+    // REMOVE_START
+    [Fact]
+    // REMOVE_END
+    public void Run()
+    {
+        // STEP_START connect
+        var muxer = ConnectionMultiplexer.Connect("localhost:6379");
+        var db = muxer.GetDatabase();
+        // STEP_END
+
+        // HIDE_START
+        // Get module command interfaces (hidden from docs)
+        var ft = db.FT();      // Search/Query commands
+        var json = db.JSON();  // JSON commands
+        var bf = db.BF();      // Bloom filter commands
+        // HIDE_END
+
+        // REMOVE_START
+        // Test setup/cleanup (completely removed from docs)
+        db.KeyDelete(["mykey", "user:1", "user:2"]);
+        try { ft.DropIndex("idx:users"); } catch { }
+        // REMOVE_END
+
+        // STEP_START basic_string_ops
+        bool setResult = db.StringSet("mykey", "Hello");
+        Console.WriteLine(setResult);  // >>> True
+
+        var getValue = db.StringGet("mykey");
+        Console.WriteLine(getValue);   // >>> Hello
+        // STEP_END
+
+        // REMOVE_START
+        Assert.True(setResult);
+        Assert.Equal("Hello", getValue.ToString());
+        // REMOVE_END
+
+        // STEP_START hash_ops
+        db.HashSet("user:1", [
+            new("name", "Alice"),
+            new("email", "alice@example.com"),
+            new("age", 30)
+        ]);
+
+        var name = db.HashGet("user:1", "name");
+        Console.WriteLine($"Name: {name}");  // >>> Name: Alice
+
+        var allFields = db.HashGetAll("user:1");
+        Console.WriteLine(string.Join(", ", allFields.Select(f => $"{f.Name}={f.Value}")));
+        // >>> name=Alice, email=alice@example.com, age=30
+        // STEP_END
+
+        // REMOVE_START
+        Assert.Equal("Alice", name);
+        Assert.Equal(3, allFields.Length);
+        // REMOVE_END
+
+        // STEP_START json_ops
+        var user = new { name = "Bob", email = "bob@example.com", age = 25 };
+        bool jsonSet = json.Set("user:2", "$", user);
+        Console.WriteLine(jsonSet);  // >>> True
+
+        var jsonGet = json.Get("user:2", path: "$.name");
+        Console.WriteLine(jsonGet);  // >>> ["Bob"]
+        // STEP_END
+
+        // REMOVE_START
+        Assert.True(jsonSet);
+        Assert.Equal("[\"Bob\"]", jsonGet.ToString());
+        // REMOVE_END
+
+        // STEP_START create_index
+        var schema = new Schema()
+            .AddTextField(new FieldName("$.name", "name"))
+            .AddNumericField(new FieldName("$.age", "age"));
+
+        bool indexCreated = ft.Create(
+            "idx:users",
+            new FTCreateParams()
+                .On(IndexDataType.JSON)
+                .Prefix("user:"),
+            schema
+        );
+        // STEP_END
+
+        // REMOVE_START
+        Assert.True(indexCreated);
+        // REMOVE_END
+
+        // STEP_START search_query
+        SearchResult result = ft.Search("idx:users", new Query("Bob"));
+        Console.WriteLine($"Found {result.TotalResults} results");
+        // >>> Found 1 results
+
+        foreach (Document doc in result.Documents)
+        {
+            Console.WriteLine($"Key: {doc.Id}, Data: {doc["json"]}");
+        }
+        // STEP_END
+
+        // REMOVE_START
+        Assert.Equal(1, result.TotalResults);
+        // REMOVE_END
+
+        // STEP_START aggregation
+        var aggRequest = new AggregationRequest("*")
+            .GroupBy("@age", Reducers.Count().As("count"));
+
+        AggregationResult aggResult = ft.Aggregate("idx:users", aggRequest);
+        Console.WriteLine($"Groups: {aggResult.TotalResults}");
+        // STEP_END
+
+        // HIDE_START
+        muxer.Close();
+    }
+}
+// HIDE_END
+

--- a/for-ais-only/examples/predis/PREDIS_TEST_PATTERNS.md
+++ b/for-ais-only/examples/predis/PREDIS_TEST_PATTERNS.md
@@ -1,0 +1,215 @@
+# Predis Test File Patterns
+
+This document describes the conventions used in Predis documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable PHPUnit tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Sample template**: `/path/to/docs/for-ais-only/examples/predis/SampleTest.php`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```php
+<?php
+// EXAMPLE: example_name
+// BINDER_ID php-example
+
+// REMOVE_START
+namespace Predis\Examples;
+
+use PHPUnit\Framework\TestCase;
+// REMOVE_END
+
+// HIDE_START
+require __DIR__ . '/vendor/autoload.php';
+
+use Predis\Client;
+// HIDE_END
+
+// REMOVE_START
+class SampleTest extends TestCase
+{
+    public function testRun()
+    {
+// REMOVE_END
+        // STEP_START connect
+        $redis = new Client([
+            'host' => '127.0.0.1',
+            'port' => 6379,
+        ]);
+        // STEP_END
+
+        // REMOVE_START
+        $redis->del('mykey');
+        // REMOVE_END
+
+        // STEP_START string_ops
+        $res = $redis->set('mykey', 'Hello');
+        echo $res . "\n"; // >>> OK
+
+        $value = $redis->get('mykey');
+        echo $value . "\n"; // >>> Hello
+        // STEP_END
+
+        // REMOVE_START
+        $this->assertEquals('OK', $res);
+        $this->assertEquals('Hello', $value);
+        $redis->del('mykey');
+        // REMOVE_END
+// REMOVE_START
+    }
+}
+// REMOVE_END
+```
+
+## Key Patterns
+
+### 1. Autoload and Imports (in HIDE block)
+```php
+// HIDE_START
+require __DIR__ . '/vendor/autoload.php';
+
+use Predis\Client;
+// HIDE_END
+```
+
+### 2. Test Class Structure (in REMOVE blocks)
+```php
+// REMOVE_START
+namespace Predis\Examples;
+
+use PHPUnit\Framework\TestCase;
+// REMOVE_END
+
+// REMOVE_START
+class SampleTest extends TestCase
+{
+    public function testRun()
+    {
+// REMOVE_END
+        // ... code ...
+// REMOVE_START
+    }
+}
+// REMOVE_END
+```
+
+### 3. Connection Setup
+```php
+// STEP_START connect
+$redis = new Client([
+    'host' => '127.0.0.1',
+    'port' => 6379,
+]);
+// STEP_END
+```
+
+### 4. Assertions (in REMOVE blocks)
+```php
+// REMOVE_START
+$this->assertEquals('OK', $res);
+$this->assertEquals('Hello', $value);
+$this->assertCount(3, $all);
+$redis->del('mykey');
+// REMOVE_END
+```
+
+### 5. Console Output Comments
+```php
+echo $res . "\n"; // >>> OK
+echo $value . "\n"; // >>> Hello
+
+print_r($all);
+/* >>>
+Array
+(
+    [field1] => value1
+    [field2] => value2
+)
+*/
+```
+
+### 6. Hash Operations
+```php
+// Single field
+$redis->hset('myhash', 'field1', 'value1');
+
+// Multiple fields
+$redis->hmset('myhash', [
+    'field2' => 'value2',
+    'field3' => 'value3',
+]);
+
+// Get operations
+$value = $redis->hget('myhash', 'field1');
+$all = $redis->hgetall('myhash');
+```
+
+## Setup
+
+```bash
+cd examples/predis
+composer install
+```
+
+## Running Tests
+
+```bash
+# Run with PHPUnit
+./vendor/bin/phpunit SampleTest.php
+
+# Run specific test
+./vendor/bin/phpunit --filter testRun SampleTest.php
+```
+
+## composer.json
+
+```json
+{
+    "name": "redis/predis-examples",
+    "description": "Predis example tests for Redis documentation",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "predis/predis": "^2.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Redis\\Examples\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Redis\\Examples\\Tests\\": "tests/"
+        }
+    }
+}
+```
+
+## API Notes
+
+- Predis uses lowercase method names: `hset`, `hget`, `hgetall`
+- `hmset` for setting multiple hash fields at once
+- Returns strings or arrays depending on command
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/predis/SampleTest.php`

--- a/for-ais-only/examples/predis/SampleTest.php
+++ b/for-ais-only/examples/predis/SampleTest.php
@@ -1,0 +1,139 @@
+// EXAMPLE: sample_example
+<?php
+// =============================================================================
+// CANONICAL PREDIS TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for Predis
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// RUN: phpunit SampleTest.php
+// =============================================================================
+
+// BINDER_ID php-sample
+
+use PHPUnit\Framework\TestCase;
+use Predis\Client as PredisClient;
+
+class SampleTest
+// REMOVE_START
+extends TestCase
+// REMOVE_END
+{
+    public function testSampleExample(): void
+    {
+        $redis = new PredisClient([
+            'scheme' => 'tcp',
+            'host'   => '127.0.0.1',
+            'port'   => 6379,
+        ]);
+
+        // REMOVE_START
+        // Clean up any existing data before tests
+        $redis->del('mykey', 'myhash', 'bike:1', 'bike:1:stats');
+        // REMOVE_END
+
+        // STEP_START string_ops
+        // Basic string SET/GET operations
+        $res1 = $redis->set('mykey', 'Hello');
+        echo $res1 . PHP_EOL; // >>> OK
+
+        $res2 = $redis->get('mykey');
+        echo $res2 . PHP_EOL; // >>> Hello
+        // STEP_END
+
+        // REMOVE_START
+        $this->assertEquals('OK', $res1);
+        $this->assertEquals('Hello', $res2);
+        $redis->del('mykey');
+        // REMOVE_END
+
+        // STEP_START hash_ops
+        // Hash operations: HSET, HGET, HGETALL
+        $res3 = $redis->hset('myhash', 'field1', 'value1');
+        echo $res3 . PHP_EOL; // >>> 1
+
+        $res4 = $redis->hmset('myhash', [
+            'field2' => 'value2',
+            'field3' => 'value3'
+        ]);
+        echo $res4 . PHP_EOL; // >>> OK
+
+        $res5 = $redis->hget('myhash', 'field1');
+        echo $res5 . PHP_EOL; // >>> value1
+
+        $res6 = $redis->hgetall('myhash');
+        echo json_encode($res6) . PHP_EOL;
+        // >>> {"field1":"value1","field2":"value2","field3":"value3"}
+        // STEP_END
+
+        // REMOVE_START
+        $this->assertEquals(1, $res3);
+        $this->assertEquals('OK', $res4);
+        $this->assertEquals('value1', $res5);
+        $this->assertEquals('value1', $res6['field1']);
+        $redis->del('myhash');
+        // REMOVE_END
+
+        // STEP_START hash_tutorial
+        // Tutorial-style example with bike data
+        $bike1 = [
+            'model' => 'Deimos',
+            'brand' => 'Ergonom',
+            'type'  => 'Enduro bikes',
+            'price' => '4972'
+        ];
+
+        $res7 = $redis->hmset('bike:1', $bike1);
+        echo $res7 . PHP_EOL; // >>> OK
+
+        $res8 = $redis->hget('bike:1', 'model');
+        echo $res8 . PHP_EOL; // >>> Deimos
+
+        $res9 = $redis->hget('bike:1', 'price');
+        echo $res9 . PHP_EOL; // >>> 4972
+
+        $res10 = $redis->hgetall('bike:1');
+        echo json_encode($res10) . PHP_EOL;
+        // >>> {"model":"Deimos","brand":"Ergonom","type":"Enduro bikes","price":"4972"}
+        // STEP_END
+
+        // REMOVE_START
+        $this->assertEquals('OK', $res7);
+        $this->assertEquals('Deimos', $res8);
+        $this->assertEquals('4972', $res9);
+        $this->assertEquals('Deimos', $res10['model']);
+        $redis->del('bike:1');
+        // REMOVE_END
+
+        // STEP_START hincrby
+        // Numeric operations on hash fields
+        $redis->hset('bike:1:stats', 'rides', 0);
+
+        $res11 = $redis->hincrby('bike:1:stats', 'rides', 1);
+        echo $res11 . PHP_EOL; // >>> 1
+
+        $res12 = $redis->hincrby('bike:1:stats', 'rides', 1);
+        echo $res12 . PHP_EOL; // >>> 2
+
+        $res13 = $redis->hincrby('bike:1:stats', 'crashes', 1);
+        echo $res13 . PHP_EOL; // >>> 1
+        // STEP_END
+
+        // REMOVE_START
+        $this->assertEquals(1, $res11);
+        $this->assertEquals(2, $res12);
+        $this->assertEquals(1, $res13);
+        $redis->del('bike:1:stats');
+        // REMOVE_END
+    }
+}
+

--- a/for-ais-only/examples/predis/composer.json
+++ b/for-ais-only/examples/predis/composer.json
@@ -1,0 +1,23 @@
+{
+    "name": "redis/predis-examples",
+    "description": "Predis example tests for Redis documentation",
+    "type": "project",
+    "require": {
+        "php": ">=8.1",
+        "predis/predis": "^2.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Redis\\Examples\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Redis\\Examples\\Tests\\": "tests/"
+        }
+    }
+}
+

--- a/for-ais-only/examples/redis-py/REDIS_PY_TEST_PATTERNS.md
+++ b/for-ais-only/examples/redis-py/REDIS_PY_TEST_PATTERNS.md
@@ -1,0 +1,153 @@
+# redis-py Test File Patterns
+
+This document describes the conventions used in redis-py documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable Python scripts** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Original tests**: `/path/to/redis-py/doctests/*.py`
+- **Sample template**: `/path/to/docs/for-ais-only/examples/redis-py/sample_test.py`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `# EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `# BINDER_ID <id>` | Optional identifier for online code runners |
+| `# HIDE_START` / `# HIDE_END` | Code hidden from docs but still executed |
+| `# REMOVE_START` / `# REMOVE_END` | Code completely removed from docs |
+| `# STEP_START <name>` / `# STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```python
+# EXAMPLE: example_name
+# BINDER_ID python-example
+
+# HIDE_START
+import redis
+
+r = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+# HIDE_END
+
+# REMOVE_START
+# Clean up any existing data before tests
+r.delete("mykey")
+# REMOVE_END
+
+# STEP_START operation_name
+# Code that appears in documentation
+res = r.set("mykey", "Hello")
+print(res)
+# >>> True
+
+res2 = r.get("mykey")
+print(res2)
+# >>> Hello
+# STEP_END
+
+# REMOVE_START
+assert res == True
+assert res2 == "Hello"
+r.delete("mykey")
+# REMOVE_END
+```
+
+## Key Patterns
+
+### 1. Connection Setup (in HIDE block)
+```python
+# HIDE_START
+import redis
+
+r = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+# HIDE_END
+```
+
+### 2. Assertions (Always in REMOVE blocks)
+```python
+# REMOVE_START
+assert res == 1
+assert value == "Hello"
+assert data == {"field1": "value1", "field2": "value2"}
+r.delete("mykey")
+# REMOVE_END
+```
+
+### 3. Console Output Comments
+Always include expected output as comments:
+```python
+print(res)
+# >>> True
+
+print(data)
+# >>> {'field1': 'value1', 'field2': 'value2'}
+```
+
+### 4. Hash Operations
+```python
+# Single field
+r.hset("myhash", "field1", "value1")
+
+# Multiple fields
+r.hset("myhash", mapping={"field2": "value2", "field3": "value3"})
+
+# Get operations
+value = r.hget("myhash", "field1")
+all_values = r.hgetall("myhash")
+```
+
+### 5. Numeric Operations
+```python
+r.hincrby("stats", "counter", 1)
+r.hincrbyfloat("stats", "rate", 0.5)
+```
+
+## Common Imports
+
+```python
+import redis
+from redis.commands.search.field import TextField, NumericField, TagField
+from redis.commands.search.indexDefinition import IndexDefinition, IndexType
+from redis.commands.search.query import Query
+from redis.commands.json.path import Path
+```
+
+## Setup
+
+Create a virtual environment and install dependencies:
+
+```bash
+cd examples/redis-py
+python -m venv venv
+source venv/bin/activate  # On Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Running Tests
+
+```bash
+# Activate venv first
+source venv/bin/activate
+
+# Run as standalone script
+python sample_test.py
+```
+
+## requirements.txt
+
+```txt
+# Redis Python client
+redis>=5.0.0
+```
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/redis-py/sample_test.py`
+- Hash commands: `/path/to/redis-py/doctests/cmds_hash.py`
+- String commands: `/path/to/redis-py/doctests/cmds_string.py`

--- a/for-ais-only/examples/redis-py/requirements.txt
+++ b/for-ais-only/examples/redis-py/requirements.txt
@@ -1,0 +1,2 @@
+# Redis Python client
+redis>=5.0.0

--- a/for-ais-only/examples/redis-py/sample_test.py
+++ b/for-ais-only/examples/redis-py/sample_test.py
@@ -1,0 +1,133 @@
+# =============================================================================
+# CANONICAL REDIS-PY TEST FILE TEMPLATE
+# =============================================================================
+# This file demonstrates the structure and conventions used for redis-py
+# documentation test files. These tests serve dual purposes:
+# 1. Executable tests that validate code snippets
+# 2. Source for documentation code examples (processed via special markers)
+#
+# MARKER REFERENCE:
+# - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+# - BINDER_ID <id>      - Optional identifier for online code runners
+# - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+# - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+# - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+#
+# RUN: python sample_test.py (or pytest sample_test.py)
+# =============================================================================
+
+# EXAMPLE: sample_example
+# BINDER_ID python-sample
+
+# HIDE_START
+import redis
+
+r = redis.Redis(host="localhost", port=6379, db=0, decode_responses=True)
+# HIDE_END
+
+# REMOVE_START
+# Clean up any existing data before tests
+r.delete("mykey", "myhash", "bike:1")
+# REMOVE_END
+
+# STEP_START string_ops
+# Basic string SET/GET operations
+res1 = r.set("mykey", "Hello")
+print(res1)
+# >>> True
+
+res2 = r.get("mykey")
+print(res2)
+# >>> Hello
+# STEP_END
+
+# REMOVE_START
+assert res1 == True
+assert res2 == "Hello"
+r.delete("mykey")
+# REMOVE_END
+
+# STEP_START hash_ops
+# Hash operations: HSET, HGET, HGETALL
+res3 = r.hset("myhash", "field1", "value1")
+print(res3)
+# >>> 1
+
+res4 = r.hset("myhash", mapping={"field2": "value2", "field3": "value3"})
+print(res4)
+# >>> 2
+
+res5 = r.hget("myhash", "field1")
+print(res5)
+# >>> value1
+
+res6 = r.hgetall("myhash")
+print(res6)
+# >>> {'field1': 'value1', 'field2': 'value2', 'field3': 'value3'}
+# STEP_END
+
+# REMOVE_START
+assert res3 == 1
+assert res4 == 2
+assert res5 == "value1"
+assert res6 == {"field1": "value1", "field2": "value2", "field3": "value3"}
+r.delete("myhash")
+# REMOVE_END
+
+# STEP_START hash_tutorial
+# Tutorial-style example with bike data
+bike1 = {
+    "model": "Deimos",
+    "brand": "Ergonom",
+    "type": "Enduro bikes",
+    "price": "4972"
+}
+
+res7 = r.hset("bike:1", mapping=bike1)
+print(res7)
+# >>> 4
+
+res8 = r.hget("bike:1", "model")
+print(res8)
+# >>> Deimos
+
+res9 = r.hget("bike:1", "price")
+print(res9)
+# >>> 4972
+
+res10 = r.hgetall("bike:1")
+print(res10)
+# >>> {'model': 'Deimos', 'brand': 'Ergonom', 'type': 'Enduro bikes', 'price': '4972'}
+# STEP_END
+
+# REMOVE_START
+assert res7 == 4
+assert res8 == "Deimos"
+assert res9 == "4972"
+assert res10 == {"model": "Deimos", "brand": "Ergonom", "type": "Enduro bikes", "price": "4972"}
+r.delete("bike:1")
+# REMOVE_END
+
+# STEP_START hincrby
+# Numeric operations on hash fields
+r.hset("bike:1:stats", "rides", 0)
+res11 = r.hincrby("bike:1:stats", "rides", 1)
+print(res11)
+# >>> 1
+
+res12 = r.hincrby("bike:1:stats", "rides", 1)
+print(res12)
+# >>> 2
+
+res13 = r.hincrby("bike:1:stats", "crashes", 1)
+print(res13)
+# >>> 1
+# STEP_END
+
+# REMOVE_START
+assert res11 == 1
+assert res12 == 2
+assert res13 == 1
+r.delete("bike:1:stats")
+# REMOVE_END
+

--- a/for-ais-only/examples/rust-async/Cargo.toml
+++ b/for-ais-only/examples/rust-async/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "redis_examples_async"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redis = { version = "1.0", features = ["tokio-comp"] }
+tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+# Tests use the same dependencies
+

--- a/for-ais-only/examples/rust-async/RUST_ASYNC_TEST_PATTERNS.md
+++ b/for-ais-only/examples/rust-async/RUST_ASYNC_TEST_PATTERNS.md
@@ -1,0 +1,206 @@
+# Rust Async (redis-rs) Test File Patterns
+
+This document describes the conventions used in redis-rs asynchronous documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable Rust async tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Sample template**: `/path/to/docs/for-ais-only/examples/rust-async/tests/sample_test.rs`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```rust
+// EXAMPLE: example_name
+
+// HIDE_START
+use redis::AsyncCommands;
+// HIDE_END
+
+// REMOVE_START
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_run() {
+// REMOVE_END
+        // STEP_START connect
+        let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+        let mut con = client.get_multiplexed_async_connection().await.unwrap();
+        // STEP_END
+
+        // REMOVE_START
+        let _: () = redis::cmd("DEL").arg("mykey").query_async(&mut con).await.unwrap();
+        // REMOVE_END
+
+        // STEP_START string_ops
+        let _: () = con.set("mykey", "Hello").await.unwrap();
+        println!("SET mykey Hello: OK"); // >>> OK
+
+        let value: String = con.get("mykey").await.unwrap();
+        println!("GET mykey: {}", value); // >>> Hello
+        // STEP_END
+
+        // REMOVE_START
+        assert_eq!(value, "Hello");
+        let _: () = redis::cmd("DEL").arg("mykey").query_async(&mut con).await.unwrap();
+// REMOVE_END
+// REMOVE_START
+    }
+}
+// REMOVE_END
+```
+
+## Key Patterns
+
+### 1. Imports (in HIDE block)
+```rust
+// HIDE_START
+use redis::AsyncCommands;
+// HIDE_END
+```
+
+### 2. Async Test Structure (in REMOVE blocks)
+```rust
+// REMOVE_START
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_run() {
+// REMOVE_END
+        // ... async code ...
+// REMOVE_START
+    }
+}
+// REMOVE_END
+```
+
+### 3. Async Connection Setup
+```rust
+// STEP_START connect
+let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+let mut con = client.get_multiplexed_async_connection().await.unwrap();
+// STEP_END
+```
+
+### 4. Async Operations
+```rust
+// All operations use .await
+let _: () = con.set("key", "value").await.unwrap();
+let value: String = con.get("key").await.unwrap();
+```
+
+### 5. Assertions (in REMOVE blocks)
+```rust
+// REMOVE_START
+assert_eq!(value, "Hello");
+let _: () = redis::cmd("DEL").arg("mykey").query_async(&mut con).await.unwrap();
+// REMOVE_END
+```
+
+### 6. Hash Operations (Async)
+```rust
+// Single field
+let _: () = con.hset("myhash", "field1", "value1").await.unwrap();
+
+// Multiple fields
+let _: () = con.hset_multiple("myhash", &[
+    ("field2", "value2"),
+    ("field3", "value3"),
+]).await.unwrap();
+
+// Get operations
+let value: String = con.hget("myhash", "field1").await.unwrap();
+let all: std::collections::HashMap<String, String> = con.hgetall("myhash").await.unwrap();
+```
+
+### 7. Raw Commands (Async)
+```rust
+let _: () = redis::cmd("DEL")
+    .arg("key1")
+    .arg("key2")
+    .query_async(&mut con)
+    .await
+    .unwrap();
+```
+
+## Sync vs Async Comparison
+
+| Aspect | Sync | Async |
+|--------|------|-------|
+| Import | `use redis::Commands;` | `use redis::AsyncCommands;` |
+| Test attr | `#[test]` | `#[tokio::test]` |
+| Connection | `get_connection()` | `get_multiplexed_async_connection().await` |
+| Operations | `con.set(...).unwrap()` | `con.set(...).await.unwrap()` |
+| Raw cmd | `.query(&mut con)` | `.query_async(&mut con).await` |
+
+## Directory Structure
+
+Cargo requires test files to be in a specific location:
+
+```
+examples/rust-async/
+├── Cargo.toml
+├── RUST_ASYNC_TEST_PATTERNS.md
+└── tests/
+    └── sample_test.rs
+```
+
+## Running Tests
+
+```bash
+# Build and fetch dependencies
+cargo build
+
+# Run all tests
+cargo test
+
+# Run specific test
+cargo test test_run
+
+# Run with output
+cargo test -- --nocapture
+```
+
+## Cargo.toml
+
+```toml
+[package]
+name = "redis_examples_async"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redis = { version = "1.0", features = ["tokio-comp"] }
+tokio = { version = "1", features = ["full"] }
+
+[dev-dependencies]
+# Tests use the same dependencies
+```
+
+## API Notes
+
+- Use `redis::AsyncCommands` trait for convenient async methods
+- Requires `tokio-comp` feature in redis crate
+- Use `get_multiplexed_async_connection()` for async connection
+- All operations require `.await`
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/rust-async/tests/sample_test.rs`

--- a/for-ais-only/examples/rust-async/tests/sample_test.rs
+++ b/for-ais-only/examples/rust-async/tests/sample_test.rs
@@ -1,0 +1,161 @@
+// =============================================================================
+// CANONICAL RUST-ASYNC (redis-rs) TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for redis-rs async
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// Uses #[tokio::test] for async test execution
+// RUN: cargo test
+// =============================================================================
+
+// EXAMPLE: sample_example
+#[cfg(test)]
+mod sample_async_tests {
+    use redis::AsyncCommands;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // REMOVE_START
+        // Clean up any existing data before tests
+        let _: () = r.del(&["mykey", "myhash", "bike:1", "bike:1:stats"]).await.unwrap();
+        // REMOVE_END
+
+        // STEP_START string_ops
+        // Basic string SET/GET operations (async)
+        if let Ok(res1) = r.set("mykey", "Hello").await {
+            let res1: String = res1;
+            println!("{res1}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res1, "OK");
+            // REMOVE_END
+        }
+
+        match r.get("mykey").await {
+            Ok(res2) => {
+                let res2: String = res2;
+                println!("{res2}"); // >>> Hello
+                // REMOVE_START
+                assert_eq!(res2, "Hello");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+        // STEP_END
+
+        // REMOVE_START
+        let _: () = r.del("mykey").await.unwrap();
+        // REMOVE_END
+
+        // STEP_START hash_ops
+        // Hash operations: HSET, HGET, HGETALL (async)
+        if let Ok(res3) = r.hset("myhash", "field1", "value1").await {
+            let res3: i32 = res3;
+            println!("{res3}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res3, 1);
+            // REMOVE_END
+        }
+
+        let hash_fields = vec![("field2", "value2"), ("field3", "value3")];
+        if let Ok(res4) = r.hset_multiple("myhash", &hash_fields).await {
+            let res4: String = res4;
+            println!("{res4}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res4, "OK");
+            // REMOVE_END
+        }
+
+        match r.hget("myhash", "field1").await {
+            Ok(res5) => {
+                let res5: String = res5;
+                println!("{res5}"); // >>> value1
+                // REMOVE_START
+                assert_eq!(res5, "value1");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hgetall("myhash").await {
+            Ok(res6) => {
+                let res6: HashMap<String, String> = res6;
+                println!("{:?}", res6.get("field1")); // >>> Some("value1")
+                // REMOVE_START
+                assert_eq!(res6.get("field1"), Some(&"value1".to_string()));
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+        // STEP_END
+
+        // REMOVE_START
+        let _: () = r.del("myhash").await.unwrap();
+        // REMOVE_END
+
+        // STEP_START hash_tutorial
+        // Tutorial-style example with bike data (async)
+        let bike_fields = [
+            ("model", "Deimos"),
+            ("brand", "Ergonom"),
+            ("type", "Enduro bikes"),
+            ("price", "4972"),
+        ];
+
+        if let Ok(res7) = r.hset_multiple("bike:1", &bike_fields).await {
+            let res7: String = res7;
+            println!("{res7}"); // >>> OK
+        }
+
+        match r.hget("bike:1", "model").await {
+            Ok(res8) => {
+                let res8: String = res8;
+                println!("{res8}"); // >>> Deimos
+                // REMOVE_START
+                assert_eq!(res8, "Deimos");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hget("bike:1", "price").await {
+            Ok(res9) => {
+                let res9: String = res9;
+                println!("{res9}"); // >>> 4972
+                // REMOVE_START
+                assert_eq!(res9, "4972");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+        // STEP_END
+
+        // REMOVE_START
+        let _: () = r.del(&["bike:1", "bike:1:stats"]).await.unwrap();
+        // REMOVE_END
+    }
+}
+

--- a/for-ais-only/examples/rust-sync/Cargo.toml
+++ b/for-ais-only/examples/rust-sync/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "redis_examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redis = "1.0"
+
+[dev-dependencies]
+# Tests use the same redis dependency
+

--- a/for-ais-only/examples/rust-sync/RUST_SYNC_TEST_PATTERNS.md
+++ b/for-ais-only/examples/rust-sync/RUST_SYNC_TEST_PATTERNS.md
@@ -1,0 +1,195 @@
+# Rust Sync (redis-rs) Test File Patterns
+
+This document describes the conventions used in redis-rs synchronous documentation test files.
+
+## Purpose
+
+These test files serve dual purposes:
+1. **Executable Rust tests** - Validate code snippets work correctly
+2. **Documentation source** - Code is extracted for redis.io documentation
+
+## File Locations
+
+- **Sample template**: `/path/to/docs/for-ais-only/examples/rust-sync/sample_test.rs`
+
+## Marker Reference
+
+| Marker | Purpose |
+|--------|---------|
+| `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
+| `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
+| `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
+
+## File Structure Template
+
+```rust
+// EXAMPLE: example_name
+
+// HIDE_START
+use redis::Commands;
+// HIDE_END
+
+// REMOVE_START
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run() {
+// REMOVE_END
+        // STEP_START connect
+        let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+        let mut con = client.get_connection().unwrap();
+        // STEP_END
+
+        // REMOVE_START
+        let _: () = redis::cmd("DEL").arg("mykey").query(&mut con).unwrap();
+        // REMOVE_END
+
+        // STEP_START string_ops
+        let _: () = con.set("mykey", "Hello").unwrap();
+        println!("SET mykey Hello: OK"); // >>> OK
+
+        let value: String = con.get("mykey").unwrap();
+        println!("GET mykey: {}", value); // >>> Hello
+        // STEP_END
+
+        // REMOVE_START
+        assert_eq!(value, "Hello");
+        let _: () = redis::cmd("DEL").arg("mykey").query(&mut con).unwrap();
+// REMOVE_END
+// REMOVE_START
+    }
+}
+// REMOVE_END
+```
+
+## Key Patterns
+
+### 1. Imports (in HIDE block)
+```rust
+// HIDE_START
+use redis::Commands;
+// HIDE_END
+```
+
+### 2. Test Module Structure (in REMOVE blocks)
+```rust
+// REMOVE_START
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_run() {
+// REMOVE_END
+        // ... code ...
+// REMOVE_START
+    }
+}
+// REMOVE_END
+```
+
+### 3. Connection Setup
+```rust
+// STEP_START connect
+let client = redis::Client::open("redis://127.0.0.1/").unwrap();
+let mut con = client.get_connection().unwrap();
+// STEP_END
+```
+
+### 4. Assertions (in REMOVE blocks)
+```rust
+// REMOVE_START
+assert_eq!(value, "Hello");
+assert_eq!(count, 3);
+let _: () = redis::cmd("DEL").arg("mykey").query(&mut con).unwrap();
+// REMOVE_END
+```
+
+### 5. Console Output Comments
+```rust
+println!("SET mykey Hello: OK"); // >>> OK
+println!("GET mykey: {}", value); // >>> Hello
+```
+
+### 6. Hash Operations
+```rust
+// Single field
+let _: () = con.hset("myhash", "field1", "value1").unwrap();
+
+// Multiple fields
+let _: () = con.hset_multiple("myhash", &[
+    ("field2", "value2"),
+    ("field3", "value3"),
+]).unwrap();
+
+// Get operations
+let value: String = con.hget("myhash", "field1").unwrap();
+let all: std::collections::HashMap<String, String> = con.hgetall("myhash").unwrap();
+```
+
+### 7. Type Annotations
+```rust
+// Explicit type for set operations (returns nothing)
+let _: () = con.set("key", "value").unwrap();
+
+// Explicit type for get operations
+let value: String = con.get("key").unwrap();
+let count: i64 = con.hlen("myhash").unwrap();
+```
+
+## Directory Structure
+
+Cargo requires test files to be in a specific location:
+
+```
+examples/rust-sync/
+├── Cargo.toml
+├── RUST_SYNC_TEST_PATTERNS.md
+└── tests/
+    └── sample_test.rs
+```
+
+## Running Tests
+
+```bash
+# Build and fetch dependencies
+cargo build
+
+# Run all tests
+cargo test
+
+# Run specific test
+cargo test test_run
+
+# Run with output
+cargo test -- --nocapture
+```
+
+## Cargo.toml
+
+```toml
+[package]
+name = "redis_examples"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redis = "1.0"
+
+[dev-dependencies]
+# Tests use the same redis dependency
+```
+
+## API Notes
+
+- Use `redis::Commands` trait for convenient methods
+- All operations return `RedisResult<T>`, use `.unwrap()` for examples
+- Type annotations required for return values
+- Connection is mutable (`&mut con`)
+
+## See Also
+
+- Sample template: `/path/to/docs/for-ais-only/examples/rust-sync/sample_test.rs`

--- a/for-ais-only/examples/rust-sync/tests/sample_test.rs
+++ b/for-ais-only/examples/rust-sync/tests/sample_test.rs
@@ -1,0 +1,172 @@
+// =============================================================================
+// CANONICAL RUST-SYNC (redis-rs) TEST FILE TEMPLATE
+// =============================================================================
+// This file demonstrates the structure and conventions used for redis-rs sync
+// documentation test files. These tests serve dual purposes:
+// 1. Executable tests that validate code snippets
+// 2. Source for documentation code examples (processed via special markers)
+//
+// MARKER REFERENCE:
+// - EXAMPLE: <name>     - Identifies the example name (matches docs folder name)
+// - BINDER_ID <id>      - Optional identifier for online code runners
+// - HIDE_START/HIDE_END - Code hidden from documentation but executed in tests
+// - REMOVE_START/REMOVE_END - Code removed entirely from documentation output
+// - STEP_START <name>/STEP_END - Named code section for targeted doc inclusion
+//
+// RUN: cargo test
+// =============================================================================
+
+// EXAMPLE: sample_example
+#[cfg(test)]
+mod sample_tests {
+    use redis::Commands;
+    use std::collections::HashMap;
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // REMOVE_START
+        // Clean up any existing data before tests
+        let _: Result<i32, _> = r.del(&["mykey", "myhash", "bike:1", "bike:1:stats"]);
+        // REMOVE_END
+
+        // STEP_START string_ops
+        // Basic string SET/GET operations
+        match r.set("mykey", "Hello") {
+            Ok(res1) => {
+                let res1: String = res1;
+                println!("{res1}"); // >>> OK
+                // REMOVE_START
+                assert_eq!(res1, "OK");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.get("mykey") {
+            Ok(res2) => {
+                let res2: String = res2;
+                println!("{res2}"); // >>> Hello
+                // REMOVE_START
+                assert_eq!(res2, "Hello");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+        // STEP_END
+
+        // REMOVE_START
+        let _: Result<i32, _> = r.del("mykey");
+        // REMOVE_END
+
+        // STEP_START hash_ops
+        // Hash operations: HSET, HGET, HGETALL
+        match r.hset("myhash", "field1", "value1") {
+            Ok(res3) => {
+                let res3: i32 = res3;
+                println!("{res3}"); // >>> 1
+                // REMOVE_START
+                assert_eq!(res3, 1);
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        let hash_fields = vec![("field2", "value2"), ("field3", "value3")];
+        match r.hset_multiple("myhash", &hash_fields) {
+            Ok(res4) => {
+                let res4: String = res4;
+                println!("{res4}"); // >>> OK
+                // REMOVE_START
+                assert_eq!(res4, "OK");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hget("myhash", "field1") {
+            Ok(res5) => {
+                let res5: String = res5;
+                println!("{res5}"); // >>> value1
+                // REMOVE_START
+                assert_eq!(res5, "value1");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hgetall("myhash") {
+            Ok(res6) => {
+                let res6: HashMap<String, String> = res6;
+                println!("{:?}", res6.get("field1")); // >>> Some("value1")
+                // REMOVE_START
+                assert_eq!(res6.get("field1"), Some(&"value1".to_string()));
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+        // STEP_END
+
+        // REMOVE_START
+        let _: Result<i32, _> = r.del("myhash");
+        // REMOVE_END
+
+        // STEP_START hash_tutorial
+        // Tutorial-style example with bike data
+        let bike_fields = vec![
+            ("model", "Deimos"),
+            ("brand", "Ergonom"),
+            ("type", "Enduro bikes"),
+            ("price", "4972"),
+        ];
+
+        match r.hset_multiple("bike:1", &bike_fields) {
+            Ok(res7) => {
+                let res7: String = res7;
+                println!("{res7}"); // >>> OK
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hget("bike:1", "model") {
+            Ok(res8) => {
+                let res8: String = res8;
+                println!("{res8}"); // >>> Deimos
+                // REMOVE_START
+                assert_eq!(res8, "Deimos");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hget("bike:1", "price") {
+            Ok(res9) => {
+                let res9: String = res9;
+                println!("{res9}"); // >>> 4972
+                // REMOVE_START
+                assert_eq!(res9, "4972");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+        // STEP_END
+
+        // REMOVE_START
+        let _: Result<i32, _> = r.del(&["bike:1", "bike:1:stats"]);
+        // REMOVE_END
+    }
+}
+


### PR DESCRIPTION
All examples have been tested in my local environment. 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Adds only new example/template files and language-specific dependency manifests under `for-ais-only`, with minimal impact on runtime code; main risk is accidental inclusion in CI that would require local Redis and extra toolchains.
> 
> **Overview**
> Adds a set of **canonical, executable documentation test templates** under `for-ais-only/examples/` for multiple Redis clients (Go `go-redis`, C `hiredis`, Node `node-redis`/`ioredis`, Java `jedis`/`lettuce` async+reactive, Python `redis-py`, PHP `predis`, Rust sync/async `redis-rs`, and .NET `NRedisStack`).
> 
> Each example is paired with a `*_TEST_PATTERNS.md` guide defining the marker conventions (`EXAMPLE`, `HIDE_*`, `REMOVE_*`, `STEP_*`) used to extract doc snippets while keeping the code runnable, and includes the minimal project manifests (`go.mod`, `package.json`, `pom.xml`, `.csproj`, `composer.json`, `requirements.txt`, `Cargo.toml`) needed to run the templates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37dca72b08cb8eadc6773cf80e4e7eaf04fd1b30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->