### PR TITLE
RS: Added a note to run CRDB flush in one participating cluster only

### DIFF
--- a/content/operate/rs/7.22/databases/import-export/flush.md
+++ b/content/operate/rs/7.22/databases/import-export/flush.md
@@ -87,6 +87,10 @@ This ensures that all shards in the OSS Cluster API database are flushed properl
 
 When you flush an Active-Active database (formerly known as CRDB), all of the replicas flush their data at the same time.
 
+{{< note >}}
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+{{< /note >}}
+
 To flush data from an Active-Active database, use one of the following methods:
 
 - Cluster Manager UI

--- a/content/operate/rs/7.22/references/cli-utilities/crdb-cli/crdb/flush.md
+++ b/content/operate/rs/7.22/references/cli-utilities/crdb-cli/crdb/flush.md
@@ -20,6 +20,8 @@ crdb-cli crdb flush --crdb-guid <guid>
 
 This command is irreversible. If the data in your database is important, back it up before you flush the database.
 
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+
 ### Parameters
 
 | Parameter           | Value  | Description                         |

--- a/content/operate/rs/7.22/references/rest-api/requests/crdbs/flush.md
+++ b/content/operate/rs/7.22/references/rest-api/requests/crdbs/flush.md
@@ -24,6 +24,8 @@ PUT /v1/crdbs/{crdb_guid}/flush
 
 Flush an Active-Active database.
 
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+
 ### Request {#put-request}
 
 #### Example HTTP request

--- a/content/operate/rs/7.4/databases/import-export/flush.md
+++ b/content/operate/rs/7.4/databases/import-export/flush.md
@@ -47,6 +47,10 @@ Port 9443 is the default [port configuration]({{< relref "/operate/rs/7.4/networ
 
 When you flush an Active-Active database (formerly known as CRDB), all of the replicas flush their data at the same time.
 
+{{< note >}}
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+{{< /note >}}
+
 To flush data from an Active-Active database:
 
 - Cluster Manager UI

--- a/content/operate/rs/7.4/references/cli-utilities/crdb-cli/crdb/flush.md
+++ b/content/operate/rs/7.4/references/cli-utilities/crdb-cli/crdb/flush.md
@@ -20,6 +20,8 @@ crdb-cli crdb flush --crdb-guid <guid>
 
 This command is irreversible. If the data in your database is important, back it up before you flush the database.
 
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+
 ### Parameters
 
 | Parameter           | Value  | Description                         |

--- a/content/operate/rs/7.4/references/rest-api/requests/crdbs/flush.md
+++ b/content/operate/rs/7.4/references/rest-api/requests/crdbs/flush.md
@@ -24,6 +24,8 @@ PUT /v1/crdbs/{crdb_guid}/flush
 
 Flush an Active-Active database.
 
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+
 ### Request {#put-request}
 
 #### Example HTTP request

--- a/content/operate/rs/7.8/databases/import-export/flush.md
+++ b/content/operate/rs/7.8/databases/import-export/flush.md
@@ -47,6 +47,10 @@ Port 9443 is the default [port configuration]({{< relref "/operate/rs/7.8/networ
 
 When you flush an Active-Active database (formerly known as CRDB), all of the replicas flush their data at the same time.
 
+{{< note >}}
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+{{< /note >}}
+
 To flush data from an Active-Active database, use one of the following methods:
 
 - Cluster Manager UI

--- a/content/operate/rs/7.8/references/cli-utilities/crdb-cli/crdb/flush.md
+++ b/content/operate/rs/7.8/references/cli-utilities/crdb-cli/crdb/flush.md
@@ -20,6 +20,8 @@ crdb-cli crdb flush --crdb-guid <guid>
 
 This command is irreversible. If the data in your database is important, back it up before you flush the database.
 
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+
 ### Parameters
 
 | Parameter           | Value  | Description                         |

--- a/content/operate/rs/7.8/references/rest-api/requests/crdbs/flush.md
+++ b/content/operate/rs/7.8/references/rest-api/requests/crdbs/flush.md
@@ -24,6 +24,8 @@ PUT /v1/crdbs/{crdb_guid}/flush
 
 Flush an Active-Active database.
 
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+
 ### Request {#put-request}
 
 #### Example HTTP request

--- a/content/operate/rs/databases/import-export/flush.md
+++ b/content/operate/rs/databases/import-export/flush.md
@@ -86,6 +86,10 @@ This ensures that all shards in the OSS Cluster API database are flushed properl
 
 When you flush an Active-Active database (formerly known as CRDB), all of the replicas flush their data at the same time.
 
+{{< note >}}
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+{{< /note >}}
+
 To flush data from an Active-Active database, use one of the following methods:
 
 - Cluster Manager UI

--- a/content/operate/rs/references/cli-utilities/crdb-cli/crdb/flush.md
+++ b/content/operate/rs/references/cli-utilities/crdb-cli/crdb/flush.md
@@ -19,6 +19,10 @@ crdb-cli crdb flush --crdb-guid <guid>
 
 This command is irreversible. If the data in your database is important, back it up before you flush the database.
 
+{{< note >}}
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+{{< /note >}}
+
 ### Parameters
 
 | Parameter           | Value  | Description                         |

--- a/content/operate/rs/references/cli-utilities/crdb-cli/crdb/flush.md
+++ b/content/operate/rs/references/cli-utilities/crdb-cli/crdb/flush.md
@@ -19,9 +19,7 @@ crdb-cli crdb flush --crdb-guid <guid>
 
 This command is irreversible. If the data in your database is important, back it up before you flush the database.
 
-{{< note >}}
 Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
-{{< /note >}}
 
 ### Parameters
 

--- a/content/operate/rs/references/rest-api/requests/crdbs/flush.md
+++ b/content/operate/rs/references/rest-api/requests/crdbs/flush.md
@@ -23,6 +23,8 @@ PUT /v1/crdbs/{crdb_guid}/flush
 
 Flush an Active-Active database.
 
+Run flush from only one participating cluster. The flush operation propagates to all other clusters automatically.
+
 ### Request {#put-request}
 
 #### Example HTTP request


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no product logic, API, or behavioral modifications.
> 
> **Overview**
> Adds a documentation note across Redis Enterprise Software versions (`rs`, `7.4`, `7.8`, `7.22`) clarifying that Active-Active/CRDB `flush` should be initiated from only one participating cluster and will automatically propagate to the others.
> 
> The guidance is applied consistently in the UI-based flush docs as well as the `crdb-cli crdb flush` and REST API `PUT /v1/crdbs/{crdb_guid}/flush` reference pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a7ebec71473e2a3c175fcb231ae93bca27e4137. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->