### PR TITLE
Add Feature Form operation documentation

### DIFF
--- a/content/operate/featureform/_index.md
+++ b/content/operate/featureform/_index.md
@@ -1,0 +1,55 @@
+---
+Title: Redis Feature Form
+alwaysopen: false
+categories:
+- docs
+- operate
+- featureform
+description: Deploy and operate Feature Form on Kubernetes.
+linkTitle: Redis Feature Form
+weight: 50
+bannerText: Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
+bannerChildren: true
+---
+
+Feature Form runs as a Kubernetes-based platform for feature engineering and online feature serving. Use this section to prepare your environment, choose a deployment method, install Feature Form, and verify that the platform is ready for application teams.
+
+These docs are cloud-neutral in framing. Where Terraform examples are useful, request them from your Redis account team.
+
+Use this section to decide how you want to install Feature Form before you create workspaces or register providers.
+
+## Deployment model
+
+The Helm chart deploys:
+
+- one shared API server deployment that exposes both REST and gRPC
+- separate services for REST and gRPC
+- an optional dashboard
+- optional addons for Postgres state, provider infrastructure, and observability
+
+Authentication is required. Standard installs need OIDC configuration.
+
+## State-backend choices
+
+- External PostgreSQL: the durable default for shared deployments
+- Bundled state PostgreSQL: useful for self-contained evaluation or test installs
+- Memory state: local or CI only, not durable
+
+With memory state, gRPC and REST do not share one durable graph. Keep that in mind when troubleshooting “missing” workspaces or resources.
+
+## Exposure choices
+
+- internal-only services
+- service-specific ingresses
+- unified ingress
+- direct `LoadBalancer` services
+
+Do not combine unified ingress with service-specific ingress settings.
+
+## Helm profiles
+
+- base chart
+- `profiles/memory.yaml`
+- `profiles/provider-stack.yaml`
+- `profiles/observability-postgres.yaml`
+- `profiles/provider-observability.yaml`

--- a/content/operate/featureform/auth.md
+++ b/content/operate/featureform/auth.md
@@ -1,0 +1,110 @@
+---
+Title: Authentication and RBAC
+alwaysopen: false
+categories:
+- docs
+- operate
+- featureform
+description: Manage Feature Form auth and RBAC
+linkTitle: Authentication and RBAC
+weight: 70
+bannerText: Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
+bannerChildren: true
+---
+Feature Form separates deployment-wide administration from workspace-scoped actions. A workspace is the isolation boundary, but membership and permissions are managed separately through RBAC bindings.
+
+## Built-in roles
+
+- `global_admin` for deployment-wide administration and workspace creation
+- `workspace_admin` for workspace setup, membership, apply, and audit
+- `operator` for operational workflows
+- `viewer` for read-only workspace visibility
+- `model` for constrained reads of feature views and training sets
+
+## Typical handoff
+
+1. A global admin creates the workspace.
+2. The global admin grants `workspace_admin` to the intended principal.
+3. That principal verifies access before registering providers or applying resources.
+
+## Scope model
+
+- Global scope controls deployment-wide actions.
+- Workspace scope controls providers, secret providers, apply, graph, and audit inside one workspace.
+- Resource-constrained scope is used for limited serving or training-set access.
+
+## Create a workspace and grant access
+
+Use this flow when a global admin is creating a new workspace and handing it off to the team that will manage it.
+
+### 1. Create the workspace
+
+```bash
+ff workspace create demo-workspace \
+  --description "Workspace for the feature workflow docs path"
+```
+
+### 2. Verify it exists
+
+```bash
+ff workspace get --name demo-workspace
+ff workspace list
+```
+
+Capture the workspace ID from the result for later RBAC commands.
+
+### 3. Grant workspace-admin access
+
+```bash
+ff rbac grant workspace_admin \
+  --workspace <workspace-id> \
+  --user alice@example.com
+```
+
+You can also bind a group or service account instead of a user.
+
+### 4. Verify the binding
+
+```bash
+ff rbac list --workspace <workspace-id>
+ff rbac subjects --workspace <workspace-id>
+```
+
+### Notes
+
+- Creating the workspace does not automatically grant workspace membership to other principals.
+- New workspaces create a built-in `env` secret provider, but it is still workspace-scoped.
+- In-memory state can make gRPC and REST behave like separate state domains. Use durable PostgreSQL-backed state for shared environments.
+
+## Join an existing workspace
+
+Use this page when a workspace already exists and you need to confirm that the intended principal can proceed with setup, apply, or serving.
+
+### 1. Verify identity
+
+```bash
+ff auth whoami
+ff rbac whoami
+```
+
+### 2. Confirm the workspace is visible
+
+```bash
+ff workspace list
+ff workspace get --name demo-workspace
+```
+
+### 3. Confirm the effective binding
+
+```bash
+ff rbac list --workspace <workspace-id>
+```
+
+You should see the expected user, group, or service-account binding for that workspace.
+
+### Common failures
+
+- `permission denied` on provider or apply commands usually means missing workspace write access.
+- `workspace not found` usually means the wrong deployment, wrong transport, or wrong workspace name.
+- Missing resources after apply can indicate transport or state-backend mismatch in non-durable environments.
+

