### PR TITLE
DEV: (cmds) add COUNT aggregator to sorted set commands

### DIFF
--- a/content/commands/zinter.md
+++ b/content/commands/zinter.md
@@ -4,39 +4,36 @@ acl_categories:
 - '@sortedset'
 - '@slow'
 arguments:
-- display_text: numkeys
-  name: numkeys
+- name: numkeys
   type: integer
-- display_text: key
-  key_spec_index: 0
+- key_spec_index: 0
   multiple: true
   name: key
   type: key
-- display_text: weight
-  multiple: true
+- multiple: true
   name: weight
   optional: true
   token: WEIGHTS
   type: integer
 - arguments:
-  - display_text: sum
-    name: sum
+  - name: sum
     token: SUM
     type: pure-token
-  - display_text: min
-    name: min
+  - name: min
     token: MIN
     type: pure-token
-  - display_text: max
-    name: max
+  - name: max
     token: MAX
+    type: pure-token
+  - name: count
+    since: 8.8.0
+    token: COUNT
     type: pure-token
   name: aggregate
   optional: true
   token: AGGREGATE
   type: oneof
-- display_text: withscores
-  name: withscores
+- name: withscores
   optional: true
   token: WITHSCORES
   type: pure-token
@@ -60,25 +57,27 @@ complexity: O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted
 description: Returns the intersect of multiple sorted sets.
 group: sorted-set
 hidden: false
+history:
+- - 8.8.0
+  - Added `COUNT` aggregate option.
 key_specs:
-- RO: true
-  access: true
-  begin_search:
-    spec:
-      index: 1
-    type: index
+- begin_search:
+    index:
+      pos: 1
   find_keys:
-    spec:
+    keynum:
       firstkey: 1
       keynumidx: 0
-      keystep: 1
-    type: keynum
+      step: 1
+  flags:
+  - RO
+  - ACCESS
 linkTitle: ZINTER
 railroad_diagram: /images/railroad/zinter.svg
 since: 6.2.0
 summary: Returns the intersect of multiple sorted sets.
 syntax_fmt: "ZINTER numkeys key [key ...] [WEIGHTS\_weight [weight ...]]\n  [AGGREGATE\_\
-  <SUM | MIN | MAX>] [WITHSCORES]"
+  <SUM | MIN | MAX | COUNT>] [WITHSCORES]"
 title: ZINTER
 ---
 {{< note >}}

--- a/content/commands/zinterstore.md
+++ b/content/commands/zinterstore.md
@@ -4,36 +4,33 @@ acl_categories:
 - '@sortedset'
 - '@slow'
 arguments:
-- display_text: destination
-  key_spec_index: 0
+- key_spec_index: 0
   name: destination
   type: key
-- display_text: numkeys
-  name: numkeys
+- name: numkeys
   type: integer
-- display_text: key
-  key_spec_index: 1
+- key_spec_index: 1
   multiple: true
   name: key
   type: key
-- display_text: weight
-  multiple: true
+- multiple: true
   name: weight
   optional: true
   token: WEIGHTS
   type: integer
 - arguments:
-  - display_text: sum
-    name: sum
+  - name: sum
     token: SUM
     type: pure-token
-  - display_text: min
-    name: min
+  - name: min
     token: MIN
     type: pure-token
-  - display_text: max
-    name: max
+  - name: max
     token: MAX
+    type: pure-token
+  - name: count
+    since: 8.8.0
+    token: COUNT
     type: pure-token
   name: aggregate
   optional: true
@@ -60,37 +57,38 @@ complexity: O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted
 description: Stores the intersect of multiple sorted sets in a key.
 group: sorted-set
 hidden: false
+history:
+- - 8.8.0
+  - Added `COUNT` aggregate option.
 key_specs:
-- OW: true
-  begin_search:
-    spec:
-      index: 1
-    type: index
+- begin_search:
+    index:
+      pos: 1
   find_keys:
-    spec:
-      keystep: 1
+    range:
       lastkey: 0
       limit: 0
