### PR TITLE
FF: name change and latest update section

### DIFF
--- a/content/develop/ai/_index.md
+++ b/content/develop/ai/_index.md
@@ -19,9 +19,9 @@ Redis stores and indexes vector embeddings that semantically represent unstructu
   {{< image-card image="images/ai-brain.svg" alt="AI Redis icon" title="Use LangCache to store LLM responses" url="/develop/ai/langcache/" >}}
 </div>
 
-## Featureform
+## Redis Feature Form
 
-Use [Featureform]({{< relref "/develop/ai/featureform/" >}}) to define, manage, and serve machine learning features on top of your existing data systems. The Featureform docs cover the Python SDK workflow from provider registration through feature serving.
+Use [Redis Feature Form]({{< relref "/develop/ai/featureform/" >}}) to define, manage, and serve machine learning features on top of your existing data systems. The Feature Form docs cover the Python SDK workflow from provider registration through feature serving.
 
 #### Overview
 

--- a/content/develop/ai/featureform/_index.md
+++ b/content/develop/ai/featureform/_index.md
@@ -7,43 +7,13 @@ categories:
 - ai
 description: Build feature engineering workflows with Redis Feature Form.
 linkTitle: Redis Feature Form
-hideListLinks: true
 weight: 60
 bannerText: Redis Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
 bannerChildren: true
 ---
 
-Redis Feature Form helps data teams define, materialize, and serve machine learning features by using a declarative Python SDK on top of existing data systems.
+Redis Feature Form helps teams define, manage, materialize, and serve machine learning features while keeping existing data systems in place. In the documented workflow, Redis acts as the low-latency online store for feature serving.
 
-Feature Form works with offline systems such as Snowflake, BigQuery, and Databricks or Spark, then uses Redis as the low-latency online store for feature serving.
+This documentation describes platform setup, workspace access, provider and secret registration, definitions-file authoring, apply, and serving.
 
-## Get started
 
-- [Overview]({{< relref "/develop/ai/featureform/overview" >}})
-- [Quickstart]({{< relref "/develop/ai/featureform/quickstart" >}})
-- [Connect providers]({{< relref "/develop/ai/featureform/providers" >}})
-- [Define datasets and transformations]({{< relref "/develop/ai/featureform/datasets-and-transformations" >}})
-- [Define features and labels]({{< relref "/develop/ai/featureform/features-and-labels" >}})
-- [Work with training sets and feature views]({{< relref "/develop/ai/featureform/training-sets-and-feature-views" >}})
-
-## Latest updates
-
-The latest release adds enterprise-oriented capabilities:
-
-- **Unified batch and streaming pipelines**: Support for tiling, backfills, and incremental updates reduces custom pipeline work.
-- **Workspaces for multi-tenancy**: Isolate providers, data, authentication, and observability at the workspace level.
-- **Fine-grained job control**: Planning, impact analysis, split materializations, and queue-based job management provide visibility into changes before they affect production systems.
-- **Atomic DAG updates**: Manage graph-level changes atomically instead of versioning individual resources, which simplifies rollback and change history.
-- **Enhanced RBAC and security**: Workspace-scoped access controls, API key pairs, a granular role model, audit logs, secret-provider improvements, mTLS, and encrypted internal transport.
-- **Two-service deployment model**: A simplified deployment architecture that reduces operational complexity.
-- **Redesigned dashboard**: Configure workspaces and providers directly from the UI.
-
-## Next steps
-
-- [Streaming features]({{< relref "/develop/ai/featureform/streaming" >}})
-
-## What this section covers
-
-- The Python SDK workflow for registering providers, datasets, transformations, entities, features, labels, training sets, and feature views
-- The distinction between metadata registration and materialization in the current API
-- Point-in-time correct feature definitions for both batch and streaming workflows

--- a/content/develop/ai/featureform/_index.md
+++ b/content/develop/ai/featureform/_index.md
@@ -1,21 +1,21 @@
 ---
-Title: Featureform
+Title: Redis Feature Form
 alwaysopen: false
 categories:
 - docs
 - develop
 - ai
-description: Build feature engineering workflows with Featureform and Redis.
-linkTitle: Featureform
+description: Build feature engineering workflows with Redis Feature Form.
+linkTitle: Redis Feature Form
 hideListLinks: true
 weight: 60
-bannerText: Featureform is currently in preview and subject to change. To request access to the Featureform Docker image, contact your Redis account team.
+bannerText: Redis Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
 bannerChildren: true
 ---
 
-Featureform helps data teams define, materialize, and serve machine learning features by using a declarative Python SDK on top of existing data systems.
+Redis Feature Form helps data teams define, materialize, and serve machine learning features by using a declarative Python SDK on top of existing data systems.
 
-Featureform works with offline systems such as Snowflake, BigQuery, and Databricks or Spark, then uses Redis as the low-latency online store for feature serving.
+Feature Form works with offline systems such as Snowflake, BigQuery, and Databricks or Spark, then uses Redis as the low-latency online store for feature serving.
 
 ## Get started
 
@@ -25,6 +25,18 @@ Featureform works with offline systems such as Snowflake, BigQuery, and Databric
 - [Define datasets and transformations]({{< relref "/develop/ai/featureform/datasets-and-transformations" >}})
 - [Define features and labels]({{< relref "/develop/ai/featureform/features-and-labels" >}})
 - [Work with training sets and feature views]({{< relref "/develop/ai/featureform/training-sets-and-feature-views" >}})
+
+## Latest updates
+
+The latest release adds enterprise-oriented capabilities:
+
+- **Unified batch and streaming pipelines**: Support for tiling, backfills, and incremental updates reduces custom pipeline work.
+- **Workspaces for multi-tenancy**: Isolate providers, data, authentication, and observability at the workspace level.
+- **Fine-grained job control**: Planning, impact analysis, split materializations, and queue-based job management provide visibility into changes before they affect production systems.
+- **Atomic DAG updates**: Manage graph-level changes atomically instead of versioning individual resources, which simplifies rollback and change history.
+- **Enhanced RBAC and security**: Workspace-scoped access controls, API key pairs, a granular role model, audit logs, secret-provider improvements, mTLS, and encrypted internal transport.
+- **Two-service deployment model**: A simplified deployment architecture that reduces operational complexity.
+- **Redesigned dashboard**: Configure workspaces and providers directly from the UI.
 
 ## Next steps
 

--- a/content/develop/ai/featureform/_index.md
+++ b/content/develop/ai/featureform/_index.md
@@ -14,6 +14,6 @@ bannerChildren: true
 
 Redis Feature Form helps teams define, manage, materialize, and serve machine learning features while keeping existing data systems in place. In the documented workflow, Redis acts as the low-latency online store for feature serving.
 
-This documentation describes platform setup, workspace access, provider and secret registration, definitions-file authoring, apply, and serving.
+This documentation describes platform setup, workspace access, provider and secret registration, definitions-file authoring, apply, and serving. Refer to [Deploy]({{< relref "/operate/featureform" >}}) for installation and authentication instructions.
 
 

--- a/content/develop/ai/featureform/datasets-and-transformations.md
+++ b/content/develop/ai/featureform/datasets-and-transformations.md
@@ -1,190 +1,234 @@
 ---
-title: Datasets and transformations in Redis Feature Form
-description: Register datasets and define SQL or DataFrame transformations for Feature Form features.
-linkTitle: Datasets and transformations
-weight: 40
+title: Reference
+description: Reference documentation for Featureform APIs, CLI commands, Python surfaces, and RBAC.
+linkTitle: Reference
+weight: 90
 ---
 
-Datasets and transformations are the bridge between your raw source data and your feature definitions.
+Use these pages when you need current interfaces rather than a guided workflow.
 
-- datasets point Feature Form at existing tables or files
-- transformations create reusable feature engineering logic on top of those datasets
+## Featureform gRPC services
 
-## Register datasets
+```json metadata
+{
+  "title": "Featureform gRPC services",
+  "description": "Review the current public Featureform gRPC service surface, resource APIs, and major message types.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"service-index","title":"Service index"},{"id":"notable-service-areas","title":"Notable service areas"},{"id":"important-apply-fields","title":"Important apply fields"},{"id":"common-provider-related-models","title":"Common provider-related models"}]}
 
-Register the source objects that Feature Form should treat as named inputs.
+,
+  "codeExamples": []
+}
+```
+This section indexes the public gRPC API surface exposed by Feature Form.
 
