### PR TITLE
DOC-6486 More Markdown rendering issues

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1019,18 +1019,6 @@ input[type="radio"] {
   margin-bottom: 0;
 }
 
-.trimmable-input:not(:checked) ~ .trimmable-content::after {
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
-  bottom: 0;
-  content: "";
-  display: block;
-  height: 3rem;
-  left: 0;
-  pointer-events: none;
-  position: absolute;
-  right: 0;
-}
-
 .trimmable-input:not(:checked) ~ .trimmable-content {
   -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);
   mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -975,21 +975,6 @@ input[type="radio"] {
   @apply h-full overflow-y-auto font-monogeist;
 }
 
-.trimmable-block {
-  margin-block: 1rem;
-}
-
-.trimmable-toggle {
-  align-items: center;
-  color: #d52d1f;
-  cursor: pointer;
-  display: inline-flex;
-  gap: 0.5rem;
-  font-weight: 600;
-  margin-top: 0.6rem;
-  text-decoration: none;
-}
-
 .trimmable-label-less {
   display: none;
 }
@@ -1019,8 +1004,6 @@ input[type="radio"] {
 
 .trimmable-content {
   max-height: 10lh;
-  overflow: hidden;
-  position: relative;
 }
 
 .trimmable-content pre {

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1021,7 +1021,6 @@ input[type="radio"] {
   max-height: 10lh;
   overflow: hidden;
   position: relative;
-  transition: max-height 0.2s ease;
 }
 
 .trimmable-content pre {

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -975,6 +975,91 @@ input[type="radio"] {
   @apply h-full overflow-y-auto font-monogeist;
 }
 
+.trimmable-block {
+  margin-block: 1rem;
+}
+
+.trimmable-toggle {
+  align-items: center;
+  color: #d52d1f;
+  cursor: pointer;
+  display: inline-flex;
+  gap: 0.5rem;
+  font-weight: 600;
+  margin-top: 0.6rem;
+  text-decoration: none;
+}
+
+.trimmable-label-less {
+  display: none;
+}
+
+.trimmable-toggle::before {
+  border-bottom: 2px solid currentColor;
+  border-right: 2px solid currentColor;
+  content: "";
+  display: inline-block;
+  height: 0.5rem;
+  transform: translateY(-0.1rem) rotate(45deg);
+  transition: transform 0.2s ease;
+  width: 0.5rem;
+}
+
+.trimmable-input:checked ~ .trimmable-toggle::before {
+  transform: translateY(0.1rem) rotate(-135deg);
+}
+
+.trimmable-input:checked ~ .trimmable-toggle .trimmable-label-more {
+  display: none;
+}
+
+.trimmable-input:checked ~ .trimmable-toggle .trimmable-label-less {
+  display: inline;
+}
+
+.trimmable-content {
+  max-height: 10lh;
+  overflow: hidden;
+  position: relative;
+  transition: max-height 0.2s ease;
+}
+
+.trimmable-content pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.trimmable-content > *:first-child {
+  margin-top: 0;
+}
+
+.trimmable-content > *:last-child {
+  margin-bottom: 0;
+}
+
+.trimmable-input:not(:checked) ~ .trimmable-content::after {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+  bottom: 0;
+  content: "";
+  display: block;
+  height: 3rem;
+  left: 0;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+}
+
+.trimmable-input:not(:checked) ~ .trimmable-content {
+  -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 0%, #000 72%, transparent 100%);
+}
+
+.trimmable-input:checked ~ .trimmable-content {
+  max-height: none;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
 code {
   @apply font-monogeist;
 }

--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -508,6 +508,7 @@ dataset for big keys, but also provides information about the data types
 that the data set consists of. This mode is enabled with the `--bigkeys` option,
 and produces verbose output:
 
+{{< trimmable head="12" tail="8" >}}
 ```
 $ redis-cli --bigkeys
 
@@ -541,6 +542,7 @@ Biggest   zset found "racer_scores" has 8 members
 2 zsets with 11 members (03.64% of keys, avg size 5.50)
 25 ReJSON-RLs with 0 ? (45.45% of keys, avg size 0.00)
 ```
+{{< /trimmable >}}
 
 In the first part of the output, each new key larger than the previous larger
 key (of the same type) encountered is reported. The summary section
@@ -565,6 +567,7 @@ The `--bigkeys` option now works on cluster replicas.
 Similar to the `--bigkeys` option, `--memkeys` allows you to scan the entire keyspace to find biggest keys as well as
 the average sizes per key type.
 
+{{< trimmable head="12" tail="8" >}}
 ```
 $ redis-cli --memkeys
 
@@ -603,6 +606,7 @@ Biggest ReJSON-RL found "bikes:inventory" has 4865 bytes
 2 zsets with 304 bytes (03.64% of keys, avg size 152.00)
 25 ReJSON-RLs with 15748 bytes (45.45% of keys, avg size 629.92)
 ```
+{{< /trimmable >}}
 
 The `--memkeys` option now works on cluster replicas.
 
@@ -610,6 +614,7 @@ The `--memkeys` option now works on cluster replicas.
 
 You can use the `--keystats` and `--keystats-samples` options to combine `--memkeys` and `--bigkeys` with additional distribution data.
 
+{{< trimmable head="14" tail="12" >}}
 ```
 $ redis-cli --keystats
 
@@ -686,6 +691,7 @@ CMSk-TYPE            1   1.82%  140.68K  140.68K                 -           -
 zset                 2   3.64%     304B     152B         11 members        5.50
 ReJSON-RL           25  45.45%   15.38K     629B                 -           - 
 ```
+{{< /trimmable >}}
 
 ## Get a list of keys
 

--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -977,6 +977,7 @@ With 500MB there is sufficient space for the key quantity (10 million) and distr
 
 ## Usage
 
+{{< usage >}}
 ```
 Usage: redis-cli [OPTIONS] [cmd [arg [arg ...]]]
   -h <hostname>      Server hostname (default: 127.0.0.1).
@@ -1099,3 +1100,4 @@ When no command is given, redis-cli starts in interactive mode.
 Type "help" in interactive mode for information on available commands
 and settings.
 ```
+{{< /usage >}}

--- a/layouts/_default/section.json
+++ b/layouts/_default/section.json
@@ -2,7 +2,7 @@
 {{- /* Based on redis_docs_ai_json_guide.md specification */ -}}
 
 {{- /* Process content with shared partial (shortcode expansion, HTML unescaping, etc.) */ -}}
-{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site) -}}
+{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site "Page" .) -}}
 
 {{- /* Build the JSON object for the section itself */ -}}
 {{- /* Handle pages where .File may be nil (e.g., taxonomy pages) */ -}}
