### PR TITLE
RS: Added REST API method to configure TLS and mTLS for databases

### DIFF
--- a/content/operate/rs/security/encryption/tls/enable-tls.md
+++ b/content/operate/rs/security/encryption/tls/enable-tls.md
@@ -22,7 +22,11 @@ When you enable or turn off TLS, the change applies to new connections but does 
 
 ## Enable TLS for client connections {#client}
 
-To enable TLS for client connections:
+{{< multitabs id="enable-tls-for-client-connections"
+tab1="Cluster Manager UI"
+tab2="REST API" >}}
+
+To enable TLS for client connections using the Cluster Manager UI:
 
 1. From your database's **Security** tab, select **Edit**.
 
@@ -32,13 +36,46 @@ To enable TLS for client connections:
 
 1. Select **Save**.
 
+-tab-sep-
+
+You can also enable TLS for client connections using the REST API.
+
+To enable TLS for client connections during database creation, include `"tls_mode": "enabled"` when you [create a database]({{<relref "/operate/rs/references/rest-api/requests/bdbs#post-bdbs-v1">}}):
+
+```sh
+POST https://<host>:<port>/v1/bdbs
+{
+  "tls_mode": "enabled",
+  // Additional fields
+}
+```
+
+For additional database configuration fields, see the [BDB object]({{<relref "/operate/rs/references/rest-api/objects/bdb">}}) reference.
+
+To enable TLS for client connections after database creation, you can use an [update database configuration]({{<relref "/operate/rs/references/rest-api/requests/bdbs#put-bdbs">}}) REST API request:
+
+```sh
+PUT https://<host>:<port>/v1/bdbs/<database_id>
+{
+  "tls_mode": "enabled"
+}
+```
+
+{{< /multitabs >}}
+
 ### Enable mutual TLS
 
-Optionally, you can enable mutual TLS for client connections:
+Optionally, you can enable mutual TLS for client connections.
+
+{{< multitabs id="enable-mtls"
+tab1="Cluster Manager UI"
+tab2="REST API" >}}
+
+To enable mutual TLS using the Cluster Manager UI:
 
 1. Select **Mutual TLS (Client authentication)**.
 
-    {{<image filename="images/rs/screenshots/databases/security-mtls-clients-7-8-2.png"  alt="Mutual TLS authentication configuration.">}}
+    <img src="../../../../../../images/rs/screenshots/databases/security-mtls-clients-7-8-2.png" alt="Mutual TLS authentication configuration.">
 
 1. For each client certificate, select **+ Add certificate**, paste or upload the client certificate, then select **Done**.
 
@@ -69,11 +106,64 @@ Optionally, you can enable mutual TLS for client connections:
 
         You can only enter a single value for each field, except for the _Organizational Unit (OU)_ field. If your client certificate has a `Subject` with multiple  _Organizational Unit (OU)_ values, press the `Enter` or `Return` key after entering each value to add multiple Organizational Units.
 
-        {{<image filename="images/rs/screenshots/databases/security-mtls-add-cert-validation-multi-ou.png" width="350px" alt="An example that shows adding a certificate validation with multiple organizational units.">}}
+        <img src="../../../../../../images/rs/screenshots/databases/security-mtls-add-cert-validation-multi-ou.png" width="350px" alt="An example that shows adding a certificate validation with multiple organizational units.">
 
         **Breaking change:** If you use the [REST API]({{< relref "/operate/rs/references/rest-api" >}}) instead of the Cluster Manager UI to configure additional certificate validations, note that `authorized_names` is deprecated as of Redis Software v6.4.2. Use `authorized_subjects` instead. See the [BDB object reference]({{< relref "/operate/rs/references/rest-api/objects/bdb" >}}) for more details.
 
 1. Select **Save**.
+
+-tab-sep-
+
+You can also enable mutual TLS using the REST API.
+
+To enable mutual TLS during database creation, include the following fields when you [create a database]({{<relref "/operate/rs/references/rest-api/requests/bdbs#post-bdbs-v1">}}):
+
+```sh
+POST https://<host>:<port>/v1/bdbs
+{
+  "authorized_subjects": [{
+    "CN": <string>,
+    "O": <string>,
+    "OU": [<array of strings>],
+    "L": <string>,
+    "ST": <string>,
+    "C": <string>
+  }],
+  "authentication_ssl_client_certs": [{
+    "client_cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n"
+  }],
+  "client_cert_subject_validation_type": <"disabled" | "san_cn" | "full_subject">,
+  "enforce_client_authentication": "enabled",
+  "tls_mode": "enabled",
+  // Additional fields
+}
+```
+
+For additional database configuration fields, see the [BDB object]({{<relref "/operate/rs/references/rest-api/objects/bdb">}}) reference.
+
+To enable mutual TLS after database creation, you can use an [update database configuration]({{<relref "/operate/rs/references/rest-api/requests/bdbs#put-bdbs">}}) REST API request:
+
+```sh
+PUT https://<host>:<port>/v1/bdbs/<database_id>
+{
+  "authorized_subjects": [{
+    "CN": <string>,
+    "O": <string>,
+    "OU": [<array of strings>],
+    "L": <string>,
+    "ST": <string>,
+    "C": <string>
+  }],
+  "authentication_ssl_client_certs": [{
+    "client_cert": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n"
+  }],
+  "client_cert_subject_validation_type": <"disabled" | "san_cn" | "full_subject">,
+  "enforce_client_authentication": "enabled",
+  "tls_mode": "enabled"
+}
+```
+
+{{< /multitabs >}}
 
 ### Validate client certificate expiration
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds REST API examples for enabling TLS/mTLS and adjusts formatting/images; no product code or API behavior is modified.
> 
> **Overview**
> Updates the `Enable TLS` docs to include **REST API** instructions (alongside Cluster Manager UI) for enabling `tls_mode` and configuring mutual TLS during database creation and via `PUT /v1/bdbs/<database_id>` updates.
> 
> Reformats these sections into `multitabs` blocks and replaces Hugo `{{<image ...>}}` shortcodes with equivalent inline `<img>` tags for the mTLS screenshots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55621611f7095a15f4bf4a6bf2463c38ef8587cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->