### PR TITLE
RS: Added known issue and workaround for broken LDAP authentication in the CM UI

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -207,6 +207,25 @@ The following table provides a snapshot of supported platforms as of this Redis 
 
 ## Known issues
 
+- RS193156: Active Directory LDAP authentication can fail in the Cluster Manager UI after upgrading to Redis Software version 8.0.16-33 due to an issue with LDAP TLS client certificate handling. Users previously authenticated through Active Directory can no longer sign in to the Cluster Manager UI after the upgrade.
+
+    As a workaround, configure an LDAP client certificate using an [update cluster certificates]({{<relref "/operate/rs/references/rest-api/requests/cluster/certificates">}}) REST API request:
+
+    ```sh
+    PUT https://<host>:<port>/v1/cluster/certificates
+    {
+      "certificates": [
+        {
+          "name": "ldap_client",
+          "certificate": "<cert>",
+          "key": "<key>"
+        }
+      ]
+    }
+    ```
+    
+    See [Create certificates]({{<relref "/operate/rs/security/certificates/create-certificates">}}) and [Update certificates]({{<relref "/operate/rs/security/certificates/updating-certificates">}}) for more detailed instructions.
+
 - RS180550: You cannot set up SSO when the Cluster Manager UI is exposed through an IPv6-based load balancer or gateway.
 
     As a workaround, use an IPv4-based address for the SSO service base address, or register a DNS name that resolves to the IPv6 address.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
@@ -104,6 +104,25 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known issues
 
+- RS193156: Active Directory LDAP authentication can fail in the Cluster Manager UI after upgrading to Redis Software version 8.0.16-33 due to an issue with LDAP TLS client certificate handling. Users previously authenticated through Active Directory can no longer sign in to the Cluster Manager UI after the upgrade.
+
+    As a workaround, configure an LDAP client certificate using an [update cluster certificates]({{<relref "/operate/rs/references/rest-api/requests/cluster/certificates">}}) REST API request:
+
+    ```sh
+    PUT https://<host>:<port>/v1/cluster/certificates
+    {
+      "certificates": [
+        {
+          "name": "ldap_client",
+          "certificate": "<cert>",
+          "key": "<key>"
+        }
+      ]
+    }
+    ```
+    
+    See [Create certificates]({{<relref "/operate/rs/security/certificates/create-certificates">}}) and [Update certificates]({{<relref "/operate/rs/security/certificates/updating-certificates">}}) for more detailed instructions.
+
 - RS155734: Endpoint availability metrics do not work as expected due to a calculation error.
 
 ## Known limitations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change adding a known-issue entry and workaround; no product code or behavior is modified.
> 
> **Overview**
> Documents a new known issue (`RS193156`) where Active Directory LDAP auth can fail in the Cluster Manager UI after upgrading to Redis Software `8.0.16-33`.
> 
> Adds a concrete workaround to configure an `ldap_client` certificate via `PUT /v1/cluster/certificates`, with links to certificate creation/update docs, in both the `8.0.x` release notes index and the `8.0.16-33` release page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e13ef480a224ece6f6f62ceb1a56905d09697e19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->