### PR TITLE
Make nodejs landing example interactive

### DIFF
--- a/content/develop/clients/nodejs/_index.md
+++ b/content/develop/clients/nodejs/_index.md
@@ -48,18 +48,15 @@ npm install redis
 
 Connect to localhost on port 6379.
 
-{{< clients-example set="landing" step="connect" lang_filter="Node.js" description="Foundational: Create a client connection to a Redis server using node-redis" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="connect" lang_filter="Node.js" description="Foundational: Create a client connection to a Redis server using node-redis" difficulty="beginner" />}}
 
 Store and retrieve a simple string.
 
-{{< clients-example set="landing" step="set_get_string" lang_filter="Node.js" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="set_get_string" depends="connect" lang_filter="Node.js" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" />}}
 
 Store and retrieve a map.
 
-{{< clients-example set="landing" step="set_get_hash" lang_filter="Node.js" description="Foundational: Store and retrieve hash data structures using HSET and HGET commands" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="set_get_hash" depends="connect" lang_filter="Node.js" description="Foundational: Store and retrieve hash data structures using HSET and HGET commands" difficulty="beginner" />}}
 
 To connect to a different host or port, use a connection string in the format `redis[s]://[[username][:password]@][host][:port][/db-number]`:
 
@@ -72,8 +69,7 @@ To check if the client is connected and ready to send commands, use `client.isRe
 
 When you have finished using a connection, close it with `client.quit()`.
 
-{{< clients-example set="landing" step="close" lang_filter="Node.js" description="Foundational: Close a Redis client connection using the quit() method" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="close" depends="connect" lang_filter="Node.js" description="Foundational: Close a Redis client connection using the quit() method" difficulty="beginner" no_output="true" />}}
 
 ## More information
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1462,6 +1462,91 @@
           });
         }
 
+        // Thebe 0.9.0-rc.12's bundled CodeMirror 5 only registers the "python" mode,
+        // so JavaScript (Node.js) cells lose syntax highlighting after activation.
+        // Lazily fetch CM5's javascript mode and register it on Thebe's internal CM class,
+        // then re-apply the mode on any JS cells to force re-tokenization.
+        const CM_JS_MODE_URL = 'https://unpkg.com/codemirror@5.65.16/mode/javascript/javascript.js';
+
+        function loadCodeMirrorJsMode(CM) {
+          if (!CM || typeof CM.defineMode !== 'function') return Promise.resolve(false);
+          if (CM.modes && CM.modes.javascript) return Promise.resolve(true);
+          if (window.__cmJsModePromise) return window.__cmJsModePromise;
+
+          window.__cmJsModePromise = new Promise(function(resolve) {
+            const hadPrev = Object.prototype.hasOwnProperty.call(window, 'CodeMirror');
+            const prev = window.CodeMirror;
+            window.CodeMirror = CM;
+            const script = document.createElement('script');
+            script.src = CM_JS_MODE_URL;
+            const restore = function() {
+              if (hadPrev) { window.CodeMirror = prev; } else { try { delete window.CodeMirror; } catch (e) { window.CodeMirror = undefined; } }
+            };
+            script.onload = function() {
+              restore();
+              resolve(!!(CM.modes && CM.modes.javascript));
+            };
+            script.onerror = function() {
+              restore();
+              console.warn('[Thebe] Failed to load CodeMirror JavaScript mode from', CM_JS_MODE_URL);
+              window.__cmJsModePromise = null;
+              resolve(false);
+            };
+            document.head.appendChild(script);
+          });
+          return window.__cmJsModePromise;
+        }
+
+        // Thebe strips data-language after activation, so we identify JS cells by the
+        // CodeMirror instance's configured mode option.
+        function findJsCmInstances() {
+          const out = [];
+          document.querySelectorAll('.thebe-cell .CodeMirror').forEach(function(cmEl) {
+            const cm = cmEl.CodeMirror;
+            if (!cm) return;
+            const mode = cm.getOption('mode');
+            const modeName = (typeof mode === 'string') ? mode : (mode && mode.name);
+            if (modeName === 'javascript') out.push(cm);
+          });
+          return out;
+        }
+
+        function applyJsModeToCells() {
+          findJsCmInstances().forEach(function(cm) {
+            cm.setOption('mode', null);
+            cm.setOption('mode', 'javascript');
+          });
+        }
+
+        // Triggering paths diverge: a fresh "Run here" click follows "attached" with cells
+        // already CodeMirror-ified, while an auto-restored session may fire "attached"
+        // before Thebe has installed the editors. To cover both, watch the DOM with a
+        // MutationObserver and also run once synchronously.
+        let __jsHighlightDone = false;
+        let __jsHighlightObserver = null;
+        function __tryRegisterJsMode() {
+          if (__jsHighlightDone) return;
+          const jsCms = findJsCmInstances();
+          if (jsCms.length === 0) return;
+          __jsHighlightDone = true;
+          if (__jsHighlightObserver) { __jsHighlightObserver.disconnect(); __jsHighlightObserver = null; }
+          const CM = jsCms[0].constructor;
+          loadCodeMirrorJsMode(CM).then(function(ok) {
+            if (ok) applyJsModeToCells();
+          });
+        }
+        function ensureJsHighlightingForActivatedCells() {
+          __tryRegisterJsMode();
+          if (__jsHighlightDone || __jsHighlightObserver) return;
+          if (typeof MutationObserver !== 'function') return;
+          __jsHighlightObserver = new MutationObserver(function() { __tryRegisterJsMode(); });
+          __jsHighlightObserver.observe(document.body, { childList: true, subtree: true });
+          // Safety net: stop observing after 2 minutes even if no JS cells ever appear.
+          setTimeout(function() {
+            if (__jsHighlightObserver) { __jsHighlightObserver.disconnect(); __jsHighlightObserver = null; }
+          }, 120000);
+        }
+
         // Function to handle kernel expiration/disconnection
         function handleKernelExpired() {
           // Clear localStorage session so fresh start on reload
@@ -1506,6 +1591,10 @@
 
           // Preserve the original Hugo-rendered cell HTML before Thebe mutates it.
           storeOriginalCellHTML();
+
+          // Start watching for JS cells so we can install CM's javascript mode as soon
+          // as Thebe creates the editors (covers both fresh click and auto-reconnect).
+          ensureJsHighlightingForActivatedCells();
 
           // NOTE: Loading state is now managed by individual click handlers (lines 1189-1190)
           // This prevents all blocks from showing "Starting kernel..." when only one is clicked
@@ -1568,6 +1657,9 @@
                   enableAllButtons();
                   // Configure CodeMirror keyboard shortcuts (Cmd+Enter / Ctrl+Enter)
                   configureCodeMirrorShortcuts();
+                  // Thebe's bundled CodeMirror lacks the JavaScript mode; lazy-load it
+                  // so Node.js cells keep syntax highlighting after activation.
+                  ensureJsHighlightingForActivatedCells();
                   // Note: Removed focus() call that was causing scroll jump on page refresh
                   // Users can click into any editor to focus when they want to edit
                 }

--- a/layouts/shortcodes/jupyter-example.html
+++ b/layouts/shortcodes/jupyter-example.html
@@ -321,8 +321,11 @@
         {{/* Hint positioned outside step-code-view so it stays visible when toggling views */}}
         <span class="run-hint">Ctrl+Enter to run</span>
         {{/* Step code view - shown by default and when CodeMirror is active */}}
+        {{/* Map internal language identifier to a CodeMirror mode name for data-language */}}
+        {{ $cmLanguage := $language }}
+        {{ if eq $language "node.js" }}{{ $cmLanguage = "javascript" }}{{ end }}
         <div class="step-code-view">
-            <div data-executable="true" data-language="{{ $language }}" class="thebe-cell">
+            <div data-executable="true" data-language="{{ $cmLanguage }}" class="thebe-cell">
                 {{- highlight $stepCode $language "" -}}
             </div>
         </div>

--- a/local_examples/client-specific/nodejs/landing.js
+++ b/local_examples/client-specific/nodejs/landing.js
@@ -1,5 +1,6 @@
 // EXAMPLE: landing
 // BINDER_ID nodejs-landing
+// KERNEL_NAME javascript
 // STEP_START connect
 import { createClient } from 'redis';
 
@@ -26,14 +27,6 @@ await client.hSet('user-session:123', {
 
 let userSession = await client.hGetAll('user-session:123');
 console.log(JSON.stringify(userSession, null, 2));
-/* >>>
-{
-  "surname": "Smith",
-  "name": "John",
-  "company": "Redis",
-  "age": "29"
-}
- */
 // STEP_END
 
 // STEP_START close

--- a/local_examples/client-specific/nodejs/landing.js
+++ b/local_examples/client-specific/nodejs/landing.js
@@ -14,7 +14,7 @@ await client.connect();
 // STEP_START set_get_string
 await client.set('key', 'value');
 const value = await client.get('key');
-console.log(value); // >>> value
+console.log(value);
 // STEP_END
 
 // STEP_START set_get_hash

--- a/local_examples/client-specific/nodejs/landing.js
+++ b/local_examples/client-specific/nodejs/landing.js
@@ -1,6 +1,6 @@
 // EXAMPLE: landing
 // BINDER_ID nodejs-landing
-// KERNEL_NAME javascript
+// KERNEL_NAME jslab
 // STEP_START connect
 import { createClient } from 'redis';
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches shared `baseof.html` Thebe bootstrapping logic and dynamically loads external CodeMirror mode code, which could impact all interactive code blocks if it misbehaves or fails to load.
> 
> **Overview**
> Switches the Node.js `node-redis` landing page examples from static `clients-example` blocks to interactive `jupyter-example` cells, wiring step dependencies and suppressing output for the close step.
> 
> Updates the Thebe/CodeMirror integration to preserve JavaScript syntax highlighting for activated Node.js cells by mapping `node.js` to the `javascript` mode in `jupyter-example` and lazily loading CodeMirror 5’s JavaScript mode in `baseof.html` (with DOM observation to handle both fresh activation and session restore).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 410a672280c38738b086c5182ac5fd10ab0d92ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->