### PR TITLE
DEV: (cmds + etc) add XNACK command page and general info.

### DIFF
--- a/content/commands/xautoclaim.md
+++ b/content/commands/xautoclaim.md
@@ -97,6 +97,8 @@ However, note that you may want to continue calling `XAUTOCLAIM` even after the 
 Note that only messages that are idle longer than `<min-idle-time>` are claimed, and claiming a message resets its idle time.
 This ensures that only a single consumer can successfully claim a given pending message at a specific instant of time and trivially reduces the probability of processing the same message multiple times.
 
+Messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}) are immediately claimable since their delivery time is set to 0, satisfying any minimum idle time requirement.
+
 While iterating the PEL, if `XAUTOCLAIM` stumbles upon a message which doesn't exist in the stream anymore (either trimmed or deleted by [`XDEL`]({{< relref "/commands/xdel" >}})) it does not claim it, and deletes it from the PEL in which it was found. This feature was introduced in Redis 7.0.
 These message IDs are returned to the caller as a part of `XAUTOCLAIM`s reply.
 

--- a/content/commands/xcfgset.md
+++ b/content/commands/xcfgset.md
@@ -1,6 +1,6 @@
 ---
 acl_categories:
-- STREAM
+- '@stream'
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/xclaim.md
+++ b/content/commands/xclaim.md
@@ -109,6 +109,8 @@ This dynamic is clearly explained in the [Stream intro documentation]({{< relref
 
 Note that the message is claimed only if its idle time is greater than the minimum idle time we specify when calling `XCLAIM`. Because as a side effect `XCLAIM` will also reset the idle time (since this is a new attempt at processing the message), two consumers trying to claim a message at the same time will never both succeed: only one will successfully claim the message. This avoids that we process a given message multiple times in a trivial way (yet multiple processing is possible and unavoidable in the general case).
 
+Messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}) are immediately claimable since their delivery time is set to 0, satisfying any minimum idle time requirement.
+
 Moreover, as a side effect, `XCLAIM` will increment the count of attempted deliveries of the message unless the `JUSTID` option has been specified (which only delivers the message ID, not the message itself). In this way messages that cannot be processed for some reason, for instance because the consumers crash attempting to process them, will start to have a larger counter and can be detected inside the system.
 
 `XCLAIM` will not claim a message in the following cases:

--- a/content/commands/xinfo-stream.md
+++ b/content/commands/xinfo-stream.md
@@ -46,6 +46,8 @@ history:
 - - 8.6.0
   - Added the `idmp-duration`, `idmp-maxsize`, `pids-tracked`, `iids-tracked`, `iids-added`
     and `iids-duplicates` fields for IDMP tracking.
+- - 8.8.0
+  - Added the `nacked-count` field to consumer groups in the `FULL` output.
 key_specs:
 - RO: true
   access: true
@@ -106,11 +108,12 @@ The following information is provided for each of the groups:
 * **pel-count**: the length of the group's pending entries list (PEL), which are messages that were delivered but are yet to be acknowledged
 * **pending**: an array with pending entries information (see below)
 * **consumers**: an array with consumers information (see below)
+* **nacked-count**: the number of entries currently in the nacked zone. See the [`XNACK` command page]({{< relref "/commands/xnack" >}}) for more details. Added in Redis 8.8.
 
 The following information is provided for each pending entry:
 
 1. The ID of the message.
-2. The name of the consumer that fetched the message and has still to acknowledge it. We call it the current *owner* of the message.
+2. The name of the consumer that fetched the message and has still to acknowledge it. We call it the current *owner* of the message. For messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}), this field will be empty.
 3. The UNIX timestamp of when the message was delivered to this consumer.
 4. The number of times this message was delivered.
 

--- a/content/commands/xinfo-stream.md
+++ b/content/commands/xinfo-stream.md
@@ -108,12 +108,12 @@ The following information is provided for each of the groups:
 * **pel-count**: the length of the group's pending entries list (PEL), which are messages that were delivered but are yet to be acknowledged
 * **pending**: an array with pending entries information (see below)
 * **consumers**: an array with consumers information (see below)
