### PR TITLE
Make quick-start links always visible

### DIFF
--- a/layouts/partials/tabs/wrapper.html
+++ b/layouts/partials/tabs/wrapper.html
@@ -159,8 +159,7 @@
             {{ index $tab "content" }}
 
             {{ if $showFooter }}
-            <div class="cli-footer flex flex-col rounded-b-md bg-slate-900 mt-0 px-4 pt-0 mb-0 transition-opacity ease-in-out duration-300 opacity-0 invisible
-group-hover:opacity-100 group-hover:visible commands-foldout-open:opacity-100 commands-foldout-open:visible">
+            <div class="cli-footer flex flex-col rounded-b-md bg-slate-900 mt-0 px-4 pt-0 mb-0">
 
             {{/* Commands foldout section */}}
             {{ if $commands }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts CSS classes in the docs UI to keep the code-tab footer visible; no data or logic changes beyond presentation.
> 
> **Overview**
> Makes the code-tabs footer (including *Quick-Start* links) **always visible** by removing the hover/"commands foldout open"-gated opacity/visibility transition classes from the `cli-footer` container in `layouts/partials/tabs/wrapper.html`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f57020acc2d5fd5bb2666695f0ea648c1152333. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->