### PR TITLE
DOC-6484 removed bash code fences from example blocks

### DIFF
--- a/content/develop/data-types/timeseries/_index.md
+++ b/content/develop/data-types/timeseries/_index.md
@@ -101,7 +101,6 @@ the names and values to select subsets of all the available time series
 for queries and aggregations.
 
 {{< clients-example set="time_series_tutorial" step="create_labels" description="Labeling: Add metadata labels to time series using LABELS option when you need to organize and filter series by attributes like location or sensor type" difficulty="beginner" buildsUpon="create" >}}
-```bash
 > TS.ADD thermometer:3 1 10.4 LABELS location UK type Mercury
 (integer) 1
 > TS.INFO thermometer:3
@@ -118,7 +117,6 @@ for queries and aggregations.
        2) "Mercury"
     .
     .
-```
 {{< /clients-example >}}
 
 ## Add data points
@@ -132,12 +130,10 @@ If you use the `*` character as the timestamp, Redis will record the current
 Unix time, as reported by the server's clock.
 
 {{< clients-example set="time_series_tutorial" step="madd" description="Batch operations: Add multiple data points to one or more time series using TS.MADD when you need to reduce round trips to the server" difficulty="beginner" buildsUpon="create" >}}
-```bash
 > TS.MADD thermometer:1 1 9.2 thermometer:1 2 9.9 thermometer:2 2 10.3
 1) (integer) 1
 2) (integer) 2
 3) (integer) 2
-```
 {{< /clients-example >}}
 
 ## Query data points
@@ -146,13 +142,11 @@ Use [`TS.GET`]({{< relref "commands/ts.get/" >}}) to retrieve the data point
 with the highest timestamp in a time series. This returns both the timestamp and the value.
 
 {{< clients-example set="time_series_tutorial" step="get" description="Foundational: Use TS.GET to get the latest value and timestamp" difficulty="beginner" buildsUpon="madd" >}}
-```bash
 # The last recorded temperature for thermometer:2
 # was 10.3 at time 2ms.
 > TS.GET thermometer:2
 1) (integer) 2
 2) 10.3
-```
 {{< /clients-example >}}
 
 Use [`TS.RANGE`]({{< relref "commands/ts.range/" >}}) to retrieve data points
@@ -164,7 +158,6 @@ an array of timestamp-value pairs returned in ascending order by timestamp.
 If you want the results in descending order, use [`TS.REVRANGE`]({{< relref "commands/ts.revrange/" >}}) with the same parameters.
 
 {{< clients-example set="time_series_tutorial" step="range" description="Range queries: Retrieve data points within a timestamp range using TS.RANGE (ascending) or TS.REVRANGE (descending) when you need to analyze historical data" difficulty="intermediate" buildsUpon="madd" >}}
-```bash
 # Add 5 data points to a time series named "rg:1".
 > TS.CREATE rg:1
 OK
@@ -222,7 +215,6 @@ OK
    2) 14
 2) 1) (integer) 0
    2) 18
-```
 {{< /clients-example >}}
 
 Both `TS.RANGE` and `TS.REVRANGE` also let you filter results. Specify
@@ -233,7 +225,6 @@ samples within that range. The value range is inclusive and you can
 use the same value for the minimum and maximum to filter for a single value.
 
 {{< clients-example set="time_series_tutorial" step="range_filter" description="Filtering results: Use FILTER_BY_TS and FILTER_BY_VALUE options with range queries when you need to select specific timestamps or value ranges" difficulty="intermediate" buildsUpon="range" >}}
-```bash
 > TS.RANGE rg:1 - + FILTER_BY_TS 0 2 4
 1) 1) (integer) 0
    2) 18
@@ -249,7 +240,6 @@ use the same value for the minimum and maximum to filter for a single value.
 > TS.REVRANGE rg:1 - + FILTER_BY_TS 0 2 4 FILTER_BY_VALUE 22 22
 1) 1) (integer) 2
    2) 22
-```
 {{< /clients-example >}}
 
 ### Query multiple time series