-* **nacked-count**: the number of entries currently in the nacked zone. See the [`XNACK` command page]({{< relref "/commands/xnack" >}}) for more details. Added in Redis 8.8.
+* **nacked-count**: the number of entries currently in the NACKed portion of the PEL. See the [`XNACK` command page]({{< relref "/commands/xnack" >}}) for more details. Added in Redis 8.8.
 
 The following information is provided for each pending entry:
 
 1. The ID of the message.
-2. The name of the consumer that fetched the message and has still to acknowledge it. We call it the current *owner* of the message. For messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}), this field will be empty.
+2. The name of the consumer that fetched the message and has yet to acknowledge it. We call it the current *owner* of the message. For messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}), this field will be an empty string.
 3. The UNIX timestamp of when the message was delivered to this consumer.
 4. The number of times this message was delivered.
 

--- a/content/commands/xnack.md
+++ b/content/commands/xnack.md
@@ -1,0 +1,242 @@
+---
+acl_categories:
+- '@stream'
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: group
+  type: string
+- arguments:
+  - name: silent
+    token: SILENT
+    type: pure-token
+  - name: fail
+    token: FAIL
+    type: pure-token
+  - name: fatal
+    token: FATAL
+    type: pure-token
+  name: mode
+  type: oneof
+- arguments:
+  - name: numids
+    type: integer
+  - multiple: true
+    name: id
+    type: string
+  name: ids
+  token: IDS
+  type: block
+- name: count
+  optional: true
+  token: RETRYCOUNT
+  type: integer
+- name: force
+  optional: true
+  token: FORCE
+  type: pure-token
+arity: -7
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- write
+- fast
+complexity: O(1) for each message ID processed.
+description: Releases pending messages back to the group's PEL without acknowledging
+  them, making them available for re-delivery.
+group: stream
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - UPDATE
+linkTitle: XNACK
+since: 8.8.0
+summary: Releases pending messages back to the group's PEL without acknowledging them,
+  making them available for re-delivery.
+syntax_fmt: "XNACK key group <SILENT | FAIL | FATAL> IDS\_numids id [id ...]\n  [RETRYCOUNT\_\
+  count] [FORCE]"
+title: XNACK
+---
+
+In the context of a stream consumer group, this command allows a consumer to explicitly release pending messages back to the group's Pending Entries List (PEL) without acknowledging them. Released messages become immediately available for re-delivery to other consumers in the group, eliminating the idle-timeout delay normally required for message recovery.
+
+This is particularly useful in scenarios such as graceful consumer shutdown, transient failures, resource constraints, or poison message detection. The command provides three different modes that control how the delivery counter is adjusted, giving consumers fine-grained control over retry semantics.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+Name of the stream.
+
+</details>
+
+<details open><summary><code>group</code></summary>
+
+Name of the consumer group.
+
+</details>
+
+<details open><summary><code>mode</code></summary>
+
+Controls the delivery counter adjustment. Must be one of:
+
+- **SILENT**: Decrements the delivery counter by 1, essentially "undoing" the delivery increment. Use this for transient internal failures or graceful shutdown where the delivery "didn't count".
+- **FAIL**: Keeps the current delivery counter value unchanged. Use this when the message is too complex for the current consumer but may work for others.
+- **FATAL**: Sets the delivery counter to the maximum value (LLONG_MAX or ~9.22 X 10<sup>18</sup>), marking the message as permanently failed. Use this for invalid or suspected malicious messages.
+
+</details>
+
+<details open><summary><code>ids</code></summary>
+
+Block specifying the message IDs to release, where `numids` is the number of message IDs that follow, and `id [id ...]` represents the stream entry IDs to be released back to the group.
+
+</details>
+
+## Optional arguments
+
+<details open><summary><code>RETRYCOUNT</code></summary>
+
+Directly sets the delivery counter to the specified value, overriding the mode-based adjustment. This gives explicit control over the retry counter regardless of the mode selected.
+
+</details>
+
+<details open><summary><code>FORCE</code></summary>
+
+Creates new unowned PEL entries for IDs that are not already in the group PEL. The entry must exist in the stream. When `FORCE` creates an entry, the delivery counter is set to `0` (or to `RETRYCOUNT` if specified, or to `LLONG_MAX` if mode is `FATAL`). This option is primarily used internally for AOF rewrite and replication.
+
+</details>
+
+## Examples
+
+<details open>
+<summary><strong>Basic usage with FAIL mode</strong></summary>
+
+```
+> XADD mystream * field value1
+"1526569498055-0"
+> XADD mystream * field value2
+"1526569498056-0"
+> XGROUP CREATE mystream mygroup 0
+OK
+> XREADGROUP GROUP mygroup consumer1 STREAMS mystream >
+1) 1) "mystream"
+   2) 1) 1) "1526569498055-0"
+         2) 1) "field"
+            2) "value1"
+      2) 1) "1526569498056-0"
+         2) 1) "field"
+            2) "value2"
+> XNACK mystream mygroup FAIL IDS 2 1526569498055-0 1526569498056-0
+(integer) 2
+```
+
+After NACKing, the messages appear with empty consumer in XPENDING:
+
+```
+> XPENDING mystream mygroup - + 10
+1) 1) "1526569498055-0"
+   2) ""
+   3) (integer) -1
+   4) (integer) 1
+2) 1) "1526569498056-0"
+   2) ""
+   3) (integer) -1
+   4) (integer) 1
+```
+
+</details>
+
+<details open>
+<summary><strong>Using SILENT mode for graceful shutdown</strong></summary>
+
+```
+> XNACK mystream mygroup SILENT IDS 1 1526569498055-0
+(integer) 1
+```
+
+With SILENT mode, the delivery counter is decremented, effectively "undoing" the delivery.
+
+</details>
+
+<details open>
+<summary><strong>Using FATAL mode for poison messages</strong></summary>
+
+```
+> XNACK mystream mygroup FATAL IDS 1 1526569498055-0
+(integer) 1
+```
+
+This marks the message as permanently failed by setting the delivery counter to maximum value.
+
+</details>
+
+<details open>
+<summary><strong>Using RETRYCOUNT option</strong></summary>
+
+```
+> XNACK mystream mygroup FAIL IDS 1 1526569498055-0 RETRYCOUNT 5
+(integer) 1
+```
+
+Explicitly sets the delivery counter to 5, regardless of the mode.
+
+</details>
+
+## Behavior
+
+When `XNACK` executes successfully, it:
+
+1. **Disassociates** the entry from its owning consumer (sets `consumer = NULL`)
+2. **Repositions** the entry to the head of the PEL time-ordered list (sets `delivery_time = 0`), making it immediately claimable with any `min-idle-time` threshold
+3. **Adjusts the delivery counter** according to the specified mode and options
+4. **Makes the entry available** for immediate re-delivery via [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) CLAIM, [`XCLAIM`]({{< relref "/commands/xclaim" >}}), or [`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}})
+
+NACKed messages are prioritized over other pending messages in the group's PEL, ensuring they are delivered before idle messages during claim operations.
+
+## Notes
+
+- `XNACK` will only process message IDs that exist in the consumer group's PEL. Messages that are not pending will be ignored and not counted in the return value.
+- The command creates a "NACK zone" at the head of the PEL where released messages are placed, ensuring they are prioritized for re-delivery.
+- Released messages have their delivery time set to 0, making them immediately claimable regardless of the `min-idle-time` parameter in claiming commands.
+- Unlike [`XACK`]({{< relref "/commands/xack" >}}), this command does not remove messages from the PEL but instead makes them available for other consumers.
+
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The number of messages successfully released back to the group PEL. Messages that are not in the consumer group PEL will not be counted.
+
+-tab-sep-
+
+[Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The number of messages successfully released back to the group PEL. Messages that are not in the consumer group PEL will not be counted.
+
+{{< /multitabs >}}
+
+## See also
+
+- [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}): Read messages from a consumer group
+- [`XACK`]({{< relref "/commands/xack" >}}): Acknowledge processed messages
+- [`XCLAIM`]({{< relref "/commands/xclaim" >}}): Claim pending messages from other consumers
+- [`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}}): Automatically claim idle pending messages
+- [`XPENDING`]({{< relref "/commands/xpending" >}}): Inspect pending messages in a consumer group

