### PR TITLE
DEV: (cmds) More JSON commands clarifications

### DIFF
--- a/content/commands/json.objkeys.md
+++ b/content/commands/json.objkeys.md
@@ -22,7 +22,7 @@ categories:
 complexity: O(N) when path is evaluated to a single value, where N is the number of
   keys in the object, O(N) when path is evaluated to multiple values, where N is the
   size of the key
-description: Returns the key names of JSON objects located at the paths that match a given path expression
+description: Returns the key names of JSON objects located at the paths matching a given path expression
 group: json
 hidden: false
 linkTitle: JSON.OBJKEYS
@@ -30,11 +30,11 @@ module: JSON
 railroad_diagram: /images/railroad/json.objkeys.svg
 since: 1.0.0
 stack_path: docs/data-types/json
-summary: Returns the key names of JSON objects located at the paths that match a given path expression
+summary: Returns the key names of JSON objects located at the paths matching a given path expression
 syntax_fmt: JSON.OBJKEYS key [path]
 title: JSON.OBJKEYS
 ---
-Returns the key names of JSON objects located at the paths that match a given path expression.
+Returns the key names of JSON objects located at the paths matching a given path expression.
 
 {{< note >}}
 A JSON object is a structure within a JSON document that contains an unordered set of key-value pairs (also called name-value pairs). Do not confuse Redis keys with JSON object keys.

--- a/content/commands/json.objkeys.md
+++ b/content/commands/json.objkeys.md
@@ -22,7 +22,7 @@ categories:
 complexity: O(N) when path is evaluated to a single value, where N is the number of
   keys in the object, O(N) when path is evaluated to multiple values, where N is the
   size of the key
-description: Returns the key names of JSON objects located at the paths matching a given path expression
+description: Returns the key names of JSON objects at the paths matching a given path expression
 group: json
 hidden: false
 linkTitle: JSON.OBJKEYS
@@ -30,11 +30,11 @@ module: JSON
 railroad_diagram: /images/railroad/json.objkeys.svg
 since: 1.0.0
 stack_path: docs/data-types/json
-summary: Returns the key names of JSON objects located at the paths matching a given path expression
+summary: Returns the key names of JSON objects at the paths matching a given path expression
 syntax_fmt: JSON.OBJKEYS key [path]
 title: JSON.OBJKEYS
 ---
-Returns the key names of JSON objects located at the paths matching a given path expression.
+Returns the key names of JSON objects at the paths matching a given path expression.
 
 {{< note >}}
 A JSON object is a structure within a JSON document that contains an unordered set of key-value pairs (also called name-value pairs). Do not confuse Redis keys with JSON object keys.

--- a/content/commands/json.objlen.md
+++ b/content/commands/json.objlen.md
@@ -21,7 +21,7 @@ categories:
 - clients
 complexity: O(1) when path is evaluated to a single value, O(N) when path is evaluated
   to multiple values, where N is the size of the key
-description: Returns the number of keys in JSON objects located at the paths matching a given path expression
+description: Returns the number of keys in JSON objects at the paths matching a given path expression
 group: json
 hidden: false
 linkTitle: JSON.OBJLEN
@@ -29,11 +29,11 @@ module: JSON
 railroad_diagram: /images/railroad/json.objlen.svg
 since: 1.0.0
 stack_path: docs/data-types/json
-summary: Returns the number of keys in JSON objects located at the paths matching a given path expression
+summary: Returns the number of keys in JSON objects at the paths matching a given path expression
 syntax_fmt: JSON.OBJLEN key [path]
 title: JSON.OBJLEN
 ---
-Returns the number of keys in JSON objects located at the paths matching a given path expression.
+Returns the number of keys in JSON objects at the paths matching a given path expression.
 
 {{< note >}}
 A JSON object is a structure within a JSON document that contains an unordered set of key-value pairs (also called name-value pairs). Do not confuse Redis keys with JSON object keys.

--- a/content/commands/json.objlen.md
+++ b/content/commands/json.objlen.md
@@ -21,7 +21,7 @@ categories:
 - clients
 complexity: O(1) when path is evaluated to a single value, O(N) when path is evaluated
   to multiple values, where N is the size of the key
-description: Returns the number of keys in JSON objects located at the paths that match a given path expression
+description: Returns the number of keys in JSON objects located at the paths matching a given path expression
 group: json
 hidden: false
 linkTitle: JSON.OBJLEN
@@ -29,11 +29,11 @@ module: JSON
 railroad_diagram: /images/railroad/json.objlen.svg
 since: 1.0.0
 stack_path: docs/data-types/json
