### PR TITLE
RS: Clarified the difference between default_db_config and db_config in the CRDB API

### DIFF
--- a/content/operate/rs/7.22/references/rest-api/objects/crdb/_index.md
+++ b/content/operate/rs/7.22/references/rest-api/objects/crdb/_index.md
@@ -18,7 +18,7 @@ An object that represents an Active-Active database.
 |------|------------|-------------|
 | guid | string | The global unique ID of the Active-Active database |
 | causal_consistency | boolean | Enables causal consistency across CRDT instances |
-| default_db_config| [CRDB database_config]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. Use this for settings that should be consistent across all instances. For instance-specific settings, use `db_config` in the individual [instance objects]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/instance_info" >}}). |
+| default_db_config| [CRDB database_config]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. In most cases, instances should use the same configuration. If you need to override `default_db_config` or add configuration values for specific instances, you can use `db_config` in individual [instance objects]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/instance_info" >}}). |
 | encryption | boolean | Encrypt communication |
 | featureset_version | integer | Active-Active database active FeatureSet version
 | instances | array of [CRDB instance_info]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/instance_info" >}}) objects | |

--- a/content/operate/rs/7.22/references/rest-api/objects/crdb/database_config.md
+++ b/content/operate/rs/7.22/references/rest-api/objects/crdb/database_config.md
@@ -13,9 +13,9 @@ url: '/operate/rs/7.22/references/rest-api/objects/crdb/database_config/'
 
 An object that represents the database configuration. This configuration object is used in two contexts within CRDB objects:
 
-- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb" >}}) for settings that apply to all instances.
+- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb" >}}) for settings that apply to all instances. In most cases, instances should use the same configuration.
 
-- As `db_config` in individual [instance objects]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/instance_info" >}}) for instance-specific settings.
+- As `db_config` in individual [instance objects]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/instance_info" >}}) to override `default_db_config` or add configuration values for specific instances. Use `db_config` only when an instance needs different settings than the default configuration.
 
 | Name | Type/Value | Description |
 |------|------------|-------------|

--- a/content/operate/rs/7.22/references/rest-api/objects/crdb/instance_info.md
+++ b/content/operate/rs/7.22/references/rest-api/objects/crdb/instance_info.md
@@ -18,5 +18,5 @@ An object that represents Active-Active instance info.
 | id | integer | Unique instance ID |
 | cluster | [CRDB cluster_info]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/cluster_info" >}}) object | |
 | compression | integer | Compression level when syncing from this source |
-| db_config | [CRDB database_config]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration specific to this instance. For settings that should apply to all instances, use `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb" >}}). |
+| db_config | [CRDB database_config]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration for this specific instance. Use `db_config` only when you need to override or add configuration values that differ from the `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.22/references/rest-api/objects/crdb" >}}). |
 | db_uid | string | ID of local database instance. This field is likely to be empty for instances other than the local one. |

--- a/content/operate/rs/7.4/references/rest-api/objects/crdb/_index.md
+++ b/content/operate/rs/7.4/references/rest-api/objects/crdb/_index.md
@@ -18,7 +18,7 @@ An object that represents an Active-Active database.
 |------|------------|-------------|
 | guid | string | The global unique ID of the Active-Active database |
 | causal_consistency | boolean | Enables causal consistency across CRDT instances |
-| default_db_config| [CRDB database_config]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. Use this for settings that should be consistent across all instances. For instance-specific settings, use `db_config` in the individual [instance objects]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/instance_info" >}}). |
+| default_db_config| [CRDB database_config]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. In most cases, instances should use the same configuration. If you need to override `default_db_config` or add configuration values for specific instances, you can use `db_config` in individual [instance objects]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/instance_info" >}}). |
 | encryption | boolean | Encrypt communication |
 | featureset_version | integer | Active-Active database active FeatureSet version
 | instances | array of [CRDB instance_info]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/instance_info" >}}) objects | |

--- a/content/operate/rs/7.4/references/rest-api/objects/crdb/database_config.md
+++ b/content/operate/rs/7.4/references/rest-api/objects/crdb/database_config.md
@@ -13,9 +13,9 @@ url: '/operate/rs/7.4/references/rest-api/objects/crdb/database_config/'
 
 An object that represents the database configuration. This configuration object is used in two contexts within CRDB objects:
 
-- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb" >}}) for settings that apply to all instances.
+- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb" >}}) for settings that apply to all instances. In most cases, instances should use the same configuration.
 
-- As `db_config` in individual [instance objects]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/instance_info" >}}) for instance-specific settings.
+- As `db_config` in individual [instance objects]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/instance_info" >}}) to override `default_db_config` or add configuration values for specific instances. Use `db_config` only when an instance needs different settings than the default configuration.
 
 | Name | Type/Value | Description |
 |------|------------|-------------|

--- a/content/operate/rs/7.4/references/rest-api/objects/crdb/instance_info.md
+++ b/content/operate/rs/7.4/references/rest-api/objects/crdb/instance_info.md
@@ -18,5 +18,5 @@ An object that represents Active-Active instance info.
 | id | integer | Unique instance ID |
 | cluster | [CRDB cluster_info]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/cluster_info" >}}) object | |
 | compression | integer | Compression level when syncing from this source |
-| db_config | [CRDB database_config]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration specific to this instance. For settings that should apply to all instances, use `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb" >}}). |
+| db_config | [CRDB database_config]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration for this specific instance. Use `db_config` only when you need to override or add configuration values that differ from the `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.4/references/rest-api/objects/crdb" >}}). |
 | db_uid | string | ID of local database instance. This field is likely to be empty for instances other than the local one. |

--- a/content/operate/rs/7.8/references/rest-api/objects/crdb/_index.md
+++ b/content/operate/rs/7.8/references/rest-api/objects/crdb/_index.md
@@ -18,7 +18,7 @@ An object that represents an Active-Active database.
 |------|------------|-------------|
 | guid | string | The global unique ID of the Active-Active database |
 | causal_consistency | boolean | Enables causal consistency across CRDT instances |
-| default_db_config| [CRDB database_config]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. Use this for settings that should be consistent across all instances. For instance-specific settings, use `db_config` in the individual [instance objects]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/instance_info" >}}). |
+| default_db_config| [CRDB database_config]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. In most cases, instances should use the same configuration. If you need to override `default_db_config` or add configuration values for specific instances, you can use `db_config` in individual [instance objects]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/instance_info" >}}). |
 | encryption | boolean | Encrypt communication |
 | featureset_version | integer | Active-Active database active FeatureSet version
 | instances | array of [CRDB instance_info]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/instance_info" >}}) objects | |

--- a/content/operate/rs/7.8/references/rest-api/objects/crdb/database_config.md
+++ b/content/operate/rs/7.8/references/rest-api/objects/crdb/database_config.md
@@ -13,9 +13,9 @@ url: '/operate/rs/7.8/references/rest-api/objects/crdb/database_config/'
 
 An object that represents the database configuration. This configuration object is used in two contexts within CRDB objects:
 
-- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb" >}}) for settings that apply to all instances.
+- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb" >}}) for settings that apply to all instances. In most cases, instances should use the same configuration.
 
-- As `db_config` in individual [instance objects]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/instance_info" >}}) for instance-specific settings.
+- As `db_config` in individual [instance objects]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/instance_info" >}}) to override `default_db_config` or add configuration values for specific instances. Use `db_config` only when an instance needs different settings than the default configuration.
 
 | Name | Type/Value | Description |
 |------|------------|-------------|

--- a/content/operate/rs/7.8/references/rest-api/objects/crdb/instance_info.md
+++ b/content/operate/rs/7.8/references/rest-api/objects/crdb/instance_info.md
@@ -18,5 +18,5 @@ An object that represents Active-Active instance info.
 | id | integer | Unique instance ID |
 | cluster | [CRDB cluster_info]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/cluster_info" >}}) object | |
 | compression | integer | Compression level when syncing from this source |
-| db_config | [CRDB database_config]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration specific to this instance. For settings that should apply to all instances, use `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb" >}}). |
+| db_config | [CRDB database_config]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration for this specific instance. Use `db_config` only when you need to override or add configuration values that differ from the `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/7.8/references/rest-api/objects/crdb" >}}). |
 | db_uid | string | ID of local database instance. This field is likely to be empty for instances other than the local one. |

