### PR TITLE
RC RDI: Add note for PEM format requirement for certs and keys

### DIFF
--- a/content/embeds/rdi-tls-secrets.md
+++ b/content/embeds/rdi-tls-secrets.md
@@ -1,0 +1,9 @@
+When creating secrets for TLS or mTLS, ensure that all certificates and keys are in `PEM` format. The only exception to this is that for PostgreSQL, the private key `SOURCE_DB_KEY` secret must be in `DER` format. If you have a key in `PEM` format, you must convert it to `DER` before creating the `SOURCE_DB_KEY` secret using the command:
+
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform DER \
+    -in /path/to/myclient.pem \
+    -out /path/to/myclient.pk8 -nocrypt
+```
+
+This command assumes that the private key is not encrypted. See the [`openssl` documentation](https://docs.openssl.org/master/) to learn how to convert an encrypted private key.

--- a/content/integrate/redis-data-integration/data-pipelines/deploy.md
+++ b/content/integrate/redis-data-integration/data-pipelines/deploy.md
@@ -49,15 +49,8 @@ secrets are only relevant for TLS/mTLS connections.
 | `TARGET_DB_KEY` | (For mTLS only) Target database private key |
 | `TARGET_DB_KEY_PASSWORD` | (For mTLS only) Target database private key password |
 
-{{< note >}}When creating secrets for TLS or mTLS, ensure that all certificates and keys are in `PEM` format. The only exception to this is that for PostgreSQL, the private key `SOURCE_DB_KEY` secret must be in `DER` format. If you have a key in `PEM` format, you must convert it to `DER` before creating the `SOURCE_DB_KEY` secret using the command:
-
-```bash
-openssl pkcs8 -topk8 -inform PEM -outform DER \
-    -in /path/to/myclient.pem \
-    -out /path/to/myclient.pk8 -nocrypt
-```
-
-This command assumes that the private key is not encrypted. See the [`openssl` documentation](https://docs.openssl.org/master/) to learn how to convert an encrypted private key.
+{{< note >}}
+{{< embed-md "rdi-tls-secrets.md" >}}
 {{< /note >}}
   
 ### Set secrets for VM deployment

--- a/content/operate/rc/databases/rdi/setup.md
+++ b/content/operate/rc/databases/rdi/setup.md
@@ -336,6 +336,10 @@ The required secrets depend on your source database's security configuration. Th
 | mTLS connection | <ul><li>Credentials secret (username and password for the RDI pipeline user)</li><li>CA Certificate secret (server certificate)</li><li>Client certificate secret</li><li>Client key secret</li></ul> |
 | mTLS connection with client key passphrase | <ul><li>Credentials secret (username and password for the RDI pipeline user)</li><li>CA Certificate secret (server certificate)</li><li>Client certificate secret</li><li>Client key secret</li><li>Client key passphrase secret</li></ul> |
 
+{{< note >}}
+{{< embed-md "rdi-tls-secrets.md" >}}
+{{< /note >}}
+
 Select a tab to learn how to create the required secret.
 
 {{< multitabs id="rdi-cloud-secrets"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that extracts and reuses existing guidance; main risk is broken embed rendering or incorrect include path.
> 
> **Overview**
> Adds a reusable embedded doc snippet `rdi-tls-secrets.md` describing TLS/mTLS secret certificate/key format requirements (PEM, with PostgreSQL `SOURCE_DB_KEY` requiring DER and an `openssl` conversion example).
> 
> Replaces the duplicated inline note in the RDI pipeline deployment docs and inserts the same note into the Redis Cloud RDI setup guide by embedding that snippet via `{{< embed-md "rdi-tls-secrets.md" >}}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1294f897a7198fd60c21fb990c559da06345f3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->