### PR TITLE
DEV: update redis-cli docs with word-jump nav. info.

### DIFF
--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -387,6 +387,9 @@ syntax hints. Like command history, this behavior can be turned on and off via t
 
 Reverse history searches, such as `CTRL-R` in terminals, is supported.
 
+Starting with Redis 8.8, `redis-cli` supports word-jump navigation (`Alt/Option + ←/→`, `Ctrl + ←/→`), which makes
+editing long commands much more efficient.
+
 ### Preferences
 
 There are two ways to customize `redis-cli` behavior. The file `.redisclirc`


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a note about new `redis-cli` word-jump keybindings; no runtime behavior or APIs are affected.
> 
> **Overview**
> Updates the `redis-cli` interactive editing docs to mention that **Redis 8.8 adds word-jump navigation** using `Alt/Option + ←/→` and `Ctrl + ←/→`, improving long-command editing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dfe93e108bb8dc78f0aca4d122c9f2ddc8a8f621. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->