### PR TITLE
DOC-6480 fix some of the latest 404s

### DIFF
--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/interact/search-and-query
 - /develop/interact/search-and-query/
 - /interact/search-and-query/
+- /search/
 categories:
 - docs
 - develop

--- a/content/develop/clients/dotnet/_index.md
+++ b/content/develop/clients/dotnet/_index.md
@@ -1,5 +1,8 @@
 ---
-aliases: /develop/connect/clients/dotnet
+aliases:
+- /develop/connect/clients/dotnet
+- /connect/clients/dotnet/
+- /clients/dotnet/
 categories:
 - docs
 - develop

--- a/content/develop/clients/go/_index.md
+++ b/content/develop/clients/go/_index.md
@@ -1,5 +1,8 @@
 ---
-aliases: /develop/connect/clients/go
+aliases:
+- /develop/connect/clients/go
+- /connect/clients/go/
+- /clients/go/
 categories:
 - docs
 - develop

--- a/content/develop/clients/hiredis/_index.md
+++ b/content/develop/clients/hiredis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /connect/clients/hiredis/
+- /clients/hiredis/
 categories:
 - docs
 - develop

--- a/content/develop/clients/ioredis/_index.md
+++ b/content/develop/clients/ioredis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /connect/clients/ioredis/
+- /clients/ioredis/
 categories:
 - docs
 - develop

--- a/content/develop/clients/jedis/_index.md
+++ b/content/develop/clients/jedis/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /develop/connect/clients/java/jedis
 - /connect/clients/java/
+- /connect/clients/jedis/
 - /clients/jedis/
 categories:
 - docs

--- a/content/develop/clients/lettuce/_index.md
+++ b/content/develop/clients/lettuce/_index.md
@@ -1,5 +1,8 @@
 ---
-aliases: /develop/connect/clients/java/lettuce
+aliases:
+- /develop/connect/clients/java/lettuce
+- /connect/clients/lettuce/
+- /clients/lettuce/
 categories:
 - docs
 - develop

--- a/content/develop/clients/nodejs/_index.md
+++ b/content/develop/clients/nodejs/_index.md
@@ -1,5 +1,8 @@
 ---
-aliases: /develop/connect/clients/nodejs
+aliases:
+- /develop/connect/clients/nodejs
+- /connect/clients/nodejs/
+- /clients/nodejs/
 categories:
 - docs
 - develop

--- a/content/develop/clients/om-clients/_index.md
+++ b/content/develop/clients/om-clients/_index.md
@@ -1,5 +1,8 @@
 ---
-aliases: /develop/connect/om-clients
+aliases:
+- /develop/connect/om-clients
+- /connect/clients/om-clients/
+- /clients/om-clients/
 categories:
 - docs
 - develop

--- a/content/develop/clients/patterns/_index.md
+++ b/content/develop/clients/patterns/_index.md
@@ -1,4 +1,8 @@
 ---
+aliases:
+- /develop/use/patterns
+- /connect/clients/patterns/
+- /clients/patterns/
 categories:
 - docs
 - develop
@@ -13,7 +17,6 @@ description: Novel patterns for working with Redis data structures
 hideListLinks: true
 linkTitle: Coding patterns
 title: Coding patterns
-aliases: /develop/use/patterns
 weight: 100
 ---
 

--- a/content/develop/clients/php/_index.md
+++ b/content/develop/clients/php/_index.md
@@ -1,5 +1,8 @@
 ---
-aliases: /develop/connect/clients/php
+aliases:
+- /develop/connect/clients/php
+- /connect/clients/php/
+- /clients/php/
 categories:
 - docs
 - develop

--- a/content/develop/clients/redis-py/_index.md
+++ b/content/develop/clients/redis-py/_index.md
@@ -3,6 +3,8 @@ aliases:
 - /develop/connect/clients/python/redis-py
 - /develop/connect/clients/python/
 - /clients/python/
+- /connect/clients/redis-py/
+- /clients/redis-py/
 categories:
 - docs
 - develop

--- a/content/develop/clients/ruby/_index.md
+++ b/content/develop/clients/ruby/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /connect/clients/ruby/
+- /clients/ruby/
 categories:
 - docs
 - develop

--- a/content/develop/clients/rust/_index.md
+++ b/content/develop/clients/rust/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /connect/clients/rust/
+- /clients/rust/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/bitfields.md
+++ b/content/develop/data-types/bitfields.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/bitfields/
+- /manual/data-types/bitfields/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/bitmaps.md
+++ b/content/develop/data-types/bitmaps.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/bitmaps/
+- /manual/data-types/bitmaps/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/geospatial.md
+++ b/content/develop/data-types/geospatial.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/geospatial/
+- /manual/data-types/geospatial/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/hashes/
+- /manual/data-types/hashes/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/json/_index.md
+++ b/content/develop/data-types/json/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/json/
+- /manual/data-types/json/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/lists.md
+++ b/content/develop/data-types/lists.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/lists/
+- /manual/data-types/lists/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/probabilistic/_index.md
+++ b/content/develop/data-types/probabilistic/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/
+- /manual/data-types/probabilistic/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/probabilistic/bloom-filter.md
+++ b/content/develop/data-types/probabilistic/bloom-filter.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/bloom-filter/
+- /manual/data-types/probabilistic/bloom-filter/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/probabilistic/configuration.md
+++ b/content/develop/data-types/probabilistic/configuration.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/configuration/
+- /manual/data-types/probabilistic/configuration/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/probabilistic/count-min-sketch.md
+++ b/content/develop/data-types/probabilistic/count-min-sketch.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/count-min-sketch/
+- /manual/data-types/probabilistic/count-min-sketch/
 categories:
 - docs
 - develop
