### PR TITLE
[RDSC-5016] Improving documentation for using full row format and mapping

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-row-format.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-row-format.md
@@ -151,3 +151,5 @@ output:
           expression: concat([after.CITY, ', ', after.STATE])
           language: jmespath
     ```
+
+- When using the `full` row format, all data fields in transformation and key calculations should be prepended with `before` or `after.` depending on whether you want to access the previous or current value of the row. Exception from this case is the `mapping` section where only the `after` values are available. And you should use directly the column/value name without the `after.` prefix.

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-row-format.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-row-format.md
@@ -152,4 +152,4 @@ output:
           language: jmespath
     ```
 
-- When using the `full` row format, all data fields in transformation and key calculations should be prepended with `before` or `after.` depending on whether you want to access the previous or current value of the row. Exception from this case is the `mapping` section where only the `after` values are available. And you should use directly the column/value name without the `after.` prefix.
+- When using the `full` row format, you should prepend all data fields in transformation and key calculations with `before` or `after` depending on whether you want to access the previous or current value of the row. The only exception to this is the `mapping` section where only the `after` values are available, so you should use the column/value name without the `after` prefix.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime behavior impact; risk is limited to potential confusion if the guidance is incorrect.
> 
> **Overview**
> Clarifies `row_format: full` documentation to avoid field-referencing mistakes by explicitly stating that transformations and key expressions must use `before.`/`after.` prefixes.
> 
> Adds an explicit exception for `mapping`: it only exposes `after` values, so column/value names should be referenced *without* the `after` prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49907712430279d81f9f4fd28003ef7db3ac30d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->