### PR TITLE
K8s: wisco maint 8

### DIFF
--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-13-march2026.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-13-march2026.md
@@ -1,0 +1,28 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: A maintenance release that includes support for Redis Software 7.8.6-256.
+hideListLinks: true
+linkTitle: 7.8.6-13 (March 2026)
+title: Redis Enterprise for Kubernetes 7.8.6-13 (March 2026) release notes
+weight: 19
+---
+
+Redis Enterprise for Kubernetes 7.8.6-13 (March 2026) is a maintenance release that includes support for [Redis Software 7.8.6-256]({{<relref "/operate/rs/release-notes/rs-7-8-releases/" >}}).
+
+For supported distributions, known limitations, and API changes, see [Redis Enterprise for Kubernetes 7.8.6-1 March 2025 release notes]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-march2025" >}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:7.8.6-256`
+- **Operator**: `redislabs/operator:7.8.6-13`
+- **Services Rigger**: `redislabs/k8s-controller:7.8.6-13`
+- **OLM operator bundle** : `v7.8.6-13.0`
+
+## Known limitations
+
+See [7.8.6 releases]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases" >}}) for information on known limitations.
+

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.8.6 release notes
 weight: 68
 ---
 
-Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-11 with support for Redis Enterprise Software version 7.8.6-253.
+Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-13 with support for Redis Enterprise Software version 7.8.6-256.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only update adding a new release notes page and bumping the 7.8.6 index to point to the latest versions.
> 
> **Overview**
> Adds release notes for **Redis Enterprise for Kubernetes `7.8.6-13` (March 2026)**, including updated download image tags and OLM bundle version aligned to Redis Software `7.8.6-256`.
> 
> Updates the `7.8.6` release notes index to mark `7.8.6-13` / `7.8.6-256` as the latest release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5a960aa8b176d0ef5a53406f66b80d88e86c68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->