--- a/content/commands/xnack.md
+++ b/content/commands/xnack.md
@@ -218,6 +218,11 @@ NACKed messages are prioritized over other pending messages in the group's PEL, 
 - Released messages have their delivery time set to 0, making them immediately claimable regardless of the `min-idle-time` parameter in claiming commands.
 - Unlike [`XACK`]({{< relref "/commands/xack" >}}), this command does not remove messages from the PEL but instead makes them available for other consumers.
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
 
 ## Return information
 

--- a/content/commands/xnack.md
+++ b/content/commands/xnack.md
@@ -78,7 +78,7 @@ title: XNACK
 
 In the context of a stream consumer group, this command allows a consumer to explicitly release pending messages back to the group's Pending Entries List (PEL) without acknowledging them. Released messages become immediately available for re-delivery to other consumers in the group, eliminating the idle-timeout delay normally required for message recovery.
 
-This is particularly useful in scenarios such as graceful consumer shutdown, transient failures, resource constraints, or poison message detection. The command provides three different modes that control how the delivery counter is adjusted, giving consumers fine-grained control over retry semantics.
+This is particularly useful in scenarios such as graceful consumer shutdown, consumer-side failures, resource constraints, or poison message detection. The command provides three different modes that control how the delivery counter is adjusted, giving consumers fine-grained control over retry semantics.
 
 ## Required arguments
 
