### PR TITLE
DOC: add q42025/Q1 2026 What's New sections

### DIFF
--- a/content/develop/whats-new/_index.md
+++ b/content/develop/whats-new/_index.md
@@ -106,10 +106,9 @@ weight: 10
 - Fixed fuzzy search documentation with specific attribute examples
 - Updated client library description differences across all major clients
 - Added observability overview with OpenTelemetry metrics
-- Added client-specific observability pages for Python and Go
-
 - Added Smart client handoffs overview
 - Docs for n8n Redis vector store integration
+- Added railroad diagrams and API methods to all command pages
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only update; primary risk is broken or incorrect `relref` links and inconsistent release notes listings.
> 
> **Overview**
> Adds new **Q1 2026** and **Q4 2025** sections to `content/develop/whats-new/_index.md`, expanding the Develop “What’s new?” page with links and callouts for Redis Insight releases, new/updated AI & vector docs (including Featureform and integrations), data type example metadata updates, multiple client library doc additions/updates, and Redis 8.6/8.4 documentation notes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c77de185f8a500844a13c5fbd105a9215bb4e7c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->