### PR TITLE
RS: Added note that upgrading existing Active-Active DBs to Redis 8 will not automatically enable JSON

### DIFF
--- a/content/embeds/rs-8-enabled-modules.md
+++ b/content/embeds/rs-8-enabled-modules.md
@@ -2,4 +2,6 @@
 |---------------|------------------------------------|
 | RAM-only | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<br />[Time series]({{<relref "/operate/oss_and_stack/stack-with-enterprise/timeseries">}})<br />[Probabilistic]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}})  |
 | Flash-enabled ([Redis Flex]({{<relref "/operate/rs/databases/flash">}})) | [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<br />[Probabilistic]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}}) |
-| [Active-Active]({{<relref "/operate/rs/databases/active-active">}}) | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}) |
+| [Active-Active]({{<relref "/operate/rs/databases/active-active">}}) | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<sup>[1](#enabled-modules-table-note-1)</sup> |
+
+1. <a name="enabled-modules-table-note-1"></a>Upgrading existing Active-Active databases to Redis version 8 does not enable JSON. Only new Active-Active databases created with Redis version 8 enable JSON by default.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-17.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-17.md
@@ -97,7 +97,9 @@ Redis Software databases created with or upgraded to Redis version 8 include all
 |---------------|------------------------------------|
 | RAM-only | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<br />[Time series]({{<relref "/operate/oss_and_stack/stack-with-enterprise/timeseries">}})<br />[Probabilistic]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}})  |
 | Flash-enabled ([Redis Flex]({{<relref "/operate/rs/databases/flash">}})) | [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<br />[Probabilistic]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}}) |
-| [Active-Active]({{<relref "/operate/rs/databases/active-active">}}) | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}) |
+| [Active-Active]({{<relref "/operate/rs/databases/active-active">}}) | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<sup>[1](#enabled-modules-table-note-1)</sup> |
+
+1. <a name="enabled-modules-table-note-1"></a>Upgrading existing Active-Active databases to Redis version 8 does not enable JSON. Only new Active-Active databases created with Redis version 8 enable JSON by default.
 
 #### Performance improvements and memory reduction
 


### PR DESCRIPTION
Staged previews:
1. https://redis.io/docs/staging/DOC-6358/operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-17/#built-in-capabilities-with-redis-8
2. https://redis.io/docs/staging/DOC-6358/operate/rs/databases/configure/#capabilities
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it clarifies module enablement behavior for Active-Active upgrades and could only impact reader expectations if incorrect.
> 
> **Overview**
> Clarifies in the Redis 8 *built-in capabilities* tables that **JSON is not automatically enabled when upgrading existing Active-Active databases to Redis 8**.
> 
> Adds a footnote to both the reusable embed (`content/embeds/rs-8-enabled-modules.md`) and the `8.0.2-17` release notes stating that **only newly created Active-Active databases on Redis 8 enable JSON by default**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5053344c7d7c63c37bde5c2e4dcec1075d2af0d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->