### PR TITLE
Fix relrefs for .md files in redisvl latest release

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -190,6 +190,12 @@ jobs:
 
               # Replace https://docs.redisvl.com links
               sed -E -i 's#https://docs.redisvl.com/en/latest/.+/([^_]+).+\.html(\#[^)]+)#{{< relref "\1\2" >}}#g; s#https://docs.redisvl.com/en/latest/(.+)\.html#https://redis.io/docs/latest/develop/ai/redisvl/\1#g' "${markdown_page}"
+
+              # Replace .md links with relrefs, stripping numeric prefixes like 01_, 02_, etc.
+              sed -E -i 's#\]\(([^)]*/)([0-9]+_)?([^/)]+)\.md\)#]({{< relref "\1\3" >}})#g' "${markdown_page}"
+
+              # Replace .md links without paths (same directory)
+              sed -E -i 's#\]\(([0-9]+_)?([^/)]+)\.md\)#]({{< relref "\2" >}})#g' "${markdown_page}"
           done
 
           # Fix links in api pages


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the docs sync workflow’s link-rewrite rules, which could affect many generated pages if the new regexes mis-handle edge cases or anchors.
> 
> **Overview**
> Updates the `redisvl_docs_sync` GitHub Actions workflow to rewrite intra-doc `*.md` links into Hugo `relref` shortcodes during the markdown formatting step, including support for stripping numeric filename prefixes (e.g. `01_`) and handling both path-based and same-directory links.
> 
> This reduces broken navigation in the generated RedisVL “latest” docs by ensuring cross-page links resolve correctly after files are renamed/organized for Hugo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e782c057c346835a81e6be168bf5dfd1354dabac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->