### PR TITLE
K8s: yellow submarine maint 8

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
@@ -1,0 +1,28 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: Maintenance release to support Redis Enterprise Software version 7.22.2-93 with bug and security fixes.
+hideListLinks: true
+linkTitle: 7.22.2-38 (March 2026)
+title: Redis Enterprise for Kubernetes 7.22.2-38 (March 2026) release notes
+weight: 19
+---
+
+## Highlights
+
+This is a maintenance release to support Redis Enterprise Software version 7.22.2-93. For supported distributions and known limitations, see the [7.22.2 releases]({{< relref "/operate/kubernetes/release-notes/7-22-2-releases/" >}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:7.22.2-93`
+- **Operator**: `redislabs/operator:7.22.2-38`
+- **Services Rigger**: `redislabs/k8s-controller:7.22.2-38`
+- **OLM operator bundle**: `v7.22.2-38.0`
+
+## Known limitations
+
+See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.
+

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.22.2 release notes
 weight: 65
 ---
 
-Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-37 with support for Redis Enterprise Software version 7.22.2-79.
+Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-38 with support for Redis Enterprise Software version 7.22.2-93.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new release notes page and updates the index to point to the latest 7.22.2-38 / 7.22.2-93 versions.
> 
> **Overview**
> Adds release notes for **Redis Enterprise for Kubernetes `7.22.2-38` (March 2026)**, including updated image tags and OLM bundle version (`7.22.2-93` software, `7.22.2-38` operator/rigger).
> 
> Updates the `7.22.2` release notes index to mark `7.22.2-38` as the latest release (from `7.22.2-37`) and reflect the newer supported Redis Enterprise Software version (`7.22.2-93`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 375cdea652929ce5786c0aaa76de0e5ef75d2aa1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->