### PR TITLE
DOC-6389 fix to SCH default options

### DIFF
--- a/content/develop/clients/go/connect.md
+++ b/content/develop/clients/go/connect.md
@@ -136,8 +136,10 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
-To enable SCH on the client, add the `MaintNotificationsConfig` option during the
-connection, as shown in the following example:
+By default, `go-redis` always attempts to connect via SCH but falls back to
+a non-SCH connection if the server doesn't support it. However, you can configure SCH
+explicitly by passing a `MaintNotificationsConfig` object during the connection,
+as shown in the following example:
 
 ```go
 rdb := redis.NewClient(&redis.Options{

--- a/content/develop/clients/lettuce/connect.md
+++ b/content/develop/clients/lettuce/connect.md
@@ -264,7 +264,8 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
-SCH is enabled on the client by default. However, you can configure it
+By default, `Lettuce` always attempts to connect via SCH but falls back to
+a non-SCH connection if the server doesn't support it. However, you can configure SCH
 explicitly by creating a `MaintNotificationsConfig` object and/or a `TimeoutOptions`
 object and passing them to the `ClientOptions` builder as shown in the example below.
 Note that SCH also requires the

--- a/content/develop/clients/redis-py/connect.md
+++ b/content/develop/clients/redis-py/connect.md
@@ -262,7 +262,8 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
-SCH is enabled on the client by default, but you can configure it
+By default, `redis-py` always attempts to connect via SCH but falls back to
+a non-SCH connection if the server doesn't support it. However, you can configure SCH
 explicitly by passing a `MaintNotificationsConfig` object during the connection,
 as shown in the following example:
 


### PR DESCRIPTION
Default behaviour is actually to attempt an SCH connection but then fall back to non-SCH if the server doesn't support it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change clarifying Smart client handoffs defaults; no product or runtime behavior is modified.
> 
> **Overview**
> Clarifies Smart client handoffs (SCH) connection behavior in the `go-redis`, `Lettuce`, and `redis-py` connect guides: clients *attempt SCH by default* but **fall back to non-SCH** when the server doesn’t support it, and SCH can still be configured explicitly via `MaintNotificationsConfig` (and `TimeoutOptions` for Lettuce).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9297478f729b16f4c0e3b8bd9b38feab857b20a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->