-### Warehouse tables
+### Service index
+
+| Service | Purpose |
+| --- | --- |
+| `WorkspaceService` | Workspace CRUD and lookup |
+| `ProviderService` | Workspace-scoped provider CRUD |
+| `SecretProviderService` | Workspace-scoped secret-provider CRUD |
+| `ApplyService` | Declarative graph apply and dry-run planning |
+| `ResourceService` | Graph browsing, lineage, search, versions, and workspace stats |
+| `CatalogService` | Physical catalog inspection |
+| `ServingService` | Online serving and serving metadata |
+| `DataframeService` | Dataframe plan resolution |
+| `RbacService` | Roles, permissions, access, and bindings |
+| `MachineCredentialService` | Machine credential lifecycle |
+| `AuditService` | Audit log listing |
+| `VersionService` | Version compatibility and auth discovery metadata |
+
+### Notable service areas
+
+- `WorkspaceService`: create, get, list, update, delete
+- `ProviderService`: register, get, list, update, delete
+- `SecretProviderService`: register, get, list, update, delete
+- `ApplyService`: apply and plan
+- `ResourceService`: per-resource get and list plus lineage, impact, versions, and workspace stats
+
+### Important apply fields
+
+- `workspace_id`
+- `resources`
+- `dry_run`
+- `apply_strategy`
+- `execution_mode`
+
+### Common provider-related models
+
+- `PostgresConfig`
+- `SnowflakeConfig`
+- `S3Config`
+- `SparkProviderConfig`
+- `ProviderHealth`
+- `SecretRef`
+
+## Feature Form CLI
+
+This section documents the current public `ff` CLI surface.
+
+### Global flags
+
+Connection and transport:
+
+- `--server`, `-s`
+- `--grpc-server`
+- `--transport rest|grpc`
+- `--timeout`, `-t`
+- `--no-tls`
+
+Authentication:
+
+- `--token`
+- `--client-id`
+- `--client-secret`
+- `--issuer-url`
+
+CLI behavior:
+
+- `--output`, `-o`
+- `--config`
+- `--no-color`
+- `--verbose`, `-v`
+- `--skip-version-check`
+
+### Top-level commands
+
+- `ff version`
+- `ff ping`
+- `ff workspace`
+- `ff provider`
+- `ff secret-provider`
+- `ff apply`
+- `ff auth`
+- `ff rbac`
+- `ff machine-credential`
+- `ff audit`
+- `ff catalog`
+- `ff graph`
+- `ff scheduler`
+- `ff dataframe`
+- `ff config`
+
+### Transport note
+
+The CLI defaults to REST in code, but many operational examples use explicit gRPC. In memory-backed deployments, REST and gRPC do not share one durable state backend.
+
+## Python client and DSL reference
+
+```json metadata
+{
+  "title": "Python client and DSL reference",
+  "description": "Review the main Featureform Python client APIs, resource types, helpers, and common authoring patterns.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"client-apis","title":"Client APIs"},{"id":"common-error-types","title":"Common error types"},{"id":"secret-provider-and-provider-helpers","title":"Secret-provider and provider helpers"},{"id":"core-resource-types","title":"Core resource types"},{"id":"common-pattern","title":"Common pattern"}]}
+
+,
+  "codeExamples": []
+}
+```
+This section indexes the main public Python surface exported from `featureform`.
+
+### Client APIs
+
+- `ff.Client`
+- `ff.WorkspaceClient`
+- `ff.ProviderClient`
+- `ff.SecretProviderClient`
+- `ff.ApplyResult`
+- `ff.ApplyWaitResult`
+
+### Common error types
+
+- `ff.FeatureformError`
+- `ff.ConnectionError`
+- `ff.InvalidArgumentError`
+- `ff.NotFoundError`
+- `ff.TimeoutError`
+- `ff.ValidationError`
+
+### Secret-provider and provider helpers
+
+- `ff.EnvSecretProvider`
+- `ff.VaultSecretProvider`
+- `ff.K8sSecretProvider`
+- `ff.PostgresProvider`
+- `ff.RedisProvider`
+- `ff.S3Provider`
+- `ff.SparkProvider`
+- `ff.get_postgres(name)`
+- `ff.get_provider(name)`
+
+### Core resource types
+
+- `ff.Entity`
+- `ff.Dataset`
+- `ff.Feature`
+- `ff.Label`
+- `ff.TrainingSet`
+- `ff.FeatureView`
+
+### Common pattern
 
 ```python
-transactions = snowflake.register_table(
-    name="transactions",
-    table="TRANSACTIONS",
-    description="Raw transaction table",
-)
+postgres = ff.get_postgres("demo_postgres")
+transactions = postgres.dataset(name="transactions")
 ```
 
-For Snowflake providers, the provider-level `database`, `schema`, and `catalog` configuration determines where Feature Form resolves the table unless you override those values during registration.
+The onboarding quickstart in this repo uses an explicit `resources = [...]` list because it is easier to reason about during apply.
 
-### Delta tables
+## RBAC roles and persmissions
 
-```python
-transactions = spark.register_delta_table(
-    name="transactions",
-    database="my_catalog.my_schema",
-    table="transactions",
-)
+# Roles and permissions
+
+```json metadata
+{
+  "title": "Roles and permissions",
+  "description": "Review the built-in Featureform RBAC roles, permission areas, and useful inspection commands.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"roles","title":"Roles"},{"id":"permission-areas","title":"Permission areas"},{"id":"useful-inspection-commands","title":"Useful inspection commands"}]}
+
+,
+  "codeExamples": []
+}
+```
+This section summarizes the built-in RBAC catalog exposed by the current authorization service.
+
+### Roles
+
+- `viewer` for read-only workspace visibility
+- `operator` for resource and scheduler operations
+- `workspace_admin` for full workspace administration
+- `global_admin` for deployment-wide administration
+- `model` for constrained serving and training-set access
+
+### Permission areas
+
+- workspace
+- graph
+- catalog
+- provider
+- secret provider
+- apply
+- serving
+- dataframe
+- training set
+- scheduler
+- audit
+- machine credential
+
+`model` is not a reduced workspace-admin role. It depends on explicit resource bindings for the feature views or training sets it can read.
+
+### Useful inspection commands
+
+```bash
+ff --transport grpc --grpc-server localhost:9090 --no-tls rbac roles
+ff --transport grpc --grpc-server localhost:9090 --no-tls rbac permissions
 ```
 
-Use `catalog.schema` in the `database` parameter when you are working with Unity Catalog.
 
-### Apache Iceberg tables
 
-If your provider is configured with an Iceberg-compatible catalog, register the table against that provider and then use it like any other dataset:
 
-```python
-orders = snowflake.register_table(
-    name="orders_iceberg",
-    table="ORDERS_ICEBERG",
-    description="Apache Iceberg table registered through the configured catalog",
-)
-```
 
-You can then reference the Iceberg-backed dataset in transformations:
 
-```python
-@snowflake.sql_transformation(inputs=[orders])
-def recent_orders(orders):
-    return """
-    SELECT
-        order_id,
-        customer_id,
-        order_total,
-        order_timestamp
-    FROM {{ orders }}
-    WHERE order_timestamp >= DATEADD(day, -30, CURRENT_TIMESTAMP())
-    """
-```
-
-### File-based datasets
-
-```python
-events = spark.register_file(
-    name="events",
-    file_path="s3://my-bucket/events/transactions.parquet",
-    description="Event data stored in parquet",
-)
-```
-
-Spark providers also support JSON-backed primary sources:
-
-```python
-events = spark.register_json(
-    name="raw_events",
-    file_path="s3://my-bucket/events.jsonl",
-)
-```
-
-Flatten JSON-backed sources in a transformation before you use them for features or labels.
-
-Choose dataset types that match your source-of-truth platform. The goal is to create stable named inputs that other definitions can depend on.
-
-## SQL transformations
-
-Use SQL transformations when your provider is SQL-native and the logic is easiest to express in SQL:
-
-```python
-@snowflake.sql_transformation(inputs=[transactions])
-def user_spend(transactions):
-    return """
-        SELECT
-            user_id,
-            AVG(amount) AS avg_transaction_amount,
-            MAX(timestamp) AS latest_transaction
-        FROM {{ transactions }}
-        GROUP BY user_id
-    """
-```
-
-For Snowflake providers configured with an Iceberg catalog, you can also create dynamic-table-backed transformations:
-
-```python
-from featureform import SnowflakeDynamicTableConfig, RefreshMode, Initialize
-
-@snowflake.sql_transformation(
-    inputs=[transactions],
-    resource_snowflake_config=SnowflakeDynamicTableConfig(
-        refresh_mode=RefreshMode.INCREMENTAL,
-        initialize=Initialize.ON_CREATE,
-        target_lag="30 minutes",
-    )
-)
-def incremental_user_features(transactions):
-    return """
-    SELECT
-        user_id,
-        AVG(amount) AS avg_amount,
-        COUNT(*) AS tx_count,
-        MAX(timestamp) AS last_tx
-    FROM {{ transactions }}
-    GROUP BY user_id
-    """
-```
-
-## DataFrame transformations
-
-Use DataFrame transformations when you need programmatic control or Spark-native operations:
-
-```python
-@spark.df_transformation(inputs=[transactions])
-def user_transaction_features(transactions_df):
-    from pyspark.sql import functions as F
-
-    return transactions_df.groupBy("user_id").agg(
-        F.avg("amount").alias("avg_transaction_amount"),
-        F.count("*").alias("transaction_count"),
-        F.max("timestamp").alias("latest_transaction"),
-    )
-```
-
-## Chaining transformations
-
-You can build transformations on top of other transformations. This keeps feature engineering logic modular and easier to review:
-
-```python
-@spark.df_transformation(inputs=[user_transaction_features])
-def high_value_users(features_df):
-    return features_df.filter("avg_transaction_amount > 100")
-```
-
-## Accessing transformation data
-
-For development and validation, Feature Form can retrieve the output of registered datasets or transformations as data frames:
-
-```python
-df = client.dataframe(user_transaction_features)
-```
-
-Use this sparingly in production workflows. Its main value is validation and iteration.
-
-## Apply registrations
-
-Once datasets and transformations are defined, register them with Feature Form:
-
-```python
-client.apply()
-```
-
-This step records the metadata and dependency graph so later resources, such as features and training sets, can reference them.
-
-## Best practices
-
-- Register stable business-level datasets, not every transient table.
-- Keep transformation names descriptive and reusable.
-- Push provider-specific parsing, casting, and joins into transformations before defining features.
-- Include timestamps where temporal correctness matters later in training or serving.
-
-## What to read next
-
-- [Define features and labels]({{< relref "/develop/ai/featureform/features-and-labels" >}})
-- [Work with training sets and feature views]({{< relref "/develop/ai/featureform/training-sets-and-feature-views" >}})

--- a/content/develop/ai/featureform/datasets-and-transformations.md
+++ b/content/develop/ai/featureform/datasets-and-transformations.md
@@ -1,18 +1,18 @@
 ---
-title: Datasets and transformations in Featureform
-description: Register datasets and define SQL or DataFrame transformations for Featureform features.
+title: Datasets and transformations in Redis Feature Form
+description: Register datasets and define SQL or DataFrame transformations for Feature Form features.
 linkTitle: Datasets and transformations
 weight: 40
 ---
 
 Datasets and transformations are the bridge between your raw source data and your feature definitions.
 
-- datasets point Featureform at existing tables or files
+- datasets point Feature Form at existing tables or files
 - transformations create reusable feature engineering logic on top of those datasets
 
 ## Register datasets
 
-Register the source objects that Featureform should treat as named inputs.
+Register the source objects that Feature Form should treat as named inputs.
 
 ### Warehouse tables
 
@@ -24,7 +24,7 @@ transactions = snowflake.register_table(
 )
 ```
 
