### PR TITLE
OP: add Redis Open Source v8.6.1 release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
@@ -12,6 +12,19 @@ min-version-rs: blah
 weight: 20
 ---
 
+## Redis Open Source 8.6.1 (February 2026)
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+### Security fixes
+
+- A user can manipulate data read by a connection by injecting `\r\n` sequences into a Redis error reply.
+
+### Bug fixes
+
+- [#14785](https://github.com/redis/redis/pull/14785) `HOTKEYS`: The `INFO` command may display module information, and the missing `HOTKEYS HELP` subcommand has been added.
+- [#14789](https://github.com/redis/redis/pull/14789) Bug in RDB loading prevented hash table expansion, increasing load time.
+
 ## Redis Open Source 8.6.0 (February 2026)
 
 This is the General Availability release of Redis 8.6 in Redis Open Source.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or behavior changes beyond updated release notes content.
> 
> **Overview**
> Documents the Redis Open Source `8.6.1` patch release by adding a new section to the `redisos-8.6-release-notes.md` page.
> 
> The new entry flags the release as **security urgent** and lists one security fix plus two linked bug fixes (including `HOTKEYS` help/`INFO` output and an RDB loading performance issue).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caa36790a6da13e8207f583ea3740c099f4d3ed4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->