### PR TITLE
OP: add Redis Open Source release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisce-7.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisce-7.4-release-notes.md
@@ -11,6 +11,15 @@ min-version-db: blah
 min-version-rs: blah
 weight: 100
 ---
+
+## Redis Community Edition 7.4.8 (February 2026)
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+### Security fixes
+
+- A user can manipulate data read by a connection by injecting `\r\n` sequences into a Redis error reply.
+
 ## Redis Community Edition 7.4.7 (November 2025)
 
 Update urgency: `HIGH`: There is a critical bug that may affect a subset of users.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes.md
@@ -11,6 +11,15 @@ min-version-db: blah
 min-version-rs: blah
 weight: 80
 ---
+
+## Redis Open Source 8.0.6 (February 2026)
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+### Security fixes
+
+- A user can manipulate data read by a connection by injecting `\r\n` sequences into a Redis error reply.
+
 ## Redis Open Source 8.0.5 (November 2025)
 
 Update urgency: `HIGH`: There are critical bugs that may affect a subset of users.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes.md
@@ -12,6 +12,14 @@ min-version-rs: blah
 weight: 60
 ---
 
+## Redis Open Source 8.2.5 (February 2026)
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+### Security fixes
+
+- A user can manipulate data read by a connection by injecting `\r\n` sequences into a Redis error reply.
+
 ## Redis Open Source 8.2.4 (February 2026)
 
 Update urgency: `SECURITY`: There are security fixes in the release.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
@@ -12,6 +12,14 @@ min-version-rs: blah
 weight: 40
 ---
 
+## Redis Open Source 8.4.2 (February 2026)
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+### Security fixes
+
+- A user can manipulate data read by a connection by injecting `\r\n` sequences into a Redis error reply.
+
 ## Redis Open Source 8.4.1 (February 2026)
 
 Update urgency: `SECURITY`: There are security fixes in the release.


### PR DESCRIPTION
... for 7.4.8, 8.0.6, 8.2.5, and 8.4.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding new release-note entries; low risk aside from ensuring the security advisory text is accurate and consistently applied across versions.
> 
> **Overview**
> Adds new *February 2026* release-note sections for `Redis Community Edition 7.4.8` and `Redis Open Source 8.0.6`, `8.2.5`, and `8.4.2`.
> 
> Each new entry is marked with **Update urgency: `SECURITY`** and documents a security fix where a user could inject `\r\n` sequences into a Redis error reply to manipulate data read by a connection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1ddd3475d38a69d544bae18f0dc87c65c0a34a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->