### PR TITLE
OP: update Redis (OSS) CLUSTER SLOT-STATS page per GH issue

### DIFF
--- a/content/commands/cluster-slot-stats.md
+++ b/content/commands/cluster-slot-stats.md
@@ -110,7 +110,7 @@ The command reports on the following statistics:
 * `NETWORK-BYTES-OUT`: Total outbound network traffic (in bytes) sent from the slot.
 
 {{< note>}}
-`MEMORY-BYTES` requires that you set `cluster-slot-stats-enabled` to `yes` in your `redis.conf` file.
+All metrics except `KEY-COUNT` require that `cluster-slot-stats-enabled` is set to `yes` in the `redis.conf` file.
 {{< /note >}}
 
 ## Redis Software and Redis Cloud compatibility


### PR DESCRIPTION
Fixes #2911.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies configuration prerequisites for reported metrics.
> 
> **Overview**
> Updates the `CLUSTER SLOT-STATS` docs to clarify that **all metrics except `KEY-COUNT`** require `cluster-slot-stats-enabled=yes` in `redis.conf`, replacing the previous note that singled out only `MEMORY-BYTES`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 580ba57b9bf354d859b17014e639b04dd80df69b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->