### PR TITLE
DEV: update RESP2 protocol content

### DIFF
--- a/content/develop/reference/protocol-spec.md
+++ b/content/develop/reference/protocol-spec.md
@@ -124,6 +124,7 @@ The following table summarizes the RESP data types that Redis supports:
 | [Simple Errors](#simple-errors) | RESP2 | Simple | `-` |
 | [Integers](#integers) | RESP2 | Simple | `:` |
 | [Bulk strings](#bulk-strings) | RESP2 | Aggregate | `$` |
+| [Null bulk strings](#null-bulk-strings) | RESP2 | Aggregate | `$-1\r\n` |
 | [Arrays](#arrays) | RESP2 | Aggregate | `*` |
 | [Nulls](#nulls) | RESP3 | Simple | `_` |
 | [Booleans](#booleans) | RESP3 | Simple | `#` |
@@ -235,7 +236,7 @@ The empty string's encoding is:
 
 <a name="nil-reply"></a>
 
-#### Null bulk strings
+### Null bulk strings
 Whereas RESP3 has a dedicated data type for [null values](#nulls), RESP2 has no such type.
 Instead, due to historical reasons, the representation of null values in RESP2 is via predetermined forms of the [bulk strings](#bulk-strings) and [arrays](#arrays) types.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds/clarifies RESP2 Null Bulk String representation and fixes its section heading formatting.
> 
> **Overview**
> Updates the RESP protocol spec to explicitly list **RESP2 Null Bulk Strings** in the data-type summary table (including the `$-1\r\n` encoding) and promotes the *Null bulk strings* section to a proper `###` heading for consistent formatting/linking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43be90a4bf81a97492daf607cd484cd37d9277d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->