### PR TITLE
fix: correct OTel instrument kind for `db.client.connection.count` and `db.client.connection.pending_requests`

### DIFF
--- a/data/client_obs_metrics.json
+++ b/data/client_obs_metrics.json
@@ -226,8 +226,8 @@
       "metrics": [
         {
           "name": "db.client.connection.count",
-          "type": "Gauge",
-          "observable": true,
+          "type": "UpDownCounter",
+          "observable": false,
           "unit": {
             "symbol": "{connection}",
             "semantic": "connections"
@@ -254,11 +254,11 @@
               "cardinality": "optional"
             }
           ],
-          "description": "Current connections by state (idle/used). Sum by state for “live connections”. This is an async(observable) metric.",
+          "description": "Current connections by state (idle/used). Sum by state for “live connections”.",
           "otel": {
-            "instrument_kind": "observable_gauge",
+            "instrument_kind": "updowncounter",
             "monotonic": false,
-            "async": true
+            "async": false
           }
         },
         {
@@ -358,8 +358,8 @@
       "metrics": [
         {
           "name": "db.client.connection.pending_requests",
-          "type": "Gauge",
-          "observable": true,
+          "type": "UpDownCounter",
+          "observable": false,
           "unit": {
             "symbol": "{request}",
             "semantic": "requests"
@@ -378,11 +378,11 @@
               "cardinality": "required"
             }
           ],
-          "description": "The number of current pending requests for an open connection. This is an async (observable) metric.",
+          "description": "The number of current pending requests for an open connection.",
           "otel": {
-            "instrument_kind": "observable_gauge",
+            "instrument_kind": "updowncounter",
             "monotonic": false,
-            "async": true
+            "async": false
           }
         },
         {


### PR DESCRIPTION

Two client observability metrics (`db.client.connection.count` and `db.client.connection.pending_requests`) changed from a gauge to an UpDownCounter. This Pr brings the docs in alignment with the change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs/spec update: only the metric metadata in `data/client_obs_metrics.json` changes, with no runtime code impact. Risk is limited to consumers relying on the previous Gauge/async semantics for these two metric definitions.
> 
> **Overview**
> Updates the client observability metrics spec to reflect that `db.client.connection.count` and `db.client.connection.pending_requests` are **synchronous `UpDownCounter`s** rather than **observable Gauges**.
> 
> This changes their declared `type`, `otel.instrument_kind`, and `async/observable` flags, and removes wording that described them as async metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cd7ba1459f3d20a74fb8e3822fda60f2286de3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->