### PR TITLE
DOC-6475 updated RDI supported sources

### DIFF
--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -1,13 +1,13 @@
 | Database | Versions | AWS RDS  Versions | GCP SQL Versions |
 | :-- | :-- | :-- | :-- |
-| Oracle | 19c, 21c | 19c, 21c | - |
-| MariaDB | 10.5, 11.4.3 | 10.4 to 10.11, 11.4.3 | - |
+| Oracle | 19c, 21c, 23ai (LogMiner only) | 19c, 21c | - |
+| MariaDB | 10.5, 11.4.x, 11.7.x | 10.4 to 10.11, 11.4.3 | - |
 | MongoDB | 6.0, 7.0, 8.0 | - | - |
-| MySQL | 5.7, 8.0.x, 8.2 | 8.0.x | 8.0 |
-| PostgreSQL | 10, 11, 12, 13, 14, 15, 16  | 11, 12, 13, 14, 15, 16 | 15 |
-| Supabase (uses PostgreSQL) | 10, 11, 12, 13, 14, 15, 16  | - | - |
+| MySQL | 5.7, 8.0.x, 8.4.x, 9.0, 9.1 | 8.0.x | 8.0 |
+| PostgreSQL | 10, 11, 12, 13, 14, 15, 16, 17  | 11, 12, 13, 14, 15, 16 | 15 |
+| Supabase (uses PostgreSQL) | 10, 11, 12, 13, 14, 15, 16, 17  | - | - |
 | SQL Server | 2017, 2019, 2022 | 2016, 2017, 2019, 2022 | 2019 |
 | Spanner | - | - | All versions |
 | AlloyDB for PostgreSQL | 14.2, 15.7 | - | 14.2, 15.7 |
 | AWS Aurora/PostgreSQL | 15 | 15 | - |
-| Neon | 14, 15, 16 | - | - |
+| Neon | 14, 15, 16, 17 | - | - |


### PR DESCRIPTION
This is the latest info for [Debezium 3.4](https://debezium.io/releases/). Let me know if the AWS/GCP product versions also need to be updated.

Staging link: https://redis.io/docs/staging/DOC-6475-rdi-source-version-update/integrate/redis-data-integration/#supported-source-databases

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a compatibility table; no runtime behavior is affected.
> 
> **Overview**
> Updates `rdi-supported-source-versions.md` to reflect newer supported source versions: adds Oracle `23ai` (LogMiner-only), expands MariaDB to `11.4.x`/`11.7.x`, updates MySQL to include `8.4.x` and `9.0`/`9.1`, and extends PostgreSQL/Supabase and Neon support through version `17`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c05e2cedd161e90445697c2490f17678bab17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->