### PR TITLE
Add migration guide links for Redis Cloud and Azure Redis

### DIFF
--- a/content/operate/rc/_index.md
+++ b/content/operate/rc/_index.md
@@ -60,6 +60,15 @@ Use the [REST API]({{< relref "/operate/rc/api" >}}) to manage Redis Cloud datab
 - [Get started with the REST API]({{< relref "/operate/rc/api/get-started" >}})
 - REST API [reference]({{< relref "/operate/rc/api/api-reference" >}}) & [examples]({{< relref "/operate/rc/api/examples" >}})
 
+## Migrate to Redis Cloud
+Follow the step-by-step guide for your source environment:
+- [ElastiCache to Redis Cloud](https://redis.io/tutorials/migration/elasticache-to-redis-cloud/) — offline and live migration from AWS ElastiCache
+- [Memorystore to Redis Cloud](https://redis.io/tutorials/migration/memorystore-to-redis-cloud/) — offline and live migration from Google Cloud Memorystore
+- [Open source Redis to Redis Cloud](https://redis.io/tutorials/migration/redis-open-source-to-redis-cloud/) — migrate from a self-hosted Redis instance
+
+## Migrate to Azure Managed Redis
+- [ElastiCache to Azure Managed Redis (AMR)](https://redis.io/tutorials/learn/migration/elasti-cache-to-azure-managed-redis/) — move your workload from AWS to Azure
+- [Memorystore to Azure Managed Redis (AMR)](https://redis.io/tutorials/learn/migration/memorystore-to-azure-managed-redis/) — move your workload from Google Cloud to Azure
 
 ## Related info
 - [Redis Software]({{< relref "/operate/rs" >}})


### PR DESCRIPTION
Added migration guide links for Redis Cloud and Azure Managed Redis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds outbound migration links; main risk is broken/incorrect URLs or labeling.
> 
> **Overview**
> Adds two new sections to the Redis Cloud landing page (`content/operate/rc/_index.md`) that link to step-by-step migration guides.
> 
> Includes migration paths *to Redis Cloud* (from AWS ElastiCache, GCP Memorystore, and self-hosted Redis) and *to Azure Managed Redis (AMR)* (from AWS ElastiCache and GCP Memorystore).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0112096f43c2a34369f260bb939f690a49a63da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->