### PR TITLE
Add K8s 7.8.6-14 April 2026 maintenance release notes

### DIFF
--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-14-april2026.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-14-april2026.md
@@ -1,0 +1,29 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: A maintenance release that includes support for Redis Software 7.8.6-260.
+hideListLinks: true
+linkTitle: 7.8.6-14 (April 2026)
+title: Redis Enterprise for Kubernetes 7.8.6-14 (April 2026) release notes
+weight: 18
+---
+
+Redis Enterprise for Kubernetes 7.8.6-14 (April 2026) is a maintenance release that includes support for [Redis Software 7.8.6-260]({{<relref "/operate/rs/release-notes/rs-7-8-releases/" >}}).
+
+For supported distributions, known limitations, and API changes, see [Redis Enterprise for Kubernetes 7.8.6-1 March 2025 release notes]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-march2025" >}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:7.8.6-260`
+- **Operator**: `redislabs/operator:7.8.6-14`
+- **Services Rigger**: `redislabs/k8s-controller:7.8.6-14`
+- **OLM operator bundle** : `v7.8.6-14.0`
+
+## Known limitations
+
+See [7.8.6 releases]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases" >}}) for information on known limitations.
+
+

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.8.6 release notes
 weight: 92
 ---
 
-Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-13 with support for Redis Enterprise Software version 7.8.6-256.
+Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-14 with support for Redis Enterprise Software version 7.8.6-260.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change adding a new maintenance release note and updating the “latest release” pointer; no runtime or API behavior is modified.
> 
> **Overview**
> Adds release notes for **Redis Enterprise for Kubernetes `7.8.6-14` (April 2026)**, documenting support for Redis Software `7.8.6-260` and publishing the associated image/bundle tags.
> 
> Updates the `7.8.6` release notes index to mark `7.8.6-14` / `7.8.6-260` as the latest release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da4ba486aa18e5c47d6cc1e283dab54827543cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->