### PR TITLE
Fix version dropdown bug that excludes kubernetes 7.22

### DIFF
--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -33,20 +33,23 @@
 
           {{- range $lines }}
           {{- $v := strings.TrimSpace . -}}
-          {{- if and (ne $v "") (findRE `^\d+\.\d+\.\d+$` $v) -}}
+          {{- if and (ne $v "") (findRE `^\d+\.\d+(\.\d+)?$` $v) -}}
             {{- $p := split $v "." -}}
-            {{- $key := printf "%03d.%03d.%03d" (int (index $p 0)) (int (index $p 1)) (int (index $p 2)) -}}
+            {{- $pat := 0 -}}
+            {{- if ge (len $p) 3 -}}{{- $pat = int (index $p 2) -}}{{- end -}}
+            {{- $key := printf "%03d.%03d.%03d" (int (index $p 0)) (int (index $p 1)) $pat -}}
             {{- $vers = $vers | append (dict "v" $v "key" $key) -}}
           {{- end -}}
         {{- end -}}
         {{ else }}
           {{- $entries := readDir "content/operate/kubernetes" -}}
           {{- range $e := $entries -}}
-            {{- if and $e.IsDir (findRE `^\d+\.\d+\.\d+$` $e.Name) -}}
+            {{- if and $e.IsDir (findRE `^\d+\.\d+(\.\d+)?$` $e.Name) -}}
               {{- $p := split $e.Name "." -}}
               {{- $maj := int (index $p 0) -}}
               {{- $min := int (index $p 1) -}}
-              {{- $pat := int (index $p 2) -}}
+              {{- $pat := 0 -}}
+              {{- if ge (len $p) 3 -}}{{- $pat = int (index $p 2) -}}{{- end -}}
               {{- $key := printf "%03d.%03d.%03d" $maj $min $pat -}} {{/* for sorting */}}
               {{- $vers = $vers | append (dict "v" $e.Name "key" $key) -}}
             {{- end -}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small Hugo template tweak that only affects how Kubernetes doc versions are detected and sorted in the sidebar dropdown.
> 
> **Overview**
> Fixes the Kubernetes docs version selector to accept `major.minor` version strings (in addition to `major.minor.patch`) when building the dropdown from `kubernetes-versions` or `content/operate/kubernetes` directories.
> 
> Updates the sort key generation to treat a missing patch number as `0`, ensuring versions like `7.22` are included and sort consistently.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6bef461e5e9efd0b3b4e25f68f8ef2cddb648e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->