### PR TITLE
Add K8s 7.22.2-39 April 2026 maintenance release notes

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
@@ -1,0 +1,33 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: Maintenance release to support Redis Enterprise Software version 7.22.2-116 with bug and security fixes.
+hideListLinks: true
+linkTitle: 7.22.2-39 (April 2026)
+title: Redis Enterprise for Kubernetes 7.22.2-39 (April 2026) release notes
+weight: 18
+---
+
+## Highlights
+
+This is a maintenance release to support Redis Enterprise Software version 7.22.2-116. For supported distributions and known limitations, see the [7.22.2 releases]({{< relref "/operate/kubernetes/release-notes/7-22-2-releases/" >}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:7.22.2-116`
+- **Operator**: `redislabs/operator:7.22.2-39`
+- **Services Rigger**: `redislabs/k8s-controller:7.22.2-39`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-39`
+
+### Openshift downloads
+
+- **OLM operator bundle**: `v7.22.2-39.0`
+- **Call Home Client**: `redislabs/call-home-client:7.22.2-39`
+
+## Known limitations
+
+See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.
+

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.22.2 release notes
 weight: 90
 ---
 
-Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-38 with support for Redis Enterprise Software version 7.22.2-93.
+Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-39 with support for Redis Enterprise Software version 7.22.2-116.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change adding a new release-notes page and updating the index “latest release” pointer; no runtime or API behavior is affected.
> 
> **Overview**
> Adds new release notes page `7-22-2-39-april2026.md` for the Kubernetes 7.22.2-39 maintenance release, including highlights and updated download image/tag references (Redis Enterprise 7.22.2-116 and matching operator/rigger/call-home versions).
> 
> Updates the 7.22.2 release-notes index `_index.md` to mark 7.22.2-39 (software 7.22.2-116) as the latest release instead of 7.22.2-38.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e42ff7b723c10ac8e02114e286f6c4981ed6d4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->