### PR TITLE
docs: fix "therefor" typo in redis-cli docs

### DIFF
--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -964,7 +964,7 @@ The program shows stats every second. In the first seconds the cache starts to b
     127000 Gets/sec | Hits: 50870 (40.06%) | Misses: 76130 (59.94%)
     124250 Gets/sec | Hits: 50147 (40.36%) | Misses: 74103 (59.64%)
 
-A miss rate of 59% may not be acceptable for certain use cases therefor
+A miss rate of 59% may not be acceptable for certain use cases; therefore,
 100MB of memory is not enough. Observe an example using a half gigabyte of memory. After several
 minutes the output stabilizes to the following figures:
 


### PR DESCRIPTION
## Summary
- Fix the \"therefor\" typo in the redis-cli documentation

## Related issue
- N/A (trivial docs-only typo fix)

## Guideline alignment
- Followed the repo guidance in `README.md` and `AI_AGENT_DEVELOPER_GUIDE.md`
- Keeps the change to one sentence in one documentation file

## Validation/testing
- Not run; docs-only wording change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only edit that corrects wording/punctuation with no functional or behavioral impact.
> 
> **Overview**
> Fixes a typo/grammar issue in the `redis-cli` documentation (`content/develop/tools/cli.md`) by changing “therefor” to “therefore” and adjusting punctuation in the LRU cache miss-rate explanation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383f094280616f0ce3d0253cb3e17740c98913d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->