### PR TITLE
DOC-6428: Amend resolved issues for RS 7.22.2-93 release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-93.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-93.md
@@ -6,7 +6,7 @@ categories:
 - operate
 - rs
 compatibleOSSVersion: Redis 7.4.3, 7.2.7, 6.2.13
-description: Bug fixes for node manager crashes after cluster upgrades and flash database percent capacity displayed in the Cluster Manager UI. Internal fixes and improvements.
+description: Bug fix for flash database percent capacity displayed in the Cluster Manager UI. Internal fixes and improvements.
 linkTitle: 7.22.2-93 (March 2026)
 weight: 81
 ---
@@ -17,7 +17,7 @@ This is a maintenance release for ​​Redis Software version 7.22.2.
 
 This version offers:
 
-- Bug fixes for node manager crashes after cluster upgrades and flash database percent capacity displayed in the Cluster Manager UI
+- A bug fix for flash database percent capacity displayed in the Cluster Manager UI
 
 - Internal fixes and improvements
 
@@ -42,8 +42,6 @@ The following table shows which Redis modules are compatible with each Redis dat
 | 6.2 | [RediSearch 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md" >}})<br />[RedisJSON 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.4-release-notes.md" >}})<br />[RedisTimeSeries 1.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.8-release-notes.md" >}})<br />[RedisBloom 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.4-release-notes.md" >}})  |
 
 ### Resolved issues
-
-- RS177450: Fixed an issue that could cause `node_mgr FATAL` crashes after cluster upgrades.
 
 - RS176173: Fixed an issue that could cause the Cluster Manager UI to display over 100% capacity for flash databases, even when memory usage was under the configured limit.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes a previously listed resolved issue; no product code or behavior is modified.
> 
> **Overview**
> Updates the `7.22.2-93` Redis Software release notes to **drop the previously advertised fix for `node_mgr` crashes after cluster upgrades** (and the associated `RS177450` resolved-issue entry).
> 
> The release notes now only call out the **Cluster Manager UI flash database capacity display fix** (`RS176173`) in the front-matter description, highlights, and resolved issues.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aef69a68f88c14b3d5d1d3aed809a9e97d507b3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->