### PR TITLE
DOC-6479 added missing clients to Develop landing page

### DIFF
--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -20,9 +20,14 @@ or analyze and manage your database with our
 | [Python]({{< relref "/develop/clients/redis-py" >}}) | [See Python examples]({{< relref "/develop/clients/redis-py/connect" >}}) | [See Python examples]({{< relref "/develop/clients/redis-py/queryjson" >}}) | [See Python examples]({{< relref "/develop/clients/redis-py/vecsearch" >}}) |
 | [C#/.NET]({{< relref "/develop/clients/dotnet" >}}) | [See C# examples]({{< relref "/develop/clients/dotnet/connect" >}}) | [See C# examples]({{< relref "/develop/clients/dotnet/queryjson" >}}) | [See C# examples]({{< relref "/develop/clients/dotnet/vecsearch" >}}) |
 | [Node.js]({{< relref "/develop/clients/nodejs" >}}) | [See JS examples]({{< relref "/develop/clients/nodejs/connect" >}}) | [See JS examples]({{< relref "/develop/clients/nodejs/queryjson" >}}) | [See JS examples]({{< relref "/develop/clients/nodejs/vecsearch" >}}) |
-| [Java]({{< relref "/develop/clients/jedis" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/connect" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/queryjson" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/vecsearch" >}}) |
+| [Java (Jedis)]({{< relref "/develop/clients/jedis" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/connect" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/queryjson" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/vecsearch" >}}) |
+| [Java (Lettuce)]({{< relref "/develop/clients/lettuce" >}}) | [See Java examples]({{< relref "/develop/clients/lettuce/connect" >}}) | [See Java examples]({{< relref "/develop/clients/lettuce/queryjson" >}}) | [See Java examples]({{< relref "/develop/clients/lettuce/vecsearch" >}}) |
 | [Go]({{< relref "/develop/clients/go" >}}) | [See Go examples]({{< relref "/develop/clients/go/connect" >}}) | [See Go examples]({{< relref "/develop/clients/go/queryjson" >}}) | [See Go examples]({{< relref "/develop/clients/go/vecsearch" >}}) |
 | [PHP]({{< relref "/develop/clients/php" >}}) | [See PHP examples]({{< relref "/develop/clients/php/connect" >}}) | [See PHP examples]({{< relref "/develop/clients/php/queryjson" >}}) | [See PHP examples]({{< relref "/develop/clients/php/vecsearch" >}}) |
+| [JavaScript (ioredis)]({{< relref "/develop/clients/ioredis" >}}) | [See JS examples]({{< relref "/develop/clients/ioredis/connect" >}}) | - | - |
+| [Rust]({{< relref "/develop/clients/rust" >}}) | - | - | - |
+| [C]({{< relref "/develop/clients/hiredis" >}}) | - | - | - |
+| [Ruby]({{< relref "/develop/clients/ruby" >}}) | - | - | - |
 
 | | |
 | - | - |


### PR DESCRIPTION
Mirko asked for the other clients to be added to the list in the Develop landing page. Does the table still work when the clients at the end don't have the full set of examples?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is broken/incorrect `relref` links or table rendering for rows with placeholder dashes.
> 
> **Overview**
> Updates `content/develop/_index.md` to expand the client examples table: renames the generic Java entry to **Java (Jedis)**, adds **Java (Lettuce)**, and adds new rows for **ioredis**, **Rust**, **C (hiredis)**, and **Ruby**. For clients without available document/vector search examples, the table now uses `-` placeholders instead of links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403acabad6a9f2e2195a231b21b1e18a7ae93f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->