### PR TITLE
Use env for github context values

### DIFF
--- a/.github/workflows/autocomment_staging_links.yaml
+++ b/.github/workflows/autocomment_staging_links.yaml
@@ -22,15 +22,17 @@ jobs:
         run: sudo apt-get install jq
 
       - name: Create Comment
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BRANCH_NAME: ${{ github.head_ref }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -e
 
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          BRANCH_NAME=${{ github.head_ref }}
-          GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          CREATE_COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/${PR_NUMBER}/comments"
-          UPDATE_COMMENT_URL="https://api.github.com/repos/${{ github.repository }}/issues/comments"
-          FILES_URL="https://api.github.com/repos/${{ github.repository }}/pulls/${PR_NUMBER}/files"
+          CREATE_COMMENT_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments"
+          UPDATE_COMMENT_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/comments"
+          FILES_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files"
 
           # Check if comment already exists
           EXISTING_COMMENT_JSON=$(curl -Ls \

--- a/.github/workflows/cleanup_pr_folders.yaml
+++ b/.github/workflows/cleanup_pr_folders.yaml
@@ -32,13 +32,12 @@ jobs:
         project_id: '${{ env.STAGING_PROJECT_ID }}'
         version: '>= 363.0.0'
 
-    - name: Remove pull request staging folder 
+    - name: Remove pull request staging folder
+      env:
+        BRANCH_TO_CLEANUP: ${{ github.event.pull_request.head.ref }}
       run: |
-        BRANCH_TO_CLEANUP="${{ github.event.pull_request.head.ref }}"
-        STAGING_BUCKET="${{ env.STAGING_BUCKET }}"
-
-        if gsutil -q stat gs://${STAGING_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*; then
-          gsutil -q -m rm -r gs://${STAGING_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*
+        if gsutil -q stat "gs://${STAGING_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*"; then
+          gsutil -q -m rm -r "gs://${STAGING_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*"
           echo "Removed gs://${STAGING_BUCKET}/staging/${BRANCH_TO_CLEANUP}"
         fi
 
@@ -69,11 +68,10 @@ jobs:
         version: '>= 363.0.0'
 
     - name: Remove pull request staging folder
+      env:
+        BRANCH_TO_CLEANUP: ${{ github.event.pull_request.head.ref }}
       run: |
-        BRANCH_TO_CLEANUP="${{ github.event.pull_request.head.ref }}"
-        PROD_BUCKET="${{ env.PROD_BUCKET }}"
-
-        if gsutil -q stat gs://${PROD_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*; then
-          gsutil -q -m rm -r gs://${PROD_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*
+        if gsutil -q stat "gs://${PROD_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*"; then
+          gsutil -q -m rm -r "gs://${PROD_BUCKET}/staging/${BRANCH_TO_CLEANUP}/*"
           echo "Removed gs://${PROD_BUCKET}/staging/${BRANCH_TO_CLEANUP}"
         fi

--- a/.github/workflows/k8s_apis_sync.yaml
+++ b/.github/workflows/k8s_apis_sync.yaml
@@ -46,9 +46,10 @@ jobs:
           aws-region: us-east-1
 
       - name: 'Fetch release'
+        env:
+          RELEASE: ${{ github.event.inputs.release }}
+          BUCKET_FOLDER: ${{ github.event.inputs.bucket_folder }}
         run: |-
-          RELEASE="${{ github.event.inputs.release }}"
-          BUCKET_FOLDER="${{ github.event.inputs.bucket_folder }}"
           aws s3 cp "s3://redislabs-k8s/${BUCKET_FOLDER}/redis-enterprise-operator-${RELEASE}.tar.gz" .
 
           tar xf "redis-enterprise-operator-${RELEASE}.tar.gz"
@@ -199,8 +200,8 @@ jobs:
       - name: 'Send pull request'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE: ${{ github.event.inputs.release }}
         run: |-
-          RELEASE="${{ github.event.inputs.release }}"
           BRANCH="k8s_apis_docs_${RELEASE}"
 
           # Setup git email and username

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,11 +33,13 @@ jobs:
         sudo rm -rf /opt/hostedtoolcache/CodeQL
 
     - name: Validate the branch name
+      env:
+        BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        if [[ "${{ github.ref_name }}" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
-          echo "The branch name ${{ github.ref_name }} is valid."
+        if [[ "$BRANCH_NAME" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+          echo "The branch name $BRANCH_NAME is valid."
         else
-          echo "ERROR: Invalid branch name ${{ github.ref_name }}!"
+          echo "ERROR: Invalid branch name $BRANCH_NAME!"
           exit 1
         fi
 

--- a/.github/workflows/redis_docs_sync.yaml
+++ b/.github/workflows/redis_docs_sync.yaml
@@ -30,8 +30,8 @@ jobs:
       - name: 'Generate modules-api-ref.md and commands.json files and push if necessary'
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          RELEASE: ${{ github.event.inputs.release }}
         run: |-
-          RELEASE="${{ github.event.inputs.release }}"
           BRANCH="redis_docs_sync_${RELEASE}"
 
           # Generate modules-api-ref.md


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only refactors GitHub Actions workflow scripts to use `env`-provided context values and adds quoting; behavior should be unchanged aside from reduced YAML interpolation edge cases.
> 
> **Overview**
> Refactors several GitHub Actions workflows to pass `github.*` context values via step-level `env` variables (e.g., PR number, branch name, release inputs) instead of inline shell assignments.
> 
> Also standardizes URL construction to use `GITHUB_REPOSITORY` and tightens quoting in `gsutil` cleanup commands, reducing the chance of interpolation/word-splitting issues while keeping the underlying workflow behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba288ca45b04dac04d639fe1d94227799da47825. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->