-For Snowflake providers, the provider-level `database`, `schema`, and `catalog` configuration determines where Featureform resolves the table unless you override those values during registration.
+For Snowflake providers, the provider-level `database`, `schema`, and `catalog` configuration determines where Feature Form resolves the table unless you override those values during registration.
 
 ### Delta tables
 
@@ -159,7 +159,7 @@ def high_value_users(features_df):
 
 ## Accessing transformation data
 
-For development and validation, Featureform can retrieve the output of registered datasets or transformations as data frames:
+For development and validation, Feature Form can retrieve the output of registered datasets or transformations as data frames:
 
 ```python
 df = client.dataframe(user_transaction_features)
@@ -169,7 +169,7 @@ Use this sparingly in production workflows. Its main value is validation and ite
 
 ## Apply registrations
 
-Once datasets and transformations are defined, register them with Featureform:
+Once datasets and transformations are defined, register them with Feature Form:
 
 ```python
 client.apply()

--- a/content/develop/ai/featureform/features-and-labels.md
+++ b/content/develop/ai/featureform/features-and-labels.md
@@ -1,108 +1,96 @@
 ---
-title: Features and labels in Redis Feature Form
-description: Define entities, features, labels, and aggregate windows in Feature Form.
-linkTitle: Features and labels
+title: Tutorials
+description: Step through guided Feature Form workflows for definitions files and end-to-end resource setup.
+linkTitle: Tutorials
 weight: 50
 ---
 
-Features and labels are the core semantic objects in Feature Form. They describe what you want to predict, how feature values are keyed, and how those values should be computed over time.
+Use these walkthroughs when you want more context than a short how-to provides.
 
-## Entities
+## Work with a python definitions file
 
-An entity represents the business object that features belong to, such as a user, merchant, account, device, or product.
+Featureform treats a Python definitions file as the source of a desired resource graph. The quickstart example in this repo is intentionally small so you can see how the pieces fit together.
 
-```python
-@ff.entity
-class User:
-    pass
+### Typical file structure
+
+- import `featureform as ff`
+- define entities and datasets
+- define transformations
+- define features and labels
+- define a training set and feature view
+- export a `resources = [...]` list
+
+### Supported loading patterns
+
+`ff apply` loads resources from Python in this order:
+
+1. an explicit `resources = [...]` list
+2. the auto-registration registry, if no explicit list is present
+
+The explicit list is the clearer onboarding pattern and is what the published quickstart uses.
+
+### The file should reference
+
+- registered provider names such as `demo_postgres` and `demo_redis`
+- secret references such as `env:PG_PASSWORD`
+- stable resource names that make sense across re-apply cycles
+
+### The file should not do
+
+- replace provider registration
+- assume providers exist before the workspace registers them
+- mix infrastructure provisioning into the definitions entrypoint
+
+## Build your first feature workflow
+
+Use this tutorial when you want a guided run through the core Featureform path rather than a short checklist.
+
+### 1. Verify the workspace
+
+```bash
+ff workspace get --name <workspace-name>
+ff secret-provider get env --workspace <workspace-id>
 ```
 
-Attach features and labels to the entity class so Feature Form can reason about keys and lineage.
+### 2. Register providers
 
-## Define features
+Use the provider setup guides for:
 
-Use the builder-style API to define features from registered datasets or transformations:
+- [Postgres]()
+- [Redis]()
 
-```python
-@ff.entity
-class User:
-    avg_transaction_amount = (
-        ff.Feature()
-        .from_dataset(
-            user_transaction_features,
-            entity="user_id",
-            values="avg_transaction_amount",
-            timestamp="latest_transaction",
-        )
-    )
+### 3. Review the definitions file
+
+The quickstart definitions entrypoint is resources.py.
+
+### 4. Apply the resources
+
+```bash
+ff apply \
+  --workspace <workspace-id> \
+  --file examples/featureform/docs/resources.py \
+  --wait \
+  --wait-for finished
 ```
 
-## Aggregate features
+### 5. Inspect the workspace
 
-Aggregate features create time-windowed feature values from event data:
-
-```python
-from datetime import timedelta
-
-@ff.entity
-class User:
-    transaction_count = (
-        ff.Feature()
-        .from_dataset(
-            transactions,
-            entity="user_id",
-            values="amount",
-            timestamp="timestamp",
-        )
-        .aggregate(
-            function=ff.AggregateFunction.COUNT,
-            windows=[timedelta(days=7), timedelta(days=30)],
-        )
-    )
+```bash
+ff graph workspace stats --workspace <workspace-id>
+ff graph feature list --workspace <workspace-id>
+ff catalog list --workspace <workspace-id>
 ```
 
-Access a specific window by indexing the feature with the matching `timedelta`:
+### 6. Iterate safely
 
-```python
-count_7d = User.transaction_count[timedelta(days=7)]
+```bash
+ff apply \
+  --workspace <workspace-id> \
+  --file examples/featureform/docs/resources.py \
+  --plan
 ```
 
-## Define labels
+### 7. Serve from the feature view
 
-Labels represent the target you want to predict:
+Continue with the Serve features how-to.
 
-```python
-@ff.entity
-class User:
-    is_fraud = (
-        ff.Label()
-        .from_dataset(transactions)
-        .value("is_fraud")
-        .timestamp("timestamp")
-        .entity("user", "user_id")
-        .description("Binary fraud classification label")
-    )
-```
-
-## Point-in-time correctness
-
-Timestamps are central to correct ML training and serving workflows. When you include the relevant event timestamp in your feature and label definitions, Feature Form can align historical examples correctly instead of leaking future information into the training data.
-
-Use timestamps consistently when:
-
-- defining event-derived features
-- defining labels with historical outcomes
-- creating aggregate windows
-- building training sets from time-varying data
-
-## Best practices
-
-- Model entities after real business keys that your applications already use.
-- Prefer the builder-style feature API for new work.
-- Add timestamps wherever feature values change over time.
-- Keep feature names stable and descriptive so they can be reused across training sets and feature views.
-
-## What to read next
-
-- [Work with training sets and feature views]({{< relref "/develop/ai/featureform/training-sets-and-feature-views" >}})
-- [Streaming features]({{< relref "/develop/ai/featureform/streaming" >}})

--- a/content/develop/ai/featureform/features-and-labels.md
+++ b/content/develop/ai/featureform/features-and-labels.md
@@ -1,11 +1,11 @@
 ---
-title: Features and labels in Featureform
-description: Define entities, features, labels, and aggregate windows in Featureform.
+title: Features and labels in Redis Feature Form
+description: Define entities, features, labels, and aggregate windows in Feature Form.
 linkTitle: Features and labels
 weight: 50
 ---
 
-Features and labels are the core semantic objects in Featureform. They describe what you want to predict, how feature values are keyed, and how those values should be computed over time.
+Features and labels are the core semantic objects in Feature Form. They describe what you want to predict, how feature values are keyed, and how those values should be computed over time.
 
 ## Entities
 
