### PR TITLE
Handle updated release naming

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -52,6 +52,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           version="${{ matrix.version }}"
+          version="${version#v}"
           isLatest="${{ matrix.isLatest }}"
 
           pushd redis-vl-python
@@ -74,6 +75,7 @@ jobs:
       - name: 'Format markdown files for hugo compatibility'
         run: |
           version="${{ matrix.version }}"
+          version="${version#v}"
           isLatest="${{ matrix.isLatest }}"
 
           #!/bin/bash
@@ -323,6 +325,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           release="${{ matrix.version }}"
+          release="${release#v}"
           branch="redisvl_docs_sync_${release}"
           redisvl_change=false
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small workflow tweak to normalize version strings; impact is limited to CI docs sync behavior if version parsing is wrong.
> 
> **Overview**
> This updates the `redisvl_docs_sync` GitHub Actions workflow to **normalize release/version values** by stripping a leading `v` (e.g. `v0.6.0` -> `0.6.0`).
> 
> The normalized version is now used consistently when checking out tags, naming build output folders, and creating the sync branch/PR (`redisvl_docs_sync_<version>`), improving compatibility with updated release naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21a5debd8c27823b764ffafa424d255ca62aeb15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->