### PR TITLE
Fix 404 page deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -716,22 +716,14 @@ jobs:
       PROD_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.PROD_WORKLOAD_IDENTITY_PROVIDER }}
 
     steps:
-    - name: Check the branch out
-      uses: actions/checkout@v4
+    - name: Download latest artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: build-latest
+        path: public/
 
-    - name: Install Hugo
+    - name: Prepare 404 page
       run: |
-        wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-        && sudo dpkg -i ${{ runner.temp }}/hugo.deb
-
-    - name: Install dependencies
-      run: make deps
-
-    - name: Build 404 page
-      run: |
-        hugo_root_path="docs/latest"
-        sed -i "s#baseURL = \"https://redis.io\"#baseURL = \"https://redis.io/${hugo_root_path}\"#g" config.toml
-        make hugo
         sed -i "s#/docs/latest/scss/#https://storage.googleapis.com/$BUCKET/docs/latest/scss/#g" public/404.html
         sed -i "s#/docs/latest/css/#https://storage.googleapis.com/$BUCKET/docs/latest/css/#g" public/404.html
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow change that only affects the `deploy_404` GitHub Actions job by reusing an existing build artifact instead of rebuilding; main risk is a missing/stale `404.html` in the uploaded artifact causing broken 404 deployment.
> 
> **Overview**
> Fixes the `deploy_404` workflow to **stop rebuilding the site** (checkout/Hugo install/`make deps`/`make hugo`) and instead **download the `build-latest` artifact** into `public/`.
> 
> The 404 step is simplified to just rewrite asset URLs in `public/404.html` before uploading it to GCS, making the 404 deployment depend on the already-produced latest build output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73f996c76c66bdf706600909d8a826b0911a4478. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->