@@ -52,4 +52,3 @@
   "last_updated": {{ $lastUpdated | jsonify }},
   "children": {{ $children | jsonify }}
 }
-

--- a/layouts/_default/section.md
+++ b/layouts/_default/section.md
@@ -23,6 +23,6 @@
 ```
 
 {{- /* Process content with shared partial (shortcode expansion, HTML unescaping, etc.) */ -}}
-{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site) -}}
+{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site "Page" .) -}}
 
 {{ $content }}

--- a/layouts/_default/single.json
+++ b/layouts/_default/single.json
@@ -2,7 +2,7 @@
 {{- /* Based on redis_docs_ai_json_guide.md specification */ -}}
 
 {{- /* Process content with shared partial (shortcode expansion, HTML unescaping, etc.) */ -}}
-{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site) -}}
+{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site "Page" .) -}}
 
 {{- /* Build the JSON object */ -}}
 {{- /* Handle pages where .File may be nil (e.g., taxonomy pages) */ -}}
@@ -31,4 +31,3 @@
   "tags": {{ $tags | jsonify }},
   "last_updated": {{ $lastUpdated | jsonify }}
 }
-

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -23,6 +23,6 @@
 ```
 
 {{- /* Process content with shared partial (shortcode expansion, HTML unescaping, etc.) */ -}}
-{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site) -}}
+{{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site "Page" .) -}}
 
 {{ $content }}

--- a/layouts/partials/markdown-code-examples.html
+++ b/layouts/partials/markdown-code-examples.html
@@ -68,6 +68,8 @@
   {{- $difficulty := replaceRE $pattern `$4` $match -}}
   {{- $buildsUponStr := replaceRE $pattern `$5` $match -}}
   {{- $cliContent := replaceRE $pattern `$6` $match -}}
+  {{- $cliContent = replaceRE "^\\s*\\}\\}\\s*" "" $cliContent -}}
+  {{- $cliContent = strings.TrimSpace $cliContent -}}
 
   {{- /* Unescape HTML entities in description */ -}}
   {{- if $description -}}
@@ -173,7 +175,6 @@
 
     {{- /* Collect all language examples and build availability list */ -}}
     {{- $langExamples := slice -}}
-    {{- $redisCliLang := dict -}}
     {{- $availableLangs := slice -}}
 
     {{- /* Add Redis CLI to availability list if we have CLI content */ -}}
@@ -184,9 +185,7 @@
     {{- /* Collect all other languages */ -}}
     {{- range $lang, $langData := $exampleData -}}
       {{- if ne $lang "steps_commands" -}}
-        {{- if eq $lang "redis-cli" -}}
-          {{- $redisCliLang = dict "key" $lang "data" $langData -}}
-        {{- else -}}
+        {{- if ne $lang "redis-cli" -}}
           {{- $langCode := index $langData "language" -}}
           {{- $displayName := index $keyNames $lang -}}
           {{- if not $displayName -}}
@@ -203,7 +202,9 @@
 
     {{- /* Sort available languages alphabetically (except Redis CLI which stays first) */ -}}
     {{- $sortedLangs := slice -}}
-    {{- $sortedLangs = $sortedLangs | append "Redis CLI" -}}
+    {{- if in $availableLangs "Redis CLI" -}}
+      {{- $sortedLangs = $sortedLangs | append "Redis CLI" -}}
+    {{- end -}}
     {{- $otherLangs := slice -}}
     {{- range $lang := $availableLangs -}}
       {{- if ne $lang "Redis CLI" -}}
@@ -221,8 +222,6 @@
 
     {{- /* Add CLI example first if provided */ -}}
     {{- if $cliContent -}}
-      {{- /* Clean up the CLI content - remove leading/trailing whitespace and stray }} */ -}}
-      {{- $cliContent = replaceRE "^\\s*\\}\\}\\s*" "" $cliContent -}}
       {{- /* Use H5 heading for Redis CLI - consistent with other language examples */ -}}
       {{- $replacement = printf "%s##### Redis CLI\n\n```\n%s\n```\n\n" $replacement $cliContent -}}
     {{- end -}}
