### PR TITLE
DOC-6348 fixed (hopefully) bad scrolling in pages with Mermaid diagrams

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -108,7 +108,7 @@ section.prose {
 .prose h4[id],
 .prose h5[id],
 .prose h6[id] {
-  @apply mt-16 scroll-mt-6;
+	  @apply mt-16 scroll-mt-24;
 }
 
 /* Reduce top margin when headers immediately follow other headers */

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -188,13 +188,42 @@ const mobileMenu = (() => {
 
 // Simple click-to-open for standalone images
 document.addEventListener('click', function(e) {
-  // Check if clicked element is a standalone img (not inside an anchor, not image-card, not no-click)
-  if (e.target.tagName === 'IMG' &&
-      !e.target.closest('a') &&
-      !e.target.classList.contains('image-card-img') &&
-      !e.target.src.includes('#no-click')) {
+	  // Check if clicked element is a standalone img (not inside an anchor, not image-card, not no-click)
+	  if (e.target.tagName === 'IMG' &&
+	      !e.target.closest('a') &&
+	      !e.target.classList.contains('image-card-img') &&
+	      !e.target.src.includes('#no-click')) {
+	  
+	    // Open image in same tab, just like clicking a regular link
+	    window.location.href = e.target.src
+	  }
+	})
 
-    // Open image in same tab, just like clicking a regular link
-    window.location.href = e.target.src
-  }
+// Ensure hash-based navigation lands correctly after dynamic content (like Mermaid diagrams)
+// has finished rendering and potentially shifted the layout.
+window.addEventListener('load', () => {
+	  if (!window.location.hash) return
+
+	  // Support hashes with optional query parameters (e.g., #pattern-1-fail-fast?lang=Python)
+	  const rawHash = window.location.hash
+	  const baseHash = rawHash.split('?')[0]
+	  const targetId = decodeURIComponent(baseHash.substring(1))
+	  if (!targetId) return
+
+	  const scrollToTarget = () => {
+	    const target = document.getElementById(targetId)
+	    if (!target) return
+
+	    const header = document.querySelector('header.sticky')
+	    const headerHeight = header ? header.offsetHeight : 0
+	    const offset = headerHeight + 16 // small extra padding
+
+	    const targetTop = target.getBoundingClientRect().top + window.scrollY - offset
+	    window.scrollTo({ top: targetTop, behavior: 'auto' })
+	  }
+
+	  // Run a few times to account for late layout shifts (e.g., Mermaid rendering)
+	  ;[50, 250, 500].forEach(delay => {
+	    setTimeout(scrollToTarget, delay)
+	  })
 })


### PR DESCRIPTION
Augie seems to have fixed the issue where an anchor link jumps slightly off-position when the target page has Mermaid diagrams in it. I've tried a few other pages but I can't swear that this doesn't introduce some other fault, so I'd be happy to hear any feedback about this.

Example: the link in this section to the other [Pattern 1: Fail fast](https://redis.io/docs/staging/DOC-6348-dodgy-scrolling/develop/clients/rust/error-handling/#pattern-1-fail-fast) section in the target page should now jump to the heading correctly - previously, it didn't.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts global heading anchor offsets and adds load-time hash re-scrolling, which can change navigation behavior site-wide and may introduce unexpected scroll positioning on some pages.
> 
> **Overview**
> Improves in-page anchor navigation in docs pages that render dynamic content (e.g., Mermaid) by **increasing header `scroll-margin-top`** (`scroll-mt-6` → `scroll-mt-24`) so targets land below the sticky header.
> 
> Adds a `window.load` handler that, when a hash is present, **re-scrolls to the target element multiple times** (after short delays) using an explicit offset based on `header.sticky` height, including support for hashes that include query parameters.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16cabe27ef19c4e5e35e1068acbc5ed73dd831c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->