-    type: range
-  update: true
-- RO: true
-  access: true
-  begin_search:
-    spec:
-      index: 2
-    type: index
+      step: 1
+  flags:
+  - OW
+  - UPDATE
+- begin_search:
+    index:
+      pos: 2
   find_keys:
-    spec:
+    keynum:
       firstkey: 1
       keynumidx: 0
-      keystep: 1
-    type: keynum
+      step: 1
+  flags:
+  - RO
+  - ACCESS
 linkTitle: ZINTERSTORE
 railroad_diagram: /images/railroad/zinterstore.svg
 since: 2.0.0
 summary: Stores the intersect of multiple sorted sets in a key.
 syntax_fmt: "ZINTERSTORE destination numkeys key [key ...] [WEIGHTS\_weight\n  [weight\
-  \ ...]] [AGGREGATE\_<SUM | MIN | MAX>]"
+  \ ...]] [AGGREGATE\_<SUM | MIN | MAX | COUNT>]"
 title: ZINTERSTORE
 ---
 {{< note >}}

--- a/content/commands/zunion.md
+++ b/content/commands/zunion.md
@@ -67,8 +67,10 @@ key_specs:
     keynum:
       firstkey: 1
       keynumidx: 0
-      keystep: 1
-    type: keynum
+      step: 1
+  flags:
+  - RO
+  - ACCESS
 linkTitle: ZUNION
 railroad_diagram: /images/railroad/zunion.svg
 since: 6.2.0

--- a/content/commands/zunion.md
+++ b/content/commands/zunion.md
@@ -4,39 +4,36 @@ acl_categories:
 - '@sortedset'
 - '@slow'
 arguments:
-- display_text: numkeys
-  name: numkeys
+- name: numkeys
   type: integer
-- display_text: key
-  key_spec_index: 0
+- key_spec_index: 0
   multiple: true
   name: key
   type: key
-- display_text: weight
-  multiple: true
+- multiple: true
   name: weight
   optional: true
   token: WEIGHTS
   type: integer
 - arguments:
-  - display_text: sum
-    name: sum
+  - name: sum
     token: SUM
     type: pure-token
-  - display_text: min
-    name: min
+  - name: min
     token: MIN
     type: pure-token
-  - display_text: max
-    name: max
+  - name: max
     token: MAX
+    type: pure-token
+  - name: count
+    since: 8.8.0
+    token: COUNT
     type: pure-token
   name: aggregate
   optional: true
   token: AGGREGATE
   type: oneof
-- display_text: withscores
-  name: withscores
+- name: withscores
   optional: true
   token: WITHSCORES
   type: pure-token
@@ -59,15 +56,15 @@ complexity: O(N)+O(M*log(M)) with N being the sum of the sizes of the input sort
 description: Returns the union of multiple sorted sets.
 group: sorted-set
 hidden: false
+history:
+- - 8.8.0
+  - Added `COUNT` aggregate option.
 key_specs:
-- RO: true
-  access: true
-  begin_search:
-    spec:
-      index: 1
-    type: index
+- begin_search:
+    index:
+      pos: 1
   find_keys:
-    spec:
+    keynum:
       firstkey: 1
       keynumidx: 0
       keystep: 1
@@ -77,7 +74,7 @@ railroad_diagram: /images/railroad/zunion.svg
 since: 6.2.0
 summary: Returns the union of multiple sorted sets.
 syntax_fmt: "ZUNION numkeys key [key ...] [WEIGHTS\_weight [weight ...]]\n  [AGGREGATE\_\
-  <SUM | MIN | MAX>] [WITHSCORES]"
+  <SUM | MIN | MAX | COUNT>] [WITHSCORES]"
 title: ZUNION
 ---
 {{< note >}}

--- a/content/commands/zunionstore.md
+++ b/content/commands/zunionstore.md
@@ -4,36 +4,33 @@ acl_categories:
 - '@sortedset'
 - '@slow'
 arguments:
-- display_text: destination
-  key_spec_index: 0
+- key_spec_index: 0
   name: destination
   type: key
-- display_text: numkeys
-  name: numkeys
+- name: numkeys
   type: integer
-- display_text: key
-  key_spec_index: 1
+- key_spec_index: 1
   multiple: true
   name: key
   type: key