@@ -14,8 +17,6 @@ description: Count-min sketch is a probabilistic data structure that estimates t
 linkTitle: Count-min sketch
 stack: true
 title: Count-min sketch
-aliases:
-- /data-types/probabilistic/count-min-sketch/
 weight: 60
 ---
 

--- a/content/develop/data-types/probabilistic/cuckoo-filter.md
+++ b/content/develop/data-types/probabilistic/cuckoo-filter.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/cuckoo-filter/
+- /manual/data-types/probabilistic/cuckoo-filter/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/probabilistic/hyperloglogs.md
+++ b/content/develop/data-types/probabilistic/hyperloglogs.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/hyperloglogs/
+- /manual/data-types/probabilistic/hyperloglogs/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/probabilistic/t-digest.md
+++ b/content/develop/data-types/probabilistic/t-digest.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/t-digest/
+- /manual/data-types/probabilistic/t-digest/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/probabilistic/top-k.md
+++ b/content/develop/data-types/probabilistic/top-k.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/probabilistic/top-k/
+- /manual/data-types/probabilistic/top-k/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/sets.md
+++ b/content/develop/data-types/sets.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/sets/
+- /manual/data-types/sets/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/sorted-sets.md
+++ b/content/develop/data-types/sorted-sets.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/sorted-sets/
+- /manual/data-types/sorted-sets/
 categories:
 - docs
 - develop
@@ -14,8 +17,6 @@ description: 'Introduction to Redis sorted sets
   '
 linkTitle: Sorted sets
 title: Redis sorted sets
-aliases:
-- /data-types/sorted-sets/
 weight: 50
 ---
 

--- a/content/develop/data-types/streams/_index.md
+++ b/content/develop/data-types/streams/_index.md
@@ -1,4 +1,9 @@
 ---
+aliases:
+- /manual/data-types/streams/
+- /data-types/streams/
+- /develop/data-types/streams-tutorial/
+- /io/data-structures/streams/
 categories:
 - docs
 - develop
@@ -12,11 +17,6 @@ categories:
 description: Introduction to Redis streams
 linkTitle: Streams
 title: Redis Streams
-aliases:
-- /manual/data-types/streams/
-- /data-types/streams/
-- /develop/data-types/streams-tutorial/
-- /io/data-structures/streams/
 weight: 60
 ---
 

--- a/content/develop/data-types/strings.md
+++ b/content/develop/data-types/strings.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/strings/
+- /manual/data-types/strings/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/timeseries/_index.md
+++ b/content/develop/data-types/timeseries/_index.md
@@ -1,4 +1,13 @@
 ---
+aliases:
+- /develop/data-types/timeseries/quickstart
+- /develop/data-types/timeseries/quickstart/
+- /develop/data-types/timeseries/clients
+- /develop/data-types/timeseries/clients/
+- /develop/data-types/timeseries/development
+- /develop/data-types/timeseries/development/
+- /data-types/timeseries/
+- /manual/data-types/timeseries/
 categories:
 - docs
 - develop
@@ -10,14 +19,6 @@ categories:
 - kubernetes
 - clients
 description: Ingest and query time series data with Redis
-aliases:
-- /develop/data-types/timeseries/quickstart
-- /develop/data-types/timeseries/quickstart/
-- /develop/data-types/timeseries/clients
-- /develop/data-types/timeseries/clients/
-- /develop/data-types/timeseries/development
-- /develop/data-types/timeseries/development/
-- /data-types/timeseries/
 linkTitle: Time series
 stack: true
 title: Time series

--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/vector-sets/
+- /manual/data-types/vector-sets/
 categories:
 - docs
 - develop

--- a/content/develop/get-started/_index.md
+++ b/content/develop/get-started/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /getting-started/
 categories:
 - docs
 - develop
@@ -15,8 +17,6 @@ description: 'Redis quick start guides
 hideListLinks: true
 linkTitle: Quick starts
 title: Quick starts
-aliases:
-- /getting-started/
 weight: 20
 ---
 


### PR DESCRIPTION
Some more aliases for recurring 404s found by the crawl report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds URL aliases/redirects; main risk is unintended redirect collisions or missing leading/trailing slashes causing continued 404s.
> 
> **Overview**
> Adds a batch of new `aliases` entries across multiple docs landing pages (Redis Search, client library guides, and several data-type pages) to redirect common legacy URLs (for example `/connect/clients/...`, `/clients/...`, and `/manual/data-types/...`) to their current locations.
> 
> Also normalizes some frontmatter by converting single `-aliases:` fields into proper `aliases:` lists and expands a few pages with additional legacy paths (for example streams/timeseries and Redis Search).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bab3345e34c4b076c10bd6102f6e09669c75d55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->