### PR TITLE
docs: fix "commmand" typo in node-redis migration guide

### DIFF
--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -148,7 +148,7 @@ client.hset('user', 'name', 'Bob', 'age', 20, 'description', 'I am a programmer'
 ```
 
 `node-redis` uses predefined formats for command arguments. These include specific
-classes for commmand options that generally don't correspond to the syntax
+classes for command options that generally don't correspond to the syntax
 of the CLI command. Internally, `node-redis` constructs the correct command using
 the method arguments you pass:
 


### PR DESCRIPTION
## Summary
- Fix the \"commmand\" typo in the node-redis migration guide

## Related issue
- N/A (trivial docs-only typo fix)

## Guideline alignment
- Followed the repo guidance in `README.md` and `AI_AGENT_DEVELOPER_GUIDE.md`
- Keeps the change to one sentence in one documentation file

## Validation/testing
- Not run; docs-only wording change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change correcting a single typo with no impact to runtime behavior.
> 
> **Overview**
> Fixes a typo in the Node.js `node-redis` migration guide by correcting “commmand” to “command” in the command-argument handling section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4fc4292765ae1b1d600a9691cbff1325dd7d48f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->