### PR TITLE
DEV: add warning to BM25STD scoring page

### DIFF
--- a/content/develop/ai/search-and-query/advanced-concepts/scoring.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/scoring.md
@@ -80,6 +80,11 @@ FT.SEARCH myIndex "foo" SCORER TFIDF.DOCNORM
 
 ## BM25STD (default)
 
+{{< warning >}}
+Replacing an indexed document with the same key can temporarily affect document scores, even when the new content is identical to the old content. This can also occur when a document is effectively replaced by deleting it and then setting it again. Scores return to normal after the Redis Search garbage collector runs.
+{{< /warning >}}
+
+
 A variation on the basic `TFIDF` scorer, see [this Wikipedia article for more info](https://en.wikipedia.org/wiki/Okapi_BM25).
 
 The relevance score for each document is multiplied by the presumptive document score and a penalty is applied based on slop as in `TFIDF`.

--- a/content/develop/ai/search-and-query/advanced-concepts/scoring.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/scoring.md
@@ -81,7 +81,8 @@ FT.SEARCH myIndex "foo" SCORER TFIDF.DOCNORM
 ## BM25STD (default)
 
 {{< warning >}}
-Replacing an indexed document with the same key can temporarily affect document scores, even when the new content is identical to the old content. This can also occur when a document is effectively replaced by deleting it and then setting it again. Scores return to normal after the Redis Search garbage collector runs.
+Deleting or replacing an indexed document can temporarily affect the scores of other documents that contain any of the same terms.
+As a result, `FT.SEARCH` score values may be inaccurate until the Redis Search garbage collector runs and removes the stale term data.
 {{< /warning >}}
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds guidance about potentially unstable `FT.SEARCH` scores after document deletion/replacement until garbage collection runs.
> 
> **Overview**
> Adds a **warning** to the `BM25STD` scorer documentation noting that deleting or replacing indexed documents can temporarily skew scores for other documents sharing terms, and that `FT.SEARCH` scores may remain inaccurate until the Redis Search garbage collector removes stale term data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fe705d20561deba3524a0b23fb5d23abf7d16af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->