@@ -17,7 +17,7 @@ class User:
     pass
 ```
 
-Attach features and labels to the entity class so Featureform can reason about keys and lineage.
+Attach features and labels to the entity class so Feature Form can reason about keys and lineage.
 
 ## Define features
 
@@ -86,7 +86,7 @@ class User:
 
 ## Point-in-time correctness
 
-Timestamps are central to correct ML training and serving workflows. When you include the relevant event timestamp in your feature and label definitions, Featureform can align historical examples correctly instead of leaking future information into the training data.
+Timestamps are central to correct ML training and serving workflows. When you include the relevant event timestamp in your feature and label definitions, Feature Form can align historical examples correctly instead of leaking future information into the training data.
 
 Use timestamps consistently when:
 

--- a/content/develop/ai/featureform/overview.md
+++ b/content/develop/ai/featureform/overview.md
@@ -45,4 +45,4 @@ The latest release adds enterprise-oriented capabilities:
 ## What to read next
 
 - [Quickstart]({{< relref "/develop/ai/featureform/quickstart" >}})
-- [Connect providers]({{< relref "/develop/ai/featureform/providers" >}})
+- [Connect providers]({{< relref "/develop/ai/featureform/streaming" >}})

--- a/content/develop/ai/featureform/overview.md
+++ b/content/develop/ai/featureform/overview.md
@@ -1,17 +1,17 @@
 ---
-title: Featureform overview
-description: Learn what Featureform is, who it is for, and how it fits into Redis-based ML workflows.
+title: Redis Feature Form overview
+description: Learn what Redis Feature Form is, who it is for, and how it fits into Redis-based ML workflows.
 linkTitle: Overview
 weight: 10
 ---
 
-Featureform is a feature engineering and feature serving workflow built for teams that want to define machine learning features in code while keeping their existing data platforms. It gives application teams a declarative Python SDK for working with providers, datasets, transformations, entities, features, labels, training sets, and online feature serving.
+Redis Feature Form is a feature engineering and feature serving workflow built for teams that want to define machine learning features in code while keeping their existing data platforms. It gives application teams a declarative Python SDK for working with providers, datasets, transformations, entities, features, labels, training sets, and online feature serving.
 
-In a typical deployment, Featureform reads or computes feature data in an offline system such as Snowflake, BigQuery, or Databricks and materializes selected features to Redis for low-latency inference.
+In a typical deployment, Feature Form reads or computes feature data in an offline system such as Snowflake, BigQuery, or Databricks and materializes selected features to Redis for low-latency inference.
 
 ## Core workflow
 
-The Featureform workflow follows a consistent progression:
+The Feature Form workflow follows a consistent progression:
 
 1. Register providers for your offline systems and your Redis online store.
 2. Register datasets that represent raw inputs or curated tables.
@@ -23,18 +23,30 @@ The Featureform workflow follows a consistent progression:
 
 ## Where Redis fits
 
-Redis is the online inference store in the Featureform workflow. After you materialize a feature view, applications can retrieve feature values with low latency for prediction requests, personalization, fraud detection, recommendation systems, and similar ML use cases.
+Redis is the online inference store in the Feature Form workflow. After you materialize a feature view, applications can retrieve feature values with low latency for prediction requests, personalization, fraud detection, recommendation systems, and similar ML use cases.
 
 ## Main interfaces
 
 The main user-facing interface is the Python SDK:
 
-- `ff.Client(...)` to connect to Featureform
+- `ff.Client(...)` to connect to Feature Form
 - provider registration methods such as `register_snowflake`, `register_spark`, and `register_redis`
 - decorators and builder APIs for transformations, features, and labels
 - materialization and serving methods such as `materialize_feature_view(...)` and `serve_feature_view(...)`
 
-Featureform also includes a dashboard for viewing registered resources and tasks, but the Python SDK is the primary authoring interface.
+Feature Form also includes a dashboard for viewing registered resources and tasks, but the Python SDK is the primary authoring interface.
+
+## Latest updates
+
+The latest release adds enterprise-oriented capabilities:
+
+- **Unified batch and streaming pipelines**: Support for tiling, backfills, and incremental updates reduces custom pipeline work.
+- **Workspaces for multi-tenancy**: Isolate providers, data, authentication, and observability at the workspace level.
+- **Fine-grained job control**: Planning, impact analysis, split materializations, and queue-based job management provide visibility into changes before they affect production systems.
+- **Atomic DAG updates**: Manage graph-level changes atomically instead of versioning individual resources, which simplifies rollback and change history.
+- **Enhanced RBAC and security**: Workspace-scoped access controls, API key pairs, a granular role model, audit logs, secret-provider improvements, mTLS, and encrypted internal transport.
+- **Two-service deployment model**: A simplified deployment architecture that reduces operational complexity.
+- **Redesigned dashboard**: Configure workspaces and providers directly from the UI.
 
 ## What to read next
 

--- a/content/develop/ai/featureform/overview.md
+++ b/content/develop/ai/featureform/overview.md
@@ -5,36 +5,30 @@ linkTitle: Overview
 weight: 10
 ---
 
-Redis Feature Form is a feature engineering and feature serving workflow built for teams that want to define machine learning features in code while keeping their existing data platforms. It gives application teams a declarative Python SDK for working with providers, datasets, transformations, entities, features, labels, training sets, and online feature serving.
+This page describes the standard Feature Form onboarding path: workspace creation, access handoff, secrets, providers, definitions, apply, and serving. Use it as the high-level sequence before you dive into task-specific guides.
 
-In a typical deployment, Feature Form reads or computes feature data in an offline system such as Snowflake, BigQuery, or Databricks and materializes selected features to Redis for low-latency inference.
+## Audience
 
-## Core workflow
+- Global admins creating and handing off workspaces
+- Workspace admins wiring secrets and providers
+- Feature engineers authoring definitions files
+- Application or model teams serving ready feature views
 
-The Feature Form workflow follows a consistent progression:
+## Recommended path
 
-1. Register providers for your offline systems and your Redis online store.
-2. Register datasets that represent raw inputs or curated tables.
-3. Define SQL or DataFrame transformations for feature engineering logic.
-4. Define entities, features, and labels in the Python SDK.
-5. Register metadata with `client.apply()`.
-6. Materialize feature views to Redis for serving.
-7. Retrieve online values at inference time or create training sets for model development.
+1. Create the workspace and grant initial access.
+2. Confirm the intended principal can see the workspace.
+3. Reuse the built-in `env` secret provider or register another backend.
+4. Register the providers the workspace will reference.
+5. Author a definitions file and run `ff apply`.
+6. Inspect the graph and catalog, then serve from a feature view.
 
-## Where Redis fits
+## What to verify before the first apply
 
-Redis is the online inference store in the Feature Form workflow. After you materialize a feature view, applications can retrieve feature values with low latency for prediction requests, personalization, fraud detection, recommendation systems, and similar ML use cases.
-
-## Main interfaces
-
-The main user-facing interface is the Python SDK:
-
-- `ff.Client(...)` to connect to Feature Form
-- provider registration methods such as `register_snowflake`, `register_spark`, and `register_redis`
-- decorators and builder APIs for transformations, features, and labels
-- materialization and serving methods such as `materialize_feature_view(...)` and `serve_feature_view(...)`
-
-Feature Form also includes a dashboard for viewing registered resources and tasks, but the Python SDK is the primary authoring interface.
+- The workspace exists and the right principal can access it.
+- Secret references such as `env:PG_PASSWORD` resolve from the runtime environment.
+- Providers are already registered by the names the definitions file expects.
+- The team understands whether the definitions file represents complete desired state or a partial subset.
 
 ## Latest updates
 

--- a/content/develop/ai/featureform/providers.md
+++ b/content/develop/ai/featureform/providers.md
@@ -1,242 +1,202 @@
 ---
-title: Connect providers in Redis Feature Form
+title: How-to guides
 description: Register offline providers and Redis online stores for Feature Form workflows.
-linkTitle: Providers
-weight: 30
+linkTitle: How-to guides
+weight: 40
 ---
 
-Use providers to connect Feature Form to the systems where your data already lives.
+Perform common Feature Form tasks for secrets, providers, apply, catalog inspection, and serving.
 
-In most deployments, you'll register:
+## Apply a definitions file
 
-- offline providers store or compute source data and transformed data
-- online providers serve low-latency feature values to applications
+`ff apply` executes one Python entrypoint, collects the resources it defines, and submits that set as desired state for a single workspace.
 
-Redis is the online provider in the Feature Form workflow.
+### What `--file` can point to
 
-## Before you begin
+- a Python file
+- a package `__init__.py`
+- a package directory that contains `__init__.py`
 
-Before you register providers, make sure you have:
-
-- network access from Feature Form to the systems you want to register
-- credentials for each provider
-- a clear decision about which system is authoritative for offline feature computation
-- a Redis deployment for online serving
-
-Feature Form's current provider APIs rely heavily on catalog configuration. For Snowflake and Databricks, make sure you choose the catalog model before you register providers or datasets.
-
-## Offline providers
-
-Feature Form supports several offline systems, including:
-
-- Snowflake
-- BigQuery
-- Databricks or Spark
-
-Register the offline provider that matches your existing analytics or feature engineering environment.
-
-## Online provider
-
-Register Redis as the inference store for low-latency serving:
-
-```python
-redis = client.register_redis(
-    name="redis-prod",
-    host="redis.example.com",
-    port=6379,
-    password="redis_password",
-)
+```bash
+ff apply --workspace <workspace-id> --file examples/featureform/docs/resources.py --plan
 ```
 
-If your deployment requires TLS or ACL configuration, use the connection options supported by your current Feature Form release and align them with your Redis security standards.
+### Loading order
 
-For secured Redis deployments, you can also configure ACL usernames and TLS settings explicitly:
+`ff apply` loads resources in this order:
 
-```python
-import featureform as ff
+1. `resources = [...]` from the entry module, if present
+2. the resource registry, if no explicit list exists
 
-redis = client.register_redis(
-    name="redis-cloud",
-    host="redis.example.com",
-    port=6379,
-    username="default",
-    password="super-secret",
-    ssl_mode=True,
-    tls=ff.RedisTLSConfig(
-        ca_cert=redis_ca_pem,
-        server_name="redis.example.com",
-    ),
-)
+### Preview with `--plan`
+
+```bash
+ff apply \
+  --workspace <workspace-id> \
+  --file examples/featureform/docs/resources.py \
+  --plan
 ```
 
-## Snowflake
+Use this before large changes or whenever the file might be incomplete relative to the workspace's full desired state.
 
-Configure the catalog first, then register Snowflake with key-pair authentication. Key-pair authentication is the recommended method, and password authentication is being deprecated.
+### Standard apply
 
-```python
-import featureform as ff
-from featureform import SnowflakeCatalog, SnowflakeDynamicTableConfig, RefreshMode, Initialize
-
-catalog = SnowflakeCatalog(
-    external_volume="my_external_volume",
-    base_location="s3://my-bucket/iceberg/",
-    catalog_table_config=SnowflakeDynamicTableConfig(
-        refresh_mode=RefreshMode.FULL,
-        initialize=Initialize.ON_CREATE,
-        target_lag="1 hour",
-    ),
-)
-
-snowflake = client.register_snowflake(
-    name="snowflake-prod",
-    account="your_account",
-    organization="your_org",
-    username="featureform_user",
-    key_pair=ff.SnowflakeKeyPairConfig(
-        private_key_path="/secrets/snowflake/private_key.pem",
-    ),
-    database="FEATURE_DB",
-    schema="PUBLIC",
-    warehouse="COMPUTE_WH",
-    catalog=catalog,
-)
+```bash
+ff apply \
+  --workspace <workspace-id> \
+  --file examples/featureform/docs/resources.py \
+  --wait \
+  --wait-for finished
 ```
 
-Use Snowflake when your feature engineering workflow already centers on warehouse-native tables, Iceberg-backed tables, or dynamic table pipelines.
+### Apply modes
 
-If you are migrating from password authentication, update your provider configuration to use `SnowflakeKeyPairConfig(...)`.
+- default apply: replacement-oriented desired state
+- `--merge`: safer for intentionally partial definition sets
+- `--update`: exposed in the CLI, but treat as provisional
+- `--full-rematerialize`: also exposed, but treat as provisional
 
-## BigQuery
+Only one of `--merge`, `--update`, or `--full-rematerialize` can be used at a time.
 
-```python
-bigquery = client.register_bigquery(
-    name="bigquery-prod",
-    project_id="your-gcp-project",
-    dataset_id="feature_dataset",
-    credentials_path="/path/to/service-account.json",
-)
+If neither an explicit `resources` list nor any auto-registered resources are present after the entrypoint executes, `ff apply` fails.
+
+## Update resources and rematerialize
+
+After the first successful apply, most Feature Form work is an iteration loop: edit the definitions file, preview the delta, apply the change, and inspect the resulting graph or catalog state.
+
+### Typical cycle
+
+1. Change a resource definition.
+2. Run a plan.
+3. Apply the change.
+4. Verify the resulting graph or catalog state.
+
+```bash
+ff apply \
+  --workspace <workspace-id> \
+  --file examples/featureform/docs/resources.py \
+  --plan
 ```
 
-Use BigQuery when your source data and transformations already run in Google Cloud.
+### When to use `--merge`
 
-## Databricks or Spark
+Use `--merge` when the file you are applying is intentionally partial and omitted resources should not be treated as deletions.
 
-Use Databricks or Spark when you need DataFrame transformations, Delta tables, or lakehouse-oriented pipelines.
+### Caution with `--update` and `--full-rematerialize`
 
-Register a catalog first, then register a filestore and Spark provider. For Databricks with Unity Catalog:
+The CLI exposes both flags, but the current user-facing workflow is not as mature or as well documented as normal apply and merge. Use them only when your deployment has already validated that behavior.
 
-```python
-import featureform as ff
-from featureform import UnityCatalog, TableFormat
+### Verify the outcome
 
