### PR TITLE
Update privatelink limitations for GA

### DIFF
--- a/content/operate/rc/security/aws-privatelink.md
+++ b/content/operate/rc/security/aws-privatelink.md
@@ -31,9 +31,8 @@ See [Connect to Redis Cloud with AWS PrivateLink](https://www.youtube.com/watch?
 ## Limitations
 
 Be aware of the following limitations when using PrivateLink with Redis Cloud:
-- You cannot use the [OSS Cluster API]({{< relref "/operate/rc/databases/configuration/clustering#oss-cluster-api" >}}) with PrivateLink during preview.
-- You cannot use Layer 3 connectivity options like VPC peering or Transit Gateway with PrivateLink during private preview. 
-- Redis Cloud subscriptions with AWS PrivateLink are limited to a maximum of 55 databases. [Contact support](https://redis.com/company/support/) if you need more than 55 databases in one subscription with AWS PrivateLink.
+- You cannot use the [OSS Cluster API]({{< relref "/operate/rc/databases/configuration/clustering#oss-cluster-api" >}}) with PrivateLink yet. Support for OSS clustering API will be supported in the near future.
+- If you use Layer 3 connectivity options like VPC peering or Transit Gateway together with PrivateLink in the same consumer VPC, the database endpoints exposed through PrivateLink's private DNS will resolve to the VPC endpoint and not to the IPs associated with the Layer 3 connectivity options.
 - Your subnets must have at least 16 available IP addresses for the resource endpoint.
 - Some AWS regions do not support PrivateLink Resource Endpoints. See [AWS VPC Lattice Pricing](https://aws.amazon.com/vpc/lattice/pricing/) for a list of regions that support AWS PrivateLink Resource Endpoints.
 - Redis Cloud's PrivateLink implementation uses PrivateLink Resource Endpoints, which is based on Amazon VPC Lattice, so the [VPC Lattice quotas](https://docs.aws.amazon.com/vpc-lattice/latest/ug/quotas.html) apply. Currently, the following availability zones are not supported with Amazon VPC Lattice: 

--- a/content/operate/rc/security/aws-privatelink.md
+++ b/content/operate/rc/security/aws-privatelink.md
@@ -31,7 +31,7 @@ See [Connect to Redis Cloud with AWS PrivateLink](https://www.youtube.com/watch?
 ## Limitations
 
 Be aware of the following limitations when using PrivateLink with Redis Cloud:
-- You cannot use the [OSS Cluster API]({{< relref "/operate/rc/databases/configuration/clustering#oss-cluster-api" >}}) with PrivateLink yet. Support for OSS clustering API will be supported in the near future.
+- You cannot use the [OSS Cluster API]({{< relref "/operate/rc/databases/configuration/clustering#oss-cluster-api" >}}) with PrivateLink yet. Support for the OSS Cluster API will be supported in the near future.
 - If you use Layer 3 connectivity options like VPC peering or Transit Gateway together with PrivateLink in the same consumer VPC, the database endpoints exposed through PrivateLink's private DNS will resolve to the VPC endpoint and not to the IPs associated with the Layer 3 connectivity options.
 - Your subnets must have at least 16 available IP addresses for the resource endpoint.
 - Some AWS regions do not support PrivateLink Resource Endpoints. See [AWS VPC Lattice Pricing](https://aws.amazon.com/vpc/lattice/pricing/) for a list of regions that support AWS PrivateLink Resource Endpoints.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits adjusting stated AWS PrivateLink limitations; no product code or configuration behavior changes.
> 
> **Overview**
> Updates `aws-privatelink.md` to refresh AWS PrivateLink limitations for GA: removes private/preview language and the 55-database subscription limit, and clarifies that the `OSS Cluster API` is not yet supported.
> 
> Adds a new limitation describing how PrivateLink private DNS resolves when Layer 3 connectivity (VPC peering/Transit Gateway) is also used in the same consumer VPC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c8488666902a16d0d5bcc1aa27be5e5cb49ab81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->