### PR TITLE
DEV: update ACL page - comments allowed in ext. files

### DIFF
--- a/content/commands/acl-load.md
+++ b/content/commands/acl-load.md
@@ -38,6 +38,10 @@ sure to have an *all or nothing* behavior, that is:
 * If every line in the file is valid, all the ACLs are loaded.
 * If one or more line in the file is not valid, nothing is loaded, and the old ACL rules defined in the server memory continue to be used.
 
+Starting with Redis 8.8, your ACL file is allowed to have comment lines; lines that begin with the `#` character.
+Any such comment lines are stripped when the ACL file is loaded and they are not persisted across `ACL LOAD`/`ACL SAVE` commands.
+Make sure you save a backup of your ACL file. This is the only way to preserve comments.
+
 ## Examples
 
 ```

--- a/content/operate/oss_and_stack/management/security/acl.md
+++ b/content/operate/oss_and_stack/management/security/acl.md
@@ -570,6 +570,8 @@ The external ACL file however is more powerful. You can do the following:
 Note that [`CONFIG REWRITE`](/commands/config-rewrite) does not also trigger [`ACL SAVE`](/commands/acl-save). When you use
 an ACL file, the configuration and the ACLs are handled separately.
 
+Starting with Redis 8.8, the `ACL LOAD` command will allow comment lines starting with the `#` character. Any such comment lines are stripped when the ACL file is loaded and they are not persisted across `ACL LOAD`/`ACL SAVE` commands.
+
 ## ACL rules for Sentinel and Replicas
 
 In case you don't want to provide Redis replicas and Redis Sentinel instances


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update describing a new Redis 8.8 behavior; no runtime code or configuration logic is changed.
> 
> **Overview**
> Documents a Redis 8.8 change where external ACL files can include `#` comment lines.
> 
> Updates the `ACL LOAD` command docs and the main ACL management guide to note that comments are stripped on load and are **not** preserved across `ACL LOAD`/`ACL SAVE`, advising users to keep a backup if they want to retain comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be1264a2b186512750cbfd82084a40dc89bc5aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->