### PR TITLE
JSON.OBJKEYS: Update description and return values

### DIFF
--- a/content/commands/json.objkeys.md
+++ b/content/commands/json.objkeys.md
@@ -61,7 +61,7 @@ is either
   - Resolves to all matching locations in `key`.
 - A legacy path expression 
   - Any string that does not match the JSONPath syntax above.
-  - Allow the leading "`.`" to be omitted (e.g., "`name`" and "`.name`" are equivalent).
+  - Allow the leading "`.`" to be omitted (for example, "`name`" and "`.name`" are equivalent).
   - Resolves to only the first matching location in `key`.
 
 Default: "`.`" (legacy path pointing to the root of the document).
@@ -93,35 +93,35 @@ redis> JSON.OBJKEYS doc $..a
 
 If `path` is a JSONPath expression:
 
-- a [Simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist
-- an empty [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches
-- an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - `null` if the match is not an object
-  - an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})) containing the object's key names if the match is an object
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if the match is not an object.
+  - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) containing the object's key names if the match is an object.
 
 If `path` is a legacy path expression:
 
-- `null` if `key` does not exist
-- `null` if `path` has no matches
-- a [Simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not an object
-- an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})) containing the object's key names of the first match
+- [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if `key` does not exist.
+- [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if `path` has no matches.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not an object.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) containing the object's key names of the first match.
 
 -tab-sep-
 
 If `path` is a JSONpath expression:
 
-- a [Simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist
-- an empty [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches
-- an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - `null` if the match is not an object
-  - an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})) containing the object's key names if the match is an object
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not an object.
+  - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) containing the object's key names if the match is an object.
 
 If `path` is a legacy path expression:
 
-- `null` if `key` does not exist
-- `null` if `path` has no matches
-- a [Simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not an object
-- an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})) containing the object's key names of the first match
+- [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if `key` does not exist.
+- [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if `path` has no matches.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not an object.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) containing the object's key names of the first match.
 
 {{< /multitabs >}}
 


### PR DESCRIPTION
Clarify behavior of key and path arguments in JSON documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying `JSON.OBJKEYS` argument and return behavior; no runtime code is modified.
> 
> **Overview**
> Updates the `JSON.OBJKEYS` docs to clarify that the command returns *object key names* for all matches of a given path expression, with explicit distinction between **JSONPath** vs **legacy path** syntax (including default path behavior).
> 
> Expands the return-value specification for both RESP2/RESP3 to describe differences in errors vs `nil` vs empty arrays across JSONPath/legacy modes, and adds a note distinguishing Redis keys from JSON object keys plus new related links (`JSONPath`, `JSON.OBJLEN`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2df9dae44a268f15c7d480939ed6c396b5dfd17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->