### PR TITLE
Clean up latest folder before copying files in

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -308,6 +308,12 @@ jobs:
           done
 
           if [ ${isLatest} = true ]; then
+            # Remove old files before copying to avoid stale content
+            rm -rf content/develop/ai/redisvl/api/*
+            rm -rf content/develop/ai/redisvl/user_guide/*
+            rm -rf content/develop/ai/redisvl/overview/*
+            rm -rf content/develop/ai/redisvl/concepts/*
+
             cp -r redis_vl_hugo/* content/develop/ai/redisvl/
           else
             mkdir -p content/develop/ai/redisvl/${version}/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds `rm -rf` cleanup steps in the GitHub Actions docs sync workflow, which could remove unintended content if paths change or are misconfigured. Otherwise it’s a small workflow-only change aimed at preventing stale docs from persisting in `latest`.
> 
> **Overview**
> Prevents stale RedisVL docs from lingering in the *latest* publish location by deleting existing `content/develop/ai/redisvl/{api,user_guide,overview,concepts}/*` before copying newly generated Hugo markdown.
> 
> Versioned (non-latest) publishing behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b2431154d5cff55a61100ca87289f213caebf40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->