### PR TITLE
docs: fix "preformed" typo in Twitter clone guide

### DIFF
--- a/content/develop/clients/patterns/twitter-clone.md
+++ b/content/develop/clients/patterns/twitter-clone.md
@@ -283,7 +283,7 @@ This is the actual code:
     setcookie("auth",$authsecret,time()+3600*24*365);
     header("Location: index.php");
 
-This happens every time a user logs in, but we also need a function `isLoggedIn` in order to check if a given user is already authenticated or not. These are the logical steps preformed by the `isLoggedIn` function:
+This happens every time a user logs in, but we also need a function `isLoggedIn` in order to check if a given user is already authenticated or not. These are the logical steps performed by the `isLoggedIn` function:
 
  * Get the "auth" cookie from the user. If there is no cookie, the user is not logged in, of course. Let's call the value of the cookie `<authcookie>`.
  * Check if `<authcookie>` field in the `auths` Hash exists, and what the value (the user ID) is (1000 in the example).


### PR DESCRIPTION
## Summary
- Fix the \"preformed\" typo in the Twitter clone guide

## Related issue
- N/A (trivial docs-only typo fix)

## Guideline alignment
- Followed the repo guidance in `README.md` and `AI_AGENT_DEVELOPER_GUIDE.md`
- Keeps the change to one sentence in one documentation file

## Validation/testing
- Not run; docs-only wording change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change with no runtime or behavioral impact.
> 
> **Overview**
> Fixes a spelling mistake in `content/develop/clients/patterns/twitter-clone.md`, changing "preformed" to "performed" in the `isLoggedIn` description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533c02d7e9f392b2a648c80d93ad4c0fa00844e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->