### PR TITLE
SITE: update cmd_tools.py to handle drafting return info

### DIFF
--- a/build/cmd_tools.py
+++ b/build/cmd_tools.py
@@ -226,7 +226,10 @@ def _build_return_text(schema: dict, resp_version: int) -> str:
             return _build_return_text(options[0], resp_version)
         lines = ["One of the following:"]
         for option in options:
-            lines.append(f"* {_build_return_text(option, resp_version)}")
+            text = _build_return_text(option, resp_version)
+            # Indent continuation lines so nested structure remains visually subordinate
+            indented = text.replace('\n', '\n  ')
+            lines.append(f"* {indented}")
         return "\n".join(lines)
 
     return formatter(schema)

--- a/build/cmd_tools.py
+++ b/build/cmd_tools.py
@@ -202,8 +202,10 @@ def _format_schema_type_resp3(schema: dict) -> str:
     base = '../../develop/reference/protocol-spec'
     if t == 'integer':
         return f"[Integer reply]({base}#integers){sep}{desc}"
-    elif t in ('string', 'number'):
+    elif t == 'string':
         return f"[Bulk string reply]({base}#bulk-strings){sep}{desc}"
+    elif t == 'number':
+        return f"[Double reply]({base}#doubles){sep}{desc}"
     elif t == 'null':
         return f"[Null reply]({base}#nulls){sep}{desc}" if desc else f"[Null reply]({base}#nulls)"
     elif t == 'array':
@@ -224,7 +226,7 @@ def _build_return_text(schema: dict, resp_version: int) -> str:
             return _build_return_text(options[0], resp_version)
         lines = ["One of the following:"]
         for option in options:
-            lines.append(f"* {formatter(option)}")
+            lines.append(f"* {_build_return_text(option, resp_version)}")
         return "\n".join(lines)
 
     return formatter(schema)

--- a/build/cmd_tools.py
+++ b/build/cmd_tools.py
@@ -174,21 +174,86 @@ def generate_argument_sections(command_data: dict) -> str:
     return content
 
 
-def generate_return_section() -> str:
-    """Generate placeholder Return information section."""
-    return '''## Return information
+def _format_schema_type_resp2(schema: dict) -> str:
+    """Format a single schema entry as a RESP2 reply string."""
+    t = schema.get('type', '')
+    desc = schema.get('description', '')
+    sep = ': ' if desc else ''
+    base = '../../develop/reference/protocol-spec'
+    if t == 'integer':
+        return f"[Integer reply]({base}#integers){sep}{desc}"
+    elif t in ('string', 'number'):
+        return f"[Bulk string reply]({base}#bulk-strings){sep}{desc}"
+    elif t == 'null':
+        return f"[Nil reply]({base}#bulk-strings){sep}{desc}" if desc else f"[Nil reply]({base}#bulk-strings)"
+    elif t == 'array':
+        return f"[Array reply]({base}#arrays){sep}{desc}"
+    elif t == 'object':
+        return f"[Array reply]({base}#arrays){sep}{desc}"
+    else:
+        return f"TODO: Add RESP2 return information"
 
-{{< multitabs id="return-info"
+
+def _format_schema_type_resp3(schema: dict) -> str:
+    """Format a single schema entry as a RESP3 reply string."""
+    t = schema.get('type', '')
+    desc = schema.get('description', '')
+    sep = ': ' if desc else ''
+    base = '../../develop/reference/protocol-spec'
+    if t == 'integer':
+        return f"[Integer reply]({base}#integers){sep}{desc}"
+    elif t in ('string', 'number'):
+        return f"[Bulk string reply]({base}#bulk-strings){sep}{desc}"
+    elif t == 'null':
+        return f"[Null reply]({base}#nulls){sep}{desc}" if desc else f"[Null reply]({base}#nulls)"
+    elif t == 'array':
+        return f"[Array reply]({base}#arrays){sep}{desc}"
+    elif t == 'object':
+        return f"[Map reply]({base}#maps){sep}{desc}"
+    else:
+        return f"TODO: Add RESP3 return information"
+
+
+def _build_return_text(schema: dict, resp_version: int) -> str:
+    """Recursively build return text from a reply_schema for the given RESP version (2 or 3)."""
+    formatter = _format_schema_type_resp2 if resp_version == 2 else _format_schema_type_resp3
+
+    if 'oneOf' in schema:
+        options = schema['oneOf']
+        if len(options) == 1:
+            return _build_return_text(options[0], resp_version)
+        lines = ["One of the following:"]
+        for option in options:
+            lines.append(f"* {formatter(option)}")
+        return "\n".join(lines)
+
+    return formatter(schema)
+
+
+def generate_return_section(command_data: dict = None) -> str:
+    """Generate the Return information section, using reply_schema if available."""
+    reply_schema = command_data.get('reply_schema') if command_data else None
+
+    if reply_schema:
+        resp2_text = _build_return_text(reply_schema, resp_version=2)
+        resp3_text = _build_return_text(reply_schema, resp_version=3)
+    else:
+        resp2_text = "TODO: Add RESP2 return information"
+        resp3_text = "TODO: Add RESP3 return information"
+
+    return f'''## Return information
+
+{{{{< multitabs id="return-info"
     tab1="RESP2"
-    tab2="RESP3" >}}
+    tab2="RESP3" >}}}}
 
