### PR TITLE
Added RDI 1.16.2 version to config.toml (missed from previous PR)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,7 +56,7 @@ rdi_redis_gears_version = "1.2.6"
 rdi_debezium_server_version = "2.3.0.Final"
 rdi_db_types = "cassandra|mysql|oracle|postgresql|sqlserver"
 rdi_cli_latest = "latest"
-rdi_current_version = "1.16.1"
+rdi_current_version = "1.16.2"
 
 
 [params.clientsConfig]


### PR DESCRIPTION
No JIRA case here, just a tiny fix to a variable to make sure the right RDI version number appears in the download links.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter version bump in site config; low risk aside from ensuring generated download links/docs now point to the intended RDI release.
> 
> **Overview**
> Updates the docs site `config.toml` to bump `rdi_current_version` from `1.16.1` to `1.16.2`, ensuring RDI-related references (e.g., download links) use the latest version.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdc8df69ac46c2e897df1a32af15473ae1aa698e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->