### PR TITLE
DEV: (cmds) update HOTKEYS GET return values

### DIFF
--- a/content/commands/hotkeys-get.md
+++ b/content/commands/hotkeys-get.md
@@ -142,14 +142,14 @@ HOTKEYS GET
 
 One of the following:
 
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) when tracking data is available, containing an array of pairs of field names and values.
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) when tracking data is available, containing a single array with alternating field names and values.
 - [Null reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) when no tracking has been started or data has been reset.
 
 -tab-sep-
 
 One of the following:
 
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) when tracking data is available, containing a [map]({{< relref "/develop/reference/protocol-spec#maps" >}}) of field names and values.
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) when tracking data is available, containing a single [map]({{< relref "/develop/reference/protocol-spec#maps" >}}) with field names and values.
 - [Null reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) when no tracking has been started or data has been reset.
 
 {{< /multitabs >}}


### PR DESCRIPTION
The return values changed post-8.6. This PR corrects them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies the `HOTKEYS GET` reply format; no runtime code paths are affected.
> 
> **Overview**
> Updates `HOTKEYS GET` documentation to reflect the post-8.6 reply structure: RESP2 is documented as a *single array* with alternating field names/values, and RESP3 as a *single map* of field names/values, instead of implying multiple pairs/arrays.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c29d8960e5b6cd62607e28ce6ace399b2687909. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->