@@ -98,8 +98,8 @@ Name of the consumer group.
 
 Controls the delivery counter adjustment. Must be one of:
 
-- **SILENT**: Decrements the delivery counter by 1, essentially "undoing" the delivery increment. Use this for transient internal failures or graceful shutdown where the delivery "didn't count".
-- **FAIL**: Keeps the current delivery counter value unchanged. Use this when the message is too complex for the current consumer but may work for others.
+- **SILENT**: Decrements the delivery counter by 1, essentially "undoing" the delivery increment. Use this for an internal failure on the consumer side while processing the message or graceful shutdown where the delivery "didn't count".
+- **FAIL**: Keeps the current delivery counter value unchanged. Use this when the current consumer failed to process this message (for example, due to memory constraints). The root cause may be the message or the consumer (it is unclear), so the best strategy would be to let another consumer try to process the message.
 - **FATAL**: Sets the delivery counter to the maximum value (LLONG_MAX or ~9.22 X 10<sup>18</sup>), marking the message as permanently failed. Use this for invalid or suspected malicious messages.
 
 </details>
@@ -114,13 +114,13 @@ Block of arguments that specifies the message IDs to release, where `numids` is 
 
 <details open><summary><code>RETRYCOUNT</code></summary>
 
-Directly sets the delivery counter to the specified value, overriding the mode-based adjustment. This gives explicit control over the retry counter regardless of the mode selected.
+Directly sets the delivery counter to the specified value, overriding the mode-based adjustment. This gives explicit control over the retry counter regardless of the mode selected. Note: this is an internal argument that should usually not be used by consumers.
 
 </details>
 
 <details open><summary><code>FORCE</code></summary>
 
-Creates new unowned PEL entries for IDs that are not already in the group PEL. Each entry must exist in the stream. When `FORCE` creates an entry, the delivery counter is set to `0` (or to `RETRYCOUNT` if specified, or to `LLONG_MAX` if mode is `FATAL`). This option is primarily used internally for AOF rewrite and replication.
+Creates new unowned PEL entries for IDs that are not already in the group PEL. Each entry must exist in the stream. When `FORCE` creates an entry, the delivery counter is set to `0` (or to `RETRYCOUNT` if specified, or to `LLONG_MAX` if mode is `FATAL`). Note: this is an internal argument that should usually not be used by consumers.
 
 </details>
 
@@ -202,19 +202,21 @@ Explicitly sets the delivery counter to 5, regardless of the mode.
 
 ## Behavior
 
-When `XNACK` executes successfully, it:
+When `XNACK` executes successfully, the entry:
 
