### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -299,7 +299,9 @@ jobs:
           for user_guide in "${user_guides[@]}"; do
               if [[ ! "$user_guide" =~ _index.md$ ]]; then
                   renamed_user_guide=$(sed 's|[0-9]\+_||' <<<${user_guide})
-                  mv ${user_guide} ${renamed_user_guide}
+                  if [ "${user_guide}" != "${renamed_user_guide}" ]; then
+                      mv ${user_guide} ${renamed_user_guide}
+                  fi
               fi
           done
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tiny shell-script guard in a GitHub Actions workflow; it only affects the docs-sync job’s filename rename step.
> 
> **Overview**
> Prevents the `redisvl_docs_sync` workflow from attempting a no-op rename when stripping numeric prefixes from user guide markdown filenames by only running `mv` if the computed target path differs.
> 
> This avoids workflow failures when a file already matches the desired naming scheme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5a0e3abd6b3ed4b3d2764421c4c0ce10607933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->