-unity = UnityCatalog(
-    catalog="my_catalog",
-    schema="my_schema",
-    table_format=TableFormat.DELTA,
-)
-
-aws_creds = ff.AWSStaticCredentials(
-    access_key="your_aws_access_key",
-    secret_key="your_aws_secret_key",
-)
-
-s3 = client.register_s3(
-    name="s3-store",
-    credentials=aws_creds,
-    bucket_name="my-featureform-bucket",
-    bucket_region="us-east-1",
-)
-
-databricks = ff.DatabricksCredentials(
-    host="https://your-workspace.cloud.databricks.com",
-    token="your_databricks_token",
-    cluster_id="your_cluster_id",
-)
-
-spark = client.register_spark(
-    name="databricks-prod",
-    executor=databricks,
-    filestore=s3,
-    catalog=unity,
-)
+```bash
+ff graph workspace overview --workspace <workspace-id>
+ff catalog list --workspace <workspace-id>
 ```
 
-The Databricks credentials surface also supports OAuth machine-to-machine authentication:
+## Inspect materialized locations
+
+The Feature Form catalog records where resources managed by Feature Form physically landed after apply and materialization. It is distinct from systems such as Unity Catalog, Glue, or an Iceberg catalog.
+
+### List catalog entries
+
+```bash
+ff catalog list --workspace <workspace-id>
+```
+
+### Inspect one resource
+
+```bash
+ff catalog get demo_transactions --workspace <workspace-id>
+```
+
+### The catalog shows
+
+- logical resource name
+- owning provider
+- status
+- physical table, path, or namespace
+- update timestamps
+
+Use the catalog together with graph views: graph explains why a resource exists; catalog shows where it landed.
+
+## Query datasets and training sets
+
+Use this command when the target dataset, training set, or feature view already exists and you want to inspect rows directly.
+
+### Query a dataset
+
+```bash
+ff dataframe query demo_transactions \
+  --workspace demo-workspace \
+  --server localhost:9090 \
+  --kind dataset \
+  --limit 10 \
+  --insecure
+```
+
+### Supported kinds
+
+- `dataset`
+- `training_set`
+- `feature_view`
+
+### Useful flags
+
+- `--columns`
+- `--filter`
+- `--limit`
+- `--output table|json|csv`
+
+The dataframe command talks to the Flight endpoint on the gRPC side, so transport and endpoint mismatches are common troubleshooting points.
+
+## Serve feature view
+
+Use this page after a feature view already exists and the online store is ready. In the quickstart flow, that means `demo_customer_feature_view` has already been applied successfully.
+
+### Verify the feature view exists
+
+```bash
+ff graph feature-view get demo_customer_feature_view --workspace demo-workspace
+```
+
+### Minimal Python workflow
 
 ```python
 import featureform as ff
 
-databricks = ff.DatabricksCredentials(
-    host="https://your-workspace.cloud.databricks.com",
-    client_id="my-service-principal-client-id",
-    client_secret="my-service-principal-secret",
-    cluster_id="1234-567890-abcd123",
-)
+client = ff.Client(host="127.0.0.1:9090", insecure=True, workspace="demo-workspace")
+features = client.serve("demo_customer_feature_view", entity="C1001")
+print(features)
 ```
 
-If you want ephemeral Databricks job clusters instead of an always-on cluster, use `cluster_config` instead of `cluster_id`:
+### Operational checks
 
-```python
-import featureform as ff
+- if the feature view is not ready, serving fails
+- if the online provider is unavailable or unsupported, serving fails
+- serving-metadata permissions and serving-read permissions are separate RBAC checks
 
-cluster_config = ff.DatabricksClusterConfig(
-    spark_version="14.3.x-scala2.12",
-    node_type_id="i3.xlarge",
-    num_workers=4,
-)
 
-databricks = ff.DatabricksCredentials(
-    host="https://your-workspace.cloud.databricks.com",
-    token="your_databricks_token",
-    cluster_config=cluster_config,
-)
+## Operate a workspace 
+Use this how-to for routine operational checks after a workspace is already created and in use.
+
+### Day-2 checklist
+
+- verify connectivity with `ff ping`
+- inspect workspace metadata and `last_applied_version`
+- inspect providers and secret providers
+- inspect graph overview and stats
+- inspect catalog locations
+- confirm serving and dataframe clients point at the expected transport and state backend
+
+### Useful commands
+
+```bash
+ff ping
+ff workspace get <workspace-id>
+ff provider list --workspace <workspace-id>
+ff secret-provider list --workspace <workspace-id>
+ff graph workspace stats --workspace <workspace-id>
+ff catalog list --workspace <workspace-id>
 ```
 
-Use either `cluster_id` or `cluster_config`, not both.
-
-## Catalog options
-
-Feature Form supports several catalog models for offline data:
-
-```python
-from featureform import UnityCatalog, GlueCatalog, SnowflakeCatalog, TableFormat
-
-unity = UnityCatalog(
-    catalog="my_catalog",
-    schema="my_schema",
-    table_format=TableFormat.DELTA,
-)
-
-glue = GlueCatalog(
-    region="us-east-1",
-    database="my_database",
-    warehouse="s3://my-bucket/warehouse/",
-    assume_role_arn="arn:aws:iam::123456789:role/GlueRole",
-    table_format=TableFormat.ICEBERG,
-)
-```
-
-Choose the catalog that matches the table format and governance model in your environment.
-
-## Retrieve previously registered providers
-
-Once providers are registered, you can retrieve them by name:
-
-```python
-snowflake = client.get_snowflake("snowflake-prod")
-spark = client.get_spark("databricks-prod")
-redis = client.get_redis("redis-prod")
-```
-
-## Choose providers
-
-- Choose the offline provider that is already authoritative for your feature data.
-- Configure the catalog model before you register Snowflake or Databricks providers.
-- Choose Redis when you need low-latency online serving.
-- Keep credentials and network access aligned with your platform security standards.
-- Minimize the number of providers in early projects so registration and troubleshooting stay simple.
-
-## What to read next
-
-- [Define datasets and transformations]({{< relref "/develop/ai/featureform/datasets-and-transformations" >}})
-- [Define features and labels]({{< relref "/develop/ai/featureform/features-and-labels" >}})
+With memory-backed state, check transport mismatches first when users report missing workspaces, providers, or applied resources.

--- a/content/develop/ai/featureform/providers.md
+++ b/content/develop/ai/featureform/providers.md
@@ -1,33 +1,33 @@
 ---
-title: Connect providers in Featureform
-description: Register offline providers and Redis online stores for Featureform workflows.
+title: Connect providers in Redis Feature Form
+description: Register offline providers and Redis online stores for Feature Form workflows.
 linkTitle: Providers
 weight: 30
 ---
 
-Use providers to connect Featureform to the systems where your data already lives.
+Use providers to connect Feature Form to the systems where your data already lives.
 
 In most deployments, you'll register:
 
 - offline providers store or compute source data and transformed data
 - online providers serve low-latency feature values to applications
 
-Redis is the online provider in the Featureform workflow.
+Redis is the online provider in the Feature Form workflow.
 
 ## Before you begin
 
 Before you register providers, make sure you have:
 
-- network access from Featureform to the systems you want to register
+- network access from Feature Form to the systems you want to register
 - credentials for each provider
 - a clear decision about which system is authoritative for offline feature computation
 - a Redis deployment for online serving
 
-Featureform's current provider APIs rely heavily on catalog configuration. For Snowflake and Databricks, make sure you choose the catalog model before you register providers or datasets.
+Feature Form's current provider APIs rely heavily on catalog configuration. For Snowflake and Databricks, make sure you choose the catalog model before you register providers or datasets.
 
 ## Offline providers
 
-Featureform supports several offline systems, including:
+Feature Form supports several offline systems, including:
 
 - Snowflake
 - BigQuery
@@ -48,7 +48,7 @@ redis = client.register_redis(
 )
 ```
 
-If your deployment requires TLS or ACL configuration, use the connection options supported by your current Featureform release and align them with your Redis security standards.
+If your deployment requires TLS or ACL configuration, use the connection options supported by your current Feature Form release and align them with your Redis security standards.
 
 For secured Redis deployments, you can also configure ACL usernames and TLS settings explicitly:
 
@@ -196,7 +196,7 @@ Use either `cluster_id` or `cluster_config`, not both.
 
 ## Catalog options
 
-Featureform supports several catalog models for offline data:
+Feature Form supports several catalog models for offline data:
 
 ```python
 from featureform import UnityCatalog, GlueCatalog, SnowflakeCatalog, TableFormat

--- a/content/develop/ai/featureform/quickstart.md
+++ b/content/develop/ai/featureform/quickstart.md
@@ -1,15 +1,15 @@
 ---
-title: Featureform quickstart
+title: Redis Feature Form quickstart
 description: Register providers, define a feature, materialize it to Redis, and serve it.
 linkTitle: Quickstart
 weight: 20
 ---
 
-This quickstart helps you register a simple Featureform workflow and serve feature values from Redis.
+This quickstart helps you register a simple Redis Feature Form workflow and serve feature values from Redis.
 
 You'll do the following:
 
-1. Connect to Featureform.
+1. Connect to Feature Form.
 2. Register an offline provider and a Redis online store.
 3. Register a dataset and define a transformation.
 4. Define an entity and features.
@@ -17,18 +17,18 @@ You'll do the following:
 6. Materialize a feature view to Redis.
 7. Serve feature values.
 
-At the end, you'll have a Featureform feature view backed by Redis and a working `serve_feature_view(...)` call.
+At the end, you'll have a Feature Form feature view backed by Redis and a working `serve_feature_view(...)` call.
 
 ## Before you begin
 
 Before you start, make sure you have:
 
-- a running Featureform deployment
+- a running Feature Form deployment
 - access to an offline system, such as Databricks or Spark
 - access to a Redis deployment for online serving
 - credentials for the systems you register in this guide
 
-## Connect to Featureform
+## Connect to Feature Form
 
 ```python
 import featureform as ff

