### PR TITLE
DOC-6379: add missing call home client images to 7.22.2 release notes

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-31-december2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-31-december2025.md
@@ -41,4 +41,5 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Redis Enterprise**: `redislabs/redis:7.22.2-41`
 - **Operator**: `redislabs/operator:7.22.2-31`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-31`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-31`
 - **OLM operator bundle** : `v7.22.2-31.1`

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-32-january2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-32-january2026.md
@@ -20,6 +20,7 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 - **Redis Enterprise**: `redislabs/redis:7.22.2-55`
 - **Operator**: `redislabs/operator:7.22.2-32`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-32`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-32`
 - **OLM operator bundle**: `v7.22.2-32.1`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-37-feb2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-37-feb2026.md
@@ -20,6 +20,7 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 - **Redis Enterprise**: `redislabs/redis:7.22.2-79`
 - **Operator**: `redislabs/operator:7.22.2-37`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-37`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-37`
 - **OLM operator bundle**: `v7.22.2-37.1`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
@@ -20,9 +20,9 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 - **Redis Enterprise**: `redislabs/redis:7.22.2-93`
 - **Operator**: `redislabs/operator:7.22.2-38`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-38`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-38`
 - **OLM operator bundle**: `v7.22.2-38.0`
 
 ## Known limitations
 
 See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change that updates release note download lists; no product code or runtime behavior is affected.
> 
> **Overview**
> Adds **missing `Call Home Client` container image entries** to the *Downloads* sections for the `7.22.2-31`, `7.22.2-32`, `7.22.2-37`, and `7.22.2-38` Kubernetes release notes.
> 
> Also fixes the `7.22.2-31` Downloads formatting by ensuring the `OLM operator bundle` line is correctly listed alongside the newly added image and the file ends cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3859f571eef874c12e774012e6e18428c56347a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->