### PR TITLE
Fix formatting of DELEX command reference in transactions.md

### DIFF
--- a/content/develop/using-commands/transactions.md
+++ b/content/develop/using-commands/transactions.md
@@ -221,7 +221,7 @@ so collisions are unlikely – usually there's no need to repeat the operation.
 Starting with version 8.4, Redis offers new atomic compare-and-set and compare-and-delete commands for string keys.
 A client can use a single ([`SET`]({{< relref "/commands/set" >}}) command with the `IFEQ`/`IFNE`/`IFDEQ`/`IFDNE` options to atomically update a string key only if its value has not changed since it was fetched.
 This is much simpler and faster.
-Similarly, a client can use a single `[`DELEX`]({{< relref "/commands/delex" >}})` command for compare-and-delete: atomically deleting a string key if its value hasn't changed since it was fetched.
+Similarly, a client can use a single [`DELEX`]({{< relref "/commands/delex" >}}) command for compare-and-delete: atomically deleting a string key if its value hasn't changed since it was fetched.
 
 ## WATCH explained
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that fixes Markdown formatting for a `DELEX` command reference; no behavioral or code changes.
> 
> **Overview**
> Fixes a broken/incorrectly formatted `DELEX` command reference in `transactions.md` by correcting the Markdown link syntax so the command renders and links properly in the optimistic locking/CAS section.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 827e54abaf99d5aa02c747505d9ba3cde6dca3cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->