--- a/content/develop/ai/featureform/quickstart.md
+++ b/content/develop/ai/featureform/quickstart.md
@@ -88,8 +88,4 @@ print(features)
 ```
 
 
-## What to read next
 
-- [Connect providers]({{< relref "/develop/ai/featureform/providers" >}})
-- [Define datasets and transformations]({{< relref "/develop/ai/featureform/datasets-and-transformations" >}})
-- [Define features and labels]({{< relref "/develop/ai/featureform/features-and-labels" >}})

--- a/content/develop/ai/featureform/quickstart.md
+++ b/content/develop/ai/featureform/quickstart.md
@@ -4,168 +4,92 @@ description: Register providers, define a feature, materialize it to Redis, and 
 linkTitle: Quickstart
 weight: 20
 ---
-
-This quickstart helps you register a simple Redis Feature Form workflow and serve feature values from Redis.
-
-You'll do the following:
-
-1. Connect to Feature Form.
-2. Register an offline provider and a Redis online store.
-3. Register a dataset and define a transformation.
-4. Define an entity and features.
-5. Register metadata.
-6. Materialize a feature view to Redis.
-7. Serve feature values.
-
-At the end, you'll have a Feature Form feature view backed by Redis and a working `serve_feature_view(...)` call.
+Use this quickstart when you want one end-to-end proof that the main Feature Form path works in your environment. It assumes the workspace already exists and that sample data matching the quickstart definitions file is already loaded.
 
 ## Before you begin
 
-Before you start, make sure you have:
+- A running Feature Form deployment with durable state
+- An existing workspace
+- A working auth path for `ff`
+- Reachable Postgres and Redis endpoints for `demo_postgres` and `demo_redis`
 
-- a running Feature Form deployment
-- access to an offline system, such as Databricks or Spark
-- access to a Redis deployment for online serving
-- credentials for the systems you register in this guide
+## 1. Confirm identity and workspace access
 
-## Connect to Feature Form
+```bash
+ff rbac whoami
+ff workspace get --name <workspace-name>
+```
+
+Use the returned workspace ID in later commands.
+
+## 2. Confirm the built-in `env` secret provider
+
+```bash
+ff secret-provider list --workspace <workspace-id>
+```
+
+If your Postgres provider uses `env:PG_PASSWORD`, make sure that variable exists in the runtime environment that resolves secrets.
+
+## 3. Register the demo providers
+
+Register the offline and online providers before applying resources:
+
+- [Postgres setup]()
+- [Redis setup]()
+
+## 4. Review the quickstart definitions file
+
+The published example definitions entrypoint is the resource definitions file.
+
+That file defines:
+
+- one entity
+- one primary dataset
+- two SQL transformations
+- three features
+- one label
+- one training set
+- one feature view
+
+## 5. Apply the file
+
+```bash
+ff apply \
+  --workspace <workspace-id> \
+  --file examples/featureform/docs/resources.py \
+  --wait \
+  --wait-for finished
+```
+
+For a dry run first:
+
+```bash
+ff apply \
+  --workspace <workspace-id> \
+  --file examples/featureform/docs/resources.py \
+  --plan
+```
+
+## 6. Inspect the results
+
+```bash
+ff graph workspace stats --workspace <workspace-id>
+ff graph feature list --workspace <workspace-id>
+ff catalog list --workspace <workspace-id>
+```
+
+You should see the expected graph entries plus the catalog locations created by the applied resources.
+
+## 7. Serve from the feature view
 
 ```python
 import featureform as ff
 
-client = ff.Client(host="your-featureform-host:443")
+client = ff.Client(host="127.0.0.1:9090", insecure=True, workspace="<workspace>")
+features = client.serve("demo_customer_feature_view", entity="C1001")
+print(features)
 ```
 
-For local development, you might use an insecure endpoint:
-
-```python
-client = ff.Client(host="localhost:7878", insecure=True)
-```
-
-## Register providers
-
-This example uses Databricks as the offline provider and Redis as the online store.
-
-```python
-import featureform as ff
-
-aws_creds = ff.AWSStaticCredentials(
-    access_key="your_aws_access_key",
-    secret_key="your_aws_secret_key",
-)
-
-s3 = client.register_s3(
-    name="s3-store",
-    credentials=aws_creds,
-    bucket_name="my-featureform-bucket",
-    bucket_region="us-east-1",
-)
-
-databricks = ff.DatabricksCredentials(
-    host="https://your-workspace.cloud.databricks.com",
-    token="your_databricks_token",
-    cluster_id="your_cluster_id",
-)
-
-spark = client.register_spark(
-    name="databricks-prod",
-    executor=databricks,
-    filestore=s3,
-)
-
-redis = client.register_redis(
-    name="redis-prod",
-    host="redis.example.com",
-    port=6379,
-    password="redis_password",
-)
-```
-
-## Register a dataset and transformation
-
-Next, register a dataset from the offline system and define a transformation that computes feature values.
-
-```python
-transactions = spark.register_delta_table(
-    name="transactions",
-    database="my_catalog.my_schema",
-    table="transactions",
-    description="Raw transaction data",
-)
-
-@spark.df_transformation(inputs=[transactions])
-def user_transaction_features(transactions_df):
-    from pyspark.sql import functions as F
-
-    return transactions_df.groupBy("user_id").agg(
-        F.avg("amount").alias("avg_transaction_amount"),
-        F.count("*").alias("transaction_count"),
-        F.max("timestamp").alias("latest_transaction"),
-    )
-```
-
-## Define an entity and features
-
-Define an entity class, then attach features to it.
-
-```python
-from datetime import timedelta
-
-@ff.entity
-class User:
-    avg_transaction_amount = (
-        ff.Feature()
-        .from_dataset(
-            user_transaction_features,
-            entity="user_id",
-            values="avg_transaction_amount",
-            timestamp="latest_transaction",
-        )
-    )
-
-    transaction_count = (
-        ff.Feature()
-        .from_dataset(
-            transactions,
-            entity="user_id",
-            values="amount",
-            timestamp="timestamp",
-        )
-        .aggregate(
-            function=ff.AggregateFunction.COUNT,
-            windows=[timedelta(days=7), timedelta(days=30)],
-        )
-    )
-```
-
-## Register metadata, then materialize
-
-`client.apply()` registers providers, datasets, transformations, and feature definitions. In the current workflow, it does not create the online serving surface by itself.
-
-```python
-client.apply()
-
-client.materialize_feature_view(
-    view_name="user_features_view",
-    inference_store=redis,
-    features=[
-        User.avg_transaction_amount,
-        User.transaction_count[timedelta(days=7)],
-        User.transaction_count[timedelta(days=30)],
-    ],
-)
-```
-
-## Serve features
-
-After the feature view is materialized, retrieve feature values by entity ID:
-
-```python
-features = client.serve_feature_view(
-    view="user_features_view",
-    entity_ids=["user_123", "user_456"],
-)
-```
 
 ## What to read next
 

--- a/content/develop/ai/featureform/quickstart.md
+++ b/content/develop/ai/featureform/quickstart.md
@@ -32,10 +32,7 @@ If your Postgres provider uses `env:PG_PASSWORD`, make sure that variable exists
 
 ## 3. Register the demo providers
 
-Register the offline and online providers before applying resources:
-
-- [Postgres setup]()
-- [Redis setup]()
+See the Providers and workpsaces page for steps to register the offline and online providers before applying resources.
 
 ## 4. Review the quickstart definitions file
 

--- a/content/develop/ai/featureform/streaming.md
+++ b/content/develop/ai/featureform/streaming.md
@@ -1,11 +1,11 @@
 ---
-title: Streaming features in Featureform
+title: Streaming features in Redis Feature Form
 description: Build stream-backed features with Kafka, streaming transformations, and Redis serving.
 linkTitle: Streaming
 weight: 70
 ---
 
-Featureform supports stream-backed feature workflows for use cases that need continuously updated online values while preserving historical correctness for training.
+Redis Feature Form supports stream-backed feature workflows for use cases that need continuously updated online values while preserving historical correctness for training.
 
 This page focuses on the documented SDK surface: register Kafka, define a streaming transformation, define features with `from_stream(...)`, optionally backfill from a batch source, materialize a feature view, and serve it from Redis.
 
@@ -13,7 +13,7 @@ This page focuses on the documented SDK surface: register Kafka, define a stream
 
 Before you build streaming features, you need:
 
-- a running Featureform deployment
+- a running Feature Form deployment
 - a registered Redis online store
 - a stream-capable compute provider such as Spark or Databricks
 - a Kafka topic that contains the events you want to transform into features

--- a/content/develop/ai/featureform/streaming.md
+++ b/content/develop/ai/featureform/streaming.md
@@ -1,150 +1,296 @@
 ---
-title: Streaming features in Redis Feature Form
+title: Providers and workspaces
 description: Build stream-backed features with Kafka, streaming transformations, and Redis serving.
-linkTitle: Streaming
+linkTitle: Providers and workspaces
 weight: 70
 ---
 
-Redis Feature Form supports stream-backed feature workflows for use cases that need continuously updated online values while preserving historical correctness for training.
+Redis Feature Form supports multiple providers, secrets provider management, and workspaces.
 
-This page focuses on the documented SDK surface: register Kafka, define a streaming transformation, define features with `from_stream(...)`, optionally backfill from a batch source, materialize a feature view, and serve it from Redis.
+## Register providers
 
-## Prerequisites
+Registering a provider binds one workspace to an external system used for storage, compute, serving, or catalog-backed access. Definitions files refer to providers by name, so provider registration comes first.
 
-Before you build streaming features, you need:
+### Register a Postgres provider
 
-- a running Feature Form deployment
-- a registered Redis online store
-- a stream-capable compute provider such as Spark or Databricks
-- a Kafka topic that contains the events you want to transform into features
-
-## Register Kafka
-
-```python
-from featureform.config.file_stores import KafkaConfig
-
-kafka = ff.register_kafka(
-    name="transactions-kafka",
-    kafka_config=KafkaConfig(
-        bootstrap_servers=["kafka-1:9092", "kafka-2:9092"],
-        use_msk_iam_auth=False,
-        options={
-            "kafka.security.protocol": "SASL_SSL",
-            "kafka.sasl.mechanism": "SCRAM-SHA-512",
-        },
-    ),
-)
+```bash
+ff provider register demo_postgres \
+  --workspace <workspace-id> \
+  --type postgres \
+  --pg-host <release-name>-featureform-provider-postgres \
+  --pg-port 5432 \
+  --pg-database featureform_test \
+  --pg-user testuser \
+  --pg-password-secret env:PG_PASSWORD \
+  --pg-ssl-mode disable
 ```
 
