### PR TITLE
OP: update "tested on" information

### DIFF
--- a/content/operate/oss_and_stack/install/install-stack/_index.md
+++ b/content/operate/oss_and_stack/install/install-stack/_index.md
@@ -13,11 +13,12 @@ weight: 2
 
 The latest version of Redis Open Source has been tested on the following platforms:
 
-- Ubuntu 22.04 (Jammy Jellyfish) and 24.04 (Noble Numbat).
-- Rocky Linux 8.10, 9.5.
-- AlmaLinux 8.10, 9.5, and 10.1.
-- Debian 12 (Bookworm) and 13 (Trixie).
-- macOS 14 (Sonoma), and 15 (Sequoia).
+- Ubuntu 22.04 (Jammy Jellyfish), 24.04 (Noble Numbat), and 26.04 (Resolute Raccoon).
+- Rocky Linux 8.10, 9.7, and 10.1.
+- AlmaLinux 8.10, 9.7, and 10.1.
+- Debian 12.13 (Bookworm) and Debian 13.4 (Trixie).
+- Alpine 3.23.
+- macOS 14.8.4 (Sonoma), 15.7.4 (Sequoia), and 26.3 (Tahoe) - for both Intel and ARM processors.
 
 Follow the links below for installation instructions for your OS and distribution.
 


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update that revises the supported/tested OS versions; low risk aside from potential confusion if the list is inaccurate.
> 
> **Overview**
> Updates the install docs `tested on` platform matrix to newer OS versions and adds Alpine coverage.
> 
> Specifically refreshes Ubuntu/Rocky/Alma/Debian and macOS version details (including Intel/ARM note) in `content/operate/oss_and_stack/install/install-stack/_index.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46a5dd0ca6b4baec5460fd26350fdee64229e836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->