### PR TITLE
Document new optimistic locking commands in Redis 8.4

### DIFF
--- a/content/develop/using-commands/transactions.md
+++ b/content/develop/using-commands/transactions.md
@@ -219,7 +219,7 @@ In many use cases, multiple clients will be accessing different keys,
 so collisions are unlikely – usually there's no need to repeat the operation.
 
 Starting with version 8.4, Redis offers new atomic compare-and-set and compare-and-delete commands for string keys.
-A client can use a single ([`SET`]({{< relref "/commands/set" >}}) command with the `IFEQ`/`IFNE`/`IFDEQ`/`IFDNE` options to atomically update a string key only if its value hasn’t changed by another client since it was fetched.
+A client can use a single ([`SET`]({{< relref "/commands/set" >}}) command with the `IFEQ`/`IFNE`/`IFDEQ`/`IFDNE` options to atomically update a string key only if its value has not changed since it was fetched.
 This is much simpler and faster.
 Similarly, a client can use a single `[`DELEX`]({{< relref "/commands/delex" >}})` command for compare-and-delete: atomically deleting a string key if its value hasn't changed since it was fetched.
 


### PR DESCRIPTION
Added information about new atomic commands in Redis 8.4 for compare-and-set and compare-and-delete operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; potential risk is limited to minor inaccuracies/formatting in the newly added command references.
> 
> **Overview**
> Updates the Transactions documentation to note that Redis 8.4 adds **single-command atomic alternatives** to `WATCH`/`MULTI` optimistic locking for string keys.
> 
> Specifically documents using `SET` with `IFEQ`/`IFNE`/`IFDEQ`/`IFDNE` for compare-and-set and `DELEX` for compare-and-delete when the value (or digest) hasn’t changed since it was fetched.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0889d48a8126c23232f88cd2742f49a47ac2e067. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->