-- display_text: weight
-  multiple: true
+- multiple: true
   name: weight
   optional: true
   token: WEIGHTS
   type: integer
 - arguments:
-  - display_text: sum
-    name: sum
+  - name: sum
     token: SUM
     type: pure-token
-  - display_text: min
-    name: min
+  - name: min
     token: MIN
     type: pure-token
-  - display_text: max
-    name: max
+  - name: max
     token: MAX
+    type: pure-token
+  - name: count
+    since: 8.8.0
+    token: COUNT
     type: pure-token
   name: aggregate
   optional: true
@@ -59,37 +56,38 @@ complexity: O(N)+O(M log(M)) with N being the sum of the sizes of the input sort
 description: Stores the union of multiple sorted sets in a key.
 group: sorted-set
 hidden: false
+history:
+- - 8.8.0
+  - Added `COUNT` aggregate option.
 key_specs:
-- OW: true
-  begin_search:
-    spec:
-      index: 1
-    type: index
+- begin_search:
+    index:
+      pos: 1
   find_keys:
-    spec:
-      keystep: 1
+    range:
       lastkey: 0
       limit: 0
-    type: range
-  update: true
-- RO: true
-  access: true
-  begin_search:
-    spec:
-      index: 2
-    type: index
+      step: 1
+  flags:
+  - OW
+  - UPDATE
+- begin_search:
+    index:
+      pos: 2
   find_keys:
-    spec:
+    keynum:
       firstkey: 1
       keynumidx: 0
-      keystep: 1
-    type: keynum
+      step: 1
+  flags:
+  - RO
+  - ACCESS
 linkTitle: ZUNIONSTORE
 railroad_diagram: /images/railroad/zunionstore.svg
 since: 2.0.0
 summary: Stores the union of multiple sorted sets in a key.
 syntax_fmt: "ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS\_weight\n  [weight\
-  \ ...]] [AGGREGATE\_<SUM | MIN | MAX>]"
+  \ ...]] [AGGREGATE\_<SUM | MIN | MAX | COUNT>]"
 title: ZUNIONSTORE
 ---
 {{< note >}}
@@ -117,6 +115,10 @@ This option defaults to `SUM`, where the score of an element is summed across
 the inputs where it exists.
 When this option is set to either `MIN` or `MAX`, the resulting set will contain
 the minimum or maximum score of an element across the inputs where it exists.
+
+When `AGGREGATE COUNT` is specified, the resulting score for each element reflects how many input sets contain it (optionally scaled by
+`WEIGHTS`), rather than combining the actual scores of the elements.
+This enables a common use case: counting set membership frequency directly at the command level, without application-side workarounds.
 
 If `destination` already exists, it is overwritten.
 

--- a/content/commands/zunionstore.md
+++ b/content/commands/zunionstore.md
@@ -103,10 +103,9 @@ the input keys and the other (optional) arguments.
 By default, the resulting score of an element is the sum of its scores in the
 sorted sets where it exists.
 
-Using the `WEIGHTS` option, it is possible to specify a multiplication factor
-for each input sorted set.
-This means that the score of every element in every input sorted set is
-multiplied by this factor before being passed to the aggregation function.
+Using the `WEIGHTS` option, it is possible to specify a multiplication factor for
+each input sorted set. Each element's score is multiplied by its corresponding
+weight before aggregation.
 When `WEIGHTS` is not given, the multiplication factors default to `1`.
 
 With the `AGGREGATE` option, it is possible to specify how the results of the
@@ -115,10 +114,20 @@ This option defaults to `SUM`, where the score of an element is summed across
 the inputs where it exists.
 When this option is set to either `MIN` or `MAX`, the resulting set will contain
 the minimum or maximum score of an element across the inputs where it exists.
+For `SUM`, `MIN`, and `MAX`, each element's score is multiplied by its
+corresponding weight before aggregation.
 
