### PR TITLE
Copy to clipboard button for code examples should only copy visible text

### DIFF
--- a/static/js/codetabs.js
+++ b/static/js/codetabs.js
@@ -35,9 +35,9 @@ function copyCodeToClipboardForCodetabs(button) {
     const highlightedLines = codeElement.querySelectorAll('.line.hl');
 
     if (highlightedLines.length > 0) {
-      // Extract text from highlighted lines only
+      // Extract text from highlighted lines only, trimming trailing newlines to avoid double line breaks
       code = Array.from(highlightedLines)
-        .map(line => line.textContent)
+        .map(line => line.textContent.replace(/\n$/, ''))
         .join('\n');
     } else {
       // Fallback to all code if no highlighted lines found


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts clipboard contents based on code visibility state; main risk is edge cases with syntax highlighter DOM structure causing unexpected copied text.
> 
> **Overview**
> Updates the codetabs “copy to clipboard” behavior to **respect the collapsed/expanded state** of a code panel. When a panel is not expanded, it now copies only the visible highlighted lines (with a fallback to full code if no highlighted lines are found); when expanded (`aria-expanded`), it continues to copy the entire code block.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5703c09059a02737ea4343101e07d311909393ef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->