@@ -237,15 +236,6 @@
       {{- end -}}
     {{- end -}}
     {{- $langExamples = $sortedLangExamples -}}
-
-    {{- /* Rebuild language examples with Redis CLI first */ -}}
-    {{- if $redisCliLang -}}
-      {{- $finalLangs := slice $redisCliLang -}}
-      {{- range $langExample := $langExamples -}}
-        {{- $finalLangs = $finalLangs | append $langExample -}}
-      {{- end -}}
-      {{- $langExamples = $finalLangs -}}
-    {{- end -}}
 
     {{- /* Add code examples for each language */ -}}
     {{- range $langExample := $langExamples -}}
@@ -521,4 +511,3 @@
 {{- end -}}
 
 {{- $processed -}}
-

--- a/layouts/partials/markdown-embed-md.html
+++ b/layouts/partials/markdown-embed-md.html
@@ -1,0 +1,52 @@
+{{- /*
+  Expand embed-md shortcodes for Markdown/JSON output.
+
+  Input: dict with:
+    - "RawContent": The raw Markdown content to process
+    - "Page": The current Hugo page
+    - "Visited": Optional slice of visited page identifiers to prevent recursion loops
+
+  Output: Markdown content with embed-md shortcodes expanded
+*/ -}}
+
+{{- $content := .RawContent -}}
+{{- $visited := .Visited | default (slice) -}}
+
+{{- $currentID := .Page.RelPermalink -}}
+{{- with .Page.File -}}
+  {{- $currentID = .Path -}}
+{{- end -}}
+{{- if not (in $visited $currentID) -}}
+  {{- $visited = $visited | append $currentID -}}
+{{- end -}}
+
+{{- $patterns := slice
+  `\{\{<\s*embed-md\s+"([^"]+)"\s*/?>\}\}`
+  `\{\{&lt;\s*embed-md\s+&#34;([^&]+)&#34;\s*/?&gt;\}\}`
+-}}
+
+{{- range $pattern := $patterns -}}
+  {{- $matches := findRESubmatch $pattern $content -}}
+  {{- range $match := $matches -}}
+    {{- $shortcode := index $match 0 -}}
+    {{- $target := index $match 1 -}}
+    {{- $replacement := "" -}}
+    {{- with $.Page.Site.GetPage $target -}}
+      {{- $targetID := .RelPermalink -}}
+      {{- with .File -}}
+        {{- $targetID = .Path -}}
+      {{- end -}}
+      {{- if not (in $visited $targetID) -}}
+        {{- $replacement = partial "process-markdown-content.html" (dict
+          "RawContent" .RawContent
+          "Site" .Site
+          "Page" .
+          "Visited" ($visited | append $targetID)
+        ) -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $content = replace $content $shortcode $replacement -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $content -}}