-TODO: Add RESP2 return information
+{resp2_text}
 
 -tab-sep-
 
-TODO: Add RESP3 return information
+{resp3_text}
 
-{{< /multitabs >}}
+{{{{< /multitabs >}}}}
 
 '''
 
@@ -199,7 +264,7 @@ def generate_complete_markdown_content(command_name: str, command_data: dict) ->
     summary = command_data.get('summary', f'TODO: Add summary for {command_name}')
     content += f"{summary}\n\n"
     content += generate_argument_sections(command_data)
-    content += generate_return_section()
+    content += generate_return_section(command_data)
     return content
 
 

--- a/build/test_cmd_tools.py
+++ b/build/test_cmd_tools.py
@@ -224,13 +224,113 @@ class TestGenerateArgumentSections(unittest.TestCase):
 class TestGenerateReturnSection(unittest.TestCase):
     """Tests for generate_return_section function."""
 
-    def test_return_section_format(self):
-        """Test that return section has correct format."""
-        result = generate_return_section()
+    def test_no_schema_falls_back_to_placeholder(self):
+        """Test that missing reply_schema produces TODO placeholder text."""
+        result = generate_return_section({})
         self.assertIn("## Return information", result)
         self.assertIn("RESP2", result)
         self.assertIn("RESP3", result)
         self.assertIn("multitabs", result)
+        self.assertIn("TODO: Add RESP2 return information", result)
+        self.assertIn("TODO: Add RESP3 return information", result)
+
+    def test_none_command_data_falls_back_to_placeholder(self):
+        """Test that None command_data produces TODO placeholder text."""
+        result = generate_return_section(None)
+        self.assertIn("TODO: Add RESP2 return information", result)
+        self.assertIn("TODO: Add RESP3 return information", result)
+
+    def test_integer_schema(self):
+        """Test that an integer reply_schema generates Integer reply links."""
+        command_data = {
+            "reply_schema": {
+                "type": "integer",
+                "description": "The number of elements deleted."
+            }
+        }
+        result = generate_return_section(command_data)
+        self.assertIn("[Integer reply]", result)
+        self.assertIn("The number of elements deleted.", result)
+        self.assertNotIn("TODO:", result)
+
+    def test_string_schema(self):
+        """Test that a string reply_schema generates Bulk string reply links."""
+        command_data = {
+            "reply_schema": {
+                "type": "string",
+                "description": "The value at the given index."
+            }
+        }
+        result = generate_return_section(command_data)
+        self.assertIn("[Bulk string reply]", result)
+        self.assertIn("The value at the given index.", result)
+
+    def test_oneof_schema_resp2_uses_nil(self):
+        """Test that oneOf with null uses Nil reply for RESP2."""
+        command_data = {
+            "reply_schema": {
+                "oneOf": [
+                    {"type": "string", "description": "The value of the key."},
+                    {"type": "null", "description": "Key does not exist."}
+                ]
+            }
+        }
+        result = generate_return_section(command_data)
+        self.assertIn("One of the following:", result)
+        self.assertIn("[Bulk string reply]", result)
+        self.assertIn("[Nil reply]", result)
+
+    def test_oneof_schema_resp3_uses_null(self):
+        """Test that oneOf with null uses Null reply for RESP3 (not Nil)."""
+        command_data = {
+            "reply_schema": {
+                "oneOf": [
+                    {"type": "string", "description": "The value of the key."},
+                    {"type": "null", "description": "Key does not exist."}
+                ]
+            }
+        }
+        result = generate_return_section(command_data)
+        self.assertIn("[Null reply]", result)
+        # Nil reply should appear only in RESP2 section (before -tab-sep-)
+        parts = result.split("-tab-sep-")
+        self.assertIn("[Nil reply]", parts[0])
+        self.assertNotIn("[Nil reply]", parts[1])
+
+    def test_array_schema(self):
+        """Test that an array reply_schema generates Array reply links."""
+        command_data = {
+            "reply_schema": {
+                "type": "array",
+                "description": "A list of index-value pairs."
+            }
+        }
+        result = generate_return_section(command_data)
+        self.assertIn("[Array reply]", result)
+        self.assertIn("A list of index-value pairs.", result)
+
+    def test_object_schema_resp2_array_resp3_map(self):
+        """Test that an object reply_schema uses Array reply for RESP2 and Map reply for RESP3."""
+        command_data = {
+            "reply_schema": {
+                "type": "object",
+                "description": "Metadata about the array."
+            }
+        }
+        result = generate_return_section(command_data)
+        parts = result.split("-tab-sep-")
+        self.assertIn("[Array reply]", parts[0])
+        self.assertIn("[Map reply]", parts[1])
+
+    def test_return_section_structure(self):
+        """Test that return section always has multitabs shortcode structure."""
+        result = generate_return_section({"reply_schema": {"type": "integer", "description": "Count."}})
+        self.assertIn("## Return information", result)
+        self.assertIn("{{< multitabs", result)
+        self.assertIn("tab1=\"RESP2\"", result)
+        self.assertIn("tab2=\"RESP3\"", result)
+        self.assertIn("-tab-sep-", result)
+        self.assertIn("{{< /multitabs >}}", result)
 
 
 class TestCreateCommandPage(unittest.TestCase):

--- a/build/test_cmd_tools.py
+++ b/build/test_cmd_tools.py
@@ -322,6 +322,53 @@ class TestGenerateReturnSection(unittest.TestCase):
         self.assertIn("[Array reply]", parts[0])
         self.assertIn("[Map reply]", parts[1])
 
+    def test_number_schema_resp2_bulk_string(self):
+        """Test that a number reply_schema maps to Bulk string reply in RESP2."""
+        command_data = {
+            "reply_schema": {
+                "type": "number",
+                "description": "The score as a double."
+            }
+        }
+        result = generate_return_section(command_data)
+        parts = result.split("-tab-sep-")
+        self.assertIn("[Bulk string reply]", parts[0])
+        self.assertNotIn("[Double reply]", parts[0])
+
+    def test_number_schema_resp3_double(self):
+        """Test that a number reply_schema maps to Double reply in RESP3."""
+        command_data = {
+            "reply_schema": {
+                "type": "number",
+                "description": "The score as a double."
+            }
+        }
+        result = generate_return_section(command_data)
+        parts = result.split("-tab-sep-")
+        self.assertIn("[Double reply]", parts[1])
+        self.assertNotIn("[Bulk string reply]", parts[1])
+
+    def test_nested_oneof_within_oneof(self):
+        """Test that nested oneOf within a multi-option oneOf is handled recursively."""
+        command_data = {
+            "reply_schema": {
+                "oneOf": [
+                    {
+                        "oneOf": [
+                            {"type": "string", "description": "The element."},
+                            {"type": "number", "description": "Numeric element."}
+                        ]
+                    },
+                    {"type": "null", "description": "Key does not exist."}
+                ]
+            }
+        }
+        result = generate_return_section(command_data)
+        # The nested oneOf should recurse, not fall through to a TODO placeholder
+        self.assertNotIn("TODO:", result)
+        # Outer oneOf bullet should expand inner oneOf inline
+        self.assertIn("[Nil reply]", result.split("-tab-sep-")[0])
+
     def test_return_section_structure(self):
         """Test that return section always has multitabs shortcode structure."""
         result = generate_return_section({"reply_schema": {"type": "integer", "description": "Count."}})

--- a/build/test_cmd_tools.py
+++ b/build/test_cmd_tools.py
@@ -349,7 +349,7 @@ class TestGenerateReturnSection(unittest.TestCase):
         self.assertNotIn("[Bulk string reply]", parts[1])
 
     def test_nested_oneof_within_oneof(self):
-        """Test that nested oneOf within a multi-option oneOf is handled recursively."""
+        """Test that nested oneOf within a multi-option oneOf is indented correctly."""
         command_data = {
             "reply_schema": {
                 "oneOf": [
@@ -364,10 +364,20 @@ class TestGenerateReturnSection(unittest.TestCase):
             }
         }
         result = generate_return_section(command_data)
-        # The nested oneOf should recurse, not fall through to a TODO placeholder
+        resp2 = result.split("-tab-sep-")[0]
+
+        # No TODO placeholders — all types were recognised
         self.assertNotIn("TODO:", result)
-        # Outer oneOf bullet should expand inner oneOf inline
-        self.assertIn("[Nil reply]", result.split("-tab-sep-")[0])
+
+        # Outer bullet introduces the nested group
+        self.assertIn("* One of the following:", resp2)
+
+        # Inner bullets are indented with two spaces so they are visually subordinate
+        self.assertIn("  * [Bulk string reply]", resp2)
+        self.assertIn("  * [Bulk string reply]", resp2)  # number → bulk string in RESP2
+
+        # The null alternative is a flat outer bullet (not indented)
+        self.assertIn("* [Nil reply]", resp2)
 
     def test_return_section_structure(self):
         """Test that return section always has multitabs shortcode structure."""


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation generation logic and add tests, with no runtime impact beyond how command markdown is rendered.
> 
> **Overview**
> Command page generation now populates the **Return information** section from `command_data.reply_schema` instead of always emitting TODO placeholders.
> 
> It adds RESP2/RESP3-specific schema-to-reply formatting (including `oneOf` nesting) with links to protocol spec anchors, fixes Hugo shortcode escaping in the `multitabs` block, and expands unit tests to cover the new mappings and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a717e3adf2f376f9daa146f28abf8d78ac87b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->