### PR TITLE
RS: Added LDAP filter parentheses requirement to RS 8.0.x breaking changes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -55,6 +55,8 @@ For more detailed release notes, select a build version from the following table
 
 ### Breaking changes
 
+- LDAP filters for `user_dn_query` and `dn_group_query` now strictly require parentheses to function correctly. Filters that previously worked without parentheses will no longer work after upgrading to Redis Software 8.0.x. For example, you must include the parentheses in `(sAMAccountName=%u)`.
+
 - Redis Software installation script changes:
 
     - Changed the `--skip-updating-env-path` option to `--update-env-path` when running [`install.sh`]({{<relref "/operate/rs/installing-upgrading/install/install-script">}}).

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-17.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-17.md
@@ -356,6 +356,8 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ### Breaking changes
 
+- LDAP filters for `user_dn_query` and `dn_group_query` now strictly require parentheses to function correctly. Filters that previously worked without parentheses will no longer work after upgrading to Redis Software 8.0.x. For example, you must include the parentheses in `(sAMAccountName=%u)`.
+
 - Redis Software installation script changes:
 
     - Changed the `--skip-updating-env-path` option to `--update-env-path` when running [`install.sh`]({{<relref "/operate/rs/installing-upgrading/install/install-script">}}).

--- a/content/operate/rs/security/access-control/ldap/enable-role-based-ldap.md
+++ b/content/operate/rs/security/access-control/ldap/enable-role-based-ldap.md
@@ -64,7 +64,7 @@ These settings define the authentication query:
 | **Search user by** | Either _Template_ or _Query_ |
 | **Template** | _(template search)_ Example: `cn=%u,ou=dev,dc=example,dc=com` |
 | **Base** | _(query search)_ Example: `ou=dev,dc=example,dc=com` |
-| **Filter** | _(query search)_ Example: `(cn=%u)` |
+| **Filter** | _(query search)_ Must be enclosed in parentheses. Example: `(cn=%u)` |
 | **Scope**  | _(query search)_ Must be _baseObject_, _singleLevel_, or _wholeSubtree_ |
 
 In this example, `%u` is replaced by the username attempting to access the Redis Software resource.
@@ -78,7 +78,7 @@ These settings define the group authorization query:
 | **Search groups by** | Either _Attribute_ or _Query_ |
 | **Attribute** | _(attribute search)_ Example: `memberOf` (case-sensitive) |
 | **Base** | _(query search)_ Example: `ou=groups,dc=example,dc=com` |
-| **Filter** | _(query search)_ Example: `(members=%D)` |
+| **Filter** | _(query search)_ Must be enclosed in parentheses. Example: `(members=%D)` |
 | **Scope**  | _(query search)_ Must be _baseObject_, _singleLevel_, or _wholeSubtree_ |
 
 In this example, `%D` is replaced by the Distinguished Name of the user attempting to access the Redis Software resource.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify an LDAP configuration breaking change; no product code or behavior is modified.
> 
> **Overview**
> Adds an explicit **Redis Software 8.0.x breaking change** note that LDAP filters for `user_dn_query` and `dn_group_query` must be wrapped in parentheses, with an example of the required syntax.
> 
> Updates the role-based LDAP UI documentation to state that the authentication and group query **Filter** fields must be enclosed in parentheses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b460198ebf60566d3e5aa7c0fc0ad3800eb429e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->