--- a/layouts/partials/markdown-scrollable-tables.html
+++ b/layouts/partials/markdown-scrollable-tables.html
@@ -1,0 +1,104 @@
+{{- /*
+  Rewrite wide table-scrollable shortcode blocks into smaller Markdown tables
+  for AI-facing output only. This preserves the human HTML rendering while
+  giving the Markdown chunker safer boundaries.
+
+  Input: dict with:
+    - "RawContent": Markdown content string
+
+  Output: Markdown content with wide table-scrollable blocks replaced by
+  repeated narrower tables.
+*/ -}}
+
+{{- $content := .RawContent -}}
+{{- $pattern := `(?s)\{\{<\s*table-scrollable\s*>\}\}\s*(.*?)\s*\{\{<\s*/table-scrollable\s*>\}\}` -}}
+{{- $matches := findRESubmatch $pattern $content -}}
+
+{{- $maxColumns := 8 -}}
+{{- $columnsPerPart := 6 -}}
+{{- $rowsPerPart := 10 -}}
+
+{{- range $match := $matches -}}
+  {{- $fullBlock := index $match 0 -}}
+  {{- $inner := strings.TrimSpace (index $match 1) -}}
+  {{- $lines := split $inner "\n" -}}
+
+  {{- if ge (len $lines) 3 -}}
+    {{- $headerLine := strings.TrimSpace (index $lines 0) -}}
+    {{- $separatorLine := strings.TrimSpace (index $lines 1) -}}
+
+    {{- if and (hasPrefix $headerLine "|") (hasPrefix $separatorLine "|") -}}
+      {{- $headerParts := split $headerLine "|" -}}
+      {{- $separatorParts := split $separatorLine "|" -}}
+      {{- $headerCells := first (sub (len $headerParts) 2) (after 1 $headerParts) -}}
+      {{- $separatorCells := first (sub (len $separatorParts) 2) (after 1 $separatorParts) -}}
+      {{- $columnCount := len $headerCells -}}
+
+      {{- if gt $columnCount $maxColumns -}}
+        {{- $dataRows := after 2 $lines -}}
+        {{- $rowCount := len $dataRows -}}
+        {{- $remainingColumns := sub $columnCount 1 -}}
+        {{- $partCount := div (add $remainingColumns (sub $columnsPerPart 1)) $columnsPerPart -}}
+        {{- $replacement := "" -}}
+
+        {{- range $partIndex := seq 1 $partCount -}}
+          {{- $startOffset := add 1 (mul (sub $partIndex 1) $columnsPerPart) -}}
+          {{- $headerTail := first $columnsPerPart (after $startOffset $headerCells) -}}
+          {{- $separatorTail := first $columnsPerPart (after $startOffset $separatorCells) -}}
+
+          {{- $chunkHeader := slice (strings.TrimSpace (index $headerCells 0)) -}}
+          {{- range $cell := $headerTail -}}
+            {{- $chunkHeader = $chunkHeader | append (strings.TrimSpace $cell) -}}
+          {{- end -}}
+
+          {{- $chunkSeparator := slice (strings.TrimSpace (index $separatorCells 0)) -}}
+          {{- range $cell := $separatorTail -}}
+            {{- $chunkSeparator = $chunkSeparator | append (strings.TrimSpace $cell) -}}
+          {{- end -}}
+
+          {{- $rowPartCount := div (add $rowCount (sub $rowsPerPart 1)) $rowsPerPart -}}
+
+          {{- range $rowPartIndex := seq 1 $rowPartCount -}}
+            {{- $rowStartOffset := mul (sub $rowPartIndex 1) $rowsPerPart -}}
+            {{- $rowChunk := first $rowsPerPart (after $rowStartOffset $dataRows) -}}
+            {{- $rowStart := add $rowStartOffset 1 -}}
+            {{- $rowEnd := add $rowStartOffset (len $rowChunk) -}}
+
+            {{- $replacement = printf "%s#### Table part %d of %d, rows %d-%d\n\n" $replacement $partIndex $partCount $rowStart $rowEnd -}}
+            {{- $replacement = printf "%s| %s |\n" $replacement (delimit $chunkHeader " | ") -}}
+            {{- $replacement = printf "%s| %s |\n" $replacement (delimit $chunkSeparator " | ") -}}
+
+            {{- range $row := $rowChunk -}}
+              {{- $trimmedRow := strings.TrimSpace $row -}}
+              {{- if hasPrefix $trimmedRow "|" -}}
+                {{- $rowParts := split $trimmedRow "|" -}}
+                {{- $rowCells := first (sub (len $rowParts) 2) (after 1 $rowParts) -}}
+
+                {{- if ge (len $rowCells) $columnCount -}}
+                  {{- $rowTail := first $columnsPerPart (after $startOffset $rowCells) -}}
+                  {{- $chunkRow := slice (strings.TrimSpace (index $rowCells 0)) -}}
+                  {{- range $cell := $rowTail -}}
+                    {{- $chunkRow = $chunkRow | append (strings.TrimSpace $cell) -}}
+                  {{- end -}}
+                  {{- $replacement = printf "%s| %s |\n" $replacement (delimit $chunkRow " | ") -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+
+            {{- $replacement = printf "%s\n" $replacement -}}
+          {{- end -}}
+        {{- end -}}
+
+        {{- $content = replace $content $fullBlock $replacement -}}
+      {{- else -}}
+        {{- $content = replace $content $fullBlock $inner -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $content = replace $content $fullBlock $inner -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $content = replace $content $fullBlock $inner -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $content -}}

--- a/layouts/partials/markdown-trimmable.html
+++ b/layouts/partials/markdown-trimmable.html
@@ -1,0 +1,80 @@
+{{- /*
+  Expand trimmable shortcodes for AI-facing Markdown output.
+
+  Supported usage:
+    {{< trimmable >}}...{{< /trimmable >}}
+    {{< trimmable head="12" tail="8" >}}...{{< /trimmable >}}
+
+  If the inner block is a fenced code block, trim the lines inside the fence and
+  render the result as an indented code block. This keeps banner lines such as
+  "# Scanning ..." from being misread as headings in AI-facing Markdown.
+*/ -}}
+
+{{- $content := .RawContent -}}
+{{- $pattern := `(?s)\{\{<\s*trimmable([^>]*)>\}\}(.*?)\{\{<\s*/trimmable\s*>\}\}` -}}
+{{- $matches := findRESubmatch $pattern $content -}}
+
+{{- range $match := $matches -}}
+  {{- $fullMatch := index $match 0 -}}
+  {{- $attrs := index $match 1 -}}
+  {{- $inner := index $match 2 -}}
+
+  {{- $head := 12 -}}
+  {{- $tail := 8 -}}
+
+  {{- with findRESubmatch `head\s*=\s*"([0-9]+)"` $attrs -}}
+    {{- $head = int (index (index . 0) 1) -}}
+  {{- end -}}
+  {{- with findRESubmatch `tail\s*=\s*"([0-9]+)"` $attrs -}}
+    {{- $tail = int (index (index . 0) 1) -}}
+  {{- end -}}
+
+  {{- $trimmedInner := strings.Trim $inner "\n" -}}
+  {{- $lines := split $trimmedInner "\n" -}}
+  {{- $replacement := $trimmedInner -}}
+  {{- $marker := "... output truncated for AI-facing Markdown ..." -}}
+
+  {{- if ge (len $lines) 2 -}}
+    {{- $firstLine := strings.TrimSpace (index $lines 0) -}}
+    {{- $lastLine := strings.TrimSpace (index $lines (sub (len $lines) 1)) -}}
+    {{- $isFenced := and (hasPrefix $firstLine "```") (eq $firstLine $lastLine) -}}
+
+    {{- if $isFenced -}}
+      {{- $body := first (sub (len $lines) 2) (after 1 $lines) -}}
+      {{- $bodyLines := $body -}}
+      {{- if gt (len $body) (add $head $tail 1) -}}
+        {{- $bodyLines = slice -}}
+        {{- range $line := first $head $body -}}
+          {{- $bodyLines = $bodyLines | append $line -}}
+        {{- end -}}
+        {{- $bodyLines = $bodyLines | append $marker -}}
+        {{- range $line := first $tail (after (sub (len $body) $tail) $body) -}}
+          {{- $bodyLines = $bodyLines | append $line -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $indentedLines := slice -}}
+      {{- range $line := $bodyLines -}}
+        {{- if eq $line "" -}}
+          {{- $indentedLines = $indentedLines | append "" -}}
+        {{- else -}}
+          {{- $indentedLines = $indentedLines | append (printf "    %s" $line) -}}
+        {{- end -}}
+      {{- end -}}
+      {{- $replacement = delimit $indentedLines "\n" -}}
+    {{- else if gt (len $lines) (add $head $tail 1) -}}
+      {{- $newLines := slice -}}
+      {{- range $line := first $head $lines -}}
+        {{- $newLines = $newLines | append $line -}}
+      {{- end -}}
+      {{- $newLines = $newLines | append $marker -}}
+      {{- range $line := first $tail (after (sub (len $lines) $tail) $lines) -}}
+        {{- $newLines = $newLines | append $line -}}
+      {{- end -}}
+      {{- $replacement = delimit $newLines "\n" -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- $content = replace $content $fullMatch $replacement -}}
+{{- end -}}
+
+{{- return $content -}}

--- a/layouts/partials/markdown-usage.html
+++ b/layouts/partials/markdown-usage.html
@@ -1,0 +1,14 @@
+{{- /* Expand usage shortcodes into Markdown-friendly lists for AI output. */ -}}
+
+{{- $content := .RawContent -}}
+{{- $pattern := `(?s)\{\{<\s*usage\s*>\}\}(.*?)\{\{<\s*/usage\s*>\}\}` -}}
+{{- $matches := findRESubmatch $pattern $content -}}
+
+{{- range $match := $matches -}}
+  {{- $fullMatch := index $match 0 -}}
+  {{- $inner := index $match 1 -}}
+  {{- $replacement := partial "usage-block-markdown.html" (dict "RawContent" $inner) | htmlUnescape -}}
+  {{- $content = replace $content $fullMatch $replacement -}}
+{{- end -}}
+
+{{- return $content -}}

--- a/layouts/partials/process-markdown-content.html
+++ b/layouts/partials/process-markdown-content.html
@@ -20,6 +20,8 @@
 {{- $content = partial "markdown-embed-md.html" (dict "RawContent" $content "Page" .Page "Visited" $visited) -}}
 {{- /* Split wide table-scrollable blocks for AI-facing Markdown output only. */ -}}
 {{- $content = partial "markdown-scrollable-tables.html" (dict "RawContent" $content) -}}
+{{- /* Trim opt-in long blocks for AI-facing Markdown output only. */ -}}
+{{- $content = partial "markdown-trimmable.html" (dict "RawContent" $content) -}}
 
 {{- /* Add legend for code examples at the beginning if content contains clients-example shortcodes */ -}}
 {{- if findRE "clients-example" $content -}}

--- a/layouts/partials/process-markdown-content.html
+++ b/layouts/partials/process-markdown-content.html
@@ -7,11 +7,17 @@
   Input: dict with:
     - "RawContent": The raw Markdown content to process
     - "Site": The Hugo site object (for partial access)
+    - "Page": The current Hugo page (for shortcode/page resolution)
+    - "Visited": Optional slice of already-expanded pages to prevent embed loops
   
   Output: Processed Markdown content string
 */ -}}
 
 {{- $content := .RawContent -}}
