### PR TITLE
DEV: (cmds) add GCRASETVALUE command page

### DIFF
--- a/content/commands/gcra.md
+++ b/content/commands/gcra.md
@@ -1,6 +1,6 @@
 ---
 acl_categories:
-- '@string'
+- '@rate_limit'
 - '@write'
 arguments:
 - key_spec_index: 0
@@ -33,7 +33,7 @@ command_flags:
 - fast
 complexity: O(1)
 description: Rate limit via GCRA (Generic Cell Rate Algorithm).
-group: string
+group: rate_limit
 hidden: false
 key_specs:
 - begin_search:

--- a/content/commands/gcrasetvalue.md
+++ b/content/commands/gcrasetvalue.md
@@ -1,0 +1,90 @@
+---
+acl_categories:
+- '@rate_limit'
+- '@write'
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: tat
+  type: integer
+arity: 3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- write
+- denyoom
+- fast
+complexity: O(1)
+description: An internal command for recording a GCRA TAT value during AOF rewrite
+  and replication.
+group: rate_limit
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - ow
+  - update
+linkTitle: GCRASETVALUE
+since: 8.8.0
+summary: An internal command for recording a GCRA TAT value during AOF rewrite and
+  replication.
+syntax_fmt: GCRASETVALUE key tat
+title: GCRASETVALUE
+---
+This is an internal command; it records a GCRA [theoretical arrival time (TAT)](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm#Virtual_scheduling_description) value during AOF rewrite and replication.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+is the key associated with a specific rate limiting case.
+
+</details>
+
+<details open><summary><code>tat</code></summary>
+
+is the expiration time, based on the generic cell rate algorithm's [theoretical arrival time (TAT)](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm#Virtual_scheduling_description).
+
+</details>
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+
+- A [simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) of `OK` indicating that the operation succeeded.
+- A [simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) indicating that the operation failed.
+
+-tab-sep-
+
+One of the following:
+
+- A [simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) of `OK` indicating that the operation succeeded.
+- A [simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) indicating that the operation failed.
+
+{{< /multitabs >}}

--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -41,6 +41,7 @@
           <option value="hyperloglog" data-kind="core">HyperLogLog</option>
           <option value="json" data-kind="stack">JSON</option>
           <option value="list" data-kind="core">List</option>
+          <option value="rate_limit" data-kind="stack">Rate limiting</option>
           <option value="pubsub" data-kind="core">Pub/Sub</option>
           <option value="scripting" data-kind="core">Scripting and functions</option>
           <option value="search" data-kind="stack">Redis Search</option>

--- a/static/images/railroad/gcrasetvalue.svg
+++ b/static/images/railroad/gcrasetvalue.svg
@@ -1,0 +1,50 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 353.0 62" width="353.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M303.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M172.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="50.0" y="20"></rect><text x="111.0" y="35">GCRASETVALUE</text></g><path d="M172.0 31h10"></path><path d="M182.0 31h10"></path><g class="non-terminal ">
+<path d="M192.0 31h0.0"></path><path d="M237.5 31h0.0"></path><rect height="22" width="45.5" x="192.0" y="20"></rect><text x="214.75" y="35">key</text></g><path d="M237.5 31h10"></path><path d="M247.5 31h10"></path><g class="non-terminal ">
+<path d="M257.5 31h0.0"></path><path d="M303.0 31h0.0"></path><rect height="22" width="45.5" x="257.5" y="20"></rect><text x="280.25" y="35">tat</text></g></g><path d="M303.0 31h10"></path><path d="M 313.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
Redis 8.8 feature

Also includes changes to add `GCRA` and `GCRASETVALUE` to a new group called `rate_limit` (rate limiting).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; main risk is inaccurate or inconsistent command syntax/behavior descriptions across pages.
> 
> **Overview**
> **Documents Redis 8.8 features and command surface changes.** Adds new command docs for `GCRA` (rate limiting), `GCRASETVALUE` (internal), and `XIDMPRECORD` (internal), plus a new *Rate limiting* guide and a new `rate_limit` command group filter entry.
> 
> Updates existing command/reference docs to reflect Redis 8.8 behavior and observability: `ACL LOAD` comment-line support, new `CLIENT LIST` fields, and expanded `INFO`/`commandstats` metrics (including slowlog-derived stats). Also extends `JSON.SET` with the `FPHA` option (and diagrams/examples), updates TimeSeries range docs to support **multiple comma-separated aggregators** (and disallow `GROUPBY/REDUCE` when multiple aggregators are used), and refreshes a few ancillary docs (CLI navigation, supported OS/version tables, minor wording fixes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a422689d6c225a677a7e2010c4f2c4384b4bd90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->