### PR TITLE
OP: add Docker installation pointers to OSS install page

### DIFF
--- a/content/operate/oss_and_stack/install/install-stack/docker.md
+++ b/content/operate/oss_and_stack/install/install-stack/docker.md
@@ -10,6 +10,18 @@ title: Run Redis Open Source on Docker
 weight: 1
 ---
 
+## Install Docker
+
+Follow the Docker installation instructions for your operating system:
+
+- [Linux](https://docs.docker.com/desktop/setup/install/linux/)
+- [macOS](https://docs.docker.com/docker-for-mac/install/)
+- [Windows](https://store.docker.com/editions/community/docker-ce-desktop-windows)
+
+{{< note >}}
+On Windows, make sure Docker is configured to run Linux-based containers.
+{{< /note >}}
+
 ## Run Redis Open Source on Docker
 
 To start the Redis Open Source server using the `redis:<version>` image, run the following command in your terminal:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds external links and a Windows configuration note; no runtime or product behavior is affected.
> 
> **Overview**
> Adds a new **“Install Docker”** section to the Redis OSS Docker install guide with OS-specific Docker installation links and a note to use Linux containers on Windows.
> 
> The existing Redis `docker run` and connection instructions are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9fac6a3d1b156af4d477a06c2d009a46ab9da2f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->