### PR TITLE
OP: update APT installation instructions

### DIFF
--- a/content/operate/oss_and_stack/install/install-stack/apt.md
+++ b/content/operate/oss_and_stack/install/install-stack/apt.md
@@ -44,10 +44,14 @@ redis:
         500 https://packages.redis.io/deb bookworm/main all Packages
 {{< /highlight >}}
 
-To install an earlier version, say 7.4.2, run the following command:
+For example, to install Redis Open Source v7.4.2 on Ubuntu LTS 22.04 (Jammy Jellyfish), run the following command:
 
 {{< highlight bash >}}
-sudo apt-get install redis=6:7.4.2-1rl1~jammy1
+apt-get install \
+redis=6:7.4.2-1rl1~jammy1 \
+redis-server=6:7.4.2-1rl1~jammy1 \
+redis-sentinel=6:7.4.2-1rl1~jammy1 \
+redis-tools=6:7.4.2-1rl1~jammy1
 {{< /highlight >}}
 
 Redis should start automatically after the initial installation and also at boot time.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that updates example APT commands; no runtime or behavioral code impact.
> 
> **Overview**
> Clarifies the “install an earlier version” section of the APT guide by switching the example from installing only `redis=<version>` to pinning `redis`, `redis-server`, `redis-sentinel`, and `redis-tools` to the same version.
> 
> Also rephrases the example to be explicit about Redis Open Source v7.4.2 on Ubuntu 22.04 (Jammy).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a92423a7b2d8a8c6bc31218de8d8255cfdf9834. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->