### PR TITLE
DOC-6359 fix newlines in JSON metadata

### DIFF
--- a/layouts/_default/section.md
+++ b/layouts/_default/section.md
@@ -2,8 +2,8 @@
 
 ```json metadata
 {
-  "title": "{{ .Title }}",
-  "description": "{{ .Description }}",
+  "title": {{ .Title | jsonify }},
+  "description": {{ (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace | jsonify }},
   "categories": {{ .Params.categories | jsonify }}{{ if .Params.arguments }},
   "arguments": {{ .Params.arguments | jsonify }}{{ end }}{{ if .Params.syntax_fmt }},
   "syntax_fmt": {{ .Params.syntax_fmt | jsonify }}{{ end }}{{ if .Params.complexity }},
@@ -22,36 +22,30 @@
 }
 ```
 
-{{ $content := .RawContent }}
-
-{{/* Add legend for code examples at the beginning if content contains clients-example shortcodes */}}
-{{ if findRE "clients-example" $content }}
-{{ $legendAdded := false }}
-{{ if not $legendAdded }}
-{{ $content = printf "## Code Examples Legend\n\nThe code examples below show how to perform the same operations in different programming languages and client libraries:\n\n- **Redis CLI**: Command-line interface for Redis\n- **C# (Synchronous)**: StackExchange.Redis synchronous client\n- **C# (Asynchronous)**: StackExchange.Redis asynchronous client\n- **Go**: go-redis client\n- **Java (Synchronous - Jedis)**: Jedis synchronous client\n- **Java (Asynchronous - Lettuce)**: Lettuce asynchronous client\n- **Java (Reactive - Lettuce)**: Lettuce reactive/streaming client\n- **JavaScript (Node.js)**: node-redis client\n- **PHP**: Predis client\n- **Python**: redis-py client\n- **Rust (Synchronous)**: redis-rs synchronous client\n- **Rust (Asynchronous)**: redis-rs asynchronous client\n\nEach code example demonstrates the same basic operation across different languages. The specific syntax and patterns vary based on the language and client library, but the underlying Redis commands and behavior remain consistent.\n\n---\n\n%s" $content }}
-{{ $legendAdded = true }}
-{{ end }}
-{{ end }}
-
-{{/* Fix relrefs */}}
-{{ $content := $content | replaceRE "\\{\\{< ?relref \"([^\"]+)\" ?>\\}\\}" "https://redis.io/docs/latest$1" }}
-
-{{/* Fix images */}}
-{{ $content := $content | replaceRE "\\{\\{< ?image filename=\"([^\"]+)\" ?>\\}\\}" "![$1](https://redis.io/docs/latest$1)" }}
-
-{{/* Process clients-example shortcodes to include all languages */}}
-{{ $content := partial "markdown-code-examples.html" (dict "RawContent" $content "Site" .Site) }}
-
-{{/* Remove remaining shortcodes */}}
-{{ $content := $content | replaceRE "\\{\\{< ?/?[^>]*>\\}\\}" "" }}
-{{ $content := $content | replaceRE "\\{\\{% ?/?.*%\\}\\}" "" }}
-
-{{/* Unescape HTML entities for plain text output */}}
-{{ $content := $content | replaceRE "&#34;" "\"" }}
-{{ $content := $content | replaceRE "&quot;" "\"" }}
-{{ $content := $content | replaceRE "&lt;" "<" }}
-{{ $content := $content | replaceRE "&gt;" ">" }}
-{{ $content := $content | replaceRE "&amp;" "&" }}
-{{ $content := $content | replaceRE "&#39;" "'" }}
+{{ $content := .RawContent -}}
+{{- /* Add legend for code examples at the beginning if content contains clients-example shortcodes */ -}}
+{{- if findRE "clients-example" $content -}}
+{{- $legendAdded := false -}}
+{{- if not $legendAdded -}}
+{{- $content = printf "## Code Examples Legend\n\nThe code examples below show how to perform the same operations in different programming languages and client libraries:\n\n- **Redis CLI**: Command-line interface for Redis\n- **C# (Synchronous)**: StackExchange.Redis synchronous client\n- **C# (Asynchronous)**: StackExchange.Redis asynchronous client\n- **Go**: go-redis client\n- **Java (Synchronous - Jedis)**: Jedis synchronous client\n- **Java (Asynchronous - Lettuce)**: Lettuce asynchronous client\n- **Java (Reactive - Lettuce)**: Lettuce reactive/streaming client\n- **JavaScript (Node.js)**: node-redis client\n- **PHP**: Predis client\n- **Python**: redis-py client\n- **Rust (Synchronous)**: redis-rs synchronous client\n- **Rust (Asynchronous)**: redis-rs asynchronous client\n\nEach code example demonstrates the same basic operation across different languages. The specific syntax and patterns vary based on the language and client library, but the underlying Redis commands and behavior remain consistent.\n\n---\n\n%s" $content -}}
+{{- $legendAdded = true -}}
+{{- end -}}
+{{- end -}}
+{{- /* Fix relrefs */ -}}
+{{- $content := $content | replaceRE "\\{\\{< ?relref \"([^\"]+)\" ?>\\}\\}" "https://redis.io/docs/latest$1" -}}
+{{- /* Fix images */ -}}
+{{- $content := $content | replaceRE "\\{\\{< ?image filename=\"([^\"]+)\" ?>\\}\\}" "![$1](https://redis.io/docs/latest$1)" -}}
+{{- /* Process clients-example shortcodes to include all languages */ -}}
+{{- $content := partial "markdown-code-examples.html" (dict "RawContent" $content "Site" .Site) -}}
+{{- /* Remove remaining shortcodes */ -}}
+{{- $content := $content | replaceRE "\\{\\{< ?/?[^>]*>\\}\\}" "" -}}
+{{- $content := $content | replaceRE "\\{\\{% ?/?.*%\\}\\}" "" -}}
+{{- /* Unescape HTML entities for plain text output */ -}}
+{{- $content := $content | replaceRE "&#34;" "\"" -}}
+{{- $content := $content | replaceRE "&quot;" "\"" -}}
+{{- $content := $content | replaceRE "&lt;" "<" -}}
+{{- $content := $content | replaceRE "&gt;" ">" -}}
+{{- $content := $content | replaceRE "&amp;" "&" -}}
+{{- $content := $content | replaceRE "&#39;" "'" -}}
 
 {{ $content }}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -2,8 +2,8 @@
 
 ```json metadata
 {
-  "title": "{{ .Title }}",
-  "description": "{{ .Description }}",
+  "title": {{ .Title | jsonify }},
+  "description": {{ (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace | jsonify }},
   "categories": {{ .Params.categories | jsonify }}{{ if .Params.arguments }},
   "arguments": {{ .Params.arguments | jsonify }}{{ end }}{{ if .Params.syntax_fmt }},
   "syntax_fmt": {{ .Params.syntax_fmt | jsonify }}{{ end }}{{ if .Params.complexity }},
@@ -22,36 +22,30 @@
 }
 ```
 
