### PR TITLE
DOC-6459 Integrate RS failover docs with client-specific stuff

### DIFF
--- a/content/operate/rs/databases/active-active/disaster-recovery/client-library-based.md
+++ b/content/operate/rs/databases/active-active/disaster-recovery/client-library-based.md
@@ -47,8 +47,13 @@ The following diagram shows a client-based disaster recovery approach that also 
 <img src="../../../../../../images/active-active-disaster-recovery/client-library-connection-pool.svg" alt="Diagram of client libraries with connection pooling routing traffic to Active-Active database members" width="50%">
 </div>
 
-For additional information, see the following client library guides for failover and failback:
+For additional information, see the the introduction to
+[Client-side geographic failover]({{<relref "/develop/clients/failover">}})
+and also the following client library guides for failover and failback:
 
 - [Jedis (Java)]({{<relref "/develop/clients/jedis/failover">}})
 
+- [Lettuce (Java)]({{<relref "/develop/clients/lettuce/failover">}})
+
 - [redis-py (Python)]({{<relref "/develop/clients/redis-py/failover">}})
+


### PR DESCRIPTION
First step in integrating the general RS info about active-active health checks, failover, etc, with the info in the [clients section](https://redis.io/docs/latest/develop/clients/failover/). 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust cross-links between pages; low risk aside from potential broken `relref`/typo issues.
> 
> **Overview**
> Updates the Active-Active client-library disaster recovery doc to point readers to the overview page for `Client-side geographic failover` before listing client-specific guides.
> 
> Also expands the referenced client list by adding the `Lettuce` failover guide link alongside existing `Jedis` and `redis-py` links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b4ebe755fddec2856d57c446fcac009a9e46756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->