### PR TITLE
DOC-6499 404s from the latest crawl report

### DIFF
--- a/content/develop/clients/client-side-caching.md
+++ b/content/develop/clients/client-side-caching.md
@@ -1,5 +1,7 @@
 ---
-aliases: /develop/connect/clients/client-side-caching
+aliases:
+- /develop/connect/clients/client-side-caching
+- /manual/client-side-caching/
 categories:
 - docs
 - develop

--- a/content/develop/clients/patterns/_index.md
+++ b/content/develop/clients/patterns/_index.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/use/patterns
 - /connect/clients/patterns/
 - /clients/patterns/
+- /manual/patterns/
 categories:
 - docs
 - develop

--- a/content/develop/clients/redis-py/_index.md
+++ b/content/develop/clients/redis-py/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /develop/connect/clients/python/redis-py
 - /develop/connect/clients/python/
+- /develop/clients/python/
 - /clients/python/
 - /connect/clients/redis-py/
 - /clients/redis-py/

--- a/content/develop/data-types/_index.md
+++ b/content/develop/data-types/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /data-types/
+- /manual/data-types/
 categories:
 - docs
 - develop
@@ -13,8 +16,6 @@ description: Overview of data types supported by Redis
 linkTitle: Data types
 title: Redis data types
 hideListLinks: true
-aliases:
-- /data-types/
 weight: 35
 ---
 

--- a/content/develop/data-types/probabilistic/bloom-filter.md
+++ b/content/develop/data-types/probabilistic/bloom-filter.md
@@ -1,7 +1,11 @@
 ---
 aliases:
 - /data-types/probabilistic/bloom-filter/
+- /data-types/bloom-filter/
+- /data-types/bloom-filters/
 - /manual/data-types/probabilistic/bloom-filter/
+- /manual/bloom-filter/
+- /manual/bloom-filters/
 categories:
 - docs
 - develop

--- a/content/develop/programmability/_index.md
+++ b/content/develop/programmability/_index.md
@@ -1,4 +1,8 @@
 ---
+aliases:
+- /develop/interact/programmability
+- /develop/interact/programmability/
+- /manual/programmability/
 categories:
 - docs
 - develop
@@ -9,9 +13,6 @@ categories:
 - oss
 - kubernetes
 - clients
-aliases:
-- /develop/interact/programmability
-- /develop/interact/programmability/
 description: 'Extending Redis with Lua and Redis Functions
 
   '

--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -2,6 +2,7 @@
 aliases:
 - /develop/connect/cli
 - /connect/cli/
+- /manual/cli/
 categories:
 - docs
 - develop

--- a/content/develop/using-commands/keyspace.md
+++ b/content/develop/using-commands/keyspace.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use/keyspace
+- /manual/keyspace/
 categories:
 - docs
 - develop
@@ -16,7 +19,6 @@ description: 'Managing keys in Redis: Key expiration, scanning, altering and que
 linkTitle: Keys and values
 title: Keys and values
 weight: 10
-aliases: /develop/use/keyspace
 ---
 
 Every data object that you store in a Redis database has its own unique

--- a/content/develop/using-commands/pipelining.md
+++ b/content/develop/using-commands/pipelining.md
@@ -1,4 +1,8 @@
 ---
+aliases:
+- /develop/use/pipelining
+- /manual/pipelining/
+- /develop/reference/pipelining
 categories:
 - docs
 - develop
@@ -12,9 +16,6 @@ categories:
 description: How to optimize round-trip times by batching Redis commands
 linkTitle: Pipelining
 title: Redis pipelining
-aliases:
-- /develop/use/pipelining
-- /manual/pipelining/
 weight: 20
 ---
 

--- a/content/develop/using-commands/transactions.md
+++ b/content/develop/using-commands/transactions.md
@@ -1,4 +1,8 @@
 ---
+aliases: 
+- /develop/interact/transactions
+- /manual/transactions/
+- /interact/transactions/
 categories:
 - docs
 - develop
@@ -9,8 +13,6 @@ categories:
 - oss
 - kubernetes
 - clients
-aliases: 
-- /develop/interact/transactions
 description: How transactions work in Redis
 linkTitle: Transactions
 title: Transactions

--- a/content/operate/oss_and_stack/install/_index.md
+++ b/content/operate/oss_and_stack/install/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /install/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/install/install-stack/_index.md
+++ b/content/operate/oss_and_stack/install/install-stack/_index.md
@@ -1,4 +1,9 @@
 ---
+aliases:
+- /install/install-stack/
+- /install/install-stack/binaries/
+- /operate/oss_and_stack/install/install-stack/linux/
+- /install/install-redis/install-redis-on-linux/
 categories:
 - docs
 - operate