@@ -275,7 +265,6 @@ for details of the filter syntax. You can also request that
 data points be returned with all their labels or with a selected subset of them.
 
 {{< clients-example set="time_series_tutorial" step="query_multi" description="Multi-series queries: Use TS.MGET, TS.MRANGE, and TS.MREVRANGE with label filters when you need to query multiple time series based on label criteria" difficulty="advanced" buildsUpon="create_labels" >}}
-```bash
 # Create three new "rg:" time series (two in the US
 # and one in the UK, with different units) and add some
 # data points.
@@ -364,7 +353,7 @@ OK
       3) 1) (integer) 1
          2) 2.1
 2) 1) "rg:4"
-   2) 1) 1) "location"
+2) 1) 1) "location"
          2) "uk"
    3) 1) 1) (integer) 3
          2) 19
@@ -372,7 +361,6 @@ OK
          2) 21
       3) 1) (integer) 1
          2) 18
-```
 {{< /clients-example >}}
 
 ## Aggregation
@@ -409,7 +397,6 @@ five data points in the `rg:2` time series. The bucket size is 2ms, so there are
 aggregated values with only one value used to calculate the average for the last bucket.
 
 {{< clients-example set="time_series_tutorial" step="agg" description="Aggregation: Use AGGREGATION option with range queries to compute statistics such as avg, sum, min, and max over time buckets when you need to reduce large datasets" difficulty="intermediate" buildsUpon="madd" >}}
-```bash
 > TS.RANGE rg:2 - + AGGREGATION avg 2
 1) 1) (integer) 0
    2) 1.9500000000000002
@@ -417,7 +404,6 @@ aggregated values with only one value used to calculate the average for the last
    2) 2.0999999999999996
 3) 1) (integer) 4
    2) 1.78
-```
 {{< /clients-example >}}
 
 <note><b>NaN Handling (Redis 8.6+):</b> Starting from Redis 8.6, all existing aggregation functions ignore NaN values when computing results. For example, if a bucket contains values [1.0, NaN, 3.0], the `avg` aggregator will return 2.0 (average of 1.0 and 3.0), and the `count` aggregator will return 2. Use the new `countNaN` and `countAll` aggregators to count NaN values and total values respectively.</note>
@@ -430,7 +416,6 @@ For example, the following commands create a time series and apply a `min` aggre
 with a bucket size of 25 milliseconds at the default zero alignment.
 
 {{< clients-example set="time_series_tutorial" step="agg_bucket" description="Bucket alignment: Use AGGREGATION with default zero alignment to group data into fixed-size time buckets when you need consistent time-based aggregations" difficulty="intermediate" buildsUpon="agg" >}}
-```bash
 > TS.CREATE sensor3
 OK
 > TS.MADD sensor3 10 1000 sensor3 20 2000 sensor3 30 3000 sensor3 40 4000 sensor3 50 5000 sensor3 60 6000 sensor3 70 7000
@@ -448,7 +433,6 @@ OK
    2) 3000
 3) 1) (integer) 50
    2) 5000
-```
 {{< /clients-example >}}
 
 The diagram below shows the aggregation buckets and their alignment to the reference timestamp
@@ -466,7 +450,6 @@ Bucket(25ms): |_________________________||_________________________||___________
 You can also align the buckets to the start or end of the query range. For example, the following command aligns the buckets to the start of the query range at time 10.
 
 {{< clients-example set="time_series_tutorial" step="agg_align" description="Custom alignment: Use ALIGN option with aggregations to align buckets to query range start/end when you need aggregations relative to specific time boundaries" difficulty="advanced" buildsUpon="agg_bucket" >}}
-```bash
 > TS.RANGE sensor3 10 70 AGGREGATION min 25 ALIGN start
 1) 1) (integer) 10
    2) 1000
@@ -474,7 +457,6 @@ You can also align the buckets to the start or end of the query range. For examp
    2) 4000
 3) 1) (integer) 60
    2) 6000
-```
 {{< /clients-example >}}
 
 The diagram below shows this arrangement of buckets.
