### PR TITLE
Strip empty markdown cells for redisvl notebooks

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -59,6 +59,12 @@ jobs:
           pip3 install -e .
           popd
 
+          # Strip empty markdown cells (e.g. bare "##") that crash sphinx_markdown_builder
+          find redis-vl-python/docs -name '*.ipynb' | while read -r nb; do
+            tmp=$(mktemp)
+            jq '.cells |= map(select(.cell_type != "markdown" or ((.source | if type == "array" then join("") else . end) | test("^\\s*#+\\s*$") | not)))' "$nb" > "$tmp" && mv "$tmp" "$nb"
+          done
+
           if [ ${isLatest} = true ]; then
             sphinx-build -M markdown ./redis-vl-python/docs ./build-latest
           else


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk workflow-only change, but it mutates upstream `.ipynb` files during the docs build and could inadvertently drop intended markdown cells if the jq filter is too broad.
> 
> **Overview**
> Preprocesses `redis-vl-python` Jupyter notebooks in the `redisvl_docs_sync` GitHub Actions workflow to **remove empty/heading-only markdown cells** before running `sphinx-build`.
> 
> This prevents `sphinx_markdown_builder` from crashing on notebooks containing bare markdown headings (e.g., `##`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 077884d7bb64930021fae2f227ea2df869836c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->