+{{- $visited := .Visited | default (slice) -}}
+
+{{- /* Expand embed-md shortcodes before other transforms so embedded content can be processed too. */ -}}
+{{- $content = partial "markdown-embed-md.html" (dict "RawContent" $content "Page" .Page "Visited" $visited) -}}
 
 {{- /* Add legend for code examples at the beginning if content contains clients-example shortcodes */ -}}
 {{- if findRE "clients-example" $content -}}
@@ -66,4 +72,3 @@
 {{- $content = $content | replaceRE `\{\{%\s*/?[^%]*%\}\}` "" -}}
 
 {{- return $content -}}
-

--- a/layouts/partials/process-markdown-content.html
+++ b/layouts/partials/process-markdown-content.html
@@ -18,6 +18,8 @@
 
 {{- /* Expand embed-md shortcodes before other transforms so embedded content can be processed too. */ -}}
 {{- $content = partial "markdown-embed-md.html" (dict "RawContent" $content "Page" .Page "Visited" $visited) -}}
+{{- /* Split wide table-scrollable blocks for AI-facing Markdown output only. */ -}}
+{{- $content = partial "markdown-scrollable-tables.html" (dict "RawContent" $content) -}}
 
 {{- /* Add legend for code examples at the beginning if content contains clients-example shortcodes */ -}}
 {{- if findRE "clients-example" $content -}}