-When `AGGREGATE COUNT` is specified, the resulting score for each element reflects how many input sets contain it (optionally scaled by
-`WEIGHTS`), rather than combining the actual scores of the elements.
-This enables a common use case: counting set membership frequency directly at the command level, without application-side workarounds.
+When `AGGREGATE COUNT` is specified, the original element scores are ignored
+entirely. The resulting score for each element is determined by which input sets
+contain it, optionally scaled by `WEIGHTS`:
+
+- Without `WEIGHTS`, each input set containing the element contributes `1` to
+  its score — effectively counting set membership.
+- With `WEIGHTS`, each input set containing the element contributes its
+  corresponding weight, so the score becomes the sum of those weights.
+
+This enables a common use case: counting set membership frequency directly at
+the command level, without application-side workarounds.
 
 If `destination` already exists, it is overwritten.
 

--- a/static/images/railroad/zinter.svg
+++ b/static/images/railroad/zinter.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="131" viewBox="0 0 973.5 131" width="973.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="161" viewBox="0 0 990.5 161" width="990.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,7 +44,7 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
-<path d="M50 40h0.0"></path><path d="M923.5 40h0.0"></path><g class="terminal ">
+<path d="M50 40h0.0"></path><path d="M940.5 40h0.0"></path><g class="terminal ">
 <path d="M50.0 40h0.0"></path><path d="M121.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="29"></rect><text x="85.5" y="44">ZINTER</text></g><path d="M121.0 40h10"></path><path d="M131.0 40h10"></path><g class="non-terminal ">
 <path d="M141.0 40h0.0"></path><path d="M220.5 40h0.0"></path><rect height="22" width="79.5" x="141.0" y="29"></rect><text x="180.75" y="44">numkeys</text></g><path d="M220.5 40h10"></path><path d="M230.5 40h10"></path><g>
 <path d="M240.5 40h0.0"></path><path d="M306.0 40h0.0"></path><path d="M240.5 40h10"></path><g class="non-terminal ">
@@ -57,14 +57,15 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 <path d="M435.5 40h0.0"></path><path d="M526.5 40h0.0"></path><path d="M435.5 40h10"></path><g class="non-terminal ">
 <path d="M445.5 40h0.0"></path><path d="M516.5 40h0.0"></path><rect height="22" width="71.0" x="445.5" y="29"></rect><text x="481.0" y="44">weight</text></g><path d="M516.5 40h10"></path><path d="M445.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
 <path d="M445.5 60h71.0"></path></g><path d="M516.5 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M526.5 40h20"></path></g><g>
-<path d="M546.5 40h0.0"></path><path d="M778.5 40h0.0"></path><path d="M546.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M566.5 20h192.0"></path></g><path d="M758.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M546.5 40h20"></path><g>
-<path d="M566.5 40h0.0"></path><path d="M758.5 40h0.0"></path><g class="terminal ">
+<path d="M546.5 40h0.0"></path><path d="M795.5 40h0.0"></path><path d="M546.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M566.5 20h209.0"></path></g><path d="M775.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M546.5 40h20"></path><g>
+<path d="M566.5 40h0.0"></path><path d="M775.5 40h0.0"></path><g class="terminal ">
 <path d="M566.5 40h0.0"></path><path d="M663.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="566.5" y="29"></rect><text x="614.75" y="44">AGGREGATE</text></g><path d="M663.0 40h10"></path><g>
