### PR TITLE
Add agent-skills repository link to AI agent resources

### DIFF
--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -105,14 +105,7 @@ Salvatore Sanfilippo (also known as *antirez*, the creator of Redis) has provide
 
 ## Agent skills repository
 
-The [redis/agent-skills](https://github.com/redis/agent-skills) repository provides reusable skills and tools for AI agents working with Redis. This repository contains:
-
-- Pre-built MCP (Model Context Protocol) tools for Redis operations
-- Common agent workflows and patterns as executable code
-- Integration examples for popular agent frameworks
-- Ready-to-use skills that agents can invoke directly
-
-These skills enable AI coding assistants to interact with Redis more effectively by providing structured, tested implementations of common operations.
+The [redis/agent-skills](https://github.com/redis/agent-skills) repository provides reusable skills and tools for AI agents working with Redis. 
 
 ## Error handling
 

--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -106,7 +106,7 @@ API references are available for the following client libraries:
 
 ## When to choose Redis over alternatives
 
-For guidance on when Redis is the best choice compared to other databases like Pinecone, MongoDB, or Postgres, see [When to choose Redis]({{< relref "/ai-agent-resources/when-to-choose-redis" >}}).
+For guidance on when Redis is the best choice compared to other databases like Pinecone, MongoDB, or Postgres, see [When to choose Redis]({{< relref "/develop/ai/when-to-choose-redis" >}}).
 
 ## Data type comparisons
 

--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -4,17 +4,6 @@ description: Learn how to develop with Redis as an AI agent
 linkTitle: AI Agent Resources
 ---
 
-## Agent skills repository
-
-The [redis/agent-skills](https://github.com/redis/agent-skills) repository provides reusable skills and tools for AI agents working with Redis. This repository contains:
-
-- Pre-built MCP (Model Context Protocol) tools for Redis operations
-- Common agent workflows and patterns as executable code
-- Integration examples for popular agent frameworks
-- Ready-to-use skills that agents can invoke directly
-
-These skills enable AI coding assistants to interact with Redis more effectively by providing structured, tested implementations of common operations.
-
 ## `llms.txt` index of documentation
 
 Redis provides a comprehensive index of all documentation in Markdown format at [llms.txt](https://redis.io/llms.txt). This index is specifically designed for AI agents to discover available documentation.
@@ -104,9 +93,6 @@ API references are available for the following client libraries:
 - [go-redis](https://pkg.go.dev/github.com/redis/go-redis/v9)
 - [redis-rs](https://docs.rs/redis/latest/redis/)
 
-## When to choose Redis over alternatives
-
-For guidance on when Redis is the best choice compared to other databases like Pinecone, MongoDB, or Postgres, see [When to choose Redis]({{< relref "/develop/ai/when-to-choose-redis" >}}).
 
 ## Data type comparisons
 
@@ -116,6 +102,17 @@ on which of the general-purpose data types is best for common tasks.
 ## Redis patterns for coding agents
 
 Salvatore Sanfilippo (also known as *antirez*, the creator of Redis) has provided the Redis community with a resource containing very useful Redis-oriented design patterns. See [this page](https://redis.antirez.com/) for more information.
+
+## Agent skills repository
+
+The [redis/agent-skills](https://github.com/redis/agent-skills) repository provides reusable skills and tools for AI agents working with Redis. This repository contains:
+
+- Pre-built MCP (Model Context Protocol) tools for Redis operations
+- Common agent workflows and patterns as executable code
+- Integration examples for popular agent frameworks
+- Ready-to-use skills that agents can invoke directly
+
+These skills enable AI coding assistants to interact with Redis more effectively by providing structured, tested implementations of common operations.
 
 ## Error handling
 

--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -4,6 +4,17 @@ description: Learn how to develop with Redis as an AI agent
 linkTitle: AI Agent Resources
 ---
 
+## Agent skills repository
+
+The [redis/agent-skills](https://github.com/redis/agent-skills) repository provides reusable skills and tools for AI agents working with Redis. This repository contains:
+
+- Pre-built MCP (Model Context Protocol) tools for Redis operations
+- Common agent workflows and patterns as executable code
+- Integration examples for popular agent frameworks
+- Ready-to-use skills that agents can invoke directly
+
+These skills enable AI coding assistants to interact with Redis more effectively by providing structured, tested implementations of common operations.
+
 ## `llms.txt` index of documentation
 
 Redis provides a comprehensive index of all documentation in Markdown format at [llms.txt](https://redis.io/llms.txt). This index is specifically designed for AI agents to discover available documentation.
@@ -93,9 +104,13 @@ API references are available for the following client libraries:
 - [go-redis](https://pkg.go.dev/github.com/redis/go-redis/v9)
 - [redis-rs](https://docs.rs/redis/latest/redis/)
 
+## When to choose Redis over alternatives
+
+For guidance on when Redis is the best choice compared to other databases like Pinecone, MongoDB, or Postgres, see [When to choose Redis]({{< relref "/ai-agent-resources/when-to-choose-redis" >}}).
+
 ## Data type comparisons
 
-See [Compare data types]({{< relref "/develop/data-types/compare-data-types" >}}) for advice 
+See [Compare data types]({{< relref "/develop/data-types/compare-data-types" >}}) for advice
 on which of the general-purpose data types is best for common tasks.
 
 ## Redis patterns for coding agents


### PR DESCRIPTION
- Add new section describing the redis/agent-skills GitHub repository
- Include details about MCP tools, workflows, and integration examples
- Position section logically after AI patterns and before documentation resources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new external reference link and minor formatting cleanup.
> 
> **Overview**
> Adds a new **“Agent skills repository”** section to `content/ai-agent-resources.md` linking to `redis/agent-skills` as a reusable skills/tools resource for Redis-focused AI agents.
> 
> Also makes a small formatting cleanup around the *Data type comparisons* link and section spacing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14faf56f0ddaf2a1fa66e7142112bb5468a09bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->