### PR TITLE
OP: more work on the APT installation page

### DIFF
--- a/content/operate/oss_and_stack/install/install-stack/apt.md
+++ b/content/operate/oss_and_stack/install/install-stack/apt.md
@@ -51,22 +51,24 @@ redis:
 For example, to install Redis Open Source v7.4.8 on Ubuntu LTS 24.04 (Noble Numbat), run the following command:
 
 {{< highlight bash >}}
-apt-get install \
-redis=6:7.4.8-1rl1~noble1 1001 \
-redis-server=6:7.4.8-1rl1~noble1 1001 \
-redis-sentinel=6:7.4.8-1rl1~noble1 1001 \
-redis-tools=6:7.4.8-1rl1~noble1 1001
+sudo apt-get install \
+redis=6:7.4.8-1rl1~noble1 \
+redis-server=6:7.4.8-1rl1~noble1 \
+redis-sentinel=6:7.4.8-1rl1~noble1 \
+redis-tools=6:7.4.8-1rl1~noble1
 {{< /highlight >}}
 
 Alternatively, you can also set up a preferences file to pin a particular release:
 
-```
+{{< highlight bash >}}
 Package: redis redis-server redis-sentinel redis-tools
 Pin: version 6:7.4.*
 Pin-Priority: 1001
-```
+{{< /highlight >}}
 
-In this case, `6:7.4.8-1rl1~noble1 1001` is the latest version that matches the pinned version and it will be installed when you run this command:
+See [this document](https://manpages.debian.org/buster/apt/apt_preferences.5.en.html#How_APT_Interprets_Priorities) for more information on `Pin-Priority`.
+
+With the example preferences file give above, `6:7.4.8-1rl1~noble1` is the latest version that matches the pinned version and it will be installed when you run this command:
 
 {{< highlight bash >}}
 sudo apt-get install redis-server redis-sentinel redis-tools


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact; risk is limited to potential confusion if command examples are incorrect.
> 
> **Overview**
> Updates the APT install docs to use correct copy-pastable commands: adds `sudo` to the version-pinned `apt-get install` example and removes the stray `1001` priority suffixes from package version arguments.
> 
> Reformats the APT pinning example as a bash-highlighted block, adds a link explaining `Pin-Priority`, and tweaks the accompanying text to better describe how the pinned version is selected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1959cf941e9cc3660503978a0c34078f0187f26a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->