### PR TITLE
RS: Fixed flash relref

### DIFF
--- a/content/operate/rs/databases/active-active/develop/develop-for-aa.md
+++ b/content/operate/rs/databases/active-active/develop/develop-for-aa.md
@@ -98,7 +98,7 @@ execute them in script-replication mode.
 
 ## Eviction
 
-The default policy for Active-Active databases is _noeviction_ mode. Redis Software version 6.0.20 and later support all eviction policies for Active-Active databases, unless [Auto Tiering]({{< relref "/operate/rs/databases/auto-tiering" >}}) (previously known as Redis on Flash) is enabled.
+The default policy for Active-Active databases is _noeviction_ mode. Redis Software version 6.0.20 and later support all eviction policies for Active-Active databases, unless [Redis Flex or Auto Tiering]({{< relref "/operate/rs/databases/flash" >}}) (previously known as Redis on Flash) is enabled.
 
 For details, see [eviction for Active-Active databases (Redis Software)]({{< relref "/operate/rs/databases/memory-performance/eviction-policy#active-active-database-eviction" >}}) or [eviction for Active-Active databases (Redis Cloud)]({{< relref "/operate/rc/databases/configuration/data-eviction-policies#active-active-replication-considerations" >}}).
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single link/term; no product logic is affected.
> 
> **Overview**
> Updates the Active-Active eviction documentation to reference **Redis Flex or Auto Tiering** and fixes the internal `relref` to point to `/operate/rs/databases/flash` instead of the old Auto Tiering page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b86bf0383594a9acb05afcc21c025c75f20fb8c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->