### PR TITLE
RS: Fixed authenticate DB connections with cert-based auth

### DIFF
--- a/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
@@ -120,7 +120,7 @@ curl --request <METHOD> --url https://<hostname-or-IP-address>:9443/<API-version
 
 ## Authenticate database connections
 
-To connect to a database with certificate-based authentication, you must provide a client certificate, signed by the trusted CA `mtls_trusted_ca`, and a private key.
+To connect to a database with certificate-based authentication, you must provide a client certificate you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/7.22/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
 
 The following example shows how to connect to a Redis database with [`redis-cli`]({{<relref "/operate/rs/7.22/references/cli-utilities/redis-cli">}}):
 

--- a/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
@@ -120,7 +120,7 @@ curl --request <METHOD> --url https://<hostname-or-IP-address>:9443/<API-version
 
 ## Authenticate database connections
 
-To connect to a database with certificate-based authentication, you must provide a client certificate you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/7.22/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
+To connect to a database with certificate-based authentication, you must provide a client certificate, signed by a trusted CA, and a private key. The client certificate must either be one you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/7.22/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), or be signed by one of these certificates.
 
 The following example shows how to connect to a Redis database with [`redis-cli`]({{<relref "/operate/rs/7.22/references/cli-utilities/redis-cli">}}):
 

--- a/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
@@ -104,7 +104,7 @@ curl --request <METHOD> --url https://<hostname-or-IP-address>:9443/<API-version
 
 ## Authenticate database connections
 
-To connect to a database with certificate-based authentication, you must provide a client certificate, signed by the trusted CA `mtls_trusted_ca`, and a private key.
+To connect to a database with certificate-based authentication, you must provide a client certificate you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/7.8/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
 
 The following example shows how to connect to a Redis database with [`redis-cli`]({{<relref "/operate/rs/7.8/references/cli-utilities/redis-cli">}}):
 

--- a/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
@@ -104,7 +104,7 @@ curl --request <METHOD> --url https://<hostname-or-IP-address>:9443/<API-version
 
 ## Authenticate database connections
 
-To connect to a database with certificate-based authentication, you must provide a client certificate you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/7.8/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
+To connect to a database with certificate-based authentication, you must provide a client certificate, signed by a trusted CA, and a private key. The client certificate must either be one you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/7.8/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), or be signed by one of these certificates.
 
 The following example shows how to connect to a Redis database with [`redis-cli`]({{<relref "/operate/rs/7.8/references/cli-utilities/redis-cli">}}):
 

--- a/content/operate/rs/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/security/certificates/certificate-based-authentication.md
@@ -200,7 +200,7 @@ To set up certificate-based authentication for databases:
 
 ### Authenticate database connections
 
-To connect to a database with certificate-based authentication, you must provide a client certificate you added to the database to [enable mutual TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
+To connect to a database with certificate-based authentication, you must provide a client certificate you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
 
 The following example shows how to connect to a Redis database with [`redis-cli`]({{<relref "/operate/rs/references/cli-utilities/redis-cli">}}):
 

--- a/content/operate/rs/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/security/certificates/certificate-based-authentication.md
@@ -200,7 +200,7 @@ To set up certificate-based authentication for databases:
 
 ### Authenticate database connections
 
-To connect to a database with certificate-based authentication, you must provide a client certificate you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
+To connect to a database with certificate-based authentication, you must provide a client certificate, signed by a trusted CA, and a private key. The client certificate must either be one you previously added to the database to [enable mutual TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), or be signed by one of these certificates.
 
 The following example shows how to connect to a Redis database with [`redis-cli`]({{<relref "/operate/rs/references/cli-utilities/redis-cli">}}):
 

--- a/content/operate/rs/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/security/certificates/certificate-based-authentication.md
@@ -200,7 +200,7 @@ To set up certificate-based authentication for databases:
 
 ### Authenticate database connections
 
-To connect to a database with certificate-based authentication, you must provide a client certificate, signed by the trusted CA `mtls_trusted_ca`, and a private key.
+To connect to a database with certificate-based authentication, you must provide a client certificate you added to the database to [enable mutual TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls#enable-mutual-tls">}}) (`authentication_ssl_client_certs` in the REST API), and a private key.
 
 The following example shows how to connect to a Redis database with [`redis-cli`]({{<relref "/operate/rs/references/cli-utilities/redis-cli">}}):
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it only updates wording/formatting and does not affect runtime behavior.
> 
> **Overview**
> Updates the certificate-based authentication docs to clarify that *database* connections require a client cert that is either explicitly added to the DB for mTLS (via `authentication_ssl_client_certs`) or signed by a trusted CA, rather than implying only the cluster `mtls_trusted_ca` is valid.
> 
> Applies the same clarification to the `7.8`, `7.22`, and unversioned pages, and fixes minor formatting (restores the `Limitations` bullet/newline).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf14f440c857d0ffac153e93c5ccb06559ba31c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->