--- a/layouts/partials/process-markdown-content.html
+++ b/layouts/partials/process-markdown-content.html
@@ -22,6 +22,8 @@
 {{- $content = partial "markdown-scrollable-tables.html" (dict "RawContent" $content) -}}
 {{- /* Trim opt-in long blocks for AI-facing Markdown output only. */ -}}
 {{- $content = partial "markdown-trimmable.html" (dict "RawContent" $content) -}}
+{{- /* Reformat usage shortcodes for AI-facing Markdown output only. */ -}}
+{{- $content = partial "markdown-usage.html" (dict "RawContent" $content) -}}
 
 {{- /* Add legend for code examples at the beginning if content contains clients-example shortcodes */ -}}
 {{- if findRE "clients-example" $content -}}

--- a/layouts/partials/usage-block-markdown.html
+++ b/layouts/partials/usage-block-markdown.html
@@ -1,0 +1,138 @@
+{{- /*
+  Convert standard CLI usage text into AI- and human-friendly Markdown.
+
+  Expected format:
+  - first line starts with "Usage:"
+  - option rows are indented and begin with "-"
+  - continuation rows are further-indented
+  - optional trailing sections like "Examples:" or "Cluster Manager Commands:"
+
+  Falls back to the raw content if the shape does not match.
+*/ -}}
+
+{{- $raw := strings.Trim (.RawContent | default "") "\n" -}}
+{{- $lines := split $raw "\n" -}}
+{{- if ge (len $lines) 2 -}}
+  {{- $firstLine := strings.TrimSpace (index $lines 0) -}}
+  {{- $lastLine := strings.TrimSpace (index $lines (sub (len $lines) 1)) -}}
+  {{- if and (hasPrefix $firstLine "```") (eq $firstLine $lastLine) -}}
+    {{- $raw = strings.TrimSpace (delimit (first (sub (len $lines) 2) (after 1 $lines)) "\n") -}}
+    {{- $lines = split $raw "\n" -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if or (eq (len $lines) 0) (not (hasPrefix (strings.TrimSpace (index $lines 0)) "Usage:")) -}}
+  {{- $raw -}}
+{{- else -}}
+  {{- $s := newScratch -}}
+  {{- $s.Set "markdown" (printf "```text\n%s\n```\n\nOptions:\n\n" (strings.TrimSpace (index $lines 0))) -}}
+  {{- $s.Set "option" "" -}}
+  {{- $s.Set "desc" "" -}}
+  {{- $s.Set "sectionTitle" "" -}}
+  {{- $s.Set "sectionLines" (slice) -}}
+  {{- $s.Set "exampleParagraph" (slice) -}}
+
+  {{- range $line := after 1 $lines -}}
+    {{- $trimmed := strings.TrimSpace $line -}}
+    {{- $isHeading := and (eq $line $trimmed) (hasSuffix $trimmed ":") -}}
+    {{- $optionMatch := findRESubmatch `^(\s{2,8})((?:--?[0-9A-Za-z][0-9A-Za-z-]*)(?:\s+(?:<[^>]+>|\[[^\]]+\]))*)(?:\s+(.*))?$` $line -}}
+    {{- $isOption := gt (len $optionMatch) 0 -}}
+    {{- $hasOption := ne ($s.Get "option") "" -}}
+    {{- $sectionTitle := $s.Get "sectionTitle" -}}
+
+    {{- if $isHeading -}}
+      {{- if $hasOption -}}
+        {{- $entry := printf "- `%s`" ($s.Get "option") -}}
+        {{- if ne ($s.Get "desc") "" -}}
+          {{- $entry = printf "%s: %s" $entry ($s.Get "desc") -}}
+        {{- end -}}
+        {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
+        {{- $s.Set "option" "" -}}
+        {{- $s.Set "desc" "" -}}
+      {{- end -}}
+
+      {{- if ne $sectionTitle "" -}}
+        {{- $s.Set "markdown" (printf "%s\n#### %s\n\n" ($s.Get "markdown") $sectionTitle) -}}
+        {{- range $entry := ($s.Get "sectionLines") -}}
+          {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
+        {{- end -}}
+        {{- if gt (len ($s.Get "exampleParagraph")) 0 -}}
+          {{- $paragraph := delimit ($s.Get "exampleParagraph") " " -}}
+          {{- $s.Set "markdown" (printf "%s\n%s\n" ($s.Get "markdown") $paragraph) -}}
+          {{- $s.Set "exampleParagraph" (slice) -}}
+        {{- end -}}
+        {{- $s.Set "markdown" (printf "%s\n" ($s.Get "markdown")) -}}
+        {{- $s.Set "sectionLines" (slice) -}}
+      {{- end -}}
+
+      {{- $s.Set "sectionTitle" (strings.TrimSuffix ":" $trimmed) -}}
+    {{- else if $isOption -}}
+      {{- if $hasOption -}}
+        {{- $entry := printf "- `%s`" ($s.Get "option") -}}
+        {{- if ne ($s.Get "desc") "" -}}
+          {{- $entry = printf "%s: %s" $entry ($s.Get "desc") -}}
+        {{- end -}}
+        {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
+      {{- end -}}
+
+      {{- $groups := index $optionMatch 0 -}}
+      {{- $s.Set "option" (index $groups 2) -}}
+      {{- $s.Set "desc" (strings.TrimSpace (index $groups 3)) -}}
+
+      {{- if ne $sectionTitle "" -}}
+        {{- $s.Set "sectionTitle" "" -}}
+        {{- $s.Set "sectionLines" (slice) -}}
+        {{- $s.Set "exampleParagraph" (slice) -}}
+      {{- end -}}
+    {{- else if and $hasOption (ne $trimmed "") -}}
+      {{- $joined := strings.TrimSpace (printf "%s %s" ($s.Get "desc") $trimmed) -}}
+      {{- $s.Set "desc" $joined -}}
+    {{- else if and (ne $sectionTitle "Examples") (ne $sectionTitle "") (ne $trimmed "") -}}
+      {{- $s.Set "sectionLines" (($s.Get "sectionLines") | append $trimmed) -}}
+    {{- else if eq $sectionTitle "Examples" -}}
+      {{- if hasPrefix $line "  " -}}
+        {{- if gt (len ($s.Get "exampleParagraph")) 0 -}}
+          {{- $paragraph := delimit ($s.Get "exampleParagraph") " " -}}
+          {{- $s.Set "sectionLines" (($s.Get "sectionLines") | append $paragraph) -}}
+          {{- $s.Set "exampleParagraph" (slice) -}}
+        {{- end -}}
+        {{- if ne $trimmed "" -}}
+          {{- if hasPrefix $trimmed "(" -}}
+            {{- $s.Set "sectionLines" (($s.Get "sectionLines") | append $trimmed | append "") -}}
+          {{- else -}}
+            {{- $s.Set "sectionLines" (($s.Get "sectionLines") | append (printf "- `%s`" $trimmed)) -}}
+          {{- end -}}
+        {{- end -}}
+      {{- else if ne $trimmed "" -}}
+        {{- $s.Set "exampleParagraph" (($s.Get "exampleParagraph") | append $trimmed) -}}
+      {{- else if gt (len ($s.Get "exampleParagraph")) 0 -}}
+        {{- $paragraph := delimit ($s.Get "exampleParagraph") " " -}}
+        {{- $s.Set "sectionLines" (($s.Get "sectionLines") | append $paragraph | append "") -}}
+        {{- $s.Set "exampleParagraph" (slice) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if ne ($s.Get "option") "" -}}
+    {{- $entry := printf "- `%s`" ($s.Get "option") -}}
+    {{- if ne ($s.Get "desc") "" -}}
+      {{- $entry = printf "%s: %s" $entry ($s.Get "desc") -}}
+    {{- end -}}
+    {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
+  {{- end -}}
+
+  {{- if ne ($s.Get "sectionTitle") "" -}}
+    {{- $sectionTitle := $s.Get "sectionTitle" -}}
+    {{- $s.Set "markdown" (printf "%s\n#### %s\n\n" ($s.Get "markdown") $sectionTitle) -}}
+    {{- if gt (len ($s.Get "exampleParagraph")) 0 -}}
+      {{- $paragraph := delimit ($s.Get "exampleParagraph") " " -}}
+      {{- $s.Set "sectionLines" (($s.Get "sectionLines") | append $paragraph) -}}
+    {{- end -}}
+    {{- range $entry := ($s.Get "sectionLines") -}}
+      {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
+    {{- end -}}
+    {{- $s.Set "markdown" (printf "%s\n" ($s.Get "markdown")) -}}
+  {{- end -}}
+
+  {{- htmlUnescape (strings.TrimSpace ($s.Get "markdown")) -}}
+{{- end -}}

--- a/layouts/partials/usage-block-markdown.html
+++ b/layouts/partials/usage-block-markdown.html
@@ -10,6 +10,8 @@
   Falls back to the raw content if the shape does not match.
 */ -}}
 
+{{- $formatPlaceholders := `(<[^>\n]+>)` -}}
+
 {{- $raw := strings.Trim (.RawContent | default "") "\n" -}}
 {{- $lines := split $raw "\n" -}}
 {{- if ge (len $lines) 2 -}}
@@ -44,7 +46,7 @@
       {{- if $hasOption -}}
         {{- $entry := printf "- `%s`" ($s.Get "option") -}}
         {{- if ne ($s.Get "desc") "" -}}
-          {{- $entry = printf "%s: %s" $entry ($s.Get "desc") -}}
+          {{- $entry = printf "%s: %s" $entry (replaceRE $formatPlaceholders "`$1`" ($s.Get "desc")) -}}
         {{- end -}}
         {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
         {{- $s.Set "option" "" -}}
@@ -70,7 +72,7 @@
       {{- if $hasOption -}}
         {{- $entry := printf "- `%s`" ($s.Get "option") -}}
         {{- if ne ($s.Get "desc") "" -}}
-          {{- $entry = printf "%s: %s" $entry ($s.Get "desc") -}}
+          {{- $entry = printf "%s: %s" $entry (replaceRE $formatPlaceholders "`$1`" ($s.Get "desc")) -}}
         {{- end -}}
         {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
       {{- end -}}
@@ -116,7 +118,7 @@
   {{- if ne ($s.Get "option") "" -}}
     {{- $entry := printf "- `%s`" ($s.Get "option") -}}
     {{- if ne ($s.Get "desc") "" -}}
-      {{- $entry = printf "%s: %s" $entry ($s.Get "desc") -}}
+      {{- $entry = printf "%s: %s" $entry (replaceRE $formatPlaceholders "`$1`" ($s.Get "desc")) -}}
     {{- end -}}
     {{- $s.Set "markdown" (printf "%s%s\n" ($s.Get "markdown") $entry) -}}
   {{- end -}}

--- a/layouts/shortcodes/trimmable.html
+++ b/layouts/shortcodes/trimmable.html
@@ -1,0 +1,1 @@
+{{ .Inner | markdownify }}

--- a/layouts/shortcodes/trimmable.html
+++ b/layouts/shortcodes/trimmable.html
@@ -1,1 +1,21 @@
-{{ .Inner | markdownify }}
+{{ $trimmedInner := trim .Inner " \t\n\r" }}
+{{ if and (gt (len $trimmedInner) 0) (eq (slicestr $trimmedInner 0 1) "<") }}
+  {{ .Scratch.Set "content" .Inner }}
+{{ else }}
+  {{ .Scratch.Set "content" (.Inner | markdownify) }}
+{{ end }}
+{{ $inner := .Scratch.Get "content" }}
+{{ $counter := add (.Page.Scratch.Get "trimmable_counter" | default 0) 1 }}
+{{ .Page.Scratch.Set "trimmable_counter" $counter }}
+{{ $toggleId := printf "trimmable-%s-%d" .Page.File.UniqueID $counter }}
+
+<div class="trimmable-block my-4">
+  <input class="trimmable-input sr-only" id="{{ $toggleId }}" type="checkbox">
+  <div class="trimmable-content">
+    {{ $inner }}
+  </div>
+  <label class="trimmable-toggle" for="{{ $toggleId }}">
+    <span class="trimmable-label-more">Show full output</span>
+    <span class="trimmable-label-less">Hide full output</span>
+  </label>
+</div>

--- a/layouts/shortcodes/trimmable.html
+++ b/layouts/shortcodes/trimmable.html
@@ -9,12 +9,12 @@
 {{ .Page.Scratch.Set "trimmable_counter" $counter }}
 {{ $toggleId := printf "trimmable-%s-%d" .Page.File.UniqueID $counter }}
 
-<div class="trimmable-block my-4">
+<div class="my-4">
   <input class="trimmable-input sr-only" id="{{ $toggleId }}" type="checkbox">
-  <div class="trimmable-content">
+  <div class="trimmable-content relative overflow-hidden">
     {{ $inner }}
   </div>
-  <label class="trimmable-toggle" for="{{ $toggleId }}">
+  <label class="trimmable-toggle mt-2.5 inline-flex cursor-pointer items-center gap-2 font-semibold text-redis-red-500 no-underline" for="{{ $toggleId }}">
     <span class="trimmable-label-more">Show full output</span>
     <span class="trimmable-label-less">Hide full output</span>
   </label>

--- a/layouts/shortcodes/usage.html
+++ b/layouts/shortcodes/usage.html
@@ -1,0 +1,5 @@
+{{- $markdown := partial "usage-block-markdown.html" (dict "RawContent" .Inner) -}}
+{{- $html := $markdown | markdownify -}}
+{{- $html = replace $html "&amp;lt;" "&lt;" -}}
+{{- $html = replace $html "&amp;gt;" "&gt;" -}}
+{{- $html | safeHTML -}}


### PR DESCRIPTION
Mainly dull issues with the Markdown rendering again (such as embeds not being included). A couple of experimental visible changes in the CLI page, however:

- `trimmable` shortcode visually collapses long output from CLI commands, logs, etc, but lets you expand it if you want to see it. In the Markdown, this is reduced to just a few lines from the start and end of the text (since it isn't very helpful for AI tools to see the full detail). See the [Big keys](https://redis.io/docs/staging/DOC-6486-md-render-issues/develop/tools/cli/#big-keys) section for an example.
- `usage` shortcode takes the standard-ish usage/help output from a CLI command and renders it as a list of options, etc. This gives better formatting for humans to read, more clarity for AI, and also avoids maintenance problems because you can simply paste the new usage details into the shortcode if they change. See the [Usage](https://redis.io/docs/staging/DOC-6486-md-render-issues/develop/tools/cli/#usage) section for an example.

If we consider `trimmable` and `usage` to be beneficial then I'll add them wherever appropriate in the rest of the docs as a separate PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared Markdown processing pipeline used to generate AI-facing `.md`/`.json` outputs, which could affect many pages’ rendered content and chunking. Risk is mainly in Hugo templating/regex edge cases (embed recursion, table splitting, usage parsing).
> 
> **Overview**
> **Improves AI-facing Markdown/JSON generation** by extending `process-markdown-content.html` to expand `embed-md` includes (with loop prevention), rewrite `table-scrollable` blocks into smaller tables, trim opt-in long blocks via a new `trimmable` processor, and convert `usage` blocks into structured Markdown.
> 
> **Adds new shortcodes and UI behavior**: `trimmable` renders long outputs as a collapsible block with new CSS, and `usage` renders CLI help text into a readable options list; the Redis CLI doc updates to wrap large command outputs in `trimmable` and the Usage section in `usage`.
> 
> **Tightens code-example Markdown rendering** by cleaning/trimming captured Redis CLI example content and making “Redis CLI” appear in the availability list only when present, avoiding stray `}}`/whitespace artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cefef594259e8f528657081fb1ddc63382ceef70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->