### PR TITLE
RS: Linked to renew self-signed certs and create CA-signed certs from update certs

### DIFF
--- a/content/operate/rs/7.22/security/certificates/updating-certificates.md
+++ b/content/operate/rs/7.22/security/certificates/updating-certificates.md
@@ -15,6 +15,10 @@ url: '/operate/rs/7.22/security/certificates/updating-certificates/'
 When you update the certificates, the new certificate replaces the same certificates on all nodes in the cluster.
 {{</warning>}}
 
+## Prerequisites
+
+You need to create new certificates before you can update them in the cluster. To create replacement certificates, see [Renew self-signed certificates]({{<relref "/operate/rs/7.22/security/certificates/create-certificates#renew-self-signed-certificates">}}) or [Create CA-signed certificates]({{<relref "/operate/rs/7.22/security/certificates/create-certificates#create-ca-signed-certificates">}}) for detailed instructions.
+
 ## How to update certificates
 
 You can use the [`rladmin`]({{< relref "/operate/rs/7.22/references/cli-utilities/rladmin" >}}) command-line interface (CLI) or the [REST API]({{< relref "/operate/rs/7.22/references/rest-api" >}}) to update certificates. The Cluster Manager UI lets you update proxy, syncer, and internode encryption certificates on the **Cluster > Security > Certificates** screen.

--- a/content/operate/rs/7.4/security/certificates/updating-certificates.md
+++ b/content/operate/rs/7.4/security/certificates/updating-certificates.md
@@ -15,6 +15,10 @@ url: '/operate/rs/7.4/security/certificates/updating-certificates/'
 When you update the certificates, the new certificate replaces the same certificates on all nodes in the cluster.
 {{</warning>}}
 
+## Prerequisites
+
+You need to create new certificates before you can update them in the cluster. To create replacement certificates, see [Renew self-signed certificates]({{<relref "/operate/rs/7.4/security/certificates/create-certificates#renew-self-signed-certificates">}}) or [Create CA-signed certificates]({{<relref "/operate/rs/7.4/security/certificates/create-certificates#create-ca-signed-certificates">}}) for detailed instructions.
+
 ## How to update certificates
 
 You can use the [`rladmin`]({{< relref "/operate/rs/7.4/references/cli-utilities/rladmin" >}}) command-line interface (CLI) or the [REST API]({{< relref "/operate/rs/7.4/references/rest-api" >}}) to update certificates. The Cluster Manager UI lets you update proxy and syncer certificates on the **Cluster > Security > Certificates** screen.

--- a/content/operate/rs/7.8/security/certificates/updating-certificates.md
+++ b/content/operate/rs/7.8/security/certificates/updating-certificates.md
@@ -15,6 +15,10 @@ url: '/operate/rs/7.8/security/certificates/updating-certificates/'
 When you update the certificates, the new certificate replaces the same certificates on all nodes in the cluster.
 {{</warning>}}
 
+## Prerequisites
+
+You need to create new certificates before you can update them in the cluster. To create replacement certificates, see [Renew self-signed certificates]({{<relref "/operate/rs/7.8/security/certificates/create-certificates#renew-self-signed-certificates">}}) or [Create CA-signed certificates]({{<relref "/operate/rs/7.8/security/certificates/create-certificates#create-ca-signed-certificates">}}) for detailed instructions.
+
 ## How to update certificates
 
 You can use the [`rladmin`]({{< relref "/operate/rs/7.8/references/cli-utilities/rladmin" >}}) command-line interface (CLI) or the [REST API]({{< relref "/operate/rs/7.8/references/rest-api" >}}) to update certificates. The Cluster Manager UI lets you update proxy and syncer certificates on the **Cluster > Security > Certificates** screen.

--- a/content/operate/rs/security/certificates/updating-certificates.md
+++ b/content/operate/rs/security/certificates/updating-certificates.md
@@ -14,6 +14,10 @@ weight: 20
 When you update the certificates, the new certificate replaces the same certificates on all nodes in the cluster.
 {{</warning>}}
 
+## Prerequisites
+
+You need to create new certificates before you can update them in the cluster. To create replacement certificates, see [Renew self-signed certificates]({{<relref "/operate/rs/security/certificates/create-certificates#renew-self-signed-certificates">}}) or [Create CA-signed certificates]({{<relref "/operate/rs/security/certificates/create-certificates#create-ca-signed-certificates">}}) for detailed instructions.
+
 ## How to update certificates
 
 You can use the [`rladmin`]({{< relref "/operate/rs/references/cli-utilities/rladmin" >}}) command-line interface (CLI) or the [REST API]({{< relref "/operate/rs/references/rest-api" >}}) to update certificates. The Cluster Manager UI lets you update proxy, syncer, and internode encryption certificates on the **Cluster > Security > Certificates** screen.


### PR DESCRIPTION
Fixes #2977

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds cross-links; potential risk is only incorrect/rotted relrefs across versioned docs.
> 
> **Overview**
> Adds a new **Prerequisites** section to the Redis Software/Enterprise “Update certificates” docs (unversioned, `7.4`, `7.8`, `7.22`) that explicitly tells users to create replacement certs first and links to the relevant self-signed renewal and CA-signed creation instructions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c46a3bb6bfbaf83206a380ad0786cbdd3df13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->