-summary: Returns the number of keys in JSON objects located at the paths that match a given path expression
+summary: Returns the number of keys in JSON objects located at the paths matching a given path expression
 syntax_fmt: JSON.OBJLEN key [path]
 title: JSON.OBJLEN
 ---
-Returns the number of keys in JSON objects located at the paths that match a given path expression.
+Returns the number of keys in JSON objects located at the paths matching a given path expression.
 
 {{< note >}}
 A JSON object is a structure within a JSON document that contains an unordered set of key-value pairs (also called name-value pairs). Do not confuse Redis keys with JSON object keys.

--- a/content/commands/json.strappend.md
+++ b/content/commands/json.strappend.md
@@ -121,7 +121,7 @@ If `path` is a JSONPath expression:
 - A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
 - An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
 - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - A [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
   - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string.
 
 If `path` is a legacy path expression:

--- a/content/commands/json.strappend.md
+++ b/content/commands/json.strappend.md
@@ -47,6 +47,17 @@ is a Redis key storing a value of type JSON.
 
 </details>
 
+<details open><summary><code>value</code></summary> 
+
+is a string to append to the JSON strings at the paths matching `path`.
+
+{{% alert title="About using strings with JSON commands" color="warning" %}}
+To specify a string as an array value to append, wrap the quoted string with an additional set of single quotes. Example: `'"silver"'`. For more detailed use, see [Examples](#examples).
+{{% /alert %}}
+</details>
+
+## Optional arguments
+
 <details open><summary><code>path</code></summary> 
 
 is either 
@@ -58,16 +69,9 @@ is either
   - Any string that does not match the JSONPath syntax above.
   - Allow the leading "`.`" to be omitted (for example, "`name`" and "`.name`" are equivalent).
   - Resolves to only the first matching location in `key`.
+ 
+Default: "`.`" (legacy path pointing to the root of the document).
 
-</details>
-
-<details open><summary><code>value</code></summary> 
-
-is a string to append to the JSON strings at the paths matching `path`.
-
-{{% alert title="About using strings with JSON commands" color="warning" %}}
-To specify a string as an array value to append, wrap the quoted string with an additional set of single quotes. Example: `'"silver"'`. For more detailed use, see [Examples](#examples).
-{{% /alert %}}
 </details>
 
 ## Examples

--- a/content/commands/json.strappend.md
+++ b/content/commands/json.strappend.md
@@ -121,7 +121,7 @@ If `path` is a JSONPath expression:
 - A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
 - An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
 - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
+  - A [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
   - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string.
 
 If `path` is a legacy path expression:

--- a/content/commands/json.strappend.md
+++ b/content/commands/json.strappend.md
@@ -121,7 +121,7 @@ If `path` is a JSONPath expression:
 - A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
 - An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
 - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if the match is not a string.
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
   - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string.
 
 If `path` is a legacy path expression:

--- a/content/commands/json.strappend.md
+++ b/content/commands/json.strappend.md
@@ -23,7 +23,7 @@ categories:
 - clients
 complexity: O(1) when path is evaluated to a single value, O(N) when path is evaluated
   to multiple values, where N is the size of the key
-description: Appends a string to a JSON string value at path
+description: Appends a string to JSON strings at the paths matching a given path expression
 group: json
 hidden: false
 linkTitle: JSON.STRAPPEND
@@ -31,11 +31,11 @@ module: JSON
 railroad_diagram: /images/railroad/json.strappend.svg
 since: 1.0.0
 stack_path: docs/data-types/json
-summary: Appends a string to a JSON string value at path
+summary: Appends a string to JSON strings at the paths matching a given path expression
 syntax_fmt: JSON.STRAPPEND key [path] value
 title: JSON.STRAPPEND
 ---
-Append the `json-string` values to the string at `path`
+Appends a string to JSON strings at the paths matching a given path expression.
 
 [Examples](#examples)
 
@@ -43,23 +43,31 @@ Append the `json-string` values to the string at `path`
 
 <details open><summary><code>key</code></summary> 
 
-is key to modify.
+is a Redis key storing a value of type JSON.
+
+</details>
+
+<details open><summary><code>path</code></summary> 
+
+is either 
+
+- A JSONPath expression
+  - The root "`$`", or any string that starts with "`$.`" or "`$[`".
+  - Resolves to all matching locations in `key`.
+- A legacy path expression 
+  - Any string that does not match the JSONPath syntax above.
+  - Allow the leading "`.`" to be omitted (for example, "`name`" and "`.name`" are equivalent).
+  - Resolves to only the first matching location in `key`.
+
 </details>
 
 <details open><summary><code>value</code></summary> 
 
-is value to append to one or more strings. 
+is a string to append to the JSON strings at the paths matching `path`.
 
 {{% alert title="About using strings with JSON commands" color="warning" %}}
 To specify a string as an array value to append, wrap the quoted string with an additional set of single quotes. Example: `'"silver"'`. For more detailed use, see [Examples](#examples).
 {{% /alert %}}
-</details>
-
-## Optional arguments
-
-<details open><summary><code>path</code></summary> 
-
-is JSONPath to specify. Default is root `$`.
 </details>
 
 ## Examples
@@ -87,24 +95,46 @@ redis> JSON.GET doc $
     tab1="RESP2"
     tab2="RESP3" >}}
 
-With `$`-based path argument: [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) or [null replies]({{< relref "/develop/reference/protocol-spec#nulls" >}}), where each element is the string's new length, or `null` if the matching value is not a string.
+If `path` is a JSONPath expression:
 
-With `.`-based path argument: [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) representing the string's new length, or [null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the matching value is not a string.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if the match is not a string.
+  - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string.
+
+If `path` is a legacy path expression:
+
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `path` has no matches.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not a string.
+- An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string at the first match.
 
 -tab-sep-
 
-With `$`-based path argument (default): [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) or [null replies]({{< relref "/develop/reference/protocol-spec#nulls" >}}), where each element is the string's new length, or `null` if the matching value is not a string.
+If `path` is a JSONPath expression:
 
-With `.`-based path argument: [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) representing the string's new length, or [null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the matching value is not a string.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if the match is not a string.
+  - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string.
+
+If `path` is a legacy path expression:
+
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `path` has no matches.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not a string.
+- An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string at the first match.
 
 {{< /multitabs >}}
 
 ## See also
 
-`JSON.ARRAPEND` | [`JSON.ARRINSERT`]({{< relref "commands/json.arrinsert/" >}}) 
+[`JSON.STRLEN`]({{< relref "commands/json.strlen/" >}}) | [`JSON.ARRAPPEND`]({{< relref "commands/json.arrappend/" >}})
 
 ## Related topics
 
-* [RedisJSON]({{< relref "/develop/data-types/json/" >}})
+* [The JSON data type]({{< relref "/develop/data-types/json/" >}})
+* [JSONPath]({{< relref "/develop/data-types/json/path" >}})
 * [Index and search JSON documents]({{< relref "/develop/ai/search-and-query/indexing/" >}})
-

--- a/content/commands/json.strappend.md
+++ b/content/commands/json.strappend.md
@@ -121,7 +121,7 @@ If `path` is a JSONPath expression:
 - A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
 - An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
 - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
+  - [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
   - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the new length of the string.
 
 If `path` is a legacy path expression:

--- a/content/commands/json.strlen.md
+++ b/content/commands/json.strlen.md
@@ -108,7 +108,7 @@ If `path` is a JSONPath expression:
 - A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
 - An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
 - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - A [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.  
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.  
   - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the length of the string.
 
 If `path` is a legacy path expression:

--- a/content/commands/json.strlen.md
+++ b/content/commands/json.strlen.md
@@ -108,7 +108,7 @@ If `path` is a JSONPath expression:
 - A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
 - An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
 - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
+  - [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.  
   - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the length of the string.
 
 If `path` is a legacy path expression:

--- a/content/commands/json.strlen.md
+++ b/content/commands/json.strlen.md
@@ -21,7 +21,7 @@ categories:
 - clients
 complexity: O(1) when path is evaluated to a single value, O(N) when path is evaluated
   to multiple values, where N is the size of the key
-description: Returns the length of the JSON String at path in key
+description: Returns the length of JSON strings at the paths matching a given path expression
 group: json
 hidden: false
 linkTitle: JSON.STRLEN
@@ -29,11 +29,11 @@ module: JSON
 railroad_diagram: /images/railroad/json.strlen.svg
 since: 1.0.0
 stack_path: docs/data-types/json
-summary: Returns the length of the JSON String at path in key
+summary: Returns the length of JSON strings at the paths matching a given path expression
 syntax_fmt: JSON.STRLEN key [path]
 title: JSON.STRLEN
 ---
-Report the length of the JSON String at `path` in `key`
+Returns the length of JSON strings at the paths matching a given path expression.
 
 [Examples](#examples)
 
@@ -41,14 +41,26 @@ Report the length of the JSON String at `path` in `key`
 
 <details open><summary><code>key</code></summary> 
 
-is key to parse.
+is a Redis key storing a value of type JSON.
+
 </details>
 
 ## Optional arguments
 
 <details open><summary><code>path</code></summary> 
 
-is JSONPath to specify. Default is root `$`, if not provided. Returns null if the `key` or `path` do not exist.
+is either 
+
+- A JSONPath expression
+  - The root "`$`", or any string that starts with "`$.`" or "`$[`".
+  - Resolves to all matching locations in `key`.
+- A legacy path expression 
+  - Any string that does not match the JSONPath syntax above.
+  - Allow the leading "`.`" to be omitted (for example, "`name`" and "`.name`" are equivalent).
+  - Resolves to only the first matching location in `key`.
+
+Default: "`.`" (legacy path pointing to the root of the document).
+
 </details>
 
 ## Examples
@@ -74,23 +86,46 @@ redis> JSON.STRLEN doc $..a
     tab1="RESP2"
     tab2="RESP3" >}}
 
-With `$`-based path argument: [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) or [null replies]({{< relref "/develop/reference/protocol-spec#nulls" >}}), where each element is the string's length, or `null` if the matching value is not a string.
+If `path` is a JSONPath expression:
 
-With `.`-based path argument: [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) representing the string's length, or [null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the matching value is not a string.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if the match is not a string.
+  - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the length of the string.
+
+If `path` is a legacy path expression:
+
+- [`nil`]({{< relref "/develop/reference/protocol-spec#null-bulk-strings" >}}) if `key` does not exist.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `path` has no matches.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not a string.
+- An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the length of the string at the first match.
 
 -tab-sep-
 
-With `$`-based path argument (default): [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) or [null replies]({{< relref "/develop/reference/protocol-spec#nulls" >}}), where each element is the string's length, or `null` if the matching value is not a string.
+If `path` is a JSONPath expression:
 
-With `.`-based path argument: [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) representing the string's length, or [null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the matching value is not a string.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
+- An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
+- An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
+  - [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.
+  - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the length of the string.
+
+If `path` is a legacy path expression:
+
+- [`nil`]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if `key` does not exist.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `path` has no matches.
+- A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if the first match is not a string.
+- An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the length of the string at the first match.
 
 {{< /multitabs >}}
 
 ## See also
 
-[`JSON.ARRLEN`]({{< relref "commands/json.arrlen/" >}}) | [`JSON.ARRINSERT`]({{< relref "commands/json.arrinsert/" >}}) 
+[`JSON.STRAPPEND`]({{< relref "commands/json.strappend/" >}}) | [`JSON.ARRLEN`]({{< relref "commands/json.arrlen/" >}}) | [`JSON.OBJLEN`]({{< relref "commands/json.objlen/" >}}) 
 
 ## Related topics
 
-* [RedisJSON]({{< relref "/develop/data-types/json/" >}})
+* [The JSON data type]({{< relref "/develop/data-types/json/" >}})
+* [JSONPath]({{< relref "/develop/data-types/json/path" >}})
 * [Index and search JSON documents]({{< relref "/develop/ai/search-and-query/indexing/" >}})

--- a/content/commands/json.strlen.md
+++ b/content/commands/json.strlen.md
@@ -108,7 +108,7 @@ If `path` is a JSONPath expression:
 - A [simple error]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) if `key` does not exist.
 - An empty [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) if `path` has no matches.
 - An [array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each array element corresponds to one match:
-  - [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.  
+  - A [Null reply]({{< relref "/develop/reference/protocol-spec#nulls" >}}) if the match is not a string.  
   - An [integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): the length of the string.
 
 If `path` is a legacy path expression:


### PR DESCRIPTION
Updated the description and summary to clarify that the command returns the length of JSON strings at multiple paths matching a given path expression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only wording updates that clarify JSONPath vs legacy path behavior and expected replies; no runtime or API behavior changes.
> 
> **Overview**
> Clarifies `JSON.OBJKEYS` and `JSON.OBJLEN` descriptions/summaries to state they operate on objects at *paths matching* a path expression.
> 
> Rewrites `JSON.STRLEN` and `JSON.STRAPPEND` docs to emphasize multi-match behavior, explicitly document JSONPath vs legacy path defaults, and detail per-mode return/error semantics. Also refreshes argument descriptions and cross-links (see also/related topics) to point to `JSONPath` and related JSON string/array commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc3cab0b32e65d30891901cc51508a13d1697f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->