### PR TITLE
K8s: remove old x86 note

### DIFF
--- a/content/operate/kubernetes/reference/supported_k8s_distributions.md
+++ b/content/operate/kubernetes/reference/supported_k8s_distributions.md
@@ -12,8 +12,6 @@ weight: 10
 
 We thoroughly test each release of Redis Enterprise for Kubernetes against a set of Kubernetes distributions. The table below lists Redis Enterprise for Kubernetes versions and the Kubernetes distributions they support.
 
-{{<note>}}x86 is currently the only computer architecture supported by Redis Enterprise for Kubernetes. Support for ARM architecture is coming in future releases.{{</note>}}
-
 <span title="Check mark icon">&#x2705;</span> Supported – This distribution is supported for this version of Redis Enterprise Software for Kubernetes.
 
 <span title="Deprecation warning" class="font-serif">:warning:</span> Deprecated – This distribution is still supported for this version of Redis Enterprise Software for Kubernetes, but support will be removed in a future release.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes an outdated architecture support note; no product behavior or APIs are affected.
> 
> **Overview**
> Removes the note on `supported_k8s_distributions.md` stating that only x86 is supported and that ARM support is coming, leaving the support matrix intro focused solely on distribution/version status definitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60acbcb9d192dd1821f9dfcb6335c40040cd9ab6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->