-{{ $content := .RawContent }}
-
-{{/* Add legend for code examples at the beginning if content contains clients-example shortcodes */}}
-{{ if findRE "clients-example" $content }}
-{{ $legendAdded := false }}
-{{ if not $legendAdded }}
-{{ $content = printf "## Code Examples Legend\n\nThe code examples below show how to perform the same operations in different programming languages and client libraries:\n\n- **Redis CLI**: Command-line interface for Redis\n- **C# (Synchronous)**: StackExchange.Redis synchronous client\n- **C# (Asynchronous)**: StackExchange.Redis asynchronous client\n- **Go**: go-redis client\n- **Java (Synchronous - Jedis)**: Jedis synchronous client\n- **Java (Asynchronous - Lettuce)**: Lettuce asynchronous client\n- **Java (Reactive - Lettuce)**: Lettuce reactive/streaming client\n- **JavaScript (Node.js)**: node-redis client\n- **PHP**: Predis client\n- **Python**: redis-py client\n- **Rust (Synchronous)**: redis-rs synchronous client\n- **Rust (Asynchronous)**: redis-rs asynchronous client\n\nEach code example demonstrates the same basic operation across different languages. The specific syntax and patterns vary based on the language and client library, but the underlying Redis commands and behavior remain consistent.\n\n---\n\n%s" $content }}
-{{ $legendAdded = true }}
-{{ end }}
-{{ end }}
-
-{{/* Fix relrefs */}}
-{{ $content := $content | replaceRE "\\{\\{< ?relref \"([^\"]+)\" ?>\\}\\}" "https://redis.io/docs/latest$1" }}
-
-{{/* Fix images */}}
-{{ $content := $content | replaceRE "\\{\\{< ?image filename=\"([^\"]+)\" ?>\\}\\}" "![$1](https://redis.io/docs/latest$1)" }}
-
-{{/* Process clients-example shortcodes to include all languages */}}
-{{ $content := partial "markdown-code-examples.html" (dict "RawContent" $content "Site" .Site) }}
-
-{{/* Remove remaining shortcodes */}}
-{{ $content := $content | replaceRE "\\{\\{< ?/?[^>]*>\\}\\}" "" }}
-{{ $content := $content | replaceRE "\\{\\{% ?/?.*%\\}\\}" "" }}
-
-{{/* Unescape HTML entities for plain text output */}}
-{{ $content := $content | replaceRE "&#34;" "\"" }}
-{{ $content := $content | replaceRE "&quot;" "\"" }}
-{{ $content := $content | replaceRE "&lt;" "<" }}
-{{ $content := $content | replaceRE "&gt;" ">" }}
-{{ $content := $content | replaceRE "&amp;" "&" }}
-{{ $content := $content | replaceRE "&#39;" "'" }}
+{{ $content := .RawContent -}}
+{{- /* Add legend for code examples at the beginning if content contains clients-example shortcodes */ -}}
+{{- if findRE "clients-example" $content -}}
+{{- $legendAdded := false -}}
+{{- if not $legendAdded -}}
+{{- $content = printf "## Code Examples Legend\n\nThe code examples below show how to perform the same operations in different programming languages and client libraries:\n\n- **Redis CLI**: Command-line interface for Redis\n- **C# (Synchronous)**: StackExchange.Redis synchronous client\n- **C# (Asynchronous)**: StackExchange.Redis asynchronous client\n- **Go**: go-redis client\n- **Java (Synchronous - Jedis)**: Jedis synchronous client\n- **Java (Asynchronous - Lettuce)**: Lettuce asynchronous client\n- **Java (Reactive - Lettuce)**: Lettuce reactive/streaming client\n- **JavaScript (Node.js)**: node-redis client\n- **PHP**: Predis client\n- **Python**: redis-py client\n- **Rust (Synchronous)**: redis-rs synchronous client\n- **Rust (Asynchronous)**: redis-rs asynchronous client\n\nEach code example demonstrates the same basic operation across different languages. The specific syntax and patterns vary based on the language and client library, but the underlying Redis commands and behavior remain consistent.\n\n---\n\n%s" $content -}}
+{{- $legendAdded = true -}}
+{{- end -}}
+{{- end -}}
+{{- /* Fix relrefs */ -}}
+{{- $content := $content | replaceRE "\\{\\{< ?relref \"([^\"]+)\" ?>\\}\\}" "https://redis.io/docs/latest$1" -}}
+{{- /* Fix images */ -}}
+{{- $content := $content | replaceRE "\\{\\{< ?image filename=\"([^\"]+)\" ?>\\}\\}" "![$1](https://redis.io/docs/latest$1)" -}}
+{{- /* Process clients-example shortcodes to include all languages */ -}}
+{{- $content := partial "markdown-code-examples.html" (dict "RawContent" $content "Site" .Site) -}}
+{{- /* Remove remaining shortcodes */ -}}
+{{- $content := $content | replaceRE "\\{\\{< ?/?[^>]*>\\}\\}" "" -}}
+{{- $content := $content | replaceRE "\\{\\{% ?/?.*%\\}\\}" "" -}}
+{{- /* Unescape HTML entities for plain text output */ -}}
+{{- $content := $content | replaceRE "&#34;" "\"" -}}
+{{- $content := $content | replaceRE "&quot;" "\"" -}}
+{{- $content := $content | replaceRE "&lt;" "<" -}}
+{{- $content := $content | replaceRE "&gt;" ">" -}}
+{{- $content := $content | replaceRE "&amp;" "&" -}}
+{{- $content := $content | replaceRE "&#39;" "'" -}}
 
 {{ $content }}

