### PR TITLE
DEV: synchronize language support in search pages

### DIFF
--- a/content/commands/ft.create.md
+++ b/content/commands/ft.create.md
@@ -345,9 +345,10 @@ if set, indicates the default language for documents in the index. Default is En
 
 is a document attribute set as the document language.
 
-A stemmer is used for the supplied language during indexing. If an unsupported language is sent, the command returns an error. The supported languages are Arabic, Basque, Catalan, Danish, Dutch, English, Finnish, French, German, Greek, Hungarian,
-Indonesian, Irish, Italian, Lithuanian, Nepali, Norwegian, Portuguese, Romanian, Russian,
-Spanish, Swedish, Tamil, Turkish, and Chinese.
+A stemmer is used for the supplied language during indexing. If an unsupported language is sent, the command returns an error. The supported
+languages are `arabic`, `armenian`, `basque`, `catalan`, `danish`, `dutch`, `english`, `finnish`, `french`, `german`, `greek`, `hindi`,
+`hungarian`, `indonesian`, `irish`, `italian`, `lithuanian`, `nepali`, `norwegian`, `portuguese`, `romanian`, `russian`, `serbian`,
+`spanish`, `swedish`, `tamil`, `turkish`, `yiddish`, and `chinese`.
 
 When adding Chinese language documents, set `LANGUAGE chinese` for the indexer to properly tokenize the terms. If you use the default language, then search terms are extracted based on punctuation characters and whitespace. The Chinese language tokenizer makes use of a segmentation algorithm (via [Friso](https://github.com/lionsoul2014/friso)), which segments text and checks it against a predefined dictionary. See [Stemming]({{< relref "/develop/ai/search-and-query/advanced-concepts/stemming" >}}) for more information.
 </details>

--- a/content/develop/ai/search-and-query/advanced-concepts/stemming.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/stemming.md
@@ -80,27 +80,35 @@ redis> FT.SEARCH idx:german '@wort:(stuck)' German
 
 The following languages are supported and can be passed to the engine when indexing or querying using lowercase:
 
-* arabic
-* armenian
-* danish
-* dutch
-* english
-* finnish
-* french
-* german
-* hungarian
-* italian
-* norwegian
-* portuguese
-* romanian
-* russian
-* serbian
-* spanish
-* swedish
-* tamil
-* turkish
-* yiddish
-* chinese (see below)
+* `arabic`
+* `armenian`
+* `basque`
+* `catalan`
+* `danish`
+* `dutch`
+* `english`
+* `finnish`
+* `french`
+* `german`
+* `greek`
+* `hindi`
+* `hungarian`
+* `indonesian`
+* `irish`
+* `italian`
+* `lithuanian`
+* `nepali`
+* `norwegian`
+* `portuguese`
+* `romanian`
+* `russian`
+* `serbian`
+* `spanish`
+* `swedish`
+* `tamil`
+* `turkish`
+* `yiddish`
+* `chinese` (see below)
 
 ## Chinese support
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change updating the supported language lists for `LANGUAGE`/stemming; no runtime behavior is modified. Risk is limited to potential user confusion if the list is inaccurate.
> 
> **Overview**
> Updates docs to **synchronize and expand the listed supported stemming languages** between `FT.CREATE` (`LANGUAGE_FIELD`) and the stemming concept page.
> 
> Reformats the language lists to consistent lowercase, backticked identifiers and adds missing languages (for example `basque`, `catalan`, `greek`, `hindi`, `indonesian`, `irish`, `lithuanian`, `serbian`, `yiddish`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8034f02eac47b41fed662bb7ddd6aa99b3f466d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->