### PR TITLE
DOC-6497 added missing PHP client-specific examples

### DIFF
--- a/content/develop/clients/dotnet/vecsets.md
+++ b/content/develop/clients/dotnet/vecsets.md
@@ -13,14 +13,12 @@ description: Index and query embeddings with Redis vector sets
 linkTitle: Vector set embeddings
 title: Vector set embeddings
 weight: 40
-bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
 scope: example
 relatedPages:
 - /develop/clients/dotnet/vecsearch
 topics:
 - vector sets
 - vectors
-bannerChildren: true
 ---
 
 A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets

--- a/content/develop/clients/go/vecsets.md
+++ b/content/develop/clients/go/vecsets.md
@@ -13,14 +13,12 @@ description: Index and query embeddings with Redis vector sets
 linkTitle: Vector set embeddings
 title: Vector set embeddings
 weight: 35
-bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
 scope: example
 relatedPages:
 - /develop/clients/go/vecsearch
 topics:
 - vector sets
 - vectors
-bannerChildren: true
 ---
 
 A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets

--- a/content/develop/clients/jedis/vecsets.md
+++ b/content/develop/clients/jedis/vecsets.md
@@ -13,14 +13,12 @@ description: Index and query embeddings with Redis vector sets
 linkTitle: Vector set embeddings
 title: Vector set embeddings
 weight: 4
-bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
 scope: example
 relatedPages:
 - /develop/clients/jedis/vecsearch
 topics:
 - vector sets
 - vectors
-bannerChildren: true
 ---
 
 A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets

--- a/content/develop/clients/lettuce/vecsets.md
+++ b/content/develop/clients/lettuce/vecsets.md
@@ -13,14 +13,12 @@ description: Index and query embeddings with Redis vector sets
 linkTitle: Vector set embeddings
 title: Vector set embeddings
 weight: 40
-bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
 scope: example
 relatedPages:
 - /develop/clients/lettuce/vecsearch
 topics:
 - vector sets
 - vectors
-bannerChildren: true
 ---
 
 A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets

--- a/content/develop/clients/nodejs/vecsets.md
+++ b/content/develop/clients/nodejs/vecsets.md
@@ -13,14 +13,12 @@ description: Index and query embeddings with Redis vector sets
 linkTitle: Vector set embeddings
 title: Vector set embeddings
 weight: 4
-bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
 scope: example
 relatedPages:
 - /develop/clients/nodejs/vecsearch
 topics:
 - vector sets
 - vectors
-bannerChildren: true
 ---
 
 A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets

--- a/content/develop/clients/php/prob.md
+++ b/content/develop/clients/php/prob.md
@@ -1,0 +1,223 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Learn how to use approximate calculations with Redis.
+linkTitle: Probabilistic data types
+title: Probabilistic data types
+weight: 45
+---
+
+Redis supports several
+[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+that let you calculate values approximately rather than exactly.
+The types fall into two basic categories:
+
+-   [Set operations](#set-operations): These types let you calculate (approximately)
+    the number of items in a set of distinct values, and whether or not a given value is
+    a member of a set.
+-   [Statistics](#statistics): These types give you an approximation of
+    statistics such as the quantiles, ranks, and frequencies of numeric data points in
+    a list.
+
+To see why these approximate calculations would be useful, consider the task of
+counting the number of distinct IP addresses that access a website in one day.
+
+Assuming that you already have code that supplies you with each IP
+address as a string, you could record the addresses in Redis using
+a [set]({{< relref "/develop/data-types/sets" >}}):
+
+```php
+$r->sadd('ip_tracker', $newIpAddress);
+```
+
+The set can only contain each key once, so if the same address
+appears again during the day, the new instance will not change
+the set. At the end of the day, you could get the exact number of
+distinct addresses using the `scard()` method:
+
+```php
+$numDistinctIps = $r->scard('ip_tracker');
+```
+
+This approach is simple, effective, and precise but if your website
+is very busy, the `ip_tracker` set could become very large and consume
+a lot of memory.
+
+You would probably round the count of distinct IP addresses to the
+nearest thousand or more to deliver the usage statistics, so
+getting it exactly right is not important. It would be useful
+if you could trade off some accuracy in exchange for lower memory
+consumption. The probabilistic data types provide exactly this kind of
+trade-off. Specifically, you can count the approximate number of items in a
+set using the [HyperLogLog](#set-cardinality) data type, as described below.
+
+In general, the probabilistic data types let you perform approximations with a
+bounded degree of error that have much lower memory consumption or execution
+time than the equivalent precise calculations.
+
+## Set operations
+
+Redis supports the following approximate set operations:
+
+-   [Membership](#set-membership): The
+    [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
+    [Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+    data types let you track whether or not a given item is a member of a set.
+-   [Cardinality](#set-cardinality): The
+    [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+    data type gives you an approximate value for the number of items in a set, also
+    known as the *cardinality* of the set.
+
+The sections below describe these operations in more detail.
+
+### Set membership
+
+[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
+[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+objects provide a set membership operation that lets you track whether or not a
+particular item has been added to a set. These two types provide different
+trade-offs for memory usage and speed, so you can select the best one for your
+use case. Note that for both types, there is an asymmetry between presence and
+absence of items in the set. If an item is reported as absent, then it is definitely
+absent, but if it is reported as present, then there is a small chance it may really be
+absent.
+
+Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+a Bloom filter records the presence or absence of the
+[hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
+This gives a very compact representation of the
+set's membership with a fixed memory size, regardless of how many items you
+add. The following example adds some names to a Bloom filter representing
+a list of users and checks for the presence or absence of users in the list.
+
+{{< clients-example set="home_prob_dts" step="bloom" lang_filter="PHP" description="Foundational: Use Bloom filters for memory-efficient set membership testing with false positive possibility" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+A Cuckoo filter has similar features to a Bloom filter, but also supports
+a deletion operation to remove hashes from a set, as shown in the example
+below.
+
+{{< clients-example set="home_prob_dts" step="cuckoo" lang_filter="PHP" description="Foundational: Use Cuckoo filters for set membership testing with deletion support and faster lookups than Bloom filters" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+Which of these two data types you choose depends on your use case.
+Bloom filters are generally faster than Cuckoo filters when adding new items,
+and also have better memory usage. Cuckoo filters are generally faster
+at checking membership and also support the delete operation. See the
+[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
+[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+reference pages for more information and comparison between the two types.
+
+### Set cardinality
+
+A [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+object calculates the cardinality of a set. As you add
+items, the HyperLogLog tracks the number of distinct set members but
+doesn't let you retrieve them or query which items have been added.
+You can also merge two or more HyperLogLogs to find the cardinality of the
+[union](https://en.wikipedia.org/wiki/Union_(set_theory)) of the sets they
+represent.
+
+{{< clients-example set="home_prob_dts" step="hyperloglog" lang_filter="PHP" description="Foundational: Estimate set cardinality with HyperLogLog for memory-efficient counting of distinct items" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+The main benefit that HyperLogLogs offer is their very low
+memory usage. They can count up to 2^64 items with less than
+1% standard error using a maximum 12KB of memory. This makes
+them very useful for counting things like the total of distinct
+IP addresses that access a website or the total of distinct
+bank card numbers that make purchases within a day.
+
+## Statistics
+
+Redis supports several approximate statistical calculations
+on numeric data sets:
+
+-   [Frequency](#frequency): The
+    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    data type lets you find the approximate frequency of a labeled item in a data stream.
+-   [Quantiles](#quantiles): The
+    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    data type estimates the quantile of a query value in a data stream.
+-   [Ranking](#ranking): The
+    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    estimates the ranking of labeled items by frequency in a data stream.
+
+The sections below describe these operations in more detail.
+
+### Frequency
+
+A [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+(CMS) object keeps count of a set of related items represented by
+string labels. The count is approximate, but you can specify
+how close you want to keep the count to the true value (as a fraction)
+and the acceptable probability of failing to keep it in this
+desired range. For example, you can request that the count should
+stay within 0.1% of the true value and have a 0.05% probability
+of going outside this limit. The example below shows how to create
+a Count-min sketch object, add data to it, and then query it.
+
+{{< clients-example set="home_prob_dts" step="cms" lang_filter="PHP" description="Foundational: Track approximate item frequencies with Count-min sketch for memory-efficient statistics on data streams" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+The advantage of using a CMS over keeping an exact count with a
+[sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
+is that that a CMS has very low and fixed memory usage, even for
+large numbers of items. Use CMS objects to keep daily counts of
+items sold, accesses to individual web pages on your site, and
+other similar statistics.
+
+### Quantiles
+
+A [quantile](https://en.wikipedia.org/wiki/Quantile) is the value
+below which a certain fraction of samples lie. For example, with
+a set of measurements of people's heights, the quantile of 0.75 is
+the value of height below which 75% of all people's heights lie.
+[Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
+to quantiles, except that the fraction is expressed as a percentage.
+
+A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+object can estimate quantiles from a set of values added to it
+without having to store each value in the set explicitly. This can
+save a lot of memory when you have a large number of samples.
+
+The example below shows how to add data samples to a t-digest
+object and obtain some basic statistics, such as the minimum and
+maximum values, the quantile of 0.75, and the
+[cumulative distribution function](https://en.wikipedia.org/wiki/Cumulative_distribution_function)
+(CDF), which is effectively the inverse of the quantile function. It also
+shows how to merge two or more t-digest objects to query the combined
+data set.
+
+{{< clients-example set="home_prob_dts" step="tdigest" lang_filter="PHP" description="Foundational: Estimate quantiles and percentiles with t-digest for memory-efficient statistical analysis of large datasets" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+A t-digest object also supports several other related commands, such
+as querying by rank. See the
+[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+reference for more information.
+
+### Ranking
+
+A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+object estimates the rankings of different labeled items in a data
+stream according to frequency. For example, you could use this to
+track the top ten most frequently-accessed pages on a website, or the
+top five most popular items sold.
+
+The example below adds several different items to a Top-K object
+that tracks the top three items (this is the second parameter to
+the `topkreserve()` method). It also shows how to list the
+top *k* items and query whether or not a given item is in the
+list.
+
+{{< clients-example set="home_prob_dts" step="topk" lang_filter="PHP" description="Foundational: Track top K most frequent items in a data stream with Top-K for efficient ranking without storing all items" difficulty="intermediate" >}}
+{{< /clients-example >}}

--- a/content/develop/clients/php/transpipe.md
+++ b/content/develop/clients/php/transpipe.md
@@ -1,0 +1,77 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Learn how to use Redis pipelines and transactions
+linkTitle: Pipelines/transactions
+title: Pipelines and transactions
+scope: example
+weight: 40
+---
+
+Redis lets you send a sequence of commands to the server together in a batch.
+There are two types of batch that you can use:
+
+-   **Pipelines** avoid network and processing overhead by sending several commands
+    to the server together in a single communication. The server then sends back
+    a single communication with all the responses. See the
+    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    information.
+-   **Transactions** guarantee that all the included commands will execute
+    to completion without being interrupted by commands from other clients.
+    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    page for more information.
+
+## Execute a pipeline
+
+To execute commands in a pipeline, create a pipeline object with
+[`pipeline()`](https://github.com/predis/predis) and then add commands to it
+using methods that resemble the standard command methods (for example,
+`set()` and `get()`). The commands are buffered in the pipeline and only
+execute when you call the `execute()` method on the pipeline object. This
+method returns an array containing the results from all the commands in order.
+
+The command methods for a pipeline always return the original pipeline object,
+so you can chain several commands together. You can also pass a callback to
+`pipeline()` and let Predis execute the batch automatically when the callback
+returns, as the example below shows:
+
+{{< clients-example set="pipe_trans_tutorial" step="basic_pipe" lang_filter="PHP" description="Foundational: Use pipelines to batch multiple commands together and reduce network round trips" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Execute a transaction
+
+A transaction works in a similar way to a pipeline, but all the queued commands
+execute atomically. With Predis, you can create a transaction by calling
+`transaction()` and adding commands in a callback. Predis wraps those commands
+with `MULTI` and `EXEC` automatically:
+
+{{< clients-example set="pipe_trans_tutorial" step="basic_trans" lang_filter="PHP" description="Basic transaction: Execute commands atomically using transaction() to group related writes" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Watch keys for changes
+
+Redis supports *optimistic locking* to avoid inconsistent updates to keys that
+several clients may modify at the same time. The basic idea is to watch for
+changes to any keys that you use in a transaction while you are preparing the
+update. If the watched keys do change, you must restart the update using the
+latest value from Redis. See
+[Transactions]({{< relref "develop/using-commands/transactions" >}})
+for more information about optimistic locking.
+
+The example below reads a string that represents a `PATH` variable for a
+command shell, appends a new command path, and then writes it back inside a
+transaction. The `cas` option enables check-and-set behavior, `watch` tells
+Predis which key to monitor for changes, and `retry` lets Predis retry the
+transaction automatically if another client changes the watched key before
+`EXEC` runs:
+
+{{< clients-example set="pipe_trans_tutorial" step="trans_watch" lang_filter="PHP" description="Optimistic locking: Use WATCH with a CAS transaction to retry updates when another client modifies the key" difficulty="intermediate" >}}
+{{< /clients-example >}}

--- a/content/develop/clients/php/vecsets.md
+++ b/content/develop/clients/php/vecsets.md
@@ -13,14 +13,12 @@ description: Index and query embeddings with Redis vector sets
 linkTitle: Vector set embeddings
 title: Vector set embeddings
 weight: 40
-bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
 scope: example
 relatedPages:
 - /develop/clients/php/vecsearch
 topics:
 - vector sets
 - vectors
-bannerChildren: true
 ---
 
 A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets

--- a/content/develop/clients/php/vecsets.md
+++ b/content/develop/clients/php/vecsets.md
@@ -1,0 +1,150 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Index and query embeddings with Redis vector sets
+linkTitle: Vector set embeddings
+title: Vector set embeddings
+weight: 40
+bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
+scope: example
+relatedPages:
+- /develop/clients/php/vecsearch
+topics:
+- vector sets
+- vectors
+bannerChildren: true
+---
+
+A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+you store a set of unique keys, each with its own associated vector.
+You can then retrieve keys from the set according to the similarity between
+their stored vectors and a query vector that you specify.
+
+You can use vector sets to store any type of numeric vector but they are
+particularly optimized to work with text embedding vectors (see
+[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+embeddings). The example below shows how to use the
+[TransformersPHP](https://transformers.codewithkyrian.com/) library to
+generate text embeddings and then store and retrieve them using a vector set
+with [`Predis`]({{< relref "/develop/clients/php" >}}).
+
+## Initialize
+
+Install `Predis` and `TransformersPHP` with Composer:
+
+```bash
+composer require predis/predis codewithkyrian/transformers
+```
+
+In a new PHP file, import the required classes and function:
+
+{{< clients-example set="home_vecsets" step="import" lang_filter="PHP" description="Foundational: Import required libraries for vector sets, embeddings, and Redis operations" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+The `pipeline()` function below creates an embedding generator for the
+[`all-MiniLM-L6-v2`](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)
+model. This model generates vectors with 384 dimensions, regardless of the
+length of the input text:
+
+{{< clients-example set="home_vecsets" step="model" lang_filter="PHP" description="Foundational: Initialize a TransformersPHP embedding pipeline to generate vectors from text" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Create the data
+
+The example data is an array containing brief descriptions of famous people:
+
+{{< clients-example set="home_vecsets" step="data" lang_filter="PHP" description="Foundational: Define sample data with text descriptions and metadata for vector embedding and storage" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Add the data to a vector set
+
+The next step is to connect to Redis and add the data to a new vector set.
+
+The code below iterates through the array, uses the embedding pipeline to
+generate a `float` vector from each description, and then adds the result to a
+vector set called `famousPeople` with [`vadd()`]({{< relref "/commands/vadd" >}}).
+It then stores the `born` and `died` values as element attributes using
+[`vsetattr()`]({{< relref "/commands/vsetattr" >}}), so you can use the metadata
+later during queries.
+
+{{< clients-example set="home_vecsets" step="add_data" lang_filter="PHP" description="Foundational: Add embedding vectors to a vector set and attach metadata attributes for later filtering" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Query the vector set
+
+You can now query the data in the set. The basic approach is to generate
+another embedding vector from the query text and pass it to
+[`vsim()`]({{< relref "/commands/vsim" >}}), which returns elements ranked in
+order of similarity to that query vector.
+
+Start with a simple query for "actors":
+
+{{< clients-example set="home_vecsets" step="basic_query" lang_filter="PHP" description="Vector similarity search: Find semantically similar items in a vector set using VSIM" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+This returns the following list of elements:
+
+```
+'actors': ["Masako Natsume","Chaim Topol","Linus Pauling",
+"Marie Fredriksson","Maryam Mirzakhani","Freddie Mercury",
+"Marie Curie","Paul Erdos"]
+```
+
+The first two people in the list are the two actors, as expected, but the
+remaining results are less directly related. By default, the search attempts
+to rank all the elements in the set. You can use the `count` parameter of
+`vsim()` to limit the list to the most relevant few results:
+
+{{< clients-example set="home_vecsets" step="limited_query" lang_filter="PHP" description="Vector similarity search with limits: Restrict results to the top K most similar items using the count parameter" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+The reason for using text embeddings rather than simple text search is that
+the embeddings capture semantic information. This allows a query to find
+elements with a similar meaning even if the text is different. For example, the
+word "entertainer" doesn't appear in any of the descriptions but if you use it
+as a query, the actors and musicians rank highly in the results:
+
+{{< clients-example set="home_vecsets" step="entertainer_query" lang_filter="PHP" description="Semantic search: Use text embeddings to find related concepts even when exact keywords do not appear in the source text" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+Similarly, if you use "science" as a query, you get the scientists first,
+followed by the mathematicians:
+
+```text
+'science': ["Linus Pauling","Marie Curie","Maryam Mirzakhani",
+"Paul Erdos","Marie Fredriksson","Masako Natsume",
+"Freddie Mercury","Chaim Topol"]
+```
+
+You can also use
+[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+with `vsim()` to restrict the search further. For example, repeat the
+"science" query, but this time limit the results to people who died before the
+year 2000:
+
+{{< clients-example set="home_vecsets" step="filtered_query" lang_filter="PHP" description="Filtered vector search: Combine vector similarity with attribute filters to narrow results based on metadata conditions" difficulty="advanced" >}}
+{{< /clients-example >}}
+
+## More information
+
+See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+docs for more information and code examples. See the
+[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+about text embeddings and other AI techniques you can use with Redis.
+
+You may also be interested in
+[vector search]({{< relref "/develop/clients/php/vecsearch" >}}).
+This is a feature of
+[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+that lets you retrieve
+[JSON]({{< relref "/develop/data-types/json" >}}) and
+[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+vector data stored in their fields.

--- a/content/develop/clients/redis-py/vecsets.md
+++ b/content/develop/clients/redis-py/vecsets.md
@@ -13,14 +13,12 @@ description: Index and query embeddings with Redis vector sets
 linkTitle: Vector set embeddings
 title: Vector set embeddings
 weight: 40
-bannerText: Vector set is a new data type that is currently in preview and may be subject to change.
 scope: example
 relatedPages:
 - /develop/clients/redis-py/vecsearch
 topics:
 - vector sets
 - vectors
-bannerChildren: true
 ---
 
 A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets

--- a/local_examples/client-specific/php/HomeProbDtsTest.php
+++ b/local_examples/client-specific/php/HomeProbDtsTest.php
@@ -1,0 +1,160 @@
+// EXAMPLE: home_prob_dts
+<?php
+
+require 'vendor/autoload.php';
+
+use Predis\Client as PredisClient;
+
+$r = new PredisClient([
+    'scheme' => 'tcp',
+    'host' => '127.0.0.1',
+    'port' => 6379,
+    'password' => '',
+    'database' => 0,
+]);
+
+// STEP_START bloom
+$r->del('recorded_users');
+$r->bfreserve('recorded_users', 0.01, 1000);
+
+$added = $r->bfmadd('recorded_users', 'andy', 'cameron', 'david', 'michelle');
+echo json_encode($added), PHP_EOL;
+// >>> [1,1,1,1]
+
+$known = $r->bfexists('recorded_users', 'cameron');
+echo $known, PHP_EOL;
+// >>> 1
+
+$unknown = $r->bfexists('recorded_users', 'kaitlyn');
+echo $unknown, PHP_EOL;
+// >>> 0
+// STEP_END
+
+// STEP_START cuckoo
+$r->del('other_users');
+$r->cfreserve('other_users', 1000);
+
+$r->cfadd('other_users', 'paolo');
+$r->cfadd('other_users', 'kaitlyn');
+$r->cfadd('other_users', 'rachel');
+
+$beforeDelete = [
+    $r->cfexists('other_users', 'paolo'),
+    $r->cfexists('other_users', 'kaitlyn'),
+    $r->cfexists('other_users', 'rachel'),
+    $r->cfexists('other_users', 'andy'),
+];
+echo json_encode($beforeDelete), PHP_EOL;
+// >>> [1,1,1,0]
+
+$r->cfdel('other_users', 'paolo');
+$afterDelete = $r->cfexists('other_users', 'paolo');
+echo $afterDelete, PHP_EOL;
+// >>> 0
+// STEP_END
+
+// STEP_START hyperloglog
+$r->del('group:1', 'group:2', 'both_groups');
+
+$r->pfadd('group:1', ['andy', 'cameron', 'david']);
+$group1 = $r->pfcount('group:1');
+echo $group1, PHP_EOL;
+// >>> 3
+
+$r->pfadd('group:2', ['kaitlyn', 'michelle', 'paolo', 'rachel']);
+$group2 = $r->pfcount('group:2');
+echo $group2, PHP_EOL;
+// >>> 4
+
+$r->pfmerge('both_groups', 'group:1', 'group:2');
+$bothGroups = $r->pfcount('both_groups');
+echo $bothGroups, PHP_EOL;
+// >>> 7
+// STEP_END
+
+// STEP_START cms
+$r->del('items_sold');
+$r->cmsinitbyprob('items_sold', 0.01, 0.005);
+
+$firstCounts = $r->cmsincrby(
+    'items_sold',
+    'bread', 300,
+    'tea', 200,
+    'coffee', 200,
+    'beer', 100
+);
+echo json_encode($firstCounts), PHP_EOL;
+// >>> [300,200,200,100]
+
+$secondCounts = $r->cmsincrby(
+    'items_sold',
+    'bread', 100,
+    'coffee', 150
+);
+echo json_encode($secondCounts), PHP_EOL;
+// >>> [400,350]
+
+$queriedCounts = $r->cmsquery('items_sold', 'bread', 'tea', 'coffee', 'beer');
+echo json_encode($queriedCounts), PHP_EOL;
+// >>> [400,200,350,100]
+// STEP_END
+
+// STEP_START tdigest
+$r->del('male_heights', 'female_heights', 'all_heights');
+
+$r->tdigestcreate('male_heights');
+$r->tdigestadd('male_heights', 175.5, 181, 160.8, 152, 177, 196, 164);
+
+$maleMin = $r->tdigestmin('male_heights');
+echo $maleMin, PHP_EOL;
+// >>> 152
+
+$maleMax = $r->tdigestmax('male_heights');
+echo $maleMax, PHP_EOL;
+// >>> 196
+
+$maleQuantile = $r->tdigestquantile('male_heights', 0.75);
+echo json_encode($maleQuantile), PHP_EOL;
+// >>> ["181"]
+
+$maleCdf = $r->tdigestcdf('male_heights', 181);
+echo json_encode($maleCdf), PHP_EOL;
+// >>> ["0.7857142857142857"]
+
+$r->tdigestcreate('female_heights');
+$r->tdigestadd('female_heights', 155.5, 161, 168.5, 170, 157.5, 163, 171);
+
+$femaleQuantile = $r->tdigestquantile('female_heights', 0.75);
+echo json_encode($femaleQuantile), PHP_EOL;
+// >>> ["170"]
+
+$r->tdigestmerge('all_heights', ['male_heights', 'female_heights']);
+$allQuantile = $r->tdigestquantile('all_heights', 0.75);
+echo json_encode($allQuantile), PHP_EOL;
+// >>> ["175.5"]
+// STEP_END
+
+// STEP_START topk
+$r->del('top_3_songs');
+$r->topkreserve('top_3_songs', 3, 7, 8, 0.9);
+
+$evicted = $r->topkadd(
+    'top_3_songs',
+    'Starfish Trooper',
+    'Only one more time',
+    'Rock me, Handel',
+    'How will anyone know?',
+    'Average lover',
+    'Road to everywhere'
+);
+echo json_encode($evicted), PHP_EOL;
+// >>> [null,null,null,"Rock me, Handel","Only one more time",null]
+
+$leaders = $r->topklist('top_3_songs');
+echo json_encode($leaders), PHP_EOL;
+// >>> ["Average lover","How will anyone know?","Starfish Trooper"]
+
+$membership = $r->topkquery('top_3_songs', 'Starfish Trooper', 'Road to everywhere');
+echo json_encode($membership), PHP_EOL;
+// >>> [1,0]
+// STEP_END

--- a/local_examples/client-specific/php/HomeVecSetsTest.php
+++ b/local_examples/client-specific/php/HomeVecSetsTest.php
@@ -1,0 +1,117 @@
+// EXAMPLE: home_vecsets
+// STEP_START import
+<?php
+
+require 'vendor/autoload.php';
+
+use function Codewithkyrian\Transformers\Pipelines\pipeline;
+
+use Predis\Client as PredisClient;
+// STEP_END
+
+// STEP_START model
+$extractor = pipeline('embeddings', 'Xenova/all-MiniLM-L6-v2');
+// STEP_END
+
+// STEP_START data
+$peopleData = [
+    'Marie Curie' => [
+        'born' => 1867,
+        'died' => 1934,
+        'description' => 'Polish-French chemist and physicist. The only person ever to win two Nobel prizes for two different sciences.',
+    ],
+    'Linus Pauling' => [
+        'born' => 1901,
+        'died' => 1994,
+        'description' => 'American chemist and peace activist. One of only two people to win two Nobel prizes in different fields (chemistry and peace).',
+    ],
+    'Freddie Mercury' => [
+        'born' => 1946,
+        'died' => 1991,
+        'description' => 'British musician, best known as the lead singer of the rock band Queen.',
+    ],
+    'Marie Fredriksson' => [
+        'born' => 1958,
+        'died' => 2019,
+        'description' => 'Swedish multi-instrumentalist, mainly known as the lead singer and keyboardist of the band Roxette.',
+    ],
+    'Paul Erdos' => [
+        'born' => 1913,
+        'died' => 1996,
+        'description' => 'Hungarian mathematician, known for his eccentric personality almost as much as his contributions to many different fields of mathematics.',
+    ],
+    'Maryam Mirzakhani' => [
+        'born' => 1977,
+        'died' => 2017,
+        'description' => 'Iranian mathematician. The first woman ever to win the Fields medal for her contributions to mathematics.',
+    ],
+    'Masako Natsume' => [
+        'born' => 1957,
+        'died' => 1985,
+        'description' => 'Japanese actress. She was very famous in Japan but was primarily known elsewhere in the world for her portrayal of Tripitaka in the TV series Monkey.',
+    ],
+    'Chaim Topol' => [
+        'born' => 1935,
+        'died' => 2023,
+        'description' => "Israeli actor and singer, usually credited simply as 'Topol'. He was best known for his many appearances as Tevye in the musical Fiddler on the Roof.",
+    ],
+];
+// STEP_END
+
+$r = new PredisClient([
+    'scheme' => 'tcp',
+    'host' => '127.0.0.1',
+    'port' => 6379,
+    'password' => '',
+    'database' => 0,
+]);
+
+// STEP_START add_data
+$r->del('famousPeople');
+
+foreach ($peopleData as $name => $details) {
+    $embedding = $extractor($details['description'], normalize: true, pooling: 'mean');
+
+    $r->vadd('famousPeople', $embedding[0], $name);
+    $r->vsetattr('famousPeople', $name, [
+        'born' => $details['born'],
+        'died' => $details['died'],
+    ]);
+}
+// STEP_END
+
+// STEP_START basic_query
+$actorsEmbedding = $extractor('actors', normalize: true, pooling: 'mean');
+$actorsResults = $r->vsim('famousPeople', $actorsEmbedding[0]);
+
+echo "'actors': " . json_encode($actorsResults), PHP_EOL;
+// >>> 'actors': ["Masako Natsume","Chaim Topol","Linus Pauling","Marie Fredriksson","Maryam Mirzakhani","Freddie Mercury","Marie Curie","Paul Erdos"]
+// STEP_END
+
+// STEP_START limited_query
+$twoActorsResults = $r->vsim('famousPeople', $actorsEmbedding[0], false, false, 2);
+
+echo "'actors (2)': " . json_encode($twoActorsResults), PHP_EOL;
+// >>> 'actors (2)': ["Masako Natsume","Chaim Topol"]
+// STEP_END
+
+// STEP_START entertainer_query
+$entertainerEmbedding = $extractor('entertainer', normalize: true, pooling: 'mean');
+$entertainerResults = $r->vsim('famousPeople', $entertainerEmbedding[0]);
+
+echo "'entertainer': " . json_encode($entertainerResults), PHP_EOL;
+// >>> 'entertainer': ["Chaim Topol","Freddie Mercury","Linus Pauling","Marie Fredriksson","Masako Natsume","Paul Erdos","Maryam Mirzakhani","Marie Curie"]
+// STEP_END
+
+$scienceEmbedding = $extractor('science', normalize: true, pooling: 'mean');
+$scienceResults = $r->vsim('famousPeople', $scienceEmbedding[0]);
+
+echo "'science': " . json_encode($scienceResults), PHP_EOL;
+// >>> 'science': ["Linus Pauling","Marie Curie","Maryam Mirzakhani","Paul Erdos","Marie Fredriksson","Masako Natsume","Freddie Mercury","Chaim Topol"]
+
+// STEP_START filtered_query
+$science2000Results = $r->vsim('famousPeople', $scienceEmbedding[0], false, false, null, null, null, '.died < 2000');
+
+echo "'science2000': " . json_encode($science2000Results), PHP_EOL;
+// >>> 'science2000': ["Linus Pauling","Marie Curie","Paul Erdos","Masako Natsume","Freddie Mercury"]
+// STEP_END

--- a/local_examples/client-specific/php/TransPipeTest.php
+++ b/local_examples/client-specific/php/TransPipeTest.php
@@ -1,0 +1,89 @@
+// EXAMPLE: pipe_trans_tutorial
+<?php
+
+require 'vendor/autoload.php';
+
+use Predis\Client as PredisClient;
+use Predis\Transaction\MultiExec;
+
+$r = new PredisClient([
+    'scheme'   => 'tcp',
+    'host'     => '127.0.0.1',
+    'port'     => 6379,
+    'password' => '',
+    'database' => 0,
+]);
+
+for ($i = 0; $i < 8; $i++) {
+    $r->del("seat:$i");
+}
+
+for ($i = 1; $i < 4; $i++) {
+    $r->del("counter:$i");
+}
+
+$r->del('shellpath');
+
+// STEP_START basic_pipe
+$pipe = $r->pipeline();
+$pipe->set('seat:0', '#0')
+    ->set('seat:1', '#1')
+    ->set('seat:2', '#2')
+    ->set('seat:3', '#3')
+    ->set('seat:4', '#4');
+$pipe->execute();
+
+$pipe = $r->pipeline();
+$pipe->get('seat:0')
+    ->get('seat:1')
+    ->get('seat:2')
+    ->get('seat:3')
+    ->get('seat:4');
+$seats = $pipe->execute();
+
+echo implode(', ', $seats), PHP_EOL;
+// >>> #0, #1, #2, #3, #4
+
+$responses = $r->pipeline(function ($pipe) {
+    $pipe->set('seat:5', '#5');
+    $pipe->set('seat:6', '#6');
+    $pipe->set('seat:7', '#7');
+    $pipe->get('seat:5');
+    $pipe->get('seat:6');
+    $pipe->get('seat:7');
+});
+
+echo implode(', ', array_slice($responses, 3)), PHP_EOL;
+// >>> #5, #6, #7
+// REMOVE_START
+assert($seats === ['#0', '#1', '#2', '#3', '#4']);
+assert(array_slice($responses, 3) === ['#5', '#6', '#7']);
+// REMOVE_END
+// STEP_END
+
+// STEP_START basic_trans
+$r->transaction(function (MultiExec $tx) {
+    $tx->incr('counter:1');
+    $tx->incrby('counter:2', 2);
+    $tx->incrby('counter:3', 3);
+});
+
+echo implode(', ', $r->mget('counter:1', 'counter:2', 'counter:3')), PHP_EOL;
+// >>> 1, 2, 3
+// STEP_END
+
+// STEP_START trans_watch
+$r->set('shellpath', '/usr/syscmds/');
+
+$r->transaction(
+    ['cas' => true, 'watch' => 'shellpath', 'retry' => 3],
+    function (MultiExec $tx) {
+        $path = $tx->get('shellpath');
+        $tx->multi();
+        $tx->set('shellpath', $path . ':/usr/mycmds/');
+    }
+);
+
+echo $r->get('shellpath'), PHP_EOL;
+// >>> /usr/syscmds/:/usr/mycmds/
+// STEP_END


### PR DESCRIPTION
PHP actually does have support for pipes/transactions, probabilistic data type, and even vector sets now, so I've added some pages to the Predis section to bring it in line with the other clients.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus new example scripts; risk is mainly broken links/shortcode wiring or incorrect snippet behavior, with no production code impact.
> 
> **Overview**
> Adds new Predis (PHP) docs covering **probabilistic data types**, **pipelines/transactions (including WATCH/CAS)**, and **vector sets with text-embedding examples**, bringing the PHP client section in line with other languages.
> 
> Also removes the preview `bannerText`/`bannerChildren` front-matter from several existing `vecsets.md` pages (dotnet/go/jedis/lettuce/nodejs/redis-py), leaving the rest of the content unchanged, and introduces matching runnable PHP example snippets under `local_examples/client-specific/php` for the new pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63bdaa8d00e98a1269453931fa04553f2eff1226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->