@@ -8,10 +13,6 @@ description: Install Redis Open Source on Docker, Linux, macOS, and Windows (usi
 linkTitle: Install Redis Open Source
 stack: true
 title: Install Redis Open Source
-aliases:
-- /install/install-stack/
-- /install/install-stack/binaries/
-- /operate/oss_and_stack/install/install-stack/linux/
 weight: 2
 ---
 

--- a/content/operate/oss_and_stack/install/install-stack/homebrew.md
+++ b/content/operate/oss_and_stack/install/install-stack/homebrew.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /install/install-redis/install-redis-on-mac-os/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/install/install-stack/windows.md
+++ b/content/operate/oss_and_stack/install/install-stack/windows.md
@@ -1,4 +1,8 @@
 ---
+aliases:
+- /getting-started/installation/install-redis-on-windows/
+- /install/install-stack/windows/
+- /install/install-redis/install-redis-on-windows/
 categories:
 - docs
 - operate
@@ -7,9 +11,6 @@ categories:
 description: How to run Redis Open Source on Windows
 linkTitle: Windows
 title: Run Redis Open Source on Windows using Docker
-aliases:
-- /getting-started/installation/install-redis-on-windows/
-- /install/install-stack/windows/
 weight: 7
 ---
 

--- a/content/operate/oss_and_stack/management/config.md
+++ b/content/operate/oss_and_stack/management/config.md
@@ -1,6 +1,7 @@
 ---
 aliases:
 - /operate/oss_and_stack/management/config-file
+- /management/config/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/management/optimization/_index.md
+++ b/content/operate/oss_and_stack/management/optimization/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /manual/optimization/
+- /management/optimization/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/management/optimization/benchmarks/index.md
+++ b/content/operate/oss_and_stack/management/optimization/benchmarks/index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /manual/optimization/benchmarks/
+- /management/optimization/benchmarks/
 categories:
 - docs
 - operate
@@ -18,6 +21,7 @@ against a Linux box.
 
 The following options are supported:
 
+{{< usage >}}
     Usage: redis-benchmark [-h <host>] [-p <port>] [-c <clients>] [-n <requests]> [-k <boolean>]
 
      -h <hostname>      Server hostname (default 127.0.0.1)
@@ -53,6 +57,7 @@ The following options are supported:
      -I                 Idle mode. Just open N idle connections and wait.
      --help             Output this help and exit.
      --version          Output version and exit.
+{{< /usage >}}
 
 You need to have a running Redis instance before launching the benchmark.
 A typical example would be:

--- a/content/operate/oss_and_stack/management/optimization/cpu-profiling.md
+++ b/content/operate/oss_and_stack/management/optimization/cpu-profiling.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /manual/optimization/cpu-profiling/
+- /management/optimization/cpu-profiling/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/management/optimization/latency-monitor.md
+++ b/content/operate/oss_and_stack/management/optimization/latency-monitor.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /manual/optimization/latency-monitor/
+- /management/optimization/latency-monitor/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/management/optimization/latency.md
+++ b/content/operate/oss_and_stack/management/optimization/latency.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /manual/optimization/latency/
+- /management/optimization/latency/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/management/optimization/memory-optimization.md
+++ b/content/operate/oss_and_stack/management/optimization/memory-optimization.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /manual/optimization/memory-optimization/
+- /management/optimization/memory-optimization/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/management/replication.md
+++ b/content/operate/oss_and_stack/management/replication.md
@@ -1,4 +1,8 @@
 ---
+aliases:
+- /manual/replication/
+- /management/replication/
+- /operate/replication/
 categories:
 - docs
 - operate

--- a/content/operate/oss_and_stack/management/security/acl.md
+++ b/content/operate/oss_and_stack/management/security/acl.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /manual/security/acl/
+- /management/security/acl/
 categories:
 - docs
 - operate
@@ -7,8 +10,6 @@ categories:
 description: Redis Access Control List
 linkTitle: ACL
 title: ACL
-aliases:
-- /manual/security/acl/
 weight: 1
 ---
 

--- a/content/operate/oss_and_stack/management/sentinel.md
+++ b/content/operate/oss_and_stack/management/sentinel.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /management/sentinel/
+- /manual/sentinel/
 categories:
 - docs
 - operate
@@ -7,8 +10,6 @@ categories:
 description: High availability for non-clustered Redis
 linkTitle: High availability with Sentinel
 title: High availability with Redis Sentinel
-aliases:
-- /management/sentinel/
 weight: 4
 ---
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/bloom/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/bloom/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /stack/bloom
 Title: Probabilistic data structures
 alwaysopen: false
 categories:

--- a/content/operate/oss_and_stack/stack-with-enterprise/search/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/search/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /stack/search/
 Title: Search and query
 alwaysopen: false
 categories:

--- a/layouts/_default/apireference.html
+++ b/layouts/_default/apireference.html
@@ -50,10 +50,6 @@ params:
     {{ if .Params.backLink}}
         {{ $relref = printf "%s%s" .Site.BaseURL .Params.backLink }}
     {{ end }}
-    <!-- needed for adaptive design -->
-    <!-- <link rel="preload" href="/public/scss/style.min.65324e4de191c292ee8b6f4f0ebf01320e8c4bc8623b04e9dfad322ebb490b31.css" as="style">
-    <link href="/public/scss/style.min.65324e4de191c292ee8b6f4f0ebf01320e8c4bc8623b04e9dfad322ebb490b31.css" rel="stylesheet" integrity="">
-    <link href="/public/css/index.min.35cad491f7cd1663c88f0aa4b04c538f4c9f06265fa37217818ca53f59fed259.css" rel="stylesheet" /> -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">


### PR DESCRIPTION
Fixes for some of the most common (or low-hanging) 404s in the latest crawl report, plus an extra opportunity for the new `usage` shortcode.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (redirect metadata, formatting, and comment cleanup) with minimal functional impact beyond URL routing.
> 
> **Overview**
> Resolves a set of common crawl-reported 404s by adding or normalizing Hugo front-matter `aliases` across multiple docs sections (clients, data types, programmability, command usage, install/management pages), including new `/manual/*` and legacy path redirects.
> 
> Standardizes rendering of the `redis-benchmark` help text by wrapping it in the `usage` shortcode, and removes stale commented-out CSS preload markup from `layouts/_default/apireference.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be03235a776ff7857e0e2054f659f07c93e06bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->