@@ -498,7 +480,6 @@ that have the same timestamp and the same label value (this feature is available
 For example, the following commands create four time series, two for the UK and two for the US, and add some data points. The first `TS.MRANGE` command groups the results by country and applies a `max` aggregation to find the maximum sample value in each country at each timestamp. The second `TS.MRANGE` command uses the same grouping, but applies an `avg` aggregation.
 
 {{< clients-example set="time_series_tutorial" step="agg_multi" description="Cross-series aggregation: Use GROUPBY and REDUCE with TS.MRANGE to aggregate data across multiple time series by label when you need to compute statistics across groups" difficulty="advanced" buildsUpon="agg, create_labels" >}}
-```bash
 > TS.CREATE wind:1 LABELS country uk
 OK
 > TS.CREATE wind:2 LABELS country uk
@@ -562,7 +543,6 @@ OK
          2) 14.5
       3) 1) (integer) 3
          2) 13
-```
 {{< /clients-example >}}
 
 ## NaN Values
@@ -650,7 +630,6 @@ For example, you could use the commands below to create a time series along with
 compaction rule to find the minimum reading in each period of 3ms.
 
 {{< clients-example set="time_series_tutorial" step="create_compaction" description="Compaction rules: Use TS.CREATERULE to automatically aggregate data into a destination time series when you need to maintain pre-computed aggregations" difficulty="advanced" buildsUpon="create" >}}
-```bash
 # The source time series.
 > TS.CREATE hyg:1
 OK
@@ -677,7 +656,6 @@ OK
 22) "hyg:1"
     .
     .
-```
 {{< /clients-example >}}
 
 Adding data points within the first 3ms (the first bucket) doesn't
@@ -686,7 +664,6 @@ time 4 (in the second bucket), the compaction rule computes the minimum
 value for the first bucket and adds it to the compacted series.
 
 {{< clients-example set="time_series_tutorial" step="comp_add" description="Compaction behavior: Understand how compaction rules process data incrementally, computing aggregates for completed buckets when new data arrives" difficulty="intermediate" buildsUpon="create_compaction" >}}
-```bash
 > TS.MADD hyg:1 0 75 hyg:1 1 77 hyg:1 2 78
 1) (integer) 0
 2) (integer) 1
@@ -698,7 +675,6 @@ value for the first bucket and adds it to the compacted series.
 > ts.range hyg:compacted - +
 1) 1) (integer) 0
    2) 75
-```
 {{< /clients-example >}}
 
 The general strategy is that the rule does not add data to the
@@ -719,7 +695,6 @@ samples whose timestamp equals the start or end of the range are deleted.
 If you want to delete a single timestamp, use it as both the start and end of the range.
 
 {{< clients-example set="time_series_tutorial" step="del" description="Deleting data: Use TS.DEL to remove data points within a timestamp range when you need to clean up or correct historical data" difficulty="beginner" buildsUpon="create" >}}
-```bash
 > TS.INFO thermometer:1
  1) totalSamples
  2) (integer) 2
@@ -764,7 +739,6 @@ If you want to delete a single timestamp, use it as both the start and end of th
  2) (integer) 0
     .
     .
-```
 {{< /clients-example >}}
 
 ## Use time series with other metrics tools


### PR DESCRIPTION
Removed spurious text in the time series page that presumably originates from before we added the multi-language examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting changes with no runtime or API impact; primary risk is minor rendering/regression in the generated docs examples.
> 
> **Overview**
> Removes embedded ```bash fenced code blocks from multiple `{{< clients-example >}}` sections in `content/develop/data-types/timeseries/_index.md`, leaving the examples as plain CLI transcript text for the multi-language renderer.
> 
> Also fixes a small formatting/indentation glitch in the `TS.MREVRANGE` output example to keep the nested list structure consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5adfcb0480ddee25ad53682340cf87a22c614f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->