### PR TITLE
DEV: (cmds) document new array data structure

### DIFF
--- a/content/commands/arcount.md
+++ b/content/commands/arcount.md
@@ -45,9 +45,17 @@ Returns the number of non-empty elements in an array.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARSET myarray 0 "a"
+ARSET myarray 5 "b"
+ARCOUNT myarray
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -62,4 +70,3 @@ TODO: Add description for key (key)
 [Integer reply](../../develop/reference/protocol-spec#integers): The number of non-empty elements, or 0 if key does not exist.
 
 {{< /multitabs >}}
-

--- a/content/commands/arcount.md
+++ b/content/commands/arcount.md
@@ -1,0 +1,65 @@
+---
+acl_categories:
+- '@array'
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+arity: 2
+categories:
+- docs
+- develop
+- oss
+- rs
+- rc
+- kubernetes
+- clients
+command_flags:
+- readonly
+- fast
+complexity: O(1)
+description: Returns the number of non-empty elements in an array.
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - ro
+  - access
+linkTitle: ARCOUNT
+since: 8.8.0
+summary: Returns the number of non-empty elements in an array.
+syntax_fmt: ARCOUNT key
+title: ARCOUNT
+---
+Returns the number of non-empty elements in an array.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The number of non-empty elements, or 0 if key does not exist.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The number of non-empty elements, or 0 if key does not exist.
+
+{{< /multitabs >}}
+

--- a/content/commands/ardel.md
+++ b/content/commands/ardel.md
@@ -1,0 +1,80 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- multiple: true
+  name: index
+  type: integer
+arity: -3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- WRITE
+- FAST
+complexity: O(N) where N is the number of indices to delete
+description: Deletes elements at the specified indices in an array.
+function: ardelCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - DELETE
+linkTitle: ARDEL
+reply_schema:
+  description: Number of elements deleted.
+  type: integer
+since: 8.8.0
+summary: Deletes elements at the specified indices in an array.
+syntax_fmt: ARDEL key index [index ...]
+title: ARDEL
+---
+Deletes elements at the specified indices in an array.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>index</code></summary>
+
+TODO: Add description for index (integer)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of elements deleted.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of elements deleted.
+
+{{< /multitabs >}}
+

--- a/content/commands/ardel.md
+++ b/content/commands/ardel.md
@@ -54,15 +54,27 @@ Deletes elements at the specified indices in an array.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>index</code></summary>
 
-TODO: Add description for index (integer)
+One or more zero-based integer indices of the elements to delete. Deleting an index that does not exist counts as zero elements deleted and does not modify the array.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARSET myarray 0 "a"
+ARSET myarray 1 "b"
+ARSET myarray 2 "c"
+ARDEL myarray 1
+ARGET myarray 1
+ARDEL myarray 0 2
+ARCOUNT myarray
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -77,4 +89,3 @@ TODO: Add description for index (integer)
 [Integer reply](../../develop/reference/protocol-spec#integers): Number of elements deleted.
 
 {{< /multitabs >}}
-

--- a/content/commands/ardelrange.md
+++ b/content/commands/ardelrange.md
@@ -1,0 +1,85 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- arguments:
+  - name: start
+    type: integer
+  - name: end
+    type: integer
+  multiple: true
+  name: range
+  type: block
+arity: -4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- WRITE
+complexity: Proportional to the number of existing elements / slices touched, not
+  to the numeric span of the requested ranges
+description: Deletes elements in one or more ranges.
+function: ardelrangeCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - DELETE
+linkTitle: ARDELRANGE
+reply_schema:
+  description: Number of elements deleted.
+  type: integer
+since: 8.8.0
+summary: Deletes elements in one or more ranges.
+syntax_fmt: ARDELRANGE key start end [start end ...]
+title: ARDELRANGE
+---
+Deletes elements in one or more ranges.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>range</code></summary>
+
+TODO: Add description for range (block)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of elements deleted.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of elements deleted.
+
+{{< /multitabs >}}
+

--- a/content/commands/ardelrange.md
+++ b/content/commands/ardelrange.md
@@ -59,15 +59,25 @@ Deletes elements in one or more ranges.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>range</code></summary>
 
-TODO: Add description for range (block)
+One or more `start end` pairs, each defining an inclusive range of indices to delete. If `start` is greater than `end` for a given pair, the range is processed in ascending order regardless. Multiple pairs may overlap; each element is counted at most once.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARMSET myarray 0 "a" 1 "b" 2 "c" 3 "d" 4 "e"
+ARDELRANGE myarray 1 3
+ARCOUNT myarray
+ARGET myarray 0
+ARGET myarray 4
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -82,4 +92,3 @@ TODO: Add description for range (block)
 [Integer reply](../../develop/reference/protocol-spec#integers): Number of elements deleted.
 
 {{< /multitabs >}}
-

--- a/content/commands/arget.md
+++ b/content/commands/arget.md
@@ -1,0 +1,86 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: index
+  type: integer
+arity: 3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+- FAST
+complexity: O(1)
+description: Gets the value at an index in an array.
+function: argetCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARGET
+reply_schema:
+  oneOf:
+  - description: The value at the given index.
+    type: string
+  - description: Null reply if key or index does not exist.
+    type: 'null'
+since: 8.8.0
+summary: Gets the value at an index in an array.
+syntax_fmt: ARGET key index
+title: ARGET
+---
+Gets the value at an index in an array.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>index</code></summary>
+
+TODO: Add description for index (integer)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): The value at the given index.
+* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): Null reply if key or index does not exist.
+
+-tab-sep-
+
+One of the following:
+* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): The value at the given index.
+* [Null reply](../../develop/reference/protocol-spec#nulls): Null reply if key or index does not exist.
+
+{{< /multitabs >}}
+

--- a/content/commands/arget.md
+++ b/content/commands/arget.md
@@ -56,15 +56,23 @@ Gets the value at an index in an array.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>index</code></summary>
 
-TODO: Add description for index (integer)
+The zero-based integer index of the element to retrieve.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARSET myarray 0 "hello"
+ARGET myarray 0
+ARGET myarray 1
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -74,7 +82,7 @@ TODO: Add description for index (integer)
 
 One of the following:
 * [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): The value at the given index.
-* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): Null reply if key or index does not exist.
+* [Nil reply](../../develop/reference/protocol-spec#null-bulk-strings): Null reply if key or index does not exist.
 
 -tab-sep-
 
@@ -83,4 +91,3 @@ One of the following:
 * [Null reply](../../develop/reference/protocol-spec#nulls): Null reply if key or index does not exist.
 
 {{< /multitabs >}}
-

--- a/content/commands/argetrange.md
+++ b/content/commands/argetrange.md
@@ -57,21 +57,29 @@ Gets values in a range of indices.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>start</code></summary>
 
-TODO: Add description for start (integer)
+The zero-based integer index of the first element to return. If `start` is greater than `end`, elements are returned in reverse index order.
 
 </details>
 
 <details open><summary><code>end</code></summary>
 
-TODO: Add description for end (integer)
+The zero-based integer index of the last element to return (inclusive). If `end` is less than `start`, elements are returned in reverse index order.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARMSET myarray 0 "a" 1 "b" 3 "d"
+ARGETRANGE myarray 0 3
+ARGETRANGE myarray 3 0
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -86,4 +94,3 @@ TODO: Add description for end (integer)
 [Array reply](../../develop/reference/protocol-spec#arrays)
 
 {{< /multitabs >}}
-

--- a/content/commands/argetrange.md
+++ b/content/commands/argetrange.md
@@ -1,0 +1,89 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: start
+  type: integer
+- name: end
+  type: integer
+arity: 4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+complexity: O(N) where N is the range length
+description: Gets values in a range of indices.
+function: argetrangeCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARGETRANGE
+reply_schema:
+  items:
+    oneOf:
+    - type: string
+    - type: 'null'
+  type: array
+since: 8.8.0
+summary: Gets values in a range of indices.
+syntax_fmt: ARGETRANGE key start end
+title: ARGETRANGE
+---
+Gets values in a range of indices.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>start</code></summary>
+
+TODO: Add description for start (integer)
+
+</details>
+
+<details open><summary><code>end</code></summary>
+
+TODO: Add description for end (integer)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays)
+
+-tab-sep-
+
+[Array reply](../../develop/reference/protocol-spec#arrays)
+
+{{< /multitabs >}}
+

--- a/content/commands/arinfo.md
+++ b/content/commands/arinfo.md
@@ -91,7 +91,7 @@ Returns metadata about an array.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
@@ -99,9 +99,17 @@ TODO: Add description for key (key)
 
 <details open><summary><code>FULL</code></summary>
 
-TODO: Add description for full (pure-token)
+When present, includes per-slice statistics in the reply: the number of dense and sparse slices and their average sizes and fill rates. Raises the complexity from O(1) to O(N) where N is the number of slices.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARMSET myarray 0 "a" 1 "b" 100 "c"
+ARINSERT myarray "d"
+ARINFO myarray
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -116,4 +124,3 @@ TODO: Add description for full (pure-token)
 [Map reply](../../develop/reference/protocol-spec#maps)
 
 {{< /multitabs >}}
-

--- a/content/commands/arinfo.md
+++ b/content/commands/arinfo.md
@@ -1,0 +1,119 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: full
+  optional: true
+  token: FULL
+  type: pure-token
+arity: -2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+complexity: O(1), or O(N) with FULL option where N is the number of slices.
+description: Returns metadata about an array.
+function: arinfoCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARINFO
+reply_schema:
+  additionalProperties: false
+  properties:
+    avg-dense-fill:
+      description: Average fill rate of dense slices (FULL only).
+      type: number
+    avg-dense-size:
+      description: Average allocation size of dense slices (FULL only).
+      type: number
+    avg-sparse-size:
+      description: Average capacity of sparse slices (FULL only).
+      type: number
+    count:
+      description: Total number of non-empty elements.
+      type: integer
+    dense-slices:
+      description: Number of dense slices (FULL only).
+      type: integer
+    directory-size:
+      description: Directory allocation capacity (flat dir_alloc or superdir sdir_cap).
+      type: integer
+    len:
+      description: Logical length (highest index + 1).
+      type: integer
+    next-insert-index:
+      description: Index the next ARINSERT would use, or 0 if unset/exhausted.
+      type: integer
+    slice-size:
+      description: Configured slice size.
+      type: integer
+    slices:
+      description: Number of allocated slices.
+      type: integer
+    sparse-slices:
+      description: Number of sparse slices (FULL only).
+      type: integer
+    super-dir-entries:
+      description: Number of super-directory entries (0 if not in superdir mode).
+      type: integer
+  type: object
+since: 8.8.0
+summary: Returns metadata about an array.
+syntax_fmt: ARINFO key [FULL]
+title: ARINFO
+---
+Returns metadata about an array.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+## Optional arguments
+
+<details open><summary><code>FULL</code></summary>
+
+TODO: Add description for full (pure-token)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays)
+
+-tab-sep-
+
+[Map reply](../../develop/reference/protocol-spec#maps)
+
+{{< /multitabs >}}
+

--- a/content/commands/arinsert.md
+++ b/content/commands/arinsert.md
@@ -55,15 +55,25 @@ Inserts one or more values at consecutive indices.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>value</code></summary>
 
-TODO: Add description for value (string)
+One or more string values to insert at consecutive indices, beginning at the current insert cursor position. The cursor advances by one for each value inserted. Use [`ARNEXT`]({{< relref "/commands/arnext" >}}) to inspect the current cursor position and [`ARSEEK`]({{< relref "/commands/arseek" >}}) to reposition it.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARINSERT myarray "alpha"
+ARINSERT myarray "beta"
+ARINSERT myarray "gamma"
+ARGET myarray 1
+ARNEXT myarray
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -78,4 +88,3 @@ TODO: Add description for value (string)
 [Integer reply](../../develop/reference/protocol-spec#integers): The last index where a value was inserted.
 
 {{< /multitabs >}}
-

--- a/content/commands/arinsert.md
+++ b/content/commands/arinsert.md
@@ -1,0 +1,81 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- multiple: true
+  name: value
+  type: string
+arity: -3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- WRITE
+- DENYOOM
+- FAST
+complexity: O(N) where N is the number of values
+description: Inserts one or more values at consecutive indices.
+function: arinsertCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - UPDATE
+linkTitle: ARINSERT
+reply_schema:
+  description: The last index where a value was inserted.
+  type: integer
+since: 8.8.0
+summary: Inserts one or more values at consecutive indices.
+syntax_fmt: ARINSERT key value [value ...]
+title: ARINSERT
+---
+Inserts one or more values at consecutive indices.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>value</code></summary>
+
+TODO: Add description for value (string)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The last index where a value was inserted.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The last index where a value was inserted.
+
+{{< /multitabs >}}
+

--- a/content/commands/arlastitems.md
+++ b/content/commands/arlastitems.md
@@ -59,13 +59,13 @@ Returns the most recently inserted elements.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>count</code></summary>
 
-TODO: Add description for count (integer)
+The maximum number of most recently inserted elements to return. If the array contains fewer elements than `count`, all elements are returned.
 
 </details>
 
@@ -73,9 +73,19 @@ TODO: Add description for count (integer)
 
 <details open><summary><code>REV</code></summary>
 
-TODO: Add description for rev (pure-token)
+When present, returns elements in reverse chronological order (most recent first) instead of the default oldest-first order.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARINSERT log "first"
+ARINSERT log "second"
+ARINSERT log "third"
+ARLASTITEMS log 2
+ARLASTITEMS log 2 REV
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -90,4 +100,3 @@ TODO: Add description for rev (pure-token)
 [Array reply](../../develop/reference/protocol-spec#arrays)
 
 {{< /multitabs >}}
-

--- a/content/commands/arlastitems.md
+++ b/content/commands/arlastitems.md
@@ -1,0 +1,93 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: count
+  type: integer
+- name: rev
+  optional: true
+  token: REV
+  type: pure-token
+arity: -3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+complexity: O(N) where N is the count
+description: Returns the most recently inserted elements.
+function: arlastitemsCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARLASTITEMS
+reply_schema:
+  items:
+    oneOf:
+    - type: string
+    - type: 'null'
+  type: array
+since: 8.8.0
+summary: Returns the most recently inserted elements.
+syntax_fmt: ARLASTITEMS key count [REV]
+title: ARLASTITEMS
+---
+Returns the most recently inserted elements.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>count</code></summary>
+
+TODO: Add description for count (integer)
+
+</details>
+
+## Optional arguments
+
+<details open><summary><code>REV</code></summary>
+
+TODO: Add description for rev (pure-token)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays)
+
+-tab-sep-
+
+[Array reply](../../develop/reference/protocol-spec#arrays)
+
+{{< /multitabs >}}
+

--- a/content/commands/arlen.md
+++ b/content/commands/arlen.md
@@ -1,0 +1,71 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+- FAST
+complexity: O(1)
+description: Returns the length of an array (max index + 1).
+function: arlenCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARLEN
+reply_schema:
+  description: The length of the array (max index + 1), or 0 if key does not exist.
+  type: integer
+since: 8.8.0
+summary: Returns the length of an array (max index + 1).
+syntax_fmt: ARLEN key
+title: ARLEN
+---
+Returns the length of an array (max index + 1).
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The length of the array (max index + 1), or 0 if key does not exist.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The length of the array (max index + 1), or 0 if key does not exist.
+
+{{< /multitabs >}}
+

--- a/content/commands/arlen.md
+++ b/content/commands/arlen.md
@@ -51,9 +51,18 @@ Returns the length of an array (max index + 1).
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARSET myarray 0 "a"
+ARSET myarray 5 "b"
+ARLEN myarray
+ARCOUNT myarray
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -68,4 +77,3 @@ TODO: Add description for key (key)
 [Integer reply](../../develop/reference/protocol-spec#integers): The length of the array (max index + 1), or 0 if key does not exist.
 
 {{< /multitabs >}}
-

--- a/content/commands/armget.md
+++ b/content/commands/armget.md
@@ -57,15 +57,22 @@ Gets values at multiple indices in an array.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>index</code></summary>
 
-TODO: Add description for index (integer)
+One or more zero-based integer indices of the elements to retrieve. The reply preserves the order of the requested indices and returns nil for any index that is not set.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARMSET myarray 0 "a" 1 "b" 5 "c"
+ARMGET myarray 0 1 5 3
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -80,4 +87,3 @@ TODO: Add description for index (integer)
 [Array reply](../../develop/reference/protocol-spec#arrays)
 
 {{< /multitabs >}}
-

--- a/content/commands/armget.md
+++ b/content/commands/armget.md
@@ -1,0 +1,83 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- multiple: true
+  name: index
+  type: integer
+arity: -3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+- FAST
+complexity: O(N) where N is the number of indices
+description: Gets values at multiple indices in an array.
+function: armgetCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARMGET
+reply_schema:
+  items:
+    oneOf:
+    - type: string
+    - type: 'null'
+  type: array
+since: 8.8.0
+summary: Gets values at multiple indices in an array.
+syntax_fmt: ARMGET key index [index ...]
+title: ARMGET
+---
+Gets values at multiple indices in an array.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>index</code></summary>
+
+TODO: Add description for index (integer)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays)
+
+-tab-sep-
+
+[Array reply](../../develop/reference/protocol-spec#arrays)
+
+{{< /multitabs >}}
+

--- a/content/commands/armset.md
+++ b/content/commands/armset.md
@@ -60,15 +60,24 @@ Sets multiple index-value pairs in an array.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>data</code></summary>
 
-TODO: Add description for data (block)
+One or more `index value` pairs. Each `index` is a zero-based integer specifying where to write, and each `value` is the string to store at that position. Pairs may be non-contiguous and in any order.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARMSET myarray 0 "alpha" 5 "beta" 100 "gamma"
+ARGET myarray 0
+ARGET myarray 5
+ARGET myarray 100
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -83,4 +92,3 @@ TODO: Add description for data (block)
 [Integer reply](../../develop/reference/protocol-spec#integers): Number of new slots that were set (previously empty).
 
 {{< /multitabs >}}
-

--- a/content/commands/armset.md
+++ b/content/commands/armset.md
@@ -1,0 +1,86 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- arguments:
+  - name: index
+    type: integer
+  - name: value
+    type: string
+  multiple: true
+  name: data
+  type: block
+arity: -4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- WRITE
+- DENYOOM
+- FAST
+complexity: O(N) where N is the number of pairs
+description: Sets multiple index-value pairs in an array.
+function: armsetCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - UPDATE
+linkTitle: ARMSET
+reply_schema:
+  description: Number of new slots that were set (previously empty).
+  type: integer
+since: 8.8.0
+summary: Sets multiple index-value pairs in an array.
+syntax_fmt: ARMSET key index value [index value ...]
+title: ARMSET
+---
+Sets multiple index-value pairs in an array.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>data</code></summary>
+
+TODO: Add description for data (block)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of new slots that were set (previously empty).
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of new slots that were set (previously empty).
+
+{{< /multitabs >}}
+

--- a/content/commands/arnext.md
+++ b/content/commands/arnext.md
@@ -55,9 +55,17 @@ Returns the next index ARINSERT would use.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARINSERT myarray "a"
+ARINSERT myarray "b"
+ARNEXT myarray
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -67,7 +75,7 @@ TODO: Add description for key (key)
 
 One of the following:
 * [Integer reply](../../develop/reference/protocol-spec#integers): The next index ARINSERT would use. Returns 0 for missing keys or when no insert happened yet.
-* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): Null when the insertion cursor is exhausted (next insert would overflow).
+* [Nil reply](../../develop/reference/protocol-spec#null-bulk-strings): Null when the insertion cursor is exhausted (next insert would overflow).
 
 -tab-sep-
 
@@ -76,4 +84,3 @@ One of the following:
 * [Null reply](../../develop/reference/protocol-spec#nulls): Null when the insertion cursor is exhausted (next insert would overflow).
 
 {{< /multitabs >}}
-

--- a/content/commands/arnext.md
+++ b/content/commands/arnext.md
@@ -1,0 +1,79 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+- FAST
+complexity: O(1)
+description: Returns the next index ARINSERT would use.
+function: arnextCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARNEXT
+reply_schema:
+  oneOf:
+  - description: The next index ARINSERT would use. Returns 0 for missing keys or
+      when no insert happened yet.
+    type: integer
+  - description: Null when the insertion cursor is exhausted (next insert would overflow).
+    type: 'null'
+since: 8.8.0
+summary: Returns the next index ARINSERT would use.
+syntax_fmt: ARNEXT key
+title: ARNEXT
+---
+Returns the next index ARINSERT would use.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Integer reply](../../develop/reference/protocol-spec#integers): The next index ARINSERT would use. Returns 0 for missing keys or when no insert happened yet.
+* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): Null when the insertion cursor is exhausted (next insert would overflow).
+
+-tab-sep-
+
+One of the following:
+* [Integer reply](../../develop/reference/protocol-spec#integers): The next index ARINSERT would use. Returns 0 for missing keys or when no insert happened yet.
+* [Null reply](../../develop/reference/protocol-spec#nulls): Null when the insertion cursor is exhausted (next insert would overflow).
+
+{{< /multitabs >}}
+

--- a/content/commands/arop.md
+++ b/content/commands/arop.md
@@ -1,0 +1,138 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: start
+  type: integer
+- name: end
+  type: integer
+- arguments:
+  - name: sum
+    token: SUM
+    type: pure-token
+  - name: min
+    token: MIN
+    type: pure-token
+  - name: max
+    token: MAX
+    type: pure-token
+  - name: and
+    token: AND
+    type: pure-token
+  - name: or
+    token: OR
+    type: pure-token
+  - name: xor
+    token: XOR
+    type: pure-token
+  - arguments:
+    - name: match
+      token: MATCH
+      type: pure-token
+    - name: value
+      type: string
+    name: match
+    type: block
+  - name: used
+    token: USED
+    type: pure-token
+  name: operation
+  type: oneof
+arity: -5
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+complexity: O(P) where P is visited positions in touched slices (dense scanned slots
+  + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N),
+  where N is the number of existing elements in range.
+description: Performs aggregate operations on array elements in a range.
+function: aropCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: AROP
+reply_schema:
+  oneOf:
+  - description: Result of the operation.
+    type: string
+  - description: Integer result for MATCH, USED, AND, OR, XOR.
+    type: integer
+  - description: Null if no elements match the operation.
+    type: 'null'
+since: 8.8.0
+summary: Performs aggregate operations on array elements in a range.
+syntax_fmt: "AROP key start end <SUM | MIN | MAX | AND | OR | XOR | MATCH value |\n\
+  \  USED>"
+title: AROP
+---
+Performs aggregate operations on array elements in a range.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>start</code></summary>
+
+TODO: Add description for start (integer)
+
+</details>
+
+<details open><summary><code>end</code></summary>
+
+TODO: Add description for end (integer)
+
+</details>
+
+<details open><summary><code>operation</code></summary>
+
+TODO: Add description for operation (oneof)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): Result of the operation.
+* [Integer reply](../../develop/reference/protocol-spec#integers): Integer result for MATCH, USED, AND, OR, XOR.
+* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): Null if no elements match the operation.
+
+-tab-sep-
+
+One of the following:
+* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): Result of the operation.
+* [Integer reply](../../develop/reference/protocol-spec#integers): Integer result for MATCH, USED, AND, OR, XOR.
+* [Null reply](../../develop/reference/protocol-spec#nulls): Null if no elements match the operation.
+
+{{< /multitabs >}}
+

--- a/content/commands/arop.md
+++ b/content/commands/arop.md
@@ -94,27 +94,52 @@ Performs aggregate operations on array elements in a range.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>start</code></summary>
 
-TODO: Add description for start (integer)
+The zero-based integer index of the first element in the range to aggregate.
 
 </details>
 
 <details open><summary><code>end</code></summary>
 
-TODO: Add description for end (integer)
+The zero-based integer index of the last element in the range to aggregate (inclusive). The command always scans from the lower to the higher index regardless of argument order.
 
 </details>
 
 <details open><summary><code>operation</code></summary>
 
-TODO: Add description for operation (oneof)
+The aggregate function to apply to all non-empty elements in `[start, end]`. One of:
+
+- **`SUM`** — Returns the sum of all numeric values as a bulk string.
+- **`MIN`** — Returns the minimum numeric value as a bulk string.
+- **`MAX`** — Returns the maximum numeric value as a bulk string.
+- **`AND`** — Returns the bitwise AND of all values, treating each as an integer (floats are truncated toward zero).
+- **`OR`** — Returns the bitwise OR of all values, treating each as an integer (floats are truncated toward zero).
+- **`XOR`** — Returns the bitwise XOR of all values, treating each as an integer (floats are truncated toward zero).
+- **`MATCH value`** — Returns the count of elements whose value equals `value` as an integer reply.
+- **`USED`** — Returns the count of non-empty elements in the range as an integer reply.
+
+`SUM`, `MIN`, and `MAX` return nil when no numeric elements are present in the range. `AND`, `OR`, and `XOR` return nil when the range is empty.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARMSET myarray 0 "10" 1 "20" 2 "30"
+AROP myarray 0 2 SUM
+AROP myarray 0 2 MIN
+AROP myarray 0 2 MAX
+AROP myarray 0 2 MATCH "10"
+AROP myarray 0 2 USED
+ARMSET flags 0 "255" 1 "15" 2 "240"
+AROP flags 0 2 AND
+AROP flags 0 2 OR
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -125,7 +150,7 @@ TODO: Add description for operation (oneof)
 One of the following:
 * [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): Result of the operation.
 * [Integer reply](../../develop/reference/protocol-spec#integers): Integer result for MATCH, USED, AND, OR, XOR.
-* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): Null if no elements match the operation.
+* [Nil reply](../../develop/reference/protocol-spec#null-bulk-strings): Null if no elements match the operation.
 
 -tab-sep-
 
@@ -135,4 +160,3 @@ One of the following:
 * [Null reply](../../develop/reference/protocol-spec#nulls): Null if no elements match the operation.
 
 {{< /multitabs >}}
-

--- a/content/commands/arring.md
+++ b/content/commands/arring.md
@@ -1,0 +1,91 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: size
+  type: integer
+- multiple: true
+  name: value
+  type: string
+arity: -4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- WRITE
+- DENYOOM
+complexity: O(M) normally, O(N+M) on ring resize, where N is the maximum of the old
+  and new ring size and M is the number of inserted values
+description: Inserts values into a ring buffer of specified size, wrapping and truncating
+  as needed.
+function: arringCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - UPDATE
+linkTitle: ARRING
+reply_schema:
+  description: The last index where a value was inserted.
+  type: integer
+since: 8.8.0
+summary: Inserts values into a ring buffer of specified size, wrapping and truncating
+  as needed.
+syntax_fmt: ARRING key size value [value ...]
+title: ARRING
+---
+Inserts values into a ring buffer of specified size, wrapping and truncating as needed.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>size</code></summary>
+
+TODO: Add description for size (integer)
+
+</details>
+
+<details open><summary><code>value</code></summary>
+
+TODO: Add description for value (string)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The last index where a value was inserted.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): The last index where a value was inserted.
+
+{{< /multitabs >}}
+

--- a/content/commands/arring.md
+++ b/content/commands/arring.md
@@ -59,21 +59,33 @@ Inserts values into a ring buffer of specified size, wrapping and truncating as 
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>size</code></summary>
 
-TODO: Add description for size (integer)
+The size of the ring buffer window. Each value is inserted at `insert_idx % size`, wrapping back to index `0` when the end of the window is reached. When the buffer is full, newer values overwrite older ones. If `size` is smaller than the current window, the array is truncated to fit.
 
 </details>
 
 <details open><summary><code>value</code></summary>
 
-TODO: Add description for value (string)
+One or more string values to insert into the ring buffer. Each value is placed at the next position in the ring and the cursor advances accordingly.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARRING readings 3 "v0"
+ARRING readings 3 "v1"
+ARRING readings 3 "v2"
+ARRING readings 3 "v3"
+ARGET readings 0
+ARCOUNT readings
+ARLASTITEMS readings 3
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -88,4 +100,3 @@ TODO: Add description for value (string)
 [Integer reply](../../develop/reference/protocol-spec#integers): The last index where a value was inserted.
 
 {{< /multitabs >}}
-

--- a/content/commands/arscan.md
+++ b/content/commands/arscan.md
@@ -1,0 +1,106 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: start
+  type: integer
+- name: end
+  type: integer
+- name: limit
+  optional: true
+  token: LIMIT
+  type: integer
+arity: -4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- READONLY
+complexity: O(P) where P is visited positions in touched slices (dense scanned slots
+  + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N),
+  where N is the number of existing elements in range.
+description: Iterates existing elements in a range, returning index-value pairs.
+function: arscanCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RO
+  - ACCESS
+linkTitle: ARSCAN
+reply_schema:
+  description: 'Flat array of index-value pairs: [idx1, val1, idx2, val2, ...]'
+  items:
+    oneOf:
+    - description: Index of existing element
+      type: integer
+    - description: Value at that index
+      type: string
+  type: array
+since: 8.8.0
+summary: Iterates existing elements in a range, returning index-value pairs.
+syntax_fmt: "ARSCAN key start end [LIMIT\_limit]"
+title: ARSCAN
+---
+Iterates existing elements in a range, returning index-value pairs.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>start</code></summary>
+
+TODO: Add description for start (integer)
+
+</details>
+
+<details open><summary><code>end</code></summary>
+
+TODO: Add description for end (integer)
+
+</details>
+
+## Optional arguments
+
+<details open><summary><code>LIMIT</code></summary>
+
+TODO: Add description for limit (integer)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays): Flat array of index-value pairs: [idx1, val1, idx2, val2, ...]
+
+-tab-sep-
+
+[Array reply](../../develop/reference/protocol-spec#arrays): Flat array of index-value pairs: [idx1, val1, idx2, val2, ...]
+
+{{< /multitabs >}}
+

--- a/content/commands/arscan.md
+++ b/content/commands/arscan.md
@@ -66,19 +66,19 @@ Iterates existing elements in a range, returning index-value pairs.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>start</code></summary>
 
-TODO: Add description for start (integer)
+The zero-based integer index at which to begin scanning. If `start` is greater than `end`, elements are returned in reverse index order.
 
 </details>
 
 <details open><summary><code>end</code></summary>
 
-TODO: Add description for end (integer)
+The zero-based integer index at which to stop scanning (inclusive).
 
 </details>
 
@@ -86,9 +86,19 @@ TODO: Add description for end (integer)
 
 <details open><summary><code>LIMIT</code></summary>
 
-TODO: Add description for limit (integer)
+The maximum number of index-value pairs to return. When omitted, all elements in the range are returned. Unlike `ARGETRANGE`, empty slots are not included in the output, so `LIMIT` caps the number of existing elements returned.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARSET myarray 0 "a"
+ARSET myarray 5 "b"
+ARSET myarray 9 "c"
+ARSCAN myarray 0 10
+ARSCAN myarray 0 10 LIMIT 2
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -103,4 +113,3 @@ TODO: Add description for limit (integer)
 [Array reply](../../develop/reference/protocol-spec#arrays): Flat array of index-value pairs: [idx1, val1, idx2, val2, ...]
 
 {{< /multitabs >}}
-

--- a/content/commands/arseek.md
+++ b/content/commands/arseek.md
@@ -53,15 +53,26 @@ Sets the ARINSERT cursor to a specific index.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>index</code></summary>
 
-TODO: Add description for index (integer)
+The zero-based integer index to set as the new insert cursor position for subsequent [`ARINSERT`]({{< relref "/commands/arinsert" >}}) calls.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARINSERT myarray "a"
+ARINSERT myarray "b"
+ARNEXT myarray
+ARSEEK myarray 10
+ARINSERT myarray "c"
+ARNEXT myarray
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -76,4 +87,3 @@ TODO: Add description for index (integer)
 [Integer reply](../../develop/reference/protocol-spec#integers): 1 if the cursor was set, 0 if the key does not exist.
 
 {{< /multitabs >}}
-

--- a/content/commands/arseek.md
+++ b/content/commands/arseek.md
@@ -1,0 +1,79 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: index
+  type: integer
+arity: 3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- WRITE
+- FAST
+complexity: O(1)
+description: Sets the ARINSERT cursor to a specific index.
+function: arseekCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - UPDATE
+linkTitle: ARSEEK
+reply_schema:
+  description: 1 if the cursor was set, 0 if the key does not exist.
+  type: integer
+since: 8.8.0
+summary: Sets the ARINSERT cursor to a specific index.
+syntax_fmt: ARSEEK key index
+title: ARSEEK
+---
+Sets the ARINSERT cursor to a specific index.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>index</code></summary>
+
+TODO: Add description for index (integer)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): 1 if the cursor was set, 0 if the key does not exist.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): 1 if the cursor was set, 0 if the key does not exist.
+
+{{< /multitabs >}}
+

--- a/content/commands/arset.md
+++ b/content/commands/arset.md
@@ -1,0 +1,89 @@
+---
+acl_categories:
+- ARRAY
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: index
+  type: integer
+- multiple: true
+  name: value
+  type: string
+arity: -4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- WRITE
+- DENYOOM
+- FAST
+complexity: O(N) where N is the number of values
+description: Sets one or more contiguous values starting at an index in an array.
+function: arsetCommand
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - RW
+  - UPDATE
+linkTitle: ARSET
+reply_schema:
+  description: Number of new slots that were set (previously empty).
+  type: integer
+since: 8.8.0
+summary: Sets one or more contiguous values starting at an index in an array.
+syntax_fmt: ARSET key index value [value ...]
+title: ARSET
+---
+Sets one or more contiguous values starting at an index in an array.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+TODO: Add description for key (key)
+
+</details>
+
+<details open><summary><code>index</code></summary>
+
+TODO: Add description for index (integer)
+
+</details>
+
+<details open><summary><code>value</code></summary>
+
+TODO: Add description for value (string)
+
+</details>
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of new slots that were set (previously empty).
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): Number of new slots that were set (previously empty).
+
+{{< /multitabs >}}
+

--- a/content/commands/arset.md
+++ b/content/commands/arset.md
@@ -57,21 +57,31 @@ Sets one or more contiguous values starting at an index in an array.
 
 <details open><summary><code>key</code></summary>
 
-TODO: Add description for key (key)
+The name of the key that holds the array.
 
 </details>
 
 <details open><summary><code>index</code></summary>
 
-TODO: Add description for index (integer)
+The zero-based integer index at which to start writing. When multiple values are provided, they are stored at consecutive indices starting from `index`.
 
 </details>
 
 <details open><summary><code>value</code></summary>
 
-TODO: Add description for value (string)
+One or more string values to store at consecutive indices beginning at `index`. The number of new (previously empty) slots filled is returned.
 
 </details>
+
+## Examples
+
+{{% redis-cli %}}
+ARSET myarray 0 "hello"
+ARGET myarray 0
+ARSET myarray 2 "a" "b" "c"
+ARGET myarray 2
+ARGET myarray 4
+{{% /redis-cli %}}
 
 ## Return information
 
@@ -86,4 +96,3 @@ TODO: Add description for value (string)
 [Integer reply](../../develop/reference/protocol-spec#integers): Number of new slots that were set (previously empty).
 
 {{< /multitabs >}}
-

--- a/content/develop/data-types/_index.md
+++ b/content/develop/data-types/_index.md
@@ -30,19 +30,20 @@ Each overview includes a comprehensive tutorial with code samples.
 [Redis Open Source]({{< relref "/operate/oss_and_stack" >}})
 implements the following data types:
 
-- [String](#strings)
-- [Hash](#hashes)
-- [List](#lists)
-- [Set](#sets)
-- [Sorted set](#sorted-sets)
-- [Vector set](#vector-sets)
-- [Stream](#streams)
-- [Bitmap](#bitmaps)
-- [Bitfield](#bitfields)
-- [Geospatial](#geospatial-indexes)
+- [Strings](#strings)
+    - [Bitmaps](#bitmaps)
+    - [Bitfields](#bitfields)
+- [Arrays](#arrays)
+- [Geospatial indexes](#geospatial-indexes)
+- [Hashes](#hashes)
 - [JSON](#json)
+- [Lists](#lists)
 - [Probabilistic data types](#probabilistic-data-types)
+- [Sets](#sets)
+- [Sorted sets](#sorted-sets)
+- [Streams](#streams)
 - [Time series](#time-series)
+- [Vector sets](#vector-sets)
 
 See [Compare data types]({{< relref "/develop/data-types/compare-data-types" >}})
 for advice on which of the general-purpose data types is best for common tasks.
@@ -55,56 +56,30 @@ For more information, see:
 * [Overview of Redis strings]({{< relref "/develop/data-types/strings" >}})
 * [Redis string command reference]({{< relref "/commands/" >}}?group=string)
 
-### Lists
+### Bitfields
 
-[Redis lists]({{< relref "/develop/data-types/lists" >}}) are lists of strings sorted by insertion order.
+[Redis bitfields]({{< relref "/develop/data-types/strings/bitfields" >}}) efficiently encode multiple counters in a string value.
+Bitfields provide atomic get, set, and increment operations and support different overflow policies.
 For more information, see:
 
-* [Overview of Redis lists]({{< relref "/develop/data-types/lists" >}})
-* [Redis list command reference]({{< relref "/commands/" >}}?group=list)
+* [Overview of Redis bitfields]({{< relref "/develop/data-types/strings/bitfields" >}})
+* The [`BITFIELD`]({{< relref "/commands/bitfield" >}}) command.
 
-### Sets
+### Bitmaps
 
-[Redis sets]({{< relref "/develop/data-types/sets" >}}) are unordered collections of unique strings that act like the sets from your favorite programming language (for example, [Java HashSets](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html), [Python sets](https://docs.python.org/3.10/library/stdtypes.html#set-types-set-frozenset), and so on).
-With a Redis set, you can add, remove, and test for existence in O(1) time (in other words, regardless of the number of set elements).
+[Redis bitmaps]({{< relref "/develop/data-types/strings/bitmaps" >}}) let you perform bitwise operations on strings. 
 For more information, see:
 
-* [Overview of Redis sets]({{< relref "/develop/data-types/sets" >}})
-* [Redis set command reference]({{< relref "/commands/" >}}?group=set)
+* [Overview of Redis bitmaps]({{< relref "/develop/data-types/strings/bitmaps" >}})
+* [Redis bitmap command reference]({{< relref "/commands/" >}}?group=bitmap)
 
-### Hashes
+### Arrays
 
-[Redis hashes]({{< relref "/develop/data-types/hashes" >}}) are record types modeled as collections of field-value pairs.
-As such, Redis hashes resemble [Python dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries), [Java HashMaps](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), and [Ruby hashes](https://ruby-doc.org/core-3.1.2/Hash.html).
+[Redis arrays]({{< relref "/develop/data-types/arrays" >}}) are sparse, index-addressable sequences of strings.
 For more information, see:
 
-* [Overview of Redis hashes]({{< relref "/develop/data-types/hashes" >}})
-* [Redis hashes command reference]({{< relref "/commands/" >}}?group=hash)
-
-### Sorted sets
-
-[Redis sorted sets]({{< relref "/develop/data-types/sorted-sets" >}}) are collections of unique strings that maintain order by each string's associated score.
-For more information, see:
-
-* [Overview of Redis sorted sets]({{< relref "/develop/data-types/sorted-sets" >}})
-* [Redis sorted set command reference]({{< relref "/commands/" >}}?group=sorted-set)
-
-### Vector sets
-
-[Redis vector sets]({{< relref "/develop/data-types/vector-sets" >}}) are a specialized data type designed for managing high-dimensional vector data, enabling fast and efficient vector similarity search within Redis. Vector sets are optimized for use cases involving machine learning, recommendation systems, and semantic search, where each vector represents a data point in multi-dimensional space. Vector sets supports the [HNSW](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world) (hierarchical navigable small world) algorithm, allowing you to store, index, and query vectors based on the cosine similarity metric. With vector sets, Redis provides native support for hybrid search, combining vector similarity with structured [filters]({{< relref "/develop/data-types/vector-sets/filtered-search" >}}).
-For more information, see:
-
-* [Overview of Redis vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-* [Redis vector set command reference]({{< relref "/commands/" >}}?group=vector_set)
-
-### Streams
-
-A [Redis stream]({{< relref "/develop/data-types/streams" >}}) is a data structure that acts like an append-only log.
-Streams help record events in the order they occur and then syndicate them for processing.
-For more information, see:
-
-* [Overview of Redis Streams]({{< relref "/develop/data-types/streams" >}})
-* [Redis Streams command reference]({{< relref "/commands/" >}}?group=stream)
+* [Overview of Redis arrays]({{< relref "/develop/data-types/arrays" >}})
+* [Redis array command reference]({{< relref "/commands/" >}}?group=array)
 
 ### Geospatial indexes
 
@@ -114,22 +89,14 @@ For more information, see:
 * [Overview of Redis geospatial indexes]({{< relref "/develop/data-types/geospatial" >}})
 * [Redis geospatial indexes command reference]({{< relref "/commands/" >}}?group=geo)
 
-### Bitmaps
+### Hashes
 
-[Redis bitmaps]({{< relref "/develop/data-types/bitmaps" >}}) let you perform bitwise operations on strings. 
+[Redis hashes]({{< relref "/develop/data-types/hashes" >}}) are record types modeled as collections of field-value pairs.
+As such, Redis hashes resemble [Python dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries), [Java HashMaps](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), and [Ruby hashes](https://ruby-doc.org/core-3.1.2/Hash.html).
 For more information, see:
 
-* [Overview of Redis bitmaps]({{< relref "/develop/data-types/bitmaps" >}})
-* [Redis bitmap command reference]({{< relref "/commands/" >}}?group=bitmap)
-
-### Bitfields
-
-[Redis bitfields]({{< relref "/develop/data-types/bitfields" >}}) efficiently encode multiple counters in a string value.
-Bitfields provide atomic get, set, and increment operations and support different overflow policies.
-For more information, see:
-
-* [Overview of Redis bitfields]({{< relref "/develop/data-types/bitfields" >}})
-* The [`BITFIELD`]({{< relref "/commands/bitfield" >}}) command.
+* [Overview of Redis hashes]({{< relref "/develop/data-types/hashes" >}})
+* [Redis hashes command reference]({{< relref "/commands/" >}}?group=hash)
 
 ### JSON
 
@@ -143,25 +110,26 @@ For more information, see:
 - [Overview of Redis JSON]({{< relref "/develop/data-types/json" >}})
 - [JSON command reference]({{< relref "/commands" >}}?group=json)
 
+### Lists
+
+[Redis lists]({{< relref "/develop/data-types/lists" >}}) are lists of strings sorted by insertion order.
+For more information, see:
+
+* [Overview of Redis lists]({{< relref "/develop/data-types/lists" >}})
+* [Redis list command reference]({{< relref "/commands/" >}}?group=list)
+
 ### Probabilistic data types
 
 These data types let you gather and calculate statistics in a way
 that is approximate but highly efficient. The following types are
 available:
 
-- [HyperLogLog](#hyperloglog)
 - [Bloom filter](#bloom-filter)
+- [Count-min sketch](#count-min-sketch)
 - [Cuckoo filter](#cuckoo-filter)
+- [HyperLogLog](#hyperloglog)
 - [t-digest](#t-digest)
 - [Top-K](#top-k)
-- [Count-min sketch](#count-min-sketch)
-
-### HyperLogLog
-
-The [Redis HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}}) data structures provide probabilistic estimates of the cardinality (i.e., number of elements) of large sets. For more information, see:
-
-* [Overview of Redis HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
-* [Redis HyperLogLog command reference]({{< relref "/commands/" >}}?group=hyperloglog)
 
 ### Bloom filter
 
@@ -172,6 +140,15 @@ information, see:
 - [Overview of Redis Bloom filters]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}})
 - [Bloom filter command reference]({{< relref "/commands" >}}?group=bf)
 
+### Count-min sketch
+
+[Redis Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+estimate the frequency of a data point within a stream of values.
+For more information, see:
+
+- [Redis Count-min sketch overview]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+- [Count-min sketch command reference]({{< relref "/commands" >}}?group=cms)
+
 ### Cuckoo filter
 
 [Redis Cuckoo filters]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
@@ -181,6 +158,13 @@ and performance. For more information, see:
 
 - [Overview of Redis Cuckoo filters]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
 - [Cuckoo filter command reference]({{< relref "/commands" >}}?group=cf)
+
+### HyperLogLog
+
+The [Redis HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}}) data structures provide probabilistic estimates of the cardinality (i.e., number of elements) of large sets. For more information, see:
+
+* [Overview of Redis HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+* [Redis HyperLogLog command reference]({{< relref "/commands/" >}}?group=hyperloglog)
 
 ### t-digest
 
@@ -200,16 +184,33 @@ For more information, see:
 - [Redis Top-K overview]({{< relref "/develop/data-types/probabilistic/top-k" >}})
 - [Top-K command reference]({{< relref "/commands" >}}?group=topk)
 
-### Count-min sketch
+### Sets
 
-[Redis Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
-estimate the frequency of a data point within a stream of values.
+[Redis sets]({{< relref "/develop/data-types/sets" >}}) are unordered collections of unique strings that act like the sets from your favorite programming language (for example, [Java HashSets](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html), [Python sets](https://docs.python.org/3.10/library/stdtypes.html#set-types-set-frozenset), and so on).
+With a Redis set, you can add, remove, and test for existence in O(1) time (in other words, regardless of the number of set elements).
 For more information, see:
 
-- [Redis Count-min sketch overview]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
-- [Count-min sketch command reference]({{< relref "/commands" >}}?group=cms)
+* [Overview of Redis sets]({{< relref "/develop/data-types/sets" >}})
+* [Redis set command reference]({{< relref "/commands/" >}}?group=set)
 
-## Time series
+### Sorted sets
+
+[Redis sorted sets]({{< relref "/develop/data-types/sorted-sets" >}}) are collections of unique strings that maintain order by each string's associated score.
+For more information, see:
+
+* [Overview of Redis sorted sets]({{< relref "/develop/data-types/sorted-sets" >}})
+* [Redis sorted set command reference]({{< relref "/commands/" >}}?group=sorted-set)
+
+### Streams
+
+A [Redis stream]({{< relref "/develop/data-types/streams" >}}) is a data structure that acts like an append-only log.
+Streams help record events in the order they occur and then syndicate them for processing.
+For more information, see:
+
+* [Overview of Redis Streams]({{< relref "/develop/data-types/streams" >}})
+* [Redis Streams command reference]({{< relref "/commands/" >}}?group=stream)
+
+### Time series
 
 [Redis time series]({{< relref "/develop/data-types/timeseries" >}})
 structures let you store and query timestamped data points.
@@ -217,6 +218,14 @@ For more information, see:
 
 - [Redis time series overview]({{< relref "/develop/data-types/timeseries" >}})
 - [Time series command reference]({{< relref "/commands" >}}?group=timeseries)
+
+### Vector sets
+
+[Redis vector sets]({{< relref "/develop/data-types/vector-sets" >}}) are a specialized data type designed for managing high-dimensional vector data, enabling fast and efficient vector similarity search within Redis. Vector sets are optimized for use cases involving machine learning, recommendation systems, and semantic search, where each vector represents a data point in multi-dimensional space. Vector sets supports the [HNSW](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world) (hierarchical navigable small world) algorithm, allowing you to store, index, and query vectors based on the cosine similarity metric. With vector sets, Redis provides native support for hybrid search, combining vector similarity with structured [filters]({{< relref "/develop/data-types/vector-sets/filtered-search" >}}).
+For more information, see:
+
+* [Overview of Redis vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+* [Redis vector set command reference]({{< relref "/commands/" >}}?group=vector_set)
 
 ## Adding extensions
 

--- a/content/develop/data-types/arrays.md
+++ b/content/develop/data-types/arrays.md
@@ -1,0 +1,197 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- kubernetes
+- clients
+description: Introduction to Redis arrays
+linkTitle: Arrays
+title: Redis arrays
+weight: 15
+---
+
+{{< command-group group="array" title="Array command summary" show_link=true >}}
+
+Redis arrays are sparse, index-addressable data structures that map integer indices to string values. Unlike lists, elements are accessed directly by index rather than by position in a sequence, and you can set any index without allocating the gaps between occupied slots. This makes arrays well-suited for timestamped event logs, ring buffers, and other workloads that involve sparse or high-index access patterns.
+
+## Basic usage
+
+Use [`ARSET`]({{< relref "/commands/arset" >}}) to write one or more contiguous values starting at a given index, and [`ARGET`]({{< relref "/commands/arget" >}}) to read the value at an index. Accessing an unset index returns a nil reply.
+
+```
+> ARSET events:1 0 "login" "click" "purchase"
+(integer) 3
+> ARGET events:1 0
+"login"
+> ARGET events:1 999
+(nil)
+```
+
+To write values at arbitrary, non-contiguous indices, use [`ARMSET`]({{< relref "/commands/armset" >}}). To read several indices in one round trip, use [`ARMGET`]({{< relref "/commands/armget" >}}):
+
+```
+> ARMSET metrics 0 "10" 5 "20" 100 "30"
+(integer) 3
+> ARMGET metrics 0 5 100 999
+1) "10"
+2) "20"
+3) "30"
+4) (nil)
+```
+
+## Array length vs. element count
+
+Redis arrays expose two distinct size measurements:
+
+- [`ARLEN`]({{< relref "/commands/arlen" >}}) returns the *logical length*: the highest set index plus one.
+- [`ARCOUNT`]({{< relref "/commands/arcount" >}}) returns the number of *non-empty* elements.
+
+For a sparse array, these values can differ substantially:
+
+```
+> ARSET sparse 0 "a"
+(integer) 1
+> ARSET sparse 1000000 "b"
+(integer) 1
+> ARLEN sparse
+(integer) 1000001
+> ARCOUNT sparse
+(integer) 2
+```
+
+## Reading ranges
+
+[`ARGETRANGE`]({{< relref "/commands/argetrange" >}}) returns every position in a range—including empty slots as nil—in index order. Reversing `start` and `end` reverses the direction:
+
+```
+> ARMSET seq 0 "a" 1 "b" 3 "d"
+(integer) 3
+> ARGETRANGE seq 0 3
+1) "a"
+2) "b"
+3) (nil)
+4) "d"
+```
+
+To iterate only the elements that exist and retrieve their indices alongside their values, use [`ARSCAN`]({{< relref "/commands/arscan" >}}). It skips empty slots and returns a flat list of alternating index-value pairs, with an optional `LIMIT` to cap the result size:
+
+```
+> ARSCAN seq 0 3
+1) (integer) 0
+2) "a"
+3) (integer) 1
+4) "b"
+5) (integer) 3
+6) "d"
+```
+
+## Sequential insertion
+
+[`ARINSERT`]({{< relref "/commands/arinsert" >}}) appends values using an internal cursor that advances automatically after each call. Use [`ARNEXT`]({{< relref "/commands/arnext" >}}) to inspect where the next insert would land, and [`ARSEEK`]({{< relref "/commands/arseek" >}}) to reposition the cursor:
+
+```
+> ARINSERT log "event1"
+(integer) 0
+> ARINSERT log "event2"
+(integer) 1
+> ARNEXT log
+(integer) 2
+> ARSEEK log 10
+(integer) 1
+> ARINSERT log "event3"
+(integer) 10
+```
+
+## Ring buffer mode
+
+[`ARRING`]({{< relref "/commands/arring" >}}) turns an array into a fixed-size circular buffer. Each call inserts a value at `insert_idx % size`, wrapping back to index `0` once the window is full and overwriting the oldest entry:
+
+```
+> ARRING readings 3 "v0"
+(integer) 0
+> ARRING readings 3 "v1"
+(integer) 1
+> ARRING readings 3 "v2"
+(integer) 2
+> ARRING readings 3 "v3"
+(integer) 0
+> ARGET readings 0
+"v3"
+```
+
+[`ARLASTITEMS`]({{< relref "/commands/arlastitems" >}}) retrieves the *N* most recently inserted elements in chronological order. Pass the `REV` flag to reverse the order:
+
+```
+> ARLASTITEMS readings 3
+1) "v1"
+2) "v2"
+3) "v3"
+> ARLASTITEMS readings 3 REV
+1) "v3"
+2) "v2"
+3) "v1"
+```
+
+## Aggregate operations
+
+[`AROP`]({{< relref "/commands/arop" >}}) performs a single-pass aggregate over a contiguous range of elements:
+
+| Operation | Description |
+|-----------|-------------|
+| `SUM` | Sum of numeric values |
+| `MIN` | Minimum numeric value |
+| `MAX` | Maximum numeric value |
+| `AND` / `OR` / `XOR` | Bitwise operation on integer values |
+| `MATCH value` | Count of elements equal to `value` |
+| `USED` | Count of non-empty elements in the range |
+
+```
+> ARMSET scores 0 "10" 1 "20" 2 "30"
+(integer) 3
+> AROP scores 0 2 SUM
+"60"
+> AROP scores 0 2 MAX
+"30"
+> AROP scores 0 2 MATCH "10"
+(integer) 1
+```
+
+## Deleting elements
+
+[`ARDEL`]({{< relref "/commands/ardel" >}}) deletes one or more elements by index and returns the count of elements actually removed. [`ARDELRANGE`]({{< relref "/commands/ardelrange" >}}) removes all elements within an index range; reversing `start` and `end` is supported:
+
+```
+> ARDEL scores 1
+(integer) 1
+> ARDELRANGE scores 0 2
+(integer) 2
+```
+
+Deleting the last remaining element removes the key entirely.
+
+## Introspection
+
+[`ARINFO`]({{< relref "/commands/arinfo" >}}) returns metadata about an array's internal structure, including its logical length, element count, and next insert index. Pass the `FULL` option to include per-slice statistics such as fill rates and counts of dense versus sparse slices:
+
+```
+> ARINFO readings
+ 1) "len"
+ 2) (integer) 3
+ 3) "count"
+ 4) (integer) 3
+ 5) "next-insert-index"
+ 6) (integer) 0
+...
+```
+
+## Performance
+
+Most array commands are O(1), including [`ARSET`]({{< relref "/commands/arset" >}}), [`ARGET`]({{< relref "/commands/arget" >}}), [`ARDEL`]({{< relref "/commands/ardel" >}}), [`ARINSERT`]({{< relref "/commands/arinsert" >}}), [`ARNEXT`]({{< relref "/commands/arnext" >}}), [`ARSEEK`]({{< relref "/commands/arseek" >}}), [`ARCOUNT`]({{< relref "/commands/arcount" >}}), and [`ARLEN`]({{< relref "/commands/arlen" >}}). Operations that touch N elements—such as [`ARGETRANGE`]({{< relref "/commands/argetrange" >}}), [`ARSCAN`]({{< relref "/commands/arscan" >}}), [`ARDELRANGE`]({{< relref "/commands/ardelrange" >}}), [`AROP`]({{< relref "/commands/arop" >}}), and [`ARLASTITEMS`]({{< relref "/commands/arlastitems" >}})—are O(N). The underlying sliced-array encoding handles both dense and sparse access patterns efficiently, so large index gaps consume very little memory.
+
+## Limits
+
+[`ARGETRANGE`]({{< relref "/commands/argetrange" >}}) enforces a hard limit of 1,000,000 elements per call to guard against accidentally large range reads.

--- a/content/develop/data-types/bitfields.md
+++ b/content/develop/data-types/bitfields.md
@@ -17,7 +17,7 @@ description: 'Introduction to Redis bitfields
   '
 linkTitle: Bitfields
 title: Redis bitfields
-weight: 130
+weight: 20
 ---
 
 {{< command-group group="bitmap" title="Bitmap/bitfield command summary" show_link=true >}}

--- a/content/develop/data-types/bitmaps.md
+++ b/content/develop/data-types/bitmaps.md
@@ -15,7 +15,7 @@ categories:
 description: Introduction to Redis bitmaps
 linkTitle: Bitmaps
 title: Redis bitmaps
-weight: 120
+weight: 30
 ---
 
 {{< command-group group="bitmap" title="Bitmap/bitfield command summary" show_link=true >}}

--- a/content/develop/data-types/compare-data-types.md
+++ b/content/develop/data-types/compare-data-types.md
@@ -20,18 +20,20 @@ The following are highly specialized for precise purposes:
 
 -   [Geospatial]({{< relref "/develop/data-types/geospatial" >}}):
     store strings with associated coordinates for geospatial queries.
--   [Vector sets]({{< relref "/develop/data-types/vector-sets" >}}):
-    store strings with associated vector data (and optional metadata)
-    for vector similarity queries.
 -   [Probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}}):
     keep approximate counts and other statistics for large datasets.
 -   [Time series]({{< relref "/develop/data-types/timeseries" >}}):
     store real-valued data points along with the time they were collected.
+-   [Vector sets]({{< relref "/develop/data-types/vector-sets" >}}):
+    store strings with associated vector data (and optional metadata)
+    for vector similarity queries.
 
 The remaining data types are more general-purpose:
 
 -   [Strings]({{< relref "/develop/data-types/strings" >}}):
     store text or binary data.
+-   [Arrays]({{< relref "/develop/data-types/arrays" >}}): 
+    store text or binary data in a list.
 -   [Hashes]({{< relref "/develop/data-types/hashes" >}}):
     store key-value pairs within a single key.
 -   [JSON]({{< relref "/develop/data-types/json" >}}):
@@ -68,6 +70,15 @@ whose internal structure will be managed by your own application.
 However, they also support operations to access ranges of bits
 in the string to use as bit sets, integers, or floating-point numbers.
 
+### Arrays
+
+-   **Structure**: sparse, index-addressable sequence of strings.
+-   **Operations**: get, set, delete, range read, range scan, sequential insert, aggregate.
+-   **Suitable for**: Event logs, ring buffers, sensor readings, and other append-heavy or sparse sequences.
+
+Arrays store values addressed by integer index, making random access O(1) regardless of the array's logical size. Because arrays are sparse, setting an element at index 1,000,000 does not allocate memory for the million empty slots in between, so large index gaps are inexpensive. Arrays distinguish between *logical length* (the highest set index plus one, returned by [`ARLEN`]({{< relref "/commands/arlen" >}})) and *element count* (the number of non-empty slots, returned by [`ARCOUNT`]({{< relref "/commands/arcount" >}})).
+
+In addition to direct index access, arrays support sequential insertion via [`ARINSERT`]({{< relref "/commands/arinsert" >}}), which advances an internal cursor automatically. The cursor can be repositioned with [`ARSEEK`]({{< relref "/commands/arseek" >}}), enabling flexible append patterns. [`ARRING`]({{< relref "/commands/arring" >}}) makes the ring buffer pattern explicit: it inserts values modulo a fixed size, wrapping around and overwriting the oldest entries when the buffer is full. [`AROP`]({{< relref "/commands/arop" >}}) performs single-pass aggregations (sum, min, max, bitwise operations, value matching) over a range without fetching each element individually.
 
 ### Hashes
 

--- a/content/develop/data-types/geospatial.md
+++ b/content/develop/data-types/geospatial.md
@@ -17,7 +17,7 @@ description: 'Introduction to the Redis Geospatial data type
   '
 linkTitle: Geospatial
 title: Redis geospatial
-weight: 80
+weight: 40
 ---
 
 {{< command-group group="geo" title="Geospatial command summary" show_link=true >}}

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -17,7 +17,7 @@ description: 'Introduction to Redis hashes
   '
 linkTitle: Hashes
 title: Redis hashes
-weight: 40
+weight: 50
 ---
 
 {{< command-group group="hash" title="Hash command summary" show_link=true >}}

--- a/content/develop/data-types/json/_index.md
+++ b/content/develop/data-types/json/_index.md
@@ -16,7 +16,7 @@ description: JSON support for Redis
 linkTitle: JSON
 stack: true
 title: JSON
-weight: 11
+weight: 60
 ---
 
 {{< command-group group="json" title="JSON command summary" show_link=true >}}

--- a/content/develop/data-types/lists.md
+++ b/content/develop/data-types/lists.md
@@ -17,7 +17,7 @@ description: 'Introduction to Redis lists
   '
 linkTitle: Lists
 title: Redis lists
-weight: 20
+weight: 70
 ---
 
 {{< command-group group="list" title="List command summary" show_link=true >}}

--- a/content/develop/data-types/probabilistic/_index.md
+++ b/content/develop/data-types/probabilistic/_index.md
@@ -15,7 +15,7 @@ categories:
 description: Probabilistic data structures in Redis
 linkTitle: Probabilistic
 title: Probabilistic
-weight: 140
+weight: 80
 ---
 
 *Probabilistic data structures* give approximations of statistics such as

--- a/content/develop/data-types/probabilistic/count-min-sketch.md
+++ b/content/develop/data-types/probabilistic/count-min-sketch.md
@@ -17,7 +17,7 @@ description: Count-min sketch is a probabilistic data structure that estimates t
 linkTitle: Count-min sketch
 stack: true
 title: Count-min sketch
-weight: 60
+weight: 20
 ---
 
 {{< command-group group="cms" title="Count-min sketch command summary" show_link=true >}}

--- a/content/develop/data-types/probabilistic/cuckoo-filter.md
+++ b/content/develop/data-types/probabilistic/cuckoo-filter.md
@@ -17,7 +17,7 @@ description: Cuckoo filters are a probabilistic data structure that checks for p
 linkTitle: Cuckoo filter
 stack: true
 title: Cuckoo filter
-weight: 20
+weight: 30
 ---
 
 {{< command-group group="cf" title="Cuckoo filter command summary" show_link=true >}}

--- a/content/develop/data-types/probabilistic/hyperloglogs.md
+++ b/content/develop/data-types/probabilistic/hyperloglogs.md
@@ -18,7 +18,7 @@ description: 'HyperLogLog is a probabilistic data structure that estimates the c
   '
 linkTitle: HyperLogLog
 title: HyperLogLog
-weight: 1
+weight: 40
 ---
 
 {{< command-group group="hyperloglog" title="HyperLogLog command summary" show_link=true >}}

--- a/content/develop/data-types/probabilistic/t-digest.md
+++ b/content/develop/data-types/probabilistic/t-digest.md
@@ -17,7 +17,7 @@ description: t-digest is a probabilistic data structure that allows you to estim
 linkTitle: t-digest
 stack: true
 title: t-digest
-weight: 40
+weight: 50
 ---
 
 {{< command-group group="tdigest" title="t-digest command summary" show_link=true >}}

--- a/content/develop/data-types/probabilistic/top-k.md
+++ b/content/develop/data-types/probabilistic/top-k.md
@@ -17,7 +17,7 @@ description: Top-K is a probabilistic data structure that allows you to find the
 linkTitle: Top-K
 stack: true
 title: Top-K
-weight: 50
+weight: 60
 ---
 
 {{< command-group group="topk" title="Top-K command summary" show_link=true >}}

--- a/content/develop/data-types/sets.md
+++ b/content/develop/data-types/sets.md
@@ -17,7 +17,7 @@ description: 'Introduction to Redis sets
   '
 linkTitle: Sets
 title: Redis sets
-weight: 30
+weight: 90
 ---
 
 {{< command-group group="set" title="Set command summary" show_link=true >}}

--- a/content/develop/data-types/sorted-sets.md
+++ b/content/develop/data-types/sorted-sets.md
@@ -17,7 +17,7 @@ description: 'Introduction to Redis sorted sets
   '
 linkTitle: Sorted sets
 title: Redis sorted sets
-weight: 50
+weight: 100
 ---
 
 {{< command-group group="sorted-set" title="Sorted set command summary" show_link=true >}}

--- a/content/develop/data-types/streams/_index.md
+++ b/content/develop/data-types/streams/_index.md
@@ -17,7 +17,7 @@ categories:
 description: Introduction to Redis streams
 linkTitle: Streams
 title: Redis Streams
-weight: 60
+weight: 110
 ---
 
 {{< command-group group="stream" title="Stream command summary" show_link=true >}}

--- a/content/develop/data-types/strings/_index.md
+++ b/content/develop/data-types/strings/_index.md
@@ -11,9 +11,7 @@ categories:
 - rc
 - kubernetes
 - clients
-description: 'Introduction to Redis strings
-
-  '
+description: Introduction to Redis strings
 linkTitle: Strings
 title: Redis Strings
 weight: 10
@@ -113,7 +111,7 @@ By default, a single Redis string can be a maximum of 512 MB.
 
 ## Bitwise and bitfield operations
 
-To perform bitwise operations on a string, see the [bitmaps data type]({{< relref "/develop/data-types/bitmaps" >}}) docs. To store and manipulate integer values within a string, see the [bitfields data type]({{< relref "/develop/data-types/bitfields" >}}) docs.
+To perform bitwise operations on a string, see the [bitmaps data type]({{< relref "/develop/data-types/strings/bitmaps" >}}) docs. To store and manipulate integer values within a string, see the [bitfields data type]({{< relref "/develop/data-types/strings/bitfields" >}}) docs.
 
 ## Performance
 

--- a/content/develop/data-types/strings/bitfields.md
+++ b/content/develop/data-types/strings/bitfields.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/bitfields/
 - /manual/data-types/bitfields/
+- /develop/data-types/bitfields/
 categories:
 - docs
 - develop
@@ -12,12 +13,10 @@ categories:
 - oss
 - kubernetes
 - clients
-description: 'Introduction to Redis bitfields
-
-  '
+description: Introduction to Redis bitfields
 linkTitle: Bitfields
 title: Redis bitfields
-weight: 20
+weight: 10
 ---
 
 {{< command-group group="bitmap" title="Bitmap/bitfield command summary" show_link=true >}}

--- a/content/develop/data-types/strings/bitmaps.md
+++ b/content/develop/data-types/strings/bitmaps.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/bitmaps/
 - /manual/data-types/bitmaps/
+- /develop/data-types/bitmaps/
 categories:
 - docs
 - develop
@@ -15,7 +16,7 @@ categories:
 description: Introduction to Redis bitmaps
 linkTitle: Bitmaps
 title: Redis bitmaps
-weight: 30
+weight: 20
 ---
 
 {{< command-group group="bitmap" title="Bitmap/bitfield command summary" show_link=true >}}

--- a/content/develop/data-types/timeseries/_index.md
+++ b/content/develop/data-types/timeseries/_index.md
@@ -22,7 +22,7 @@ description: Ingest and query time series data with Redis
 linkTitle: Time series
 stack: true
 title: Time series
-weight: 150
+weight: 120
 ---
 
 {{< command-group group="timeseries" title="Time series command summary" show_link=true >}}

--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -15,7 +15,7 @@ categories:
 description: Introduction to Redis vector sets
 linkTitle: Vector sets
 title: Redis vector sets
-weight: 55
+weight: 130
 ---
 
 {{< command-group group="module" url_group="vector_set" title="Vector set command summary" show_link=true >}}

--- a/content/develop/whats-new/_index.md
+++ b/content/develop/whats-new/_index.md
@@ -40,7 +40,7 @@ weight: 10
   - [Lists]({{< relref "/develop/data-types/lists" >}})
   - [Sets]({{< relref "/develop/data-types/sets" >}})
   - [Sorted sets]({{< relref "/develop/data-types/sorted-sets" >}})
-  - [Bitmaps]({{< relref "/develop/data-types/bitmaps" >}})
+  - [Bitmaps]({{< relref "/develop/data-types/strings/bitmaps" >}})
   - [Geospatial]({{< relref "/develop/data-types/geospatial" >}})
   - [JSON]({{< relref "/develop/data-types/json" >}})
   - [Time series]({{< relref "/develop/data-types/timeseries" >}})
@@ -174,7 +174,7 @@ weight: 10
 
 ### Data Types
 
-- [Bitmaps]({{< relref "/develop/data-types/bitmaps" >}}):
+- [Bitmaps]({{< relref "/develop/data-types/strings/bitmaps" >}}):
   - Added BITOP documentation with Python testable code examples
   - Added bit operation diagrams
 

--- a/data/commands_core.json
+++ b/data/commands_core.json
@@ -402,6 +402,1075 @@
             "fast"
         ]
     },
+        "ARCOUNT": {
+        "summary": "Returns the number of non-empty elements in an array.",
+        "complexity": "O(1)",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": 2,
+        "function": "arcountCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The number of non-empty elements, or 0 if key does not exist.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    },
+    "ARDEL": {
+        "summary": "Deletes elements at the specified indices in an array.",
+        "complexity": "O(N) where N is the number of indices to delete",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -3,
+        "function": "ardelCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of elements deleted.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "multiple": true
+            }
+        ]
+    },
+    "ARDELRANGE": {
+        "summary": "Deletes elements in one or more ranges.",
+        "complexity": "Proportional to the number of existing elements / slices touched, not to the numeric span of the requested ranges",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -4,
+        "function": "ardelrangeCommand",
+        "command_flags": [
+            "WRITE"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "DELETE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of elements deleted.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "range",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "start",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "end",
+                        "type": "integer"
+                    }
+                ]
+            }
+        ]
+    },
+    "ARGET": {
+        "summary": "Gets the value at an index in an array.",
+        "complexity": "O(1)",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": 3,
+        "function": "argetCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The value at the given index.",
+                    "type": "string"
+                },
+                {
+                    "description": "Null reply if key or index does not exist.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer"
+            }
+        ]
+    },
+    "ARGETRANGE": {
+        "summary": "Gets values in a range of indices.",
+        "complexity": "O(N) where N is the range length",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": 4,
+        "function": "argetrangeCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "end",
+                "type": "integer"
+            }
+        ]
+    },
+    "ARINFO": {
+        "summary": "Returns metadata about an array.",
+        "complexity": "O(1), or O(N) with FULL option where N is the number of slices.",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -2,
+        "function": "arinfoCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "description": "Total number of non-empty elements."
+                },
+                "len": {
+                    "type": "integer",
+                    "description": "Logical length (highest index + 1)."
+                },
+                "next-insert-index": {
+                    "type": "integer",
+                    "description": "Index the next ARINSERT would use, or 0 if unset/exhausted."
+                },
+                "slices": {
+                    "type": "integer",
+                    "description": "Number of allocated slices."
+                },
+                "directory-size": {
+                    "type": "integer",
+                    "description": "Directory allocation capacity (flat dir_alloc or superdir sdir_cap)."
+                },
+                "super-dir-entries": {
+                    "type": "integer",
+                    "description": "Number of super-directory entries (0 if not in superdir mode)."
+                },
+                "slice-size": {
+                    "type": "integer",
+                    "description": "Configured slice size."
+                },
+                "dense-slices": {
+                    "type": "integer",
+                    "description": "Number of dense slices (FULL only)."
+                },
+                "sparse-slices": {
+                    "type": "integer",
+                    "description": "Number of sparse slices (FULL only)."
+                },
+                "avg-dense-size": {
+                    "type": "number",
+                    "description": "Average allocation size of dense slices (FULL only)."
+                },
+                "avg-dense-fill": {
+                    "type": "number",
+                    "description": "Average fill rate of dense slices (FULL only)."
+                },
+                "avg-sparse-size": {
+                    "type": "number",
+                    "description": "Average capacity of sparse slices (FULL only)."
+                }
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "full",
+                "type": "pure-token",
+                "token": "FULL",
+                "optional": true
+            }
+        ]
+    },
+    "ARINSERT": {
+        "summary": "Inserts one or more values at consecutive indices.",
+        "complexity": "O(N) where N is the number of values",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -3,
+        "function": "arinsertCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The last index where a value was inserted.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    },
+    "ARLASTITEMS": {
+        "summary": "Returns the most recently inserted elements.",
+        "complexity": "O(N) where N is the count",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -3,
+        "function": "arlastitemsCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer"
+            },
+            {
+                "name": "rev",
+                "type": "pure-token",
+                "token": "REV",
+                "optional": true
+            }
+        ]
+    },
+    "ARLEN": {
+        "summary": "Returns the length of an array (max index + 1).",
+        "complexity": "O(1)",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": 2,
+        "function": "arlenCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The length of the array (max index + 1), or 0 if key does not exist.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    },
+    "ARMGET": {
+        "summary": "Gets values at multiple indices in an array.",
+        "complexity": "O(N) where N is the number of indices",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -3,
+        "function": "armgetCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "string"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "multiple": true
+            }
+        ]
+    },
+    "ARMSET": {
+        "summary": "Sets multiple index-value pairs in an array.",
+        "complexity": "O(N) where N is the number of pairs",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -4,
+        "function": "armsetCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of new slots that were set (previously empty).",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "index",
+                        "type": "integer"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    },
+    "ARNEXT": {
+        "summary": "Returns the next index ARINSERT would use.",
+        "complexity": "O(1)",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": 2,
+        "function": "arnextCommand",
+        "command_flags": [
+            "READONLY",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "The next index ARINSERT would use. Returns 0 for missing keys or when no insert happened yet.",
+                    "type": "integer"
+                },
+                {
+                    "description": "Null when the insertion cursor is exhausted (next insert would overflow).",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            }
+        ]
+    },
+    "AROP": {
+        "summary": "Performs aggregate operations on array elements in a range.",
+        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -5,
+        "function": "aropCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "oneOf": [
+                {
+                    "description": "Result of the operation.",
+                    "type": "string"
+                },
+                {
+                    "description": "Integer result for MATCH, USED, AND, OR, XOR.",
+                    "type": "integer"
+                },
+                {
+                    "description": "Null if no elements match the operation.",
+                    "type": "null"
+                }
+            ]
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "end",
+                "type": "integer"
+            },
+            {
+                "name": "operation",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                    },
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                    },
+                    {
+                        "name": "and",
+                        "type": "pure-token",
+                        "token": "AND"
+                    },
+                    {
+                        "name": "or",
+                        "type": "pure-token",
+                        "token": "OR"
+                    },
+                    {
+                        "name": "xor",
+                        "type": "pure-token",
+                        "token": "XOR"
+                    },
+                    {
+                        "name": "match",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "match",
+                                "type": "pure-token",
+                                "token": "MATCH"
+                            },
+                            {
+                                "name": "value",
+                                "type": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "used",
+                        "type": "pure-token",
+                        "token": "USED"
+                    }
+                ]
+            }
+        ]
+    },
+    "ARRING": {
+        "summary": "Inserts values into a ring buffer of specified size, wrapping and truncating as needed.",
+        "complexity": "O(M) normally, O(N+M) on ring resize, where N is the maximum of the old and new ring size and M is the number of inserted values",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -4,
+        "function": "arringCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "The last index where a value was inserted.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "size",
+                "type": "integer"
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    },
+    "ARSCAN": {
+        "summary": "Iterates existing elements in a range, returning index-value pairs.",
+        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -4,
+        "function": "arscanCommand",
+        "command_flags": [
+            "READONLY"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RO",
+                    "ACCESS"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Flat array of index-value pairs: [idx1, val1, idx2, val2, ...]",
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "integer",
+                        "description": "Index of existing element"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Value at that index"
+                    }
+                ]
+            }
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer"
+            },
+            {
+                "name": "end",
+                "type": "integer"
+            },
+            {
+                "name": "limit",
+                "token": "LIMIT",
+                "type": "integer",
+                "optional": true
+            }
+        ]
+    },
+    "ARSEEK": {
+        "summary": "Sets the ARINSERT cursor to a specific index.",
+        "complexity": "O(1)",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": 3,
+        "function": "arseekCommand",
+        "command_flags": [
+            "WRITE",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "1 if the cursor was set, 0 if the key does not exist.",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer"
+            }
+        ]
+    },
+    "ARSET": {
+        "summary": "Sets one or more contiguous values starting at an index in an array.",
+        "complexity": "O(N) where N is the number of values",
+        "group": "array",
+        "since": "8.0.0",
+        "arity": -4,
+        "function": "arsetCommand",
+        "command_flags": [
+            "WRITE",
+            "DENYOOM",
+            "FAST"
+        ],
+        "acl_categories": [
+            "ARRAY"
+        ],
+        "key_specs": [
+            {
+                "flags": [
+                    "RW",
+                    "UPDATE"
+                ],
+                "begin_search": {
+                    "index": {
+                        "pos": 1
+                    }
+                },
+                "find_keys": {
+                    "range": {
+                        "lastkey": 0,
+                        "step": 1,
+                        "limit": 0
+                    }
+                }
+            }
+        ],
+        "reply_schema": {
+            "description": "Number of new slots that were set (previously empty).",
+            "type": "integer"
+        },
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer"
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "multiple": true
+            }
+        ]
+    },
     "ASKING": {
         "summary": "Signals that a cluster client is following an -ASK redirect.",
         "since": "3.0.0",

--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -29,6 +29,7 @@
                 {{ $id }}
               </option>
           {{ end */}}
+          <option value="array" data-kind="core">Array</option>
           <option value="bf" data-kind="stack">Bloom filter</option>
           <option value="bitmap" data-kind="core">Bitmap</option>
           <option value="cf" data-kind="stack">Cuckoo filter</option>

--- a/static/images/railroad/arcount.svg
+++ b/static/images/railroad/arcount.svg
@@ -1,0 +1,49 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 245.0 62" width="245.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M195.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M129.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="50.0" y="20"></rect><text x="89.75" y="35">ARCOUNT</text></g><path d="M129.5 31h10"></path><path d="M139.5 31h10"></path><g class="non-terminal ">
+<path d="M149.5 31h0.0"></path><path d="M195.0 31h0.0"></path><rect height="22" width="45.5" x="149.5" y="20"></rect><text x="172.25" y="35">key</text></g></g><path d="M195.0 31h10"></path><path d="M 205.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/ardel.svg
+++ b/static/images/railroad/ardel.svg
@@ -1,0 +1,52 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 330.5 71" width="330.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M280.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M112.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="50.0" y="20"></rect><text x="81.25" y="35">ARDEL</text></g><path d="M112.5 31h10"></path><path d="M122.5 31h10"></path><g class="non-terminal ">
+<path d="M132.5 31h0.0"></path><path d="M178.0 31h0.0"></path><rect height="22" width="45.5" x="132.5" y="20"></rect><text x="155.25" y="35">key</text></g><path d="M178.0 31h10"></path><path d="M188.0 31h10"></path><g>
+<path d="M198.0 31h0.0"></path><path d="M280.5 31h0.0"></path><path d="M198.0 31h10"></path><g class="non-terminal ">
+<path d="M208.0 31h0.0"></path><path d="M270.5 31h0.0"></path><rect height="22" width="62.5" x="208.0" y="20"></rect><text x="239.25" y="35">index</text></g><path d="M270.5 31h10"></path><path d="M208.0 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M208.0 51h62.5"></path></g><path d="M270.5 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M280.5 31h10"></path><path d="M 290.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/ardelrange.svg
+++ b/static/images/railroad/ardelrange.svg
@@ -1,0 +1,54 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 438.5 71" width="438.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M388.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M155.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="50.0" y="20"></rect><text x="102.5" y="35">ARDELRANGE</text></g><path d="M155.0 31h10"></path><path d="M165.0 31h10"></path><g class="non-terminal ">
+<path d="M175.0 31h0.0"></path><path d="M220.5 31h0.0"></path><rect height="22" width="45.5" x="175.0" y="20"></rect><text x="197.75" y="35">key</text></g><path d="M220.5 31h10"></path><path d="M230.5 31h10"></path><g>
+<path d="M240.5 31h0.0"></path><path d="M388.5 31h0.0"></path><path d="M240.5 31h10"></path><g>
+<path d="M250.5 31h0.0"></path><path d="M378.5 31h0.0"></path><g class="non-terminal ">
+<path d="M250.5 31h0.0"></path><path d="M313.0 31h0.0"></path><rect height="22" width="62.5" x="250.5" y="20"></rect><text x="281.75" y="35">start</text></g><path d="M313.0 31h10"></path><path d="M323.0 31h10"></path><g class="non-terminal ">
+<path d="M333.0 31h0.0"></path><path d="M378.5 31h0.0"></path><rect height="22" width="45.5" x="333.0" y="20"></rect><text x="355.75" y="35">end</text></g></g><path d="M378.5 31h10"></path><path d="M250.5 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M250.5 51h128.0"></path></g><path d="M378.5 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M388.5 31h10"></path><path d="M 398.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arget.svg
+++ b/static/images/railroad/arget.svg
@@ -1,0 +1,50 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 310.5 62" width="310.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M260.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M112.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="50.0" y="20"></rect><text x="81.25" y="35">ARGET</text></g><path d="M112.5 31h10"></path><path d="M122.5 31h10"></path><g class="non-terminal ">
+<path d="M132.5 31h0.0"></path><path d="M178.0 31h0.0"></path><rect height="22" width="45.5" x="132.5" y="20"></rect><text x="155.25" y="35">key</text></g><path d="M178.0 31h10"></path><path d="M188.0 31h10"></path><g class="non-terminal ">
+<path d="M198.0 31h0.0"></path><path d="M260.5 31h0.0"></path><rect height="22" width="62.5" x="198.0" y="20"></rect><text x="229.25" y="35">index</text></g></g><path d="M260.5 31h10"></path><path d="M 270.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/argetrange.svg
+++ b/static/images/railroad/argetrange.svg
@@ -1,0 +1,51 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 418.5 62" width="418.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M368.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M155.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="50.0" y="20"></rect><text x="102.5" y="35">ARGETRANGE</text></g><path d="M155.0 31h10"></path><path d="M165.0 31h10"></path><g class="non-terminal ">
+<path d="M175.0 31h0.0"></path><path d="M220.5 31h0.0"></path><rect height="22" width="45.5" x="175.0" y="20"></rect><text x="197.75" y="35">key</text></g><path d="M220.5 31h10"></path><path d="M230.5 31h10"></path><g class="non-terminal ">
+<path d="M240.5 31h0.0"></path><path d="M303.0 31h0.0"></path><rect height="22" width="62.5" x="240.5" y="20"></rect><text x="271.75" y="35">start</text></g><path d="M303.0 31h10"></path><path d="M313.0 31h10"></path><g class="non-terminal ">
+<path d="M323.0 31h0.0"></path><path d="M368.5 31h0.0"></path><rect height="22" width="45.5" x="323.0" y="20"></rect><text x="345.75" y="35">end</text></g></g><path d="M368.5 31h10"></path><path d="M 378.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arinfo.svg
+++ b/static/images/railroad/arinfo.svg
@@ -1,0 +1,52 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 340.5 71" width="340.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M290.5 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M121.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="29"></rect><text x="85.5" y="44">ARINFO</text></g><path d="M121.0 40h10"></path><path d="M131.0 40h10"></path><g class="non-terminal ">
+<path d="M141.0 40h0.0"></path><path d="M186.5 40h0.0"></path><rect height="22" width="45.5" x="141.0" y="29"></rect><text x="163.75" y="44">key</text></g><path d="M186.5 40h10"></path><g>
+<path d="M196.5 40h0.0"></path><path d="M290.5 40h0.0"></path><path d="M196.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M216.5 20h54.0"></path></g><path d="M270.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M196.5 40h20"></path><g class="terminal ">
+<path d="M216.5 40h0.0"></path><path d="M270.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="216.5" y="29"></rect><text x="243.5" y="44">FULL</text></g><path d="M270.5 40h20"></path></g></g><path d="M290.5 40h10"></path><path d="M 300.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arinsert.svg
+++ b/static/images/railroad/arinsert.svg
@@ -1,0 +1,52 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 356.0 71" width="356.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M306.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M138.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="50.0" y="20"></rect><text x="94.0" y="35">ARINSERT</text></g><path d="M138.0 31h10"></path><path d="M148.0 31h10"></path><g class="non-terminal ">
+<path d="M158.0 31h0.0"></path><path d="M203.5 31h0.0"></path><rect height="22" width="45.5" x="158.0" y="20"></rect><text x="180.75" y="35">key</text></g><path d="M203.5 31h10"></path><path d="M213.5 31h10"></path><g>
+<path d="M223.5 31h0.0"></path><path d="M306.0 31h0.0"></path><path d="M223.5 31h10"></path><g class="non-terminal ">
+<path d="M233.5 31h0.0"></path><path d="M296.0 31h0.0"></path><rect height="22" width="62.5" x="233.5" y="20"></rect><text x="264.75" y="35">value</text></g><path d="M296.0 31h10"></path><path d="M233.5 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M233.5 51h62.5"></path></g><path d="M296.0 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M306.0 31h10"></path><path d="M 316.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arlastitems.svg
+++ b/static/images/railroad/arlastitems.svg
@@ -1,0 +1,53 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 457.0 71" width="457.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M407.0 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M163.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="50.0" y="29"></rect><text x="106.75" y="44">ARLASTITEMS</text></g><path d="M163.5 40h10"></path><path d="M173.5 40h10"></path><g class="non-terminal ">
+<path d="M183.5 40h0.0"></path><path d="M229.0 40h0.0"></path><rect height="22" width="45.5" x="183.5" y="29"></rect><text x="206.25" y="44">key</text></g><path d="M229.0 40h10"></path><path d="M239.0 40h10"></path><g class="non-terminal ">
+<path d="M249.0 40h0.0"></path><path d="M311.5 40h0.0"></path><rect height="22" width="62.5" x="249.0" y="29"></rect><text x="280.25" y="44">count</text></g><path d="M311.5 40h10"></path><g>
+<path d="M321.5 40h0.0"></path><path d="M407.0 40h0.0"></path><path d="M321.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M341.5 20h45.5"></path></g><path d="M387.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M321.5 40h20"></path><g class="terminal ">
+<path d="M341.5 40h0.0"></path><path d="M387.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="341.5" y="29"></rect><text x="364.25" y="44">REV</text></g><path d="M387.0 40h20"></path></g></g><path d="M407.0 40h10"></path><path d="M 417.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arlen.svg
+++ b/static/images/railroad/arlen.svg
@@ -1,0 +1,49 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 228.0 62" width="228.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M178.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M112.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="50.0" y="20"></rect><text x="81.25" y="35">ARLEN</text></g><path d="M112.5 31h10"></path><path d="M122.5 31h10"></path><g class="non-terminal ">
+<path d="M132.5 31h0.0"></path><path d="M178.0 31h0.0"></path><rect height="22" width="45.5" x="132.5" y="20"></rect><text x="155.25" y="35">key</text></g></g><path d="M178.0 31h10"></path><path d="M 188.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/armget.svg
+++ b/static/images/railroad/armget.svg
@@ -1,0 +1,52 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 339.0 71" width="339.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M289.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M121.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="20"></rect><text x="85.5" y="35">ARMGET</text></g><path d="M121.0 31h10"></path><path d="M131.0 31h10"></path><g class="non-terminal ">
+<path d="M141.0 31h0.0"></path><path d="M186.5 31h0.0"></path><rect height="22" width="45.5" x="141.0" y="20"></rect><text x="163.75" y="35">key</text></g><path d="M186.5 31h10"></path><path d="M196.5 31h10"></path><g>
+<path d="M206.5 31h0.0"></path><path d="M289.0 31h0.0"></path><path d="M206.5 31h10"></path><g class="non-terminal ">
+<path d="M216.5 31h0.0"></path><path d="M279.0 31h0.0"></path><rect height="22" width="62.5" x="216.5" y="20"></rect><text x="247.75" y="35">index</text></g><path d="M279.0 31h10"></path><path d="M216.5 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M216.5 51h62.5"></path></g><path d="M279.0 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M289.0 31h10"></path><path d="M 299.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/armset.svg
+++ b/static/images/railroad/armset.svg
@@ -1,0 +1,54 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 421.5 71" width="421.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M371.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M121.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="20"></rect><text x="85.5" y="35">ARMSET</text></g><path d="M121.0 31h10"></path><path d="M131.0 31h10"></path><g class="non-terminal ">
+<path d="M141.0 31h0.0"></path><path d="M186.5 31h0.0"></path><rect height="22" width="45.5" x="141.0" y="20"></rect><text x="163.75" y="35">key</text></g><path d="M186.5 31h10"></path><path d="M196.5 31h10"></path><g>
+<path d="M206.5 31h0.0"></path><path d="M371.5 31h0.0"></path><path d="M206.5 31h10"></path><g>
+<path d="M216.5 31h0.0"></path><path d="M361.5 31h0.0"></path><g class="non-terminal ">
+<path d="M216.5 31h0.0"></path><path d="M279.0 31h0.0"></path><rect height="22" width="62.5" x="216.5" y="20"></rect><text x="247.75" y="35">index</text></g><path d="M279.0 31h10"></path><path d="M289.0 31h10"></path><g class="non-terminal ">
+<path d="M299.0 31h0.0"></path><path d="M361.5 31h0.0"></path><rect height="22" width="62.5" x="299.0" y="20"></rect><text x="330.25" y="35">value</text></g></g><path d="M361.5 31h10"></path><path d="M216.5 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M216.5 51h145.0"></path></g><path d="M361.5 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M371.5 31h10"></path><path d="M 381.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arnext.svg
+++ b/static/images/railroad/arnext.svg
@@ -1,0 +1,49 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 236.5 62" width="236.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M186.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M121.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="20"></rect><text x="85.5" y="35">ARNEXT</text></g><path d="M121.0 31h10"></path><path d="M131.0 31h10"></path><g class="non-terminal ">
+<path d="M141.0 31h0.0"></path><path d="M186.5 31h0.0"></path><rect height="22" width="45.5" x="141.0" y="20"></rect><text x="163.75" y="35">key</text></g></g><path d="M186.5 31h10"></path><path d="M 196.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arop.svg
+++ b/static/images/railroad/arop.svg
@@ -1,0 +1,62 @@
+<svg class="railroad-diagram" height="272" viewBox="0 0 562.5 272" width="562.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M512.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M104.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="50.0" y="20"></rect><text x="77.0" y="35">AROP</text></g><path d="M104.0 31h10"></path><path d="M114.0 31h10"></path><g class="non-terminal ">
+<path d="M124.0 31h0.0"></path><path d="M169.5 31h0.0"></path><rect height="22" width="45.5" x="124.0" y="20"></rect><text x="146.75" y="35">key</text></g><path d="M169.5 31h10"></path><path d="M179.5 31h10"></path><g class="non-terminal ">
+<path d="M189.5 31h0.0"></path><path d="M252.0 31h0.0"></path><rect height="22" width="62.5" x="189.5" y="20"></rect><text x="220.75" y="35">start</text></g><path d="M252.0 31h10"></path><path d="M262.0 31h10"></path><g class="non-terminal ">
+<path d="M272.0 31h0.0"></path><path d="M317.5 31h0.0"></path><rect height="22" width="45.5" x="272.0" y="20"></rect><text x="294.75" y="35">end</text></g><path d="M317.5 31h10"></path><g>
+<path d="M327.5 31h0.0"></path><path d="M512.5 31h0.0"></path><path d="M327.5 31h20"></path><g class="terminal ">
+<path d="M347.5 31h49.75"></path><path d="M442.75 31h49.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="397.25" y="20"></rect><text x="420.0" y="35">SUM</text></g><path d="M492.5 31h20"></path><path d="M327.5 31a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M347.5 61h49.75"></path><path d="M442.75 61h49.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="397.25" y="50"></rect><text x="420.0" y="65">MIN</text></g><path d="M492.5 61a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M327.5 31a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M347.5 91h49.75"></path><path d="M442.75 91h49.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="397.25" y="80"></rect><text x="420.0" y="95">MAX</text></g><path d="M492.5 91a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M327.5 31a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M347.5 121h49.75"></path><path d="M442.75 121h49.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="397.25" y="110"></rect><text x="420.0" y="125">AND</text></g><path d="M492.5 121a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M327.5 31a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M347.5 151h54.0"></path><path d="M438.5 151h54.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="401.5" y="140"></rect><text x="420.0" y="155">OR</text></g><path d="M492.5 151a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M327.5 31a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M347.5 181h49.75"></path><path d="M442.75 181h49.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="397.25" y="170"></rect><text x="420.0" y="185">XOR</text></g><path d="M492.5 181a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path><path d="M327.5 31a10 10 0 0 1 10 10v160a10 10 0 0 0 10 10"></path><g>
+<path d="M347.5 211h0.0"></path><path d="M492.5 211h0.0"></path><g class="terminal ">
+<path d="M347.5 211h0.0"></path><path d="M410.0 211h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="347.5" y="200"></rect><text x="378.75" y="215">MATCH</text></g><path d="M410.0 211h10"></path><path d="M420.0 211h10"></path><g class="non-terminal ">
+<path d="M430.0 211h0.0"></path><path d="M492.5 211h0.0"></path><rect height="22" width="62.5" x="430.0" y="200"></rect><text x="461.25" y="215">value</text></g></g><path d="M492.5 211a10 10 0 0 0 10 -10v-160a10 10 0 0 1 10 -10"></path><path d="M327.5 31a10 10 0 0 1 10 10v190a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M347.5 241h45.5"></path><path d="M447.0 241h45.5"></path><rect height="22" rx="10" ry="10" width="54.0" x="393.0" y="230"></rect><text x="420.0" y="245">USED</text></g><path d="M492.5 241a10 10 0 0 0 10 -10v-190a10 10 0 0 1 10 -10"></path></g></g><path d="M512.5 31h10"></path><path d="M 522.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arring.svg
+++ b/static/images/railroad/arring.svg
@@ -1,0 +1,53 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 413.0 71" width="413.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M363.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M121.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="20"></rect><text x="85.5" y="35">ARRING</text></g><path d="M121.0 31h10"></path><path d="M131.0 31h10"></path><g class="non-terminal ">
+<path d="M141.0 31h0.0"></path><path d="M186.5 31h0.0"></path><rect height="22" width="45.5" x="141.0" y="20"></rect><text x="163.75" y="35">key</text></g><path d="M186.5 31h10"></path><path d="M196.5 31h10"></path><g class="non-terminal ">
+<path d="M206.5 31h0.0"></path><path d="M260.5 31h0.0"></path><rect height="22" width="54.0" x="206.5" y="20"></rect><text x="233.5" y="35">size</text></g><path d="M260.5 31h10"></path><path d="M270.5 31h10"></path><g>
+<path d="M280.5 31h0.0"></path><path d="M363.0 31h0.0"></path><path d="M280.5 31h10"></path><g class="non-terminal ">
+<path d="M290.5 31h0.0"></path><path d="M353.0 31h0.0"></path><rect height="22" width="62.5" x="290.5" y="20"></rect><text x="321.75" y="35">value</text></g><path d="M353.0 31h10"></path><path d="M290.5 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M290.5 51h62.5"></path></g><path d="M353.0 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M363.0 31h10"></path><path d="M 373.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arscan.svg
+++ b/static/images/railroad/arscan.svg
@@ -1,0 +1,56 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 579.5 71" width="579.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M529.5 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M121.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="29"></rect><text x="85.5" y="44">ARSCAN</text></g><path d="M121.0 40h10"></path><path d="M131.0 40h10"></path><g class="non-terminal ">
+<path d="M141.0 40h0.0"></path><path d="M186.5 40h0.0"></path><rect height="22" width="45.5" x="141.0" y="29"></rect><text x="163.75" y="44">key</text></g><path d="M186.5 40h10"></path><path d="M196.5 40h10"></path><g class="non-terminal ">
+<path d="M206.5 40h0.0"></path><path d="M269.0 40h0.0"></path><rect height="22" width="62.5" x="206.5" y="29"></rect><text x="237.75" y="44">start</text></g><path d="M269.0 40h10"></path><path d="M279.0 40h10"></path><g class="non-terminal ">
+<path d="M289.0 40h0.0"></path><path d="M334.5 40h0.0"></path><rect height="22" width="45.5" x="289.0" y="29"></rect><text x="311.75" y="44">end</text></g><path d="M334.5 40h10"></path><g>
+<path d="M344.5 40h0.0"></path><path d="M529.5 40h0.0"></path><path d="M344.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M364.5 20h145.0"></path></g><path d="M509.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M344.5 40h20"></path><g>
+<path d="M364.5 40h0.0"></path><path d="M509.5 40h0.0"></path><g class="terminal ">
+<path d="M364.5 40h0.0"></path><path d="M427.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="364.5" y="29"></rect><text x="395.75" y="44">LIMIT</text></g><path d="M427.0 40h10"></path><path d="M437.0 40h10"></path><g class="non-terminal ">
+<path d="M447.0 40h0.0"></path><path d="M509.5 40h0.0"></path><rect height="22" width="62.5" x="447.0" y="29"></rect><text x="478.25" y="44">limit</text></g></g><path d="M509.5 40h20"></path></g></g><path d="M529.5 40h10"></path><path d="M 539.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arseek.svg
+++ b/static/images/railroad/arseek.svg
@@ -1,0 +1,50 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 319.0 62" width="319.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M269.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M121.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="20"></rect><text x="85.5" y="35">ARSEEK</text></g><path d="M121.0 31h10"></path><path d="M131.0 31h10"></path><g class="non-terminal ">
+<path d="M141.0 31h0.0"></path><path d="M186.5 31h0.0"></path><rect height="22" width="45.5" x="141.0" y="20"></rect><text x="163.75" y="35">key</text></g><path d="M186.5 31h10"></path><path d="M196.5 31h10"></path><g class="non-terminal ">
+<path d="M206.5 31h0.0"></path><path d="M269.0 31h0.0"></path><rect height="22" width="62.5" x="206.5" y="20"></rect><text x="237.75" y="35">index</text></g></g><path d="M269.0 31h10"></path><path d="M 279.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/arset.svg
+++ b/static/images/railroad/arset.svg
@@ -1,0 +1,53 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 413.0 71" width="413.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M363.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M112.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="50.0" y="20"></rect><text x="81.25" y="35">ARSET</text></g><path d="M112.5 31h10"></path><path d="M122.5 31h10"></path><g class="non-terminal ">
+<path d="M132.5 31h0.0"></path><path d="M178.0 31h0.0"></path><rect height="22" width="45.5" x="132.5" y="20"></rect><text x="155.25" y="35">key</text></g><path d="M178.0 31h10"></path><path d="M188.0 31h10"></path><g class="non-terminal ">
+<path d="M198.0 31h0.0"></path><path d="M260.5 31h0.0"></path><rect height="22" width="62.5" x="198.0" y="20"></rect><text x="229.25" y="35">index</text></g><path d="M260.5 31h10"></path><path d="M270.5 31h10"></path><g>
+<path d="M280.5 31h0.0"></path><path d="M363.0 31h0.0"></path><path d="M280.5 31h10"></path><g class="non-terminal ">
+<path d="M290.5 31h0.0"></path><path d="M353.0 31h0.0"></path><rect height="22" width="62.5" x="290.5" y="20"></rect><text x="321.75" y="35">value</text></g><path d="M353.0 31h10"></path><path d="M290.5 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M290.5 51h62.5"></path></g><path d="M353.0 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M363.0 31h10"></path><path d="M 373.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
Redis 8.8 feature

This is the best I could do with what little information I had at my disposal (it wasn't much). I'm sure this will need more work before 8.8 GA.

Just docs team for reviews for now until I can identify another reviewer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and site metadata updates; the only functional impact is exposing a new `array` command group in the commands index/filter and adding command metadata that could affect docs generation.
> 
> **Overview**
> Adds full documentation for the new Redis **array** data structure, including a new `develop/data-types/arrays` overview and reference pages for array commands like `ARSET`, `ARGET`, `ARMSET`, `ARDEL`, `AROP`, and related cursor/range helpers.
> 
> Updates site navigation and command metadata to surface arrays: `data/commands_core.json` gains the array command specs, the commands list UI adds an `array` group filter option, and various data-type index pages are reorganized/retitled (including bitmaps/bitfields doc path updates). Railroad diagrams are added for the new array commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9df0455dcf018cea91a353f34e54158a2d8d5c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->