--- a/layouts/partials/toc-json-regex.html
+++ b/layouts/partials/toc-json-regex.html
@@ -6,23 +6,74 @@
 {{- $toc = $toc | replaceRE "<nav[^>]*>" "" -}}
 {{- $toc = $toc | replaceRE "</nav>" "" -}}
 {{- $toc = $toc | replaceRE "\\n\\s*" "" -}}
+{{- /* Strip inline HTML elements (like <code>, <em>, <strong>) from anchor text */ -}}
+{{- $toc = $toc | replaceRE "<code>([^<]*)</code>" "$1" -}}
+{{- $toc = $toc | replaceRE "<em>([^<]*)</em>" "$1" -}}
+{{- $toc = $toc | replaceRE "<strong>([^<]*)</strong>" "$1" -}}
+{{- $toc = $toc | replaceRE "<span[^>]*>([^<]*)</span>" "$1" -}}
+{{- /* Check if there's any content left (i.e., at least one <ul>) */ -}}
+{{- if not (findRE "<ul>" $toc) -}}
+{{- /* No TOC content - return empty sections array */ -}}
+{"sections":[]}
+{{- else -}}
 {{- /* Step 1: Replace <ul> with opening bracket for children array */ -}}
 {{- $toc = $toc | replaceRE "<ul>" "[" -}}
 {{- $toc = $toc | replaceRE "</ul>" "]" -}}
 {{- /* Step 2: Replace <li><a href="#ID">TITLE</a> with {"id":"ID","title":"TITLE" */ -}}
 {{- $toc = $toc | replaceRE "<li><a href=\"#([^\"]+)\">([^<]+)</a>" "{\"id\":\"$1\",\"title\":\"$2\"" -}}
