### PR TITLE
Prevent existing session to be mistaken for active kernel on page wit…

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1100,10 +1100,14 @@
         let existingSession = null;
         let sessionStorageKey_actual = null;
 
-        // Search for any thebe-binder- key in localStorage
+        // Search for a thebe-binder- key that belongs to THIS page's binder ref.
+        // Keys end with /{ref}; matching the ref prevents a session saved on a
+        // different client page (e.g. nodejs) from being mistaken for an active
+        // kernel on a page that uses a different ref (e.g. redis-py).
+        const binderRefSuffix = '/' + binderRef;
         for (let i = 0; i < localStorage.length; i++) {
           const key = localStorage.key(i);
-          if (key && key.startsWith('thebe-binder-')) {
+          if (key && key.includes('thebe-binder-') && key.endsWith(binderRefSuffix)) {
             try {
               const data = localStorage.getItem(key);
               const sessionData = JSON.parse(data);


### PR DESCRIPTION
…h different ref

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to client-side session lookup logic; main risk is failing to detect a valid session if key formats differ from the assumed `.../{ref}` suffix.
> 
> **Overview**
> Prevents Thebe auto-reconnect from picking up an unrelated Binder session by narrowing the localStorage scan to `thebe-binder-` keys whose path suffix matches the current page’s `binderRef`.
> 
> This reduces false “existing kernel” detection when different pages use different Binder refs (e.g., Node.js vs Python environments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 451f7f7add6159dc9aeacea0395ca8fc988d1cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->