-<path d="M673.0 40h0.0"></path><path d="M758.5 40h0.0"></path><path d="M673.0 40h20"></path><g class="terminal ">
-<path d="M693.0 40h0.0"></path><path d="M738.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="693.0" y="29"></rect><text x="715.75" y="44">SUM</text></g><path d="M738.5 40h20"></path><path d="M673.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M693.0 70h0.0"></path><path d="M738.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="693.0" y="59"></rect><text x="715.75" y="74">MIN</text></g><path d="M738.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M673.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M693.0 100h0.0"></path><path d="M738.5 100h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="693.0" y="89"></rect><text x="715.75" y="104">MAX</text></g><path d="M738.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path></g></g><path d="M758.5 40h20"></path></g><g>
-<path d="M778.5 40h0.0"></path><path d="M923.5 40h0.0"></path><path d="M778.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M798.5 20h105.0"></path></g><path d="M903.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M778.5 40h20"></path><g class="terminal ">
-<path d="M798.5 40h0.0"></path><path d="M903.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="798.5" y="29"></rect><text x="851.0" y="44">WITHSCORES</text></g><path d="M903.5 40h20"></path></g></g><path d="M923.5 40h10"></path><path d="M 933.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M673.0 40h0.0"></path><path d="M775.5 40h0.0"></path><path d="M673.0 40h20"></path><g class="terminal ">
+<path d="M693.0 40h8.5"></path><path d="M747.0 40h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="701.5" y="29"></rect><text x="724.25" y="44">SUM</text></g><path d="M755.5 40h20"></path><path d="M673.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M693.0 70h8.5"></path><path d="M747.0 70h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="701.5" y="59"></rect><text x="724.25" y="74">MIN</text></g><path d="M755.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M673.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M693.0 100h8.5"></path><path d="M747.0 100h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="701.5" y="89"></rect><text x="724.25" y="104">MAX</text></g><path d="M755.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M673.0 40a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M693.0 130h0.0"></path><path d="M755.5 130h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="693.0" y="119"></rect><text x="724.25" y="134">COUNT</text></g><path d="M755.5 130a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path></g></g><path d="M775.5 40h20"></path></g><g>
+<path d="M795.5 40h0.0"></path><path d="M940.5 40h0.0"></path><path d="M795.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M815.5 20h105.0"></path></g><path d="M920.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M795.5 40h20"></path><g class="terminal ">
+<path d="M815.5 40h0.0"></path><path d="M920.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="815.5" y="29"></rect><text x="868.0" y="44">WITHSCORES</text></g><path d="M920.5 40h20"></path></g></g><path d="M940.5 40h10"></path><path d="M 950.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/zinterstore.svg
+++ b/static/images/railroad/zinterstore.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="131" viewBox="0 0 1004.5 131" width="1004.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="161" viewBox="0 0 1021.5 161" width="1021.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,7 +44,7 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
-<path d="M50 40h0.0"></path><path d="M954.5 40h0.0"></path><g class="terminal ">
+<path d="M50 40h0.0"></path><path d="M971.5 40h0.0"></path><g class="terminal ">
 <path d="M50.0 40h0.0"></path><path d="M163.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="50.0" y="29"></rect><text x="106.75" y="44">ZINTERSTORE</text></g><path d="M163.5 40h10"></path><path d="M173.5 40h10"></path><g class="non-terminal ">
 <path d="M183.5 40h0.0"></path><path d="M297.0 40h0.0"></path><rect height="22" width="113.5" x="183.5" y="29"></rect><text x="240.25" y="44">destination</text></g><path d="M297.0 40h10"></path><path d="M307.0 40h10"></path><g class="non-terminal ">
 <path d="M317.0 40h0.0"></path><path d="M396.5 40h0.0"></path><rect height="22" width="79.5" x="317.0" y="29"></rect><text x="356.75" y="44">numkeys</text></g><path d="M396.5 40h10"></path><path d="M406.5 40h10"></path><g>
@@ -58,11 +58,12 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 <path d="M611.5 40h0.0"></path><path d="M702.5 40h0.0"></path><path d="M611.5 40h10"></path><g class="non-terminal ">
 <path d="M621.5 40h0.0"></path><path d="M692.5 40h0.0"></path><rect height="22" width="71.0" x="621.5" y="29"></rect><text x="657.0" y="44">weight</text></g><path d="M692.5 40h10"></path><path d="M621.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
 <path d="M621.5 60h71.0"></path></g><path d="M692.5 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M702.5 40h20"></path></g><g>
-<path d="M722.5 40h0.0"></path><path d="M954.5 40h0.0"></path><path d="M722.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M742.5 20h192.0"></path></g><path d="M934.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M722.5 40h20"></path><g>
-<path d="M742.5 40h0.0"></path><path d="M934.5 40h0.0"></path><g class="terminal ">
+<path d="M722.5 40h0.0"></path><path d="M971.5 40h0.0"></path><path d="M722.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M742.5 20h209.0"></path></g><path d="M951.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M722.5 40h20"></path><g>
+<path d="M742.5 40h0.0"></path><path d="M951.5 40h0.0"></path><g class="terminal ">
 <path d="M742.5 40h0.0"></path><path d="M839.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="742.5" y="29"></rect><text x="790.75" y="44">AGGREGATE</text></g><path d="M839.0 40h10"></path><g>
