### PR TITLE
K8s: Add missing downloads

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-11-june2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-11-june2025.md
@@ -22,6 +22,7 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Services Rigger**: `redislabs/k8s-controller:7.22.0-11`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.0-11`
 
-### OLM bundle
+### Openshift downloads
 
-**Redis Enterprise operator bundle**: `v7.22.0-11.2`
+- **OLM operator bundle**: `v7.22.0-11.2`
+- **Call Home Client**: `redislabs/call-home-client:7.22.0-11`

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-15-july2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-15-july2025.md
@@ -90,7 +90,11 @@ Any distribution not listed below is not supported for production workloads.
 - **Operator**: `redislabs/operator:7.22.0-15`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.0-15`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.0-15`
+
+### Openshift downloads
+
 - **OLM operator bundle**: `7.22.0-15.0`
+- **Call Home Client**: `redislabs/call-home-client:7.22.0-15`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-16-august2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-16-august2025.md
@@ -22,9 +22,10 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Services Rigger**: `redislabs/k8s-controller:7.22.0-16`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.0-16`
 
-### OLM bundle
+### Openshift downloads
 
-**Redis Enterprise operator bundle**: `v7.22.0-16.0`
+- **OLM operator bundle**: `v7.22.0-16.0`
+- **Call Home Client**: `redislabs/call-home-client:7.22.0-16`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
@@ -21,7 +21,11 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Operator**: `redislabs/operator:7.22.0-17`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.0-17`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.0-17`
-- **OpenShift OperatorHub bundle**: `v7.22.0-17.0`
+
+### Openshift downloads
+
+- **OLM operator bundle**: `v7.22.0-17.0`
+- **Call Home Client**: `redislabs/call-home-client:7.22.0-17`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-7-april2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-7-april2025.md
@@ -79,7 +79,11 @@ Any distribution not listed below is not supported for production workloads.
 - **Operator**: `redislabs/operator:7.22.0-7`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.0-7`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.0-7`
+
+### Openshift downloads
+
 - **OLM operator bundle** : `7.22.0-7.0`
+- **Call Home Client**: `redislabs/call-home-client:7.22.0-7`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-21-october2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-21-october2025.md
@@ -21,7 +21,11 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Operator**: `redislabs/operator:7.22.2-21`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-21`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.2-21`
-- **OpenShift OperatorHub bundle**: `v7.22.2-21.1`
+
+### Openshift downloads
+
+- **OLM operator bundle**: `v7.22.2-21.1`
+- **Call Home Client**: `redislabs/call-home-client:7.22.2-21`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-22-october2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-22-october2025.md
@@ -21,7 +21,11 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Operator**: `redislabs/operator:7.22.2-22`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-22`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.2-22`
-- **OpenShift OperatorHub bundle**: `v7.22.2-22.0`
+
+### Openshift downloads
+
+- **OLM operator bundle**: `v7.22.2-22.0`
+- **Call Home Client**: `redislabs/call-home-client:7.22.2-22`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-31-december2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-31-december2025.md
@@ -42,4 +42,8 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Operator**: `redislabs/operator:7.22.2-31`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-31`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.2-31`
-- **OLM operator bundle** : `v7.22.2-31.1`
+
+### Openshift downloads
+
+- **OLM operator bundle**: `v7.22.2-31.1`
+- **Call Home Client**: `redislabs/call-home-client:7.22.2-31`

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-32-january2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-32-january2026.md
@@ -21,7 +21,11 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 - **Operator**: `redislabs/operator:7.22.2-32`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-32`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.2-32`
+
+### Openshift downloads
+
 - **OLM operator bundle**: `v7.22.2-32.1`
+- **Call Home Client**: `redislabs/call-home-client:7.22.2-32`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-37-feb2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-37-feb2026.md
@@ -21,7 +21,11 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 - **Operator**: `redislabs/operator:7.22.2-37`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-37`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.2-37`
+
+### Openshift downloads
+
 - **OLM operator bundle**: `v7.22.2-37.1`
+- **Call Home Client**: `redislabs/call-home-client:7.22.2-37`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
@@ -21,9 +21,12 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 - **Operator**: `redislabs/operator:7.22.2-38`
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-38`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.2-38`
+
+### Openshift downloads
+
 - **OLM operator bundle**: `v7.22.2-38.0`
+- **Call Home Client**: `redislabs/call-home-client:7.22.2-38`
 
 ## Known limitations
 
 See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.
-


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk docs-only change that updates release-note download sections; main risk is minor confusion if any image tags/bundle versions are incorrect.
> 
> **Overview**
> Updates several 7.22.0 and 7.22.2 Kubernetes release-note pages to consistently include an **`### Openshift downloads`** section with the *OLM operator bundle* version and the `redislabs/call-home-client` image tag.
> 
> Also fixes a small formatting/typo issue in the 7.22.0-7 notes (corrects the `re-call-home-client` image reference) and aligns download headings/entries for clarity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dac9d20d08e110ac8f6b1ddb7ab55a69083a9a42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->