-## Register a Kafka topic
+### Register a Redis provider
 
-```python
-transactions_stream = kafka.register_kafka_topic(
-    name="transactions-stream",
-    topic="transactions",
-    description="Raw transaction events from Kafka",
-)
+```bash
+ff provider register demo_redis \
+  --workspace <workspace-id> \
+  --type redis \
+  --redis-host <release-name>-featureform-redis \
+  --redis-port 6379
 ```
 
-## Define a streaming transformation
+If your deployment uses bundled provider addons, the default service names typically include the Helm release name. Otherwise, use the reachable hostnames for your external systems.
 
-```python
-@spark.streaming_sql_transformation(
-    name="parsed_transactions",
-    inputs=[transactions_stream],
-)
-def parsed_transactions(source):
-    return """
-        SELECT
-            get_json_object(CAST(value AS STRING), '$.user_id') AS user_id,
-            CAST(get_json_object(CAST(value AS STRING), '$.amount') AS DOUBLE) AS amount,
-            CAST(get_json_object(CAST(value AS STRING), '$.event_time') AS TIMESTAMP) AS event_time
-        FROM {{ source }}
-    """
+### Verify registration
+
+```bash
+ff provider list --workspace <workspace-id>
+ff provider get demo_postgres --workspace <workspace-id>
 ```
 
-## Define features from a stream
+Provider registration performs health validation by default. Fix connectivity or secret-resolution failures instead of treating `--skip-health-check` as the standard path.
 
-```python
-from datetime import timedelta
+## Postgres provider setup
 
-window = timedelta(days=7)
+```json metadata
+{
+  "title": "Postgres provider setup",
+  "description": "Register a Postgres provider for offline storage and SQL execution in Featureform.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"registration","title":"Registration"},{"id":"provider-role","title":"Provider role"}]}
 
-@ff.entity
-class User:
-    rolling_amount = (
-        ff.Feature()
-        .from_stream(
-            parsed_transactions,
-            entity="user_id",
-            values="amount",
-            timestamp="event_time",
-        )
-        .aggregate(
-            function=ff.AggregateFunction.SUM,
-            windows=[window],
-        )
-    )
+,
+  "codeExamples": []
+}
+```
+Use Postgres when the workspace needs an offline store and Postgres-backed SQL execution in the same path.
+
+### Registration
+
+```bash
+ff provider register demo_postgres \
+  --workspace demo-workspace \
+  --type postgres \
+  --pg-host <release-name>-featureform-provider-postgres \
+  --pg-port 5432 \
+  --pg-database featureform_test \
+  --pg-user testuser \
+  --pg-password-secret env:PG_PASSWORD \
+  --pg-ssl-mode disable
 ```
 
-## Backfill from batch history
+### Provider role
 
-If the stream is the online source of truth but you already have historical data in batch storage, backfill the stream-backed feature:
+`offline-store`, `compute`
 
-```python
-historical_transactions = spark.register_delta_table(
-    name="historical_transactions",
-    database="ml_catalog.featureform",
-    table="historical_transactions",
-)
+The password reference is resolved through the workspace secret provider at runtime.
 
-@ff.entity
-class User:
-    rolling_amount = (
-        ff.Feature()
-        .from_stream(
-            parsed_transactions,
-            entity="user_id",
-            values="amount",
-            timestamp="event_time",
-        )
-        .backfill_from(
-            source=historical_transactions,
-            entity="user_id",
-            values="amount",
-            timestamp="event_time",
-        )
-        .aggregate(
-            function=ff.AggregateFunction.SUM,
-            windows=[window],
-        )
-    )
+## Redis provider setup
+
+```json metadata
+{
+  "title": "Redis provider setup",
+  "description": "Register Redis as the online store used by Featureform feature-view serving.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"registration","title":"Registration"},{"id":"provider-role","title":"Provider role"}]}
+
+,
+  "codeExamples": []
+}
+```
+Use Redis when the workspace needs an online store for low-latency feature serving.
+
+### Registration
+
+```bash
+ff provider register demo_redis \
+  --workspace demo-workspace \
+  --type redis \
+  --redis-host <release-name>-featureform-redis \
+  --redis-port 6379
 ```
 
-## Register metadata and materialize
+### Provider role
 
-```python
-client.apply()
+`online-store`
 
-client.materialize_feature_view(
-    view_name="user_streaming_features",
-    inference_store=redis,
-    features=[User.rolling_amount[window]],
-)
+In the quickstart definitions file, the feature view references this provider with `inference_store="demo_redis"`.
+
+## S3 provider setup
+
+```json metadata
+{
+  "title": "S3 provider setup",
+  "description": "Register an S3 provider for Featureform offline-store-backed object locations.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"registration","title":"Registration"},{"id":"provider-role","title":"Provider role"}]}
+
+,
+  "codeExamples": []
+}
+```
+Use S3 when Featureform needs an object-storage-backed offline location.
+
+### Registration
+
+```bash
+ff provider register data-lake \
+  --workspace demo-workspace \
+  --type s3 \
+  --s3-bucket featureform-data \
+  --s3-region us-west-2 \
+  --s3-access-key-id-secret env:AWS_ACCESS_KEY_ID \
+  --s3-secret-access-key-secret env:AWS_SECRET_ACCESS_KEY
 ```
 
-## Serve streaming feature values
+### Provider role
 
-```python
-result = client.serve_feature_view(
-    view="user_streaming_features",
-    entity_ids=["user_1", "user_2"],
-)
+`offline-store`
+
+Use `--s3-endpoint` for MinIO or LocalStack-style endpoints when needed.
+
+## Spark provider setup
+
+```json metadata
+{
+  "title": "Spark provider setup",
+  "description": "Register a Spark compute provider for Featureform transformation and materialization workloads.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"minimal-registration","title":"Minimal registration"},{"id":"provider-role","title":"Provider role"}]}
+
+,
+  "codeExamples": []
+}
+```
+Use Spark when the workspace needs a compute provider for transformation or materialization workloads.
+
+### Minimal registration
+
+```bash
+ff provider register spark-main \
+  --workspace demo-workspace \
+  --type spark \
+  --spark-master spark://spark-master:7077
 ```
 
-## Guidance
+### Provider role
 
-- Parse and cast stream payloads in the transformation layer.
-- Reuse one transformed stream for multiple features.
-- Keep backfill semantics aligned with the stream definition so training and serving stay consistent.
-- Avoid undocumented parameters or status names in production documentation and examples.
+`compute`
+
+Keep Spark registration separate from dataset authoring and from Iceberg catalog registration.
+
+## Iceberg provider setup
+
+```json metadata
+{
+  "title": "Iceberg provider setup",
+  "description": "Register an Iceberg catalog provider for Featureform offline-store workflows.",
+  "categories": null,
+  "tableOfContents": {"sections":[{"id":"registration","title":"Registration"},{"id":"provider-role","title":"Provider role"}]}
+
+,
+  "codeExamples": []
+}
+```
+Use an Iceberg catalog provider when the workspace needs catalog-backed offline storage.
+
+### Registration
+
+```bash
+ff provider register iceberg-main \
+  --workspace demo-workspace \
+  --type iceberg_catalog \
+  --iceberg-warehouse s3://featureform-data/warehouse \
+  --iceberg-catalog-name featureform \
+  --iceberg-rest-uri https://iceberg.example.com
+```
+
+### Provider role
+
+`offline-store`
+
+The exact required fields depend on the catalog backend you choose.
+
+## Configure secret providers
+
+Use this section to confirm which secret backend a workspace will use and to register additional backends when `env` is not enough.
+
+### Check the built-in `env` provider
+
+```bash
+ff secret-provider list --workspace demo-workspace
+ff secret-provider get env --workspace demo-workspace
+```
+
+### Register another secret provider
+
+Environment provider:
+
+```bash
+ff secret-provider register local-env \
+  --workspace demo-workspace \
+  --type env \
+  --env-prefix FF_
+```
+
+Vault:
+
+```bash
+ff secret-provider register vault-main \
+  --workspace demo-workspace \
+  --type vault \
+  --vault-address https://vault.example.com \
+  --vault-token-path /var/run/secrets/vault-token
+```
+
+Kubernetes:
+
+```bash
+ff secret-provider register k8s-main \
+  --workspace demo-workspace \
+  --type k8s \
+  --k8s-namespace featureform \
+  --k8s-secret-name provider-secrets
+```
+
+AWS Secrets Manager:
+
+```bash
+ff secret-provider register aws-main \
+  --workspace demo-workspace \
+  --type aws \
+  --aws-region us-west-2
+```
+
+### Update or delete
+
+```bash
+ff secret-provider update local-env \
+  --workspace demo-workspace \
+  --env-prefix PROD_
+
+ff secret-provider delete local-env \
+  --workspace demo-workspace \
+  --yes
+```
+
+## Manage workspaces
+
+Use these commands when you need to inspect or change a workspace directly.
+
+### Core commands
+
+```bash
+ff workspace list
+ff workspace get --name demo-workspace
+ff workspace update <workspace-id> \
+  --name demo-workspace \
+  --description "Updated description"
+ff workspace delete <workspace-id> --force
+```
+
+### Workspace state to remember
+
+- workspaces have unique names and descriptions
+- each workspace tracks `last_applied_version`
+- providers, secret providers, graph state, catalog entries, and serving metadata are workspace-scoped
+
+Deleting a workspace removes its associated workspace-scoped data.
+
+