-<path d="M849.0 40h0.0"></path><path d="M934.5 40h0.0"></path><path d="M849.0 40h20"></path><g class="terminal ">
-<path d="M869.0 40h0.0"></path><path d="M914.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="869.0" y="29"></rect><text x="891.75" y="44">SUM</text></g><path d="M914.5 40h20"></path><path d="M849.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M869.0 70h0.0"></path><path d="M914.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="869.0" y="59"></rect><text x="891.75" y="74">MIN</text></g><path d="M914.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M849.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M869.0 100h0.0"></path><path d="M914.5 100h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="869.0" y="89"></rect><text x="891.75" y="104">MAX</text></g><path d="M914.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path></g></g><path d="M934.5 40h20"></path></g></g><path d="M954.5 40h10"></path><path d="M 964.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M849.0 40h0.0"></path><path d="M951.5 40h0.0"></path><path d="M849.0 40h20"></path><g class="terminal ">
+<path d="M869.0 40h8.5"></path><path d="M923.0 40h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="877.5" y="29"></rect><text x="900.25" y="44">SUM</text></g><path d="M931.5 40h20"></path><path d="M849.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M869.0 70h8.5"></path><path d="M923.0 70h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="877.5" y="59"></rect><text x="900.25" y="74">MIN</text></g><path d="M931.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M849.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M869.0 100h8.5"></path><path d="M923.0 100h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="877.5" y="89"></rect><text x="900.25" y="104">MAX</text></g><path d="M931.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M849.0 40a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M869.0 130h0.0"></path><path d="M931.5 130h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="869.0" y="119"></rect><text x="900.25" y="134">COUNT</text></g><path d="M931.5 130a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path></g></g><path d="M951.5 40h20"></path></g></g><path d="M971.5 40h10"></path><path d="M 981.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/zunion.svg
+++ b/static/images/railroad/zunion.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="131" viewBox="0 0 973.5 131" width="973.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="161" viewBox="0 0 990.5 161" width="990.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,7 +44,7 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
-<path d="M50 40h0.0"></path><path d="M923.5 40h0.0"></path><g class="terminal ">
+<path d="M50 40h0.0"></path><path d="M940.5 40h0.0"></path><g class="terminal ">
 <path d="M50.0 40h0.0"></path><path d="M121.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="29"></rect><text x="85.5" y="44">ZUNION</text></g><path d="M121.0 40h10"></path><path d="M131.0 40h10"></path><g class="non-terminal ">
 <path d="M141.0 40h0.0"></path><path d="M220.5 40h0.0"></path><rect height="22" width="79.5" x="141.0" y="29"></rect><text x="180.75" y="44">numkeys</text></g><path d="M220.5 40h10"></path><path d="M230.5 40h10"></path><g>
 <path d="M240.5 40h0.0"></path><path d="M306.0 40h0.0"></path><path d="M240.5 40h10"></path><g class="non-terminal ">
@@ -57,14 +57,15 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 <path d="M435.5 40h0.0"></path><path d="M526.5 40h0.0"></path><path d="M435.5 40h10"></path><g class="non-terminal ">
 <path d="M445.5 40h0.0"></path><path d="M516.5 40h0.0"></path><rect height="22" width="71.0" x="445.5" y="29"></rect><text x="481.0" y="44">weight</text></g><path d="M516.5 40h10"></path><path d="M445.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
 <path d="M445.5 60h71.0"></path></g><path d="M516.5 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M526.5 40h20"></path></g><g>
-<path d="M546.5 40h0.0"></path><path d="M778.5 40h0.0"></path><path d="M546.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M566.5 20h192.0"></path></g><path d="M758.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M546.5 40h20"></path><g>
-<path d="M566.5 40h0.0"></path><path d="M758.5 40h0.0"></path><g class="terminal ">
+<path d="M546.5 40h0.0"></path><path d="M795.5 40h0.0"></path><path d="M546.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M566.5 20h209.0"></path></g><path d="M775.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M546.5 40h20"></path><g>
+<path d="M566.5 40h0.0"></path><path d="M775.5 40h0.0"></path><g class="terminal ">
 <path d="M566.5 40h0.0"></path><path d="M663.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="566.5" y="29"></rect><text x="614.75" y="44">AGGREGATE</text></g><path d="M663.0 40h10"></path><g>
