### PR TITLE
added video-link shortcode

### DIFF
--- a/content/operate/rc/security/aws-privatelink.md
+++ b/content/operate/rc/security/aws-privatelink.md
@@ -25,7 +25,9 @@ AWS PrivateLink provides the following benefits:
 - **Network Flexibility**: PrivateLink enables cross-account and cross-VPC connectivity and can be configured even when the Redis Cloud VPC and your consumer VPC have overlapping CIDR/IP ranges.
 - **Simplified architecture and low latency**: PrivateLink does not require NAT, internet gateways, or VPNs. It provides simplified network routing, without the need for a network load balancer between the application and the Redis database.
 
+{{< video-link >}}
 See [Connect to Redis Cloud with AWS PrivateLink](https://www.youtube.com/watch?v=i3aTmcyFihY) for a short video tutorial on how to connect to Redis Cloud with AWS PrivateLink.
+{{< /video-link >}}
 
 ## Limitations
 

--- a/layouts/partials/components/alert-video.html
+++ b/layouts/partials/components/alert-video.html
@@ -1,0 +1,9 @@
+<div class="alert p-3 relative flex flex-row flex-wrap items-center text-base bg-redis-pencil-200 rounded-md">
+  <div class="p-2 pr-5">{{ partial "icons/Youtube.html" }}</div>
+  <div class="p-1 pl-4 sm:pl-6 border-l border-l-redis-ink-900 border-opacity-50 flex-1">
+  {{ with .Title }}
+  <div class="font-medium">{{ . | safeHTML }}:</div>
+  {{ end }}
+  {{- .Inner | markdownify -}}
+  </div>
+</div>

--- a/layouts/shortcodes/video-link.html
+++ b/layouts/shortcodes/video-link.html
@@ -1,0 +1,2 @@
+{{ $inner := .Inner }}
+{{ partial "components/alert-video.html" (dict "Title" "Video" "Inner" $inner ) }}


### PR DESCRIPTION
added video-link shortcode 

*Update content/operate/rc/security/aws-privatelink.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/UI templating change that adds a new shortcode and partial; no runtime business logic or data handling is affected.
> 
> **Overview**
> Adds a new `video-link` Hugo shortcode that renders a styled “Video” callout using a new `components/alert-video.html` partial with a YouTube icon.
> 
> Updates the AWS PrivateLink docs (`content/operate/rc/security/aws-privatelink.md`) to wrap a YouTube tutorial link in this new shortcode so it displays as a highlighted video alert.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a8c69fc7dbe08c9776ead691186c91209a2c5e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->