-1. **Disassociates** the entry from its owning consumer (sets `consumer = NULL`)
-2. **Repositions** the entry to the head of the PEL time-ordered list (sets `delivery_time = 0`), making it immediately claimable with any `min-idle-time` threshold
-3. **Adjusts the delivery counter** according to the specified mode and options
-4. **Makes the entry available** for immediate re-delivery via [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) CLAIM, [`XCLAIM`]({{< relref "/commands/xclaim" >}}), or [`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}})
+* is marked as unowned (its last consumer is set to an empty string).
+* is assigned a last delivery time of `0`.
+* is placed at the end of the NACKed portion of the PEL.
+* is available for immediate re-delivery via [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) CLAIM, [`XCLAIM`]({{< relref "/commands/xclaim" >}}), or [`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}}).
+
+The head of the PEL is reserved for all NACKed messages, ordered as a FIFO list, followed by pending messages that were neither ACKed nor NACKed in their existing order.
 
 NACKed messages are prioritized over other pending messages in the group's PEL, ensuring they are delivered before idle messages during claim operations.
 
 ## Notes
 
 - `XNACK` will only process message IDs that exist in the consumer group's PEL. Messages that are not pending will be ignored and not counted in the return value.
-- The command creates a "NACK zone" at the head of the PEL where released messages are placed, ensuring they are prioritized for re-delivery.
+- Released messages occupy a dedicated zone at the head of the PEL (called the *XNACKed portion of the PEL*), ensuring they are prioritized for re-delivery over other pending entries.
 - Released messages have their delivery time set to 0, making them immediately claimable regardless of the `min-idle-time` parameter in claiming commands.
 - Unlike [`XACK`]({{< relref "/commands/xack" >}}), this command does not remove messages from the PEL but instead makes them available for other consumers.
 
@@ -234,7 +236,7 @@ NACKed messages are prioritized over other pending messages in the group's PEL, 
 
 -tab-sep-
 
-[Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The number of messages successfully released back to the group PEL. Messages that are not in the consumer group PEL will not be counted.
+[Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The number of messages successfully released back to the consumer group PEL. Messages that are not in the consumer group PEL will not be counted.
 
 {{< /multitabs >}}
 

--- a/content/commands/xnack.md
+++ b/content/commands/xnack.md
@@ -188,18 +188,6 @@ This marks the message as permanently failed by setting the delivery counter to 
 
 </details>
 
-<details open>
-<summary><strong>Using RETRYCOUNT option</strong></summary>
-
-```
-> XNACK mystream mygroup FAIL IDS 1 1526569498055-0 RETRYCOUNT 5
-(integer) 1
-```
-
-Explicitly sets the delivery counter to 5, regardless of the mode.
-
-</details>
-
 ## Behavior
 
 When `XNACK` executes successfully, the entry:

--- a/content/commands/xnack.md
+++ b/content/commands/xnack.md
@@ -106,7 +106,7 @@ Controls the delivery counter adjustment. Must be one of:
 
 <details open><summary><code>ids</code></summary>
 
-Block specifying the message IDs to release, where `numids` is the number of message IDs that follow, and `id [id ...]` represents the stream entry IDs to be released back to the group.
+Block of arguments that specifies the message IDs to release, where `numids` is the number of message IDs that follow, and `id [id ...]` represents the stream entry IDs to be released back to the group.
 
 </details>
 
@@ -120,7 +120,7 @@ Directly sets the delivery counter to the specified value, overriding the mode-b
 
 <details open><summary><code>FORCE</code></summary>
 
-Creates new unowned PEL entries for IDs that are not already in the group PEL. The entry must exist in the stream. When `FORCE` creates an entry, the delivery counter is set to `0` (or to `RETRYCOUNT` if specified, or to `LLONG_MAX` if mode is `FATAL`). This option is primarily used internally for AOF rewrite and replication.
+Creates new unowned PEL entries for IDs that are not already in the group PEL. Each entry must exist in the stream. When `FORCE` creates an entry, the delivery counter is set to `0` (or to `RETRYCOUNT` if specified, or to `LLONG_MAX` if mode is `FATAL`). This option is primarily used internally for AOF rewrite and replication.
 
 </details>
 

--- a/content/commands/xpending.md
+++ b/content/commands/xpending.md
@@ -165,7 +165,7 @@ is detailed information for each message in the pending entries list. For
 each message four attributes are returned:
 
 1. The ID of the message.
-2. The name of the consumer that fetched the message and has still to acknowledge it. We call it the current *owner* of the message.
+2. The name of the consumer that fetched the message and has still to acknowledge it. We call it the current *owner* of the message. For messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}), this field will be empty.
 3. The number of milliseconds that elapsed since the last time this message was delivered to this consumer.
 4. The number of times this message was delivered.
 