-<path d="M673.0 40h0.0"></path><path d="M758.5 40h0.0"></path><path d="M673.0 40h20"></path><g class="terminal ">
-<path d="M693.0 40h0.0"></path><path d="M738.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="693.0" y="29"></rect><text x="715.75" y="44">SUM</text></g><path d="M738.5 40h20"></path><path d="M673.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M693.0 70h0.0"></path><path d="M738.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="693.0" y="59"></rect><text x="715.75" y="74">MIN</text></g><path d="M738.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M673.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M693.0 100h0.0"></path><path d="M738.5 100h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="693.0" y="89"></rect><text x="715.75" y="104">MAX</text></g><path d="M738.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path></g></g><path d="M758.5 40h20"></path></g><g>
-<path d="M778.5 40h0.0"></path><path d="M923.5 40h0.0"></path><path d="M778.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M798.5 20h105.0"></path></g><path d="M903.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M778.5 40h20"></path><g class="terminal ">
-<path d="M798.5 40h0.0"></path><path d="M903.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="798.5" y="29"></rect><text x="851.0" y="44">WITHSCORES</text></g><path d="M903.5 40h20"></path></g></g><path d="M923.5 40h10"></path><path d="M 933.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M673.0 40h0.0"></path><path d="M775.5 40h0.0"></path><path d="M673.0 40h20"></path><g class="terminal ">
+<path d="M693.0 40h8.5"></path><path d="M747.0 40h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="701.5" y="29"></rect><text x="724.25" y="44">SUM</text></g><path d="M755.5 40h20"></path><path d="M673.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M693.0 70h8.5"></path><path d="M747.0 70h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="701.5" y="59"></rect><text x="724.25" y="74">MIN</text></g><path d="M755.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M673.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M693.0 100h8.5"></path><path d="M747.0 100h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="701.5" y="89"></rect><text x="724.25" y="104">MAX</text></g><path d="M755.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M673.0 40a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M693.0 130h0.0"></path><path d="M755.5 130h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="693.0" y="119"></rect><text x="724.25" y="134">COUNT</text></g><path d="M755.5 130a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path></g></g><path d="M775.5 40h20"></path></g><g>
+<path d="M795.5 40h0.0"></path><path d="M940.5 40h0.0"></path><path d="M795.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M815.5 20h105.0"></path></g><path d="M920.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M795.5 40h20"></path><g class="terminal ">
+<path d="M815.5 40h0.0"></path><path d="M920.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="815.5" y="29"></rect><text x="868.0" y="44">WITHSCORES</text></g><path d="M920.5 40h20"></path></g></g><path d="M940.5 40h10"></path><path d="M 950.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/zunionstore.svg
+++ b/static/images/railroad/zunionstore.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="131" viewBox="0 0 1004.5 131" width="1004.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="161" viewBox="0 0 1021.5 161" width="1021.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,7 +44,7 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
-<path d="M50 40h0.0"></path><path d="M954.5 40h0.0"></path><g class="terminal ">
+<path d="M50 40h0.0"></path><path d="M971.5 40h0.0"></path><g class="terminal ">
 <path d="M50.0 40h0.0"></path><path d="M163.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="50.0" y="29"></rect><text x="106.75" y="44">ZUNIONSTORE</text></g><path d="M163.5 40h10"></path><path d="M173.5 40h10"></path><g class="non-terminal ">
 <path d="M183.5 40h0.0"></path><path d="M297.0 40h0.0"></path><rect height="22" width="113.5" x="183.5" y="29"></rect><text x="240.25" y="44">destination</text></g><path d="M297.0 40h10"></path><path d="M307.0 40h10"></path><g class="non-terminal ">
 <path d="M317.0 40h0.0"></path><path d="M396.5 40h0.0"></path><rect height="22" width="79.5" x="317.0" y="29"></rect><text x="356.75" y="44">numkeys</text></g><path d="M396.5 40h10"></path><path d="M406.5 40h10"></path><g>
