### PR TITLE
docs: fix "folowing" typo in lettuce AMR guide

### DIFF
--- a/content/develop/clients/lettuce/amr.md
+++ b/content/develop/clients/lettuce/amr.md
@@ -85,7 +85,7 @@ You can also add configuration to authenticate with a [service principal](#serv-
 or a [managed identity](#mgd-identity) as described in the sections below.
 
 When you have created your `TokenBasedRedisCredentialsProvider` instance, you may want to
-test it by obtaining a token, as shown in the folowing example:
+test it by obtaining a token, as shown in the following example:
 
 ```java
 // Test that the Entra ID credentials provider can resolve credentials.


### PR DESCRIPTION
## Summary
- Fix the \"folowing\" typo in the Lettuce AMR guide

## Related issue
- N/A (trivial docs-only typo fix)

## Guideline alignment
- Followed the repo guidance in `README.md` and `AI_AGENT_DEVELOPER_GUIDE.md`
- Keeps the change to one sentence in one documentation file

## Validation/testing
- Not run; docs-only wording change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change with no behavior or API impact.
> 
> **Overview**
> Corrects a single spelling typo ("folowing" → "following") in the `content/develop/clients/lettuce/amr.md` AMR connection guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01791d044e60e07aaa96c97442a440054244c563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->