--- a/content/develop/ai/featureform/training-sets-and-feature-views.md
+++ b/content/develop/ai/featureform/training-sets-and-feature-views.md
@@ -1,11 +1,11 @@
 ---
-title: Training sets and feature views in Featureform
-description: Build training sets and materialize feature views to Redis with Featureform.
+title: Training sets and feature views in Redis Feature Form
+description: Build training sets and materialize feature views to Redis with Feature Form.
 linkTitle: Training sets and feature views
 weight: 60
 ---
 
-Training sets and feature views are where Featureform turns definitions into outputs that model builders and applications can use.
+Training sets and feature views are where Feature Form turns definitions into outputs that model builders and applications can use.
 
 - training sets support model development
 - feature views support online inference

--- a/content/develop/ai/featureform/training-sets-and-feature-views.md
+++ b/content/develop/ai/featureform/training-sets-and-feature-views.md
@@ -1,90 +1,116 @@
 ---
-title: Training sets and feature views in Redis Feature Form
-description: Build training sets and materialize feature views to Redis with Feature Form.
-linkTitle: Training sets and feature views
-weight: 60
+title: Concepts
+description: Learn the core Feature Form concepts behind workspaces, providers, secrets, and serving.
+linkTitle: Concepts
+weight: 30
 ---
 
-Training sets and feature views are where Feature Form turns definitions into outputs that model builders and applications can use.
+These pages explain the resource model and the boundaries that matter when you operate Feature Form.
 
-- training sets support model development
-- feature views support online inference
+## Resources and workspace graph
 
-## Register metadata first
+A Feature Form workspace owns one logical resource graph. When you run `ff apply`, Feature Form compares the submitted desired state with the current graph and commits a new version if the change is accepted.
 
-In the current workflow, `client.apply()` registers metadata for providers, datasets, transformations, entities, features, and labels:
+### Resource types in the graph
 
-```python
-client.apply()
+- entities
+- datasets
+- transformations
+- features
+- labels
+- training sets
+- feature views
+
+### Why the graph matters
+
+- it powers lineage and dependency views
+- it tracks `last_applied_version`
+- it feeds serving metadata from committed state
+
+### Useful commands
+
+```bash
+ff graph workspace overview --workspace demo-workspace
+ff graph workspace stats --workspace demo-workspace
+ff graph dataset get demo_transactions --workspace demo-workspace
+ff graph feature-view get demo_customer_feature_view --workspace demo-workspace
 ```
 
-This is a separate step from creating the Redis-backed serving surface.
+## Providers and provider roles
 
-## Training sets
+A provider is a workspace-scoped connection to external infrastructure. Definitions files reference providers by name, but the provider itself must already be registered in the workspace.
 
-Register a training set by combining a label with the features you want to train on:
+### Provider roles
 
-```python
-fraud_training_set = client.register_training_set(
-    name="fraud_training_set",
-    label=User.is_fraud,
-    features=[
-        User.avg_transaction_amount,
-        User.transaction_count[timedelta(days=7)],
-    ],
-)
-```
+- `offline-store` for batch data and materialized datasets
+- `online-store` for low-latency serving
+- `compute` for transformations and materialization work
+- `streaming` for streaming integrations
 
-After registration, iterate over the training set or convert it to a data frame for analysis:
+### Core providers documented here
 
-```python
-training_df = client.dataframe(fraud_training_set)
-```
+- Postgres: `offline-store`, `compute`
+- Redis: `online-store`
+- S3: `offline-store`
+- Spark: `compute`
+- Iceberg catalog: `offline-store`
 
-## Feature views
+### Workflow mapping
 
-Materialize a feature view to Redis when you need online serving:
+- Datasets and training sets need an offline store.
+- Feature views need an online store.
+- SQL and Spark transformations need compute.
+- One provider can fill more than one role.
 
-```python
-client.materialize_feature_view(
-    view_name="user_features_view",
-    inference_store=redis,
-    features=[
-        User.avg_transaction_amount,
-        User.transaction_count[timedelta(days=7)],
-        User.transaction_count[timedelta(days=30)],
-    ],
-)
-```
 
-Use feature views to group the online features that an application or model needs at inference time.
+## Secrets and secret references
 
-## Serve feature values
+Feature Form stores secret references in provider configuration instead of storing plaintext secret values itself. A provider config can contain a reference like `env:PG_PASSWORD`, which Feature Form resolves through a registered secret provider at runtime.
 
-```python
-result = client.serve_feature_view(
-    view="user_features_view",
-    entity_ids=["user_1", "user_2"],
-)
-```
+### Mental model
 
-The result contains the latest materialized values stored in Redis for those entity IDs.
+- A secret provider is a workspace-scoped backend such as `env`, Vault, Kubernetes, or AWS Secrets Manager
+- A secret reference is the value stored in provider config
+- Data providers use secret references but do not own secret storage
 
-## Common point of confusion
+### Default path for a new workspace
 
-Keep these two steps separate in your mental model:
+Every new workspace creates a built-in `env` secret provider. That makes references such as `env:PG_PASSWORD` valid as long as the runtime environment actually exposes `PG_PASSWORD`.
 
-- `client.apply()` registers definitions and lineage
-- `client.materialize_feature_view(...)` creates the serving surface in Redis
+The important detail is runtime scope: in deployed environments, the resolving process is usually the Featureform server, not your local CLI shell.
 
-That distinction matters when you troubleshoot missing online data. A successful metadata registration does not, by itself, mean the feature view is ready for serving.
+### What Featureform stores
 
-## Best practices
+- Secret provider metadata and configuration
+- Secret references embedded in provider configuration
 
-- Use training sets for repeatable model development workflows.
-- Keep online feature views focused on the features needed by one serving surface.
-- Treat Redis as the online system of record for materialized feature views, not the source of offline feature computation.
+### What Featureform does not store
 
-## What to read next
+- Plaintext secret values from external backends
 
-- [Streaming features]({{< relref "/develop/ai/featureform/streaming" >}})
+## Serving and feature views
+
+A feature view is the serving interface for a set of features keyed by an entity. In the documented Redis-backed workflow, the feature view is what applications and model services read from at inference time.
+
+### A feature view includes
+
+- the feature-view name
+- the logical entity and key columns
+- the served feature schema
+- the online provider
+- serving version and key-prefix details
+
+### Serving requires
+
+- a registered online store such as Redis
+- a committed graph version containing the feature view
+- ready serving metadata for that workspace and view
+
+### Main entry points
+
+- gRPC: `ServingService.Serve`, `ServingService.GetServingMetadata`
+- REST: `/api/v1/serve`
+- Python client: `client.serve(...)`
+
+Serving reads and serving-metadata reads are separate RBAC permissions.
+

--- a/content/develop/whats-new/_index.md
+++ b/content/develop/whats-new/_index.md
@@ -25,14 +25,6 @@ weight: 10
 
 ### Redis AI & Vectors
 
-- Added [Redis Feature Form documentation]({{< relref "/develop/ai/featureform" >}}) for feature engineering workflows
-  - [Overview]({{< relref "/develop/ai/featureform/overview" >}})
-  - [Quickstart guide]({{< relref "/develop/ai/featureform/quickstart" >}})
-  - [Provider connections]({{< relref "/develop/ai/featureform/providers" >}})
-  - [Datasets and transformations]({{< relref "/develop/ai/featureform/datasets-and-transformations" >}})
-  - [Features and labels]({{< relref "/develop/ai/featureform/features-and-labels" >}})
-  - [Training sets and feature views]({{< relref "/develop/ai/featureform/training-sets-and-feature-views" >}})
-  - [Streaming features]({{< relref "/develop/ai/featureform/streaming" >}})
 - Added [n8n vector store integration]({{< relref "/integrate/n8n-vector-store" >}})
 - Updated [RedisVL 0.7.0 documentation]({{< relref "/develop/ai/redisvl/0.7.0" >}})
 - Updated [RedisVL 0.9.1 documentation]({{< relref "/develop/ai/redisvl/0.9.1" >}})

--- a/content/develop/whats-new/_index.md
+++ b/content/develop/whats-new/_index.md
@@ -25,7 +25,7 @@ weight: 10
 
 ### Redis AI & Vectors
 
-- Added [Featureform documentation]({{< relref "/develop/ai/featureform" >}}) for feature engineering workflows
+- Added [Redis Feature Form documentation]({{< relref "/develop/ai/featureform" >}}) for feature engineering workflows
   - [Overview]({{< relref "/develop/ai/featureform/overview" >}})
   - [Quickstart guide]({{< relref "/develop/ai/featureform/quickstart" >}})
   - [Provider connections]({{< relref "/develop/ai/featureform/providers" >}})


### PR DESCRIPTION
Featureform changed to Redis Feature Form or Feature Form
Added 3.0 release changes to "Latest updates" section to index page and overview pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only restructuring and copy changes; main risk is broken navigation/relref links or users being confused by renamed/reclassified pages.
> 
> **Overview**
> Renames the Featureform documentation to **Redis Feature Form / Feature Form** and updates top-level AI landing copy and banners to match the new branding.
> 
> Reorganizes the Feature Form docs into clearer buckets by repurposing several pages: adds a *Reference* page for gRPC/CLI/Python/RBAC surfaces, shifts other pages to *Tutorials*, *How-to guides*, and *Concepts*, and replaces the old streaming-focused page with a *Providers and workspaces* guide covering provider/secret/workspace setup.
> 
> Refreshes onboarding content by rewriting the quickstart and overview around the `ff` CLI workflow (workspace/access, apply/plan, inspect, serve) and adds a new “Latest updates” enterprise-capabilities section; also removes the detailed Featureform entry list from `What's new`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9b04d1b1e7b89845fd263e1133bb75cda6b0ddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->