@@ -58,11 +58,12 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 <path d="M611.5 40h0.0"></path><path d="M702.5 40h0.0"></path><path d="M611.5 40h10"></path><g class="non-terminal ">
 <path d="M621.5 40h0.0"></path><path d="M692.5 40h0.0"></path><rect height="22" width="71.0" x="621.5" y="29"></rect><text x="657.0" y="44">weight</text></g><path d="M692.5 40h10"></path><path d="M621.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
 <path d="M621.5 60h71.0"></path></g><path d="M692.5 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M702.5 40h20"></path></g><g>
-<path d="M722.5 40h0.0"></path><path d="M954.5 40h0.0"></path><path d="M722.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M742.5 20h192.0"></path></g><path d="M934.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M722.5 40h20"></path><g>
-<path d="M742.5 40h0.0"></path><path d="M934.5 40h0.0"></path><g class="terminal ">
+<path d="M722.5 40h0.0"></path><path d="M971.5 40h0.0"></path><path d="M722.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M742.5 20h209.0"></path></g><path d="M951.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M722.5 40h20"></path><g>
+<path d="M742.5 40h0.0"></path><path d="M951.5 40h0.0"></path><g class="terminal ">
 <path d="M742.5 40h0.0"></path><path d="M839.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="742.5" y="29"></rect><text x="790.75" y="44">AGGREGATE</text></g><path d="M839.0 40h10"></path><g>
-<path d="M849.0 40h0.0"></path><path d="M934.5 40h0.0"></path><path d="M849.0 40h20"></path><g class="terminal ">
-<path d="M869.0 40h0.0"></path><path d="M914.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="869.0" y="29"></rect><text x="891.75" y="44">SUM</text></g><path d="M914.5 40h20"></path><path d="M849.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M869.0 70h0.0"></path><path d="M914.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="869.0" y="59"></rect><text x="891.75" y="74">MIN</text></g><path d="M914.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M849.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M869.0 100h0.0"></path><path d="M914.5 100h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="869.0" y="89"></rect><text x="891.75" y="104">MAX</text></g><path d="M914.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path></g></g><path d="M934.5 40h20"></path></g></g><path d="M954.5 40h10"></path><path d="M 964.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M849.0 40h0.0"></path><path d="M951.5 40h0.0"></path><path d="M849.0 40h20"></path><g class="terminal ">
+<path d="M869.0 40h8.5"></path><path d="M923.0 40h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="877.5" y="29"></rect><text x="900.25" y="44">SUM</text></g><path d="M931.5 40h20"></path><path d="M849.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M869.0 70h8.5"></path><path d="M923.0 70h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="877.5" y="59"></rect><text x="900.25" y="74">MIN</text></g><path d="M931.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M849.0 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M869.0 100h8.5"></path><path d="M923.0 100h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="877.5" y="89"></rect><text x="900.25" y="104">MAX</text></g><path d="M931.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M849.0 40a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M869.0 130h0.0"></path><path d="M931.5 130h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="869.0" y="119"></rect><text x="900.25" y="134">COUNT</text></g><path d="M931.5 130a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path></g></g><path d="M951.5 40h20"></path></g></g><path d="M971.5 40h10"></path><path d="M 981.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and static diagram updates only, with no runtime or API behavior changes in this repo.
> 
> **Overview**
> Documents Redis 8.8’s new `AGGREGATE COUNT` option across `ZINTER`, `ZINTERSTORE`, `ZUNION`, and `ZUNIONSTORE`, including updated `syntax_fmt`, argument metadata, and `history` entries.
> 
> Refreshes `key_specs` YAML structure/flags formatting for these command pages and updates the railroad SVG diagrams to include `COUNT` in the `AGGREGATE` choice; `zunionstore` also adds a short explanation of how `COUNT` interacts with `WEIGHTS` and scoring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6d7177b98a2a7c2ee6d122adfeb02514665eae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->