--- a/content/operate/featureform/deploy.md
+++ b/content/operate/featureform/deploy.md
@@ -1,0 +1,134 @@
+---
+Title: Deploy
+alwaysopen: false
+categories:
+- docs
+- operate
+- featureform
+description: Deploy and operate Feature Form on Kubernetes.
+linkTitle: Deploy
+weight: 60
+bannerText: Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
+bannerChildren: true
+---
+
+Use this guide to install Feature Form with the Helm chart and verify that the core services are healthy. 
+
+## Install
+
+The default documented path is OIDC-enabled auth plus durable PostgreSQL-backed state.
+
+### Prerequisites
+
+- Kubernetes 1.27+
+- Helm 3.14+
+- an OIDC issuer URL and client ID
+- a PostgreSQL connection path or existing secret
+
+### 1. Choose auth and state values
+
+Pick one PostgreSQL-backed state path before installation:
+
+- `postgres.url`
+- `postgres.secretName`
+- `addons.statePostgres.enabled=true`
+
+External PostgreSQL is the documented durable default.
+
+### 2. Pick the base chart or a profile
+
+- Base chart for environments where provider infrastructure already exists
+- `profiles/memory.yaml` for local or test-only installs
+- `profiles/provider-stack.yaml` for bundled providers
+- `profiles/observability-postgres.yaml` for observability
+- `profiles/provider-observability.yaml` for both
+
+### 3. Install with Helm
+
+```bash
+helm upgrade --install featureform charts/featureform \
+  --set postgres.url=postgres://featureform:featureform@my-postgres:5432/featureform?sslmode=disable \
+  --set auth.oidcIssuerURL=https://idp.example.com/realms/featureform \
+  --set auth.oidcClientID=featureform-api \
+  --set rest.ingress.enabled=true \
+  --set rest.ingress.className=nginx \
+  --set rest.ingress.hosts[0].host=api.example.com \
+  --set rest.ingress.hosts[0].paths[0].path=/ \
+  --set rest.ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+### 4. Validate pods and services
+
+```bash
+kubectl get pods -n <namespace>
+kubectl get svc -n <namespace>
+kubectl describe deployment featureform-featureform-server -n <namespace>
+```
+
+Look for a healthy shared API deployment, both REST and gRPC services, and completed migrations when PostgreSQL state is enabled.
+
+### 5. Record the endpoints
+
+Capture the URLs or hosts your teams will need:
+
+- REST API endpoint
+- gRPC endpoint
+- dashboard URL if enabled
+- Grafana URL if enabled
+
+### High-risk confusion points
+
+- One shared server deployment exposes both REST and gRPC; they are not separate deployments.
+- `auth.enabled=false` is not supported.
+- `stateBackend=memory` is not durable.
+- The dashboard needs more than `dashboard.enabled=true`; it also needs correct auth and API URL settings.
+
+## Configure external access
+
+Use this section after installation to publish the right Feature Form endpoints for users, automation, and optional UI access.
+
+### REST ingress example
+
+```bash
+helm upgrade --install featureform charts/featureform \
+  --set postgres.url=postgres://featureform:featureform@my-postgres:5432/featureform?sslmode=disable \
+  --set auth.oidcIssuerURL=https://idp.example.com/realms/featureform \
+  --set auth.oidcClientID=featureform-api \
+  --set rest.ingress.enabled=true \
+  --set rest.ingress.className=nginx \
+  --set rest.ingress.hosts[0].host=api.example.com \
+  --set rest.ingress.hosts[0].paths[0].path=/ \
+  --set rest.ingress.hosts[0].paths[0].pathType=Prefix
+```
+
+### gRPC exposure guidance
+
+Use `grpc.ingress.*` only with an ingress controller that supports gRPC backends. If ingress is not a fit, use `grpc.service.type=LoadBalancer`.
+
+### Dashboard requirements
+
+A working dashboard path needs all of the following:
+
+- `dashboard.enabled=true`
+- a resolvable public API URL
+- dashboard auth secrets
+- a resolvable auth URL
+
+### Unified ingress
+
+Unified ingress publishes one host with chart-managed paths for API, dashboard, and optionally Grafana. Do not combine it with service-specific ingress settings.
+
+### Direct load balancers
+
+If your platform prefers direct external services, expose:
+
+- `rest.service.type=LoadBalancer`
+- `grpc.service.type=LoadBalancer`
+- `dashboard.service.type=LoadBalancer`
+
+### Common validation failures
+
+- missing ingress hosts
+- unified ingress mixed with service-specific ingresses
+- dashboard enabled without API URL or auth secrets
+- Grafana ingress configured without the observability stack enabled


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only additions; no runtime, security, or behavioral code changes.
> 
> **Overview**
> Adds a new `operate/featureform` documentation section introducing Redis Feature Form’s Kubernetes/Helm deployment model, state-backend options, exposure patterns, and available Helm profiles.
> 
> Includes a deployment guide with prerequisites, example Helm install/upgrade commands, post-install validation steps, and common misconfiguration pitfalls (ingress combinations, dashboard requirements, memory state caveats).
> 
> Adds an authentication/RBAC page documenting built-in roles, recommended workspace handoff flow, and CLI examples for creating workspaces and managing/validating RBAC bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b657e1e8f5374f0bd8985d8d8eab075658d130a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->