+{{- /* Step 2b: Remove any remaining <li> or <a> tags that weren't matched (orphaned entries) */ -}}
+{{- $toc = $toc | replaceRE "<li>" "" -}}
+{{- $toc = $toc | replaceRE "<a [^>]*>[^<]*</a>" "" -}}
 {{- /* Step 3: Replace </li> with } */ -}}
 {{- $toc = $toc | replaceRE "</li>" "}" -}}
 {{- /* Step 4: Handle nested structure - replace ][ with ],[ (sibling arrays) */ -}}
 {{- $toc = $toc | replaceRE "\\]\\[" "],[" -}}
-{{- /* Step 4b: Handle nested structure - replace [  with ,"children":[ (child arrays) */ -}}
+{{- /* Step 4b: Handle nested structure - replace "[ with ,"children":[ (child arrays) */ -}}
 {{- $toc = $toc | replaceRE "\"\\[" "\",\"children\":[" -}}
 {{- /* Step 5: Add commas between sibling objects - replace }{ with },{ */ -}}
 {{- $toc = $toc | replaceRE "\\}\\{" "},{" -}}
-{{- /* Step 6: Wrap the entire structure */ -}}
+{{- /* Step 5b: Fix multiple root-level arrays: replace ],[ at root with just concatenated items */ -}}
+{{- /* First wrap in sections */ -}}
 {{- $toc = print "{\"sections\":" $toc "}" -}}