--- a/content/operate/rs/references/rest-api/objects/crdb/_index.md
+++ b/content/operate/rs/references/rest-api/objects/crdb/_index.md
@@ -17,7 +17,7 @@ An object that represents an Active-Active database.
 |------|------------|-------------|
 | guid | string | The global unique ID of the Active-Active database |
 | causal_consistency | boolean | Enables causal consistency across CRDT instances |
-| default_db_config| [CRDB database_config]({{< relref "/operate/rs/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. Use this for settings that should be consistent across all instances. For instance-specific settings, use `db_config` in the individual [instance objects]({{< relref "/operate/rs/references/rest-api/objects/crdb/instance_info" >}}). |
+| default_db_config| [CRDB database_config]({{< relref "/operate/rs/references/rest-api/objects/crdb/database_config" >}}) object | Default database configuration applied to all instances in the CRDB object. In most cases, instances should use the same configuration. If you need to override `default_db_config` or add configuration values for specific instances, you can use `db_config` in individual [instance objects]({{< relref "/operate/rs/references/rest-api/objects/crdb/instance_info" >}}). |
 | encryption | boolean | Encrypt communication |
 | featureset_version | integer | Active-Active database active FeatureSet version
 | instances | array of [CRDB instance_info]({{< relref "/operate/rs/references/rest-api/objects/crdb/instance_info" >}}) objects | |

--- a/content/operate/rs/references/rest-api/objects/crdb/database_config.md
+++ b/content/operate/rs/references/rest-api/objects/crdb/database_config.md
@@ -12,9 +12,9 @@ weight: $weight
 
 An object that represents the database configuration. This configuration object is used in two contexts within CRDB objects:
 
-- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/references/rest-api/objects/crdb" >}}) for settings that apply to all instances.
+- As `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/references/rest-api/objects/crdb" >}}) for settings that apply to all instances. In most cases, instances should use the same configuration.
 
-- As `db_config` in individual [instance objects]({{< relref "/operate/rs/references/rest-api/objects/crdb/instance_info" >}}) for instance-specific settings.
+- As `db_config` in individual [instance objects]({{< relref "/operate/rs/references/rest-api/objects/crdb/instance_info" >}}) to override `default_db_config` or add configuration values for specific instances. Use `db_config` only when an instance needs different settings than the default configuration.
 
 | Name | Type/Value | Description |
 |------|------------|-------------|

--- a/content/operate/rs/references/rest-api/objects/crdb/instance_info.md
+++ b/content/operate/rs/references/rest-api/objects/crdb/instance_info.md
@@ -17,5 +17,5 @@ An object that represents Active-Active instance info.
 | id | integer | Unique instance ID |
 | cluster | [CRDB cluster_info]({{< relref "/operate/rs/references/rest-api/objects/crdb/cluster_info" >}}) object | |
 | compression | integer | Compression level when syncing from this source |
-| db_config | [CRDB database_config]({{< relref "/operate/rs/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration specific to this instance. For settings that should apply to all instances, use `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/references/rest-api/objects/crdb" >}}). |
+| db_config | [CRDB database_config]({{< relref "/operate/rs/references/rest-api/objects/crdb/database_config" >}}) object | Database configuration for this specific instance. Use `db_config` only when you need to override or add configuration values that differ from the `default_db_config` in the main [CRDB object]({{< relref "/operate/rs/references/rest-api/objects/crdb" >}}). |
 | db_uid | string | ID of local database instance. This field is likely to be empty for instances other than the local one. |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates that clarify configuration semantics; no runtime behavior or API schema changes.
> 
> **Overview**
> Clarifies how CRDB `database_config` is applied by documenting the relationship between `default_db_config` (CRDB-wide defaults) and per-instance `db_config` (overrides/additions) in the CRDB REST API reference.
> 
> Updates these descriptions consistently across the unversioned docs and versions `7.4`, `7.8`, and `7.22`, including cross-links between the CRDB, `database_config`, and `instance_info` pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7252f14a211aadee5b5be5327a7eda00e574014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->