### PR TITLE
K8s: Add validation note to helm install

### DIFF
--- a/content/operate/kubernetes/deployment/helm.md
+++ b/content/operate/kubernetes/deployment/helm.md
@@ -27,7 +27,7 @@ The steps below use the following placeholders to indicate command line paramete
 
 - `<repo-name>` is the name of the repo holding your Helm chart (example: `redis`).
 - `<release-name>` is the name you give a specific installation of the Helm chart (example: `my-redis-enterprise-operator`)
-- `<chart-version>` is the version of the Helm chart you are installing (example: `7.8.2-2`)
+- `<chart-version>` is the version of the Helm chart you are installing (example: `7.8.6-2`). Verify that the version you specify is listed in the [Redis Helm repository](https://helm.redis.io/). Using an invalid version number causes installation failures.
 - `<namespace-name>` is the name of the new namespace the Redis operator will run in (example: `ns1`)
 - `<path-to-chart>` is the filepath to the Helm chart, if it is stored in a local directory (example: `/home/charts/redis-enterprise-operator`)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds guidance around selecting a valid Helm chart version; no product or runtime behavior is affected.
> 
> **Overview**
> Updates the Kubernetes Helm install docs to clarify the `<chart-version>` placeholder, including an updated example version and a note to verify the specified version exists in the Redis Helm repository to avoid install failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f4ad75600d533d404fd30940b97308020d9ca92. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->