### PR TITLE
Docker hub link

### DIFF
--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -5,12 +5,12 @@ linkTitle: Develop
 hideListLinks: true
 ---
 
-<a href="https://hub.docker.com/_/redis">Redis Docker Hub</a>
+
 
 Get a Redis server running in minutes with a free trial of
 [Redis Cloud]({{< relref "/operate/rc" >}}), or install
 [Redis Open Source]({{< relref "/operate/oss_and_stack" >}}) locally
-on your machine. Then, explore Redis with your favorite
+on your machine. Check out the <a href="https://hub.docker.com/_/redis">Redis Docker Hub</a> for the latest release. Then, explore Redis with your favorite
 [programming language]({{< relref "/develop/clients" >}})
 or analyze and manage your database with our
 [UI tools]({{< relref "/develop/tools" >}}):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single documentation change adding an external link; no code or behavior changes.
> 
> **Overview**
> Updates the `Develop with Redis` landing page (`content/develop/_index.md`) to add a direct link to the official Redis image on Docker Hub as guidance for getting the latest Redis release when installing locally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aafb44602fac3219efa6c6b6f085be9d4fc507d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->