### PR TITLE
Release Redis Insight v3.4.1

### DIFF
--- a/content/develop/tools/insight/release-notes/v.3.4.1.md
+++ b/content/develop/tools/insight/release-notes/v.3.4.1.md
@@ -1,0 +1,49 @@
+---
+Title: Redis Insight v3.4.1, April 2026
+linkTitle: v3.4.1 (April 2026)
+date: 2026-04-17 00:00:00 +0000
+description: Redis Insight v3.4.1
+weight: 1
+---
+
+## 3.4.1 (April 2026)
+
+This is the General Availability (GA) release of Redis Insight 3.4.1, which includes new features, enhancements and bug fixes.
+
+### Headlines
+
+- New dedicated Search workspace with full index lifecycle support: create indexes from sample data or existing user data, query indexed data with an assisted editor, and save queries to a Query Library for reuse.
+- Enhancements for Azure integration, including Entra ID Docker support, Access Key authentication, and a manual connection form.
+
+### Details
+
+- New dedicated Search page with index listing, index creation, a query editor with Profile and Explain actions, and a Query Library for saving and reusing queries.
+- Create indexes from sample data to explore how Redis Search works, or from existing user data with automatic field detection and index type configuration.
+- Navigate between Browser and Search workspaces: review the indexed data in the Browser, view indexed keys and their associated indexes, and create indexes directly from the Browser key list.
+- Azure Entra ID authentication support for Docker deployments. [To get started, follow the Azure Docker setup guide.](https://github.com/redis/RedisInsight/blob/main/docs/azure-docker-setup.md)
+- Added a manual connection form for Azure Redis databases, allowing users to configure or override autodiscovery connection details.
+- Added Access Key authentication support for Azure Redis databases as an alternative to Entra ID.
+- Added client-side column sorting for the Browser key list, allowing users to sort by Key, TTL, or Size directly from the Columns popover.
+- [#5637](https://github.com/redis/RedisInsight/issues/5637) Added Linux ARM64 release support with AppImage, deb, and rpm packages.
+
+### Bug fixes
+
+- [#5394](https://github.com/redis/RedisInsight/issues/5394) Fixed startup error on first install caused by missing `.redis-insight/logs` directory when the parent directory does not exist yet.
+- [#5515](https://github.com/redis/RedisInsight/issues/5515) Added Redis Insight version display in the Web UI Settings, making it easier to verify deployments when running via Docker.
+- [#5540](https://github.com/redis/RedisInsight/issues/5540) Fixed incorrect deserialization of DateTimeOffset values in MessagePack objects.
+- [#5412](https://github.com/redis/RedisInsight/issues/5412) Fixed JSON error when viewing keys containing 'constructor' in the key name.
+- [#5608](https://github.com/redis/RedisInsight/issues/5608) Fixed Workbench view-type dropdown crash when external plugins are loaded.
+- [#5587](https://github.com/redis/RedisInsight/issues/5587) Workbench output settings now persist between commands, so users no longer need to reconfigure their preferred view each time.
+
+**Full Changelog**: https://github.com/redis/RedisInsight/compare/3.2.0...3.4.1
+
+**SHA-512 Checksums**
+
+| Package             | SHA-512                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------- |
+| Windows             |                                                                                          |
+| Linux AppImage      |                                                                                          |
+| Linux Debian        |                                                                                          |
+| Linux RPM           |                                                                                          |
+| MacOS Intel         |                                                                                          |
+| MacOS Apple silicon |                                                                                          |

--- a/content/develop/tools/insight/release-notes/v.3.4.1.md
+++ b/content/develop/tools/insight/release-notes/v.3.4.1.md
@@ -39,11 +39,14 @@ This is the General Availability (GA) release of Redis Insight 3.4.1, which incl
 
 **SHA-512 Checksums**
 
-| Package             | SHA-512                                                                                  |
-| ------------------- | ---------------------------------------------------------------------------------------- |
-| Windows             |                                                                                          |
-| Linux AppImage      |                                                                                          |
-| Linux Debian        |                                                                                          |
-| Linux RPM           |                                                                                          |
-| MacOS Intel         |                                                                                          |
-| MacOS Apple silicon |                                                                                          |
+| Package                | SHA-512                                                                                  |
+| ---------------------- | ---------------------------------------------------------------------------------------- |
+| Windows                | WxS/WgDKWjVg44o6DOVhn5AORBGeuHJEM291vOomJGdA/dzUDumGrRUkUVTVHmJkbRIAMYu6bSJhSQxS8kRZTQ== |
+| Linux AppImage (x64)   | T/FzvvjMjC8zypDZ9xZ/g1wyuVv4G4WKaZVdqhe9P4qa5jaSeBlGS4ZSwCBRQKOS5QtFJrJ+GoKLOKCNIlZqwg== |
+| Linux AppImage (arm64) | ttYKN20quNVhbzoPNpd50UUnCfiJuz6K/dfQIhqI+nNU1w8sOKA+XbL+YGG7jf0VpHZg5ew0zPaDgk86M6vSRw== |
+| Linux Debian (x64)     | hv0ztyHWkk27zum8fp/oIz32Nz/K1Y5V+H5GDiYqrPM7itQDvhezNOaLPWIG3T7+GbmtShK6C+INMbmUY0A8JQ== |
+| Linux Debian (arm64)   | aosn4p641n/31g9ZDy2eaCt+2X7grA9V15D5oKESIFSEljZTsJmaBdJUCR2FDecRnhDrv17N7gsyLrMPsv821Q== |
+| Linux RPM (x64)        | o+YlHT/QzkoIpMaF7gRMNr7JSPqGq2qGMN/MSd6Yz7fbneqTudrsaKIw5Hxa7+kYsJorrGd6CNb3+wLAQKz5aQ== |
+| Linux RPM (arm64)      | Oz7pFhiLEvWkwUwJx0UeOnD4u/BXzIGzsdcdjYcy3K4mx4or+xQ2rvTGWiR9FBrknsOMBFsuwA3VNsPQXoRCdg== |
+| MacOS Intel            | /IrFmPoRLBm2nXLcuyM8JA7shxguEuaAddxc8doPBPGT3ZFGrZxfome8hgegDG23cEifRjF9CYdkes6VCGuzgA== |
+| MacOS Apple silicon    | ReqnQrNTSEVcJnMXc+P849ki5jDvxTvxa1Rm1BIOviig9gEcJBN3WEs9YF8SAQQbbAZ7pdYR+UeMk96gQvkcDQ== |


### PR DESCRIPTION
# What

Introduce release notes for Redis Insight v3.4.1

_Note: We'll provide the checksums once we have the release artifacts generated._


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a new markdown release-notes page; no runtime code paths or production behavior are affected.
> 
> **Overview**
> Adds a new release-notes page `v.3.4.1.md` for Redis Insight 3.4.1 (April 2026), documenting the GA release highlights (new Search workspace/index lifecycle tooling, Azure integration enhancements) plus a list of bug fixes.
> 
> Includes a published **Full Changelog** link and the SHA-512 checksums table for release artifacts (including new Linux ARM64 packages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b1c6d4db03a99599a1a3b3c45c8a14135e234c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->