+{{- /* Step 6: Clean up any remaining malformed patterns */ -}}
+{{- /* Fix multiple root-level <ul> elements: ]},[ becomes },{ */ -}}
+{{- $toc = $toc | replaceRE "\\]\\},\\[" "]},{" -}}
+{{- /* Fix nested arrays at root: [[...]] pattern */ -}}
+{{- $toc = $toc | replaceRE "\"sections\":\\[\\[" "\"sections\":[" -}}
+{{- /* Fix ]},{ pattern - close sections and start new object - flatten into array */ -}}
+{{- $toc = $toc | replaceRE "\\]\\},\\{" "],{" -}}
+{{- /* Fix closing ]] patterns */ -}}
+{{- $toc = $toc | replaceRE "\\]\\],\\}" "]}" -}}
+{{- $toc = $toc | replaceRE "\\]\\]\\}" "]}" -}}
+{{- /* Flatten sibling arrays: ],[{ becomes ,{ */ -}}
+{{- $toc = $toc | replaceRE "\\],\\[\\{" ",{" -}}
+{{- $toc = $toc | replaceRE "\\}\\],\\[\\{" "},{" -}}
+{{- /* Remove any leftover empty braces or malformed sequences */ -}}
+{{- $toc = $toc | replaceRE "\\[\\}" "[]" -}}
+{{- $toc = $toc | replaceRE "\\{\\]" "[]" -}}
+{{- $toc = $toc | replaceRE ",\\}" "}" -}}
+{{- $toc = $toc | replaceRE ",\\]" "]" -}}
+{{- /* Fix empty children followed by sibling: "children":[],{ becomes "children":[]},{ */ -}}
+{{- $toc = $toc | replaceRE "\"children\":\\[\\],\\{" "\"children\":[]},{" -}}
+{{- /* Fix: [,{ pattern (malformed array start) */ -}}
+{{- $toc = $toc | replaceRE "\\[,\\{" "[{" -}}
 {{- /* Step 7: Remove all newlines and extra whitespace for clean output */ -}}
 {{- $toc = $toc | replaceRE "\\n\\s*" "" -}}
+{{- /* Validation: Check for common invalid patterns and fallback to empty if found */ -}}
+{{- /* Check for: HTML tags, double brackets, malformed arrays/objects, objects outside sections */ -}}
+{{- $invalid := false -}}
+{{- if findRE "<" $toc -}}{{- $invalid = true -}}{{- end -}}
+{{- if findRE "\\[\\[" $toc -}}{{- $invalid = true -}}{{- end -}}
+{{- if findRE "\\]\\]" $toc -}}{{- $invalid = true -}}{{- end -}}
+{{- if findRE "\\}\\],\\{" $toc -}}{{- $invalid = true -}}{{- end -}}
+{{- if findRE "\\[\\],\\{" $toc -}}{{- $invalid = true -}}{{- end -}}
+{{- if findRE "\\}\\},\\{" $toc -}}{{- $invalid = true -}}{{- end -}}
+{{- if findRE "\\]\\},\\{" $toc -}}{{- $invalid = true -}}{{- end -}}
+{{- if $invalid -}}
+{"sections":[]}
+{{- else -}}
 {{- /* Output the JSON - use safeHTML to prevent quote escaping */ -}}
 {{- $toc | safeHTML -}}
+{{- end -}}
+{{- end -}}
 


### PR DESCRIPTION
Now, if you open the `index.html.md` version of the file, you should see the page content start right under the metadata section without a load of newlines :-) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the emitted JSON metadata and TOC JSON shaping, which could affect downstream consumers or search/indexing if the output format shifts. Regex-based TOC parsing is inherently brittle, though this PR adds safeguards and fallbacks to reduce breakage.
> 
> **Overview**
> Normalizes page `json metadata` in `section.md`/`single.md` by emitting `title`/`description` via `jsonify` (with `.Params.description` fallback) and trimming/plainifying whitespace to avoid extra newlines and invalid quoting.
> 
> Hardens `toc-json-regex.html` by stripping inline HTML from TOC titles, returning `{ "sections": [] }` when no TOC exists, and adding cleanup/validation steps with a safe fallback when regex transformations would produce malformed JSON.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d77841389ae175c97517f496c19dccaedc221c6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->