--- a/content/commands/xpending.md
+++ b/content/commands/xpending.md
@@ -165,7 +165,7 @@ is detailed information for each message in the pending entries list. For
 each message four attributes are returned:
 
 1. The ID of the message.
-2. The name of the consumer that fetched the message and has still to acknowledge it. We call it the current *owner* of the message. For messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}), this field will be empty.
+2. The name of the consumer that fetched the message and has still to acknowledge it. We call it the current *owner* of the message. For messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}), this field will be an empty string.
 3. The number of milliseconds that elapsed since the last time this message was delivered to this consumer.
 4. The number of times this message was delivered.
 

--- a/content/commands/xreadgroup.md
+++ b/content/commands/xreadgroup.md
@@ -187,7 +187,8 @@ When not blocked, across streams, entries are reported in the order the streams 
 When using `CLAIM`, the following ordering guarantees apply per stream:
 
 - Idle pending entries are reported first, then incoming entries
-- Idle pending entries are ordered by idle time (longer first)
+- Among pending entries, messages released via [`XNACK`]({{< relref "/commands/xnack" >}}) are prioritized and reported first
+- Other idle pending entries are ordered by idle time (longer first)
 - Incoming entries are reported in the order they were added by `XADD` (older first)
 
 For example, if there are 20 idle pending entries and 200 incoming entries (in all the specified streams together):

--- a/content/commands/xreadgroup.md
+++ b/content/commands/xreadgroup.md
@@ -169,6 +169,8 @@ If there are no such messages, Redis will continue as normal (consume incoming m
 
 `CLAIM min-idle-time` is ignored if the specified id is not `>`.
 
+Messages that have been released back to the group using [`XNACK`]({{< relref "/commands/xnack" >}}), added in Redis 8.8, are immediately claimable since their delivery time is set to 0, satisfying any minimum idle time requirement.
+
 ### Reply extension for claimed entries
 
 When `CLAIM min-idle-time` is used, additional information is provided for each pending entry retrieved (similar to the reply of [`XPENDING`]({{< relref "/commands/xpending" >}})). For each claimed pending entry, the reply includes:

--- a/content/develop/data-types/streams/_index.md
+++ b/content/develop/data-types/streams/_index.md
@@ -385,6 +385,7 @@ Now it's time to zoom in to see the fundamental consumer group commands. They ar
 * [`XGROUP`]({{< relref "/commands/xgroup" >}}) is used in order to create, destroy and manage consumer groups.
 * [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) is used to read from a stream via a consumer group.
 * [`XACK`]({{< relref "/commands/xack" >}}) is the command that allows a consumer to mark a pending message as correctly processed.
+* [`XNACK`]({{< relref "/commands/xnack" >}}) is the command that allows a consumer to release pending messages back to the group without acknowledging them, making them immediately available for re-delivery to other consumers.
 * [`XACKDEL`]({{< relref "/commands/xackdel" >}}) combines acknowledgment and deletion in a single atomic operation with enhanced control over consumer group references.
 
 ## Creating a consumer group
@@ -673,6 +674,35 @@ That doesn't mean that there are no new idle pending messages, so the process co
 The counter that you observe in the [`XPENDING`]({{< relref "/commands/xpending" >}}) output is the number of deliveries of each message. The counter is incremented in two ways: when a message is successfully claimed via [`XCLAIM`]({{< relref "/commands/xclaim" >}}) or when an [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) call is used in order to access the history of pending messages.
 
 When there are failures, it is normal that messages will be delivered multiple times, but eventually they usually get processed and acknowledged. However there might be a problem processing some specific message, because it is corrupted or crafted in a way that triggers a bug in the processing code. In such a case what happens is that consumers will continuously fail to process this particular message. Because we have the counter of the delivery attempts, we can use that counter to detect messages that for some reason are not processable. So once the deliveries counter reaches a given large number that you chose, it is probably wiser to put such messages in another stream and send a notification to the system administrator. This is basically the way that Redis Streams implements the *dead letter* concept.
+
+## Releasing messages back to the group: XNACK
+
+Starting with Redis 8.8, the [`XNACK`]({{< relref "/commands/xnack" >}}) command provides a way for consumers to explicitly release pending messages back to the group without acknowledging them. This is the opposite of claiming - instead of taking ownership of messages from other consumers, a consumer can release its own messages back to the group for immediate re-delivery.
+
+This capability addresses several common scenarios:
+
+1. **Graceful shutdown**: When a consumer is shutting down, it can release all its pending messages so other consumers can pick them up immediately without waiting for idle timeouts.
+
+2. **Transient failures**: When a consumer encounters temporary issues (like network connectivity problems or resource constraints), it can release messages it cannot process rather than letting them sit idle.
+
+3. **Resource management**: A consumer under resource pressure can release complex or large messages that it cannot handle, allowing other consumers with more resources to process them.
+
+4. **Poison message handling**: A consumer can mark messages as permanently failed when it detects invalid or malicious content.
+
+The command provides three modes that control how the delivery counter is adjusted:
+
+- **SILENT**: Decrements the delivery counter, essentially "undoing" the delivery. Use this for graceful shutdowns or when the failure is unrelated to the message content.
+- **FAIL**: Keeps the delivery counter unchanged. Use this when the current consumer cannot handle the message but others might be able to.
+- **FATAL**: Sets the delivery counter to maximum value, marking the message as permanently failed for dead letter processing.
+
+Released messages are placed in a special "NACK zone" at the head of the consumer group's PEL, ensuring they are prioritized for re-delivery over other idle pending messages. This makes recovery much faster than traditional claiming mechanisms that rely on idle timeouts.
+
+```
+> XNACK mystream mygroup FAIL IDS 1 1526569498055-0
+(integer) 1
+```
+
+After NACKing, the message appears with an empty consumer in [`XPENDING`]({{< relref "/commands/xpending" >}}) output and becomes immediately available for claiming or consumption via [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) with the CLAIM option.
 
 ## Working with multiple consumer groups
 

--- a/content/develop/data-types/streams/_index.md
+++ b/content/develop/data-types/streams/_index.md
@@ -683,7 +683,7 @@ This capability addresses several common scenarios:
 
 1. **Graceful shutdown**: When a consumer is shutting down, it can release all its pending messages so other consumers can pick them up immediately without waiting for idle timeouts.
 
-2. **Transient failures**: When a consumer encounters temporary issues (like network connectivity problems or resource constraints), it can release messages it cannot process rather than letting them sit idle.
+2. **Consumer-side failures**: When a consumer encounters consumer-side issues (like network connectivity problems or resource constraints), it can release messages it cannot process rather than letting them sit idle.
 
 3. **Resource management**: A consumer under resource pressure can release complex or large messages that it cannot handle, allowing other consumers with more resources to process them.
 

--- a/static/images/railroad/xnack.svg
+++ b/static/images/railroad/xnack.svg
@@ -1,0 +1,68 @@
+<svg class="railroad-diagram" height="131" viewBox="0 0 995.0 131" width="995.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M945.0 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M112.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="50.0" y="29"></rect><text x="81.25" y="44">XNACK</text></g><path d="M112.5 40h10"></path><path d="M122.5 40h10"></path><g class="non-terminal ">
+<path d="M132.5 40h0.0"></path><path d="M178.0 40h0.0"></path><rect height="22" width="45.5" x="132.5" y="29"></rect><text x="155.25" y="44">key</text></g><path d="M178.0 40h10"></path><path d="M188.0 40h10"></path><g class="non-terminal ">
+<path d="M198.0 40h0.0"></path><path d="M260.5 40h0.0"></path><rect height="22" width="62.5" x="198.0" y="29"></rect><text x="229.25" y="44">group</text></g><path d="M260.5 40h10"></path><g>
+<path d="M270.5 40h0.0"></path><path d="M381.5 40h0.0"></path><path d="M270.5 40h20"></path><g class="terminal ">
+<path d="M290.5 40h0.0"></path><path d="M361.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="290.5" y="29"></rect><text x="326.0" y="44">SILENT</text></g><path d="M361.5 40h20"></path><path d="M270.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M290.5 70h8.5"></path><path d="M353.0 70h8.5"></path><rect height="22" rx="10" ry="10" width="54.0" x="299.0" y="59"></rect><text x="326.0" y="74">FAIL</text></g><path d="M361.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M270.5 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M290.5 100h4.25"></path><path d="M357.25 100h4.25"></path><rect height="22" rx="10" ry="10" width="62.5" x="294.75" y="89"></rect><text x="326.0" y="104">FATAL</text></g><path d="M361.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path></g><path d="M381.5 40h10"></path><g>
+<path d="M391.5 40h0.0"></path><path d="M605.0 40h0.0"></path><g class="terminal ">
+<path d="M391.5 40h0.0"></path><path d="M437.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="391.5" y="29"></rect><text x="414.25" y="44">IDS</text></g><path d="M437.0 40h10"></path><path d="M447.0 40h10"></path><g class="non-terminal ">
+<path d="M457.0 40h0.0"></path><path d="M528.0 40h0.0"></path><rect height="22" width="71.0" x="457.0" y="29"></rect><text x="492.5" y="44">numids</text></g><path d="M528.0 40h10"></path><path d="M538.0 40h10"></path><g>
+<path d="M548.0 40h0.0"></path><path d="M605.0 40h0.0"></path><path d="M548.0 40h10"></path><g class="non-terminal ">
+<path d="M558.0 40h0.0"></path><path d="M595.0 40h0.0"></path><rect height="22" width="37.0" x="558.0" y="29"></rect><text x="576.5" y="44">id</text></g><path d="M595.0 40h10"></path><path d="M558.0 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M558.0 60h37.0"></path></g><path d="M595.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M605.0 40h10"></path><g>
+<path d="M615.0 40h0.0"></path><path d="M842.5 40h0.0"></path><path d="M615.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M635.0 20h187.5"></path></g><path d="M822.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M615.0 40h20"></path><g>
+<path d="M635.0 40h0.0"></path><path d="M822.5 40h0.0"></path><g class="terminal ">
+<path d="M635.0 40h0.0"></path><path d="M740.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="635.0" y="29"></rect><text x="687.5" y="44">RETRYCOUNT</text></g><path d="M740.0 40h10"></path><path d="M750.0 40h10"></path><g class="non-terminal ">
+<path d="M760.0 40h0.0"></path><path d="M822.5 40h0.0"></path><rect height="22" width="62.5" x="760.0" y="29"></rect><text x="791.25" y="44">count</text></g></g><path d="M822.5 40h20"></path></g><g>
+<path d="M842.5 40h0.0"></path><path d="M945.0 40h0.0"></path><path d="M842.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M862.5 20h62.5"></path></g><path d="M925.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M842.5 40h20"></path><g class="terminal ">
+<path d="M862.5 40h0.0"></path><path d="M925.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="862.5" y="29"></rect><text x="893.75" y="44">FORCE</text></g><path d="M925.0 40h20"></path></g></g><path d="M945.0 40h10"></path><path d="M 955.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
Redis 8.8 content

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a new static SVG asset; no runtime code paths or data handling are modified.
> 
> **Overview**
> Documents the new Redis 8.8 `XNACK` command (including syntax, modes, examples, and behavior) and adds its railroad diagram asset.
> 
> Updates stream consumer-group docs (`XCLAIM`, `XAUTOCLAIM`, `XREADGROUP`, `XPENDING`, and Streams intro) to explain that `XNACK` releases messages back to the group as unowned, immediately claimable entries, affects how the consumer field is reported (empty string), and that `XREADGROUP ... CLAIM` prioritizes NACKed entries. Also extends `XINFO STREAM FULL` docs/history to include the new `nacked-count` field, and fixes `XCFGSET` front-matter formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19fb36f9596e0ed90ef89851bdf8d9cb8420fa64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->