### PR TITLE
DEV: update various metrics

### DIFF
--- a/content/commands/client-list.md
+++ b/content/commands/client-list.md
@@ -128,10 +128,9 @@ Here is the meaning of the fields:
 * `tot-net-in`: total network input bytes read from this client.
 * `tot-net-out`: total network output bytes sent to this client.
 * `tot-cmds`: total count of commands this client executed.
-* `read-events`: number of `readQueryFromClient()` calls for this client. Added in Redis 8.8
-* `avg-pipeline-len-sum`: cumulative sum of commands parsed per batch. Added in Redis 8.8
-* `avg-pipeline-len-cnt`: number of parse batches. Added in Redis 8.8
-
+* `read-events`: number of read events for this client. Added in Redis 8.8
+* `parse-batch-cmd-sum`: cumulative number of commands parsed across all parsing batches for this client. Added in Redis 8.8
+* `parse-batch-cnt`: total number of parsing batches for this client. Divide `parse-batch-cmd-sum` by this value to get the client’s average commands per batch. Added in Redis 8.8
 
 The client flags can be a combination of:
 

--- a/content/commands/info.md
+++ b/content/commands/info.md
@@ -396,9 +396,11 @@ Here is the meaning of all fields in the **stats** section:
 *   `slowlog_commands_count`: commands written to slowlog <sup>[1](#list-note-1)</sup>
 *   `slowlog_commands_time_ms_sum`: sum of execution times of commands from the slowlog <sup>[1](#list-note-1)</sup>
 *   `slowlog_commands_time_ms_max`: maximum execution time of a command from the slowlog <sup>[1](#list-note-1)</sup>
-*   `total_client_processing_events`: total `processInputBuffer()` calls <sup>[1](#list-note-1)</sup>
+*   `total_client_processing_events`: attempts to process client input buffers; does not guarantee any command was actually parsed <sup>[1](#list-note-1)</sup>
 *   `eventloop_cycles_with_clients_processing`: event loop cycles where client input buffers were processed <sup>[1](#list-note-1)</sup>
-*   `avg_pipeline_length_sum`, `avg_pipeline_length_cnt`, `avg_pipeline_length`: global pipeline depth aggregates <sup>[1](#list-note-1)</sup>
+*   `commands_per_parse_batch_sum`: cumulative number of commands parsed across all parsing batches for all clients <sup>[1](#list-note-1)</sup>
+*   `commands_per_parse_batch_cnt`: number of parsing batches across all clients. A batch is counted each time at least one command is parsed from a client's query buffer <sup>[1](#list-note-1)</sup>
+*   `commands_per_parse_batch_avg`: average commands parsed per batch (sum/cnt). Approximates pipelining depth <sup>[1](#list-note-1)</sup>
 
 1. <a name="list-note-1"></a>Added in Redis 8.8
 


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update that adds/clarifies metric field descriptions; no runtime behavior changes.
> 
> **Overview**
> Documents new Redis 8.8 observability fields.
> 
> Updates `CLIENT LIST` to include `read-events` and parsing-batch counters, and expands `INFO` docs with new slowlog- and client-processing-related metrics plus parse-batch aggregate/avg fields. Also clarifies `commandstats` output format and adds slowlog-derived per-command stats (Redis 8.8).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43e0e5f5775a4391ad9d54be053060c36e344afc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->