### PR TITLE
OP: add OSS 8.6.2 release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
@@ -12,6 +12,26 @@ min-version-rs: blah
 weight: 20
 ---
 
+## Redis Open Source 8.6.2 (March 2026)
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+### Security fixes
+
+- [#14824](https://github.com/redis/redis/pull/14824) Potential UAF: don't use reply copy avoidance for module strings.
+
+### Bug fixes
+
+- [#14848](https://github.com/redis/redis/pull/14848) Crash during command processing on replicas performing full synchronization.
+- [#14794](https://github.com/redis/redis/pull/14794) New `XIDMPRECORD` internal command and AOFRW emission to restore stream IDMP state.
+- [#14816](https://github.com/redis/redis/pull/14816) `setModuleEnumConfig()` passing prefixed name to module callbacks.
+- [#14858](https://github.com/redis/redis/pull/14858) Streams: Ensures `XADD` with `IDMP`/`IDMPAUTO` that hits an existing IID records the metadata change.
+- [#14855](https://github.com/redis/redis/pull/14855), [#14831](https://github.com/redis/redis/pull/14831), [#14817](https://github.com/redis/redis/pull/14817) Potential Memory leaks.
+- [#14869](https://github.com/redis/redis/pull/14869) Streams: IDMP cron expiration not working after RDB load.
+- [#14847](https://github.com/redis/redis/pull/14847) Potential crash during ACL checks on wrong-arity commands.
+- [#14883](https://github.com/redis/redis/pull/14883) `HSETEX` and `HGETEX` do not validate that `FIELDS` is specified only once.
+- [#14897](https://github.com/redis/redis/pull/14897) Streams: IDMP-related bugs.
+
 ## Redis Open Source 8.6.1 (February 2026)
 
 Update urgency: `SECURITY`: There are security fixes in the release.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no product code paths or runtime behavior are modified.
> 
> **Overview**
> Adds a new **`Redis Open Source 8.6.2 (March 2026)`** section to `redisos-8.6-release-notes.md`, marking the update urgency as `SECURITY` and listing the included security fix and bug-fix PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f3b53c973d8a113254a3534d07612dca38c0089. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->