### PR TITLE
K8s: small fixes

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
@@ -22,7 +22,7 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 - **Services Rigger**: `redislabs/k8s-controller:7.22.0-17`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.0-17`
 
-### Openshift downloads
+### OpenShift downloads
 
 - **OLM operator bundle**: `v7.22.0-17.0`
 - **Call Home Client**: `redislabs/call-home-client:7.22.0-17`

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
@@ -22,7 +22,7 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 - **Services Rigger**: `redislabs/k8s-controller:7.22.2-39`
 - **Call Home Client**: `redislabs/re-call-home-client:7.22.2-39`
 
-### Openshift downloads
+### OpenShift downloads
 
 - **OLM operator bundle**: `v7.22.2-39.0`
 - **Call Home Client**: `redislabs/call-home-client:7.22.2-39`

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
@@ -20,9 +20,9 @@ This is a maintenance release to support Redis Enterprise Software version 8.0.1
 - **Redis Enterprise**: `redislabs/redis:8.0.10-81`
 - **Operator**: `redislabs/operator:8.0.10-23`
 - **Services Rigger**: `redislabs/k8s-controller:8.0.10-23`
-- **Callhome client**: `redislabs/re-call-home-client:8.0.10-23`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.10-23`
 
-### Openshift downloads
+### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.10-23.0`
 - **Call Home Client**: `redislabs/call-home-client:8.0.10-23`

--- a/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-25-march2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-25-march2026.md
@@ -21,9 +21,9 @@ For version changes, supported distributions, and known limitations, see the [re
 - **Redis Enterprise**: `redislabs/redis:8.0.16-33`
 - **Operator**: `redislabs/operator:8.0.16-25`
 - **Services Rigger**: `redislabs/k8s-controller:8.0.16-25`
-- **Callhome client**: `redislabs/re-call-home-client:8.0.16-25`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.16-25`
 
-### Openshift downloads
+### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.16-25.0`
 - **Call Home Client**: `redislabs/call-home-client:8.0.16-25`

--- a/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-6-december2025.md
+++ b/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-6-december2025.md
@@ -78,9 +78,9 @@ Any distribution not listed in the table is not supported for production workloa
 | Kubernetes version | **1.28** | **1.29** | **1.30** | **1.31** | **1.32** | **1.33** | **1.34** |
 | **Community K8s** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | **Amazon EKS** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| **Azure EKS** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| **Azure AKS** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | **Google GKE** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| **Rancher REK2** | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |
+| **Rancher RKE2** | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |  |
 | **VMware TKG 2.5** |  | <span title="X icon">&#x274c;</span> | <span title="X icon">&#x274c;</span> |  |  |  |  |
 | **VMware VKS** |  |  |  |  | <span title="Supported">&#x2705;</span> |  |  |
 |  |  |  |  |  |  |  |  |
@@ -98,11 +98,11 @@ Any distribution not listed in the table is not supported for production workloa
 - **Redis Enterprise**: `redislabs/redis:8.0.2-41`
 - **Operator**: `redislabs/operator:8.0.2-6`
 - **Services Rigger**: `redislabs/k8s-controller:8.0.2-6`
-- **Callhome client**: `redislabs/re-call-home-client:8.0.2-6`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.2-6`
 
-### Openshift downloads
+### OpenShift downloads
 
-- **OLM operator bundle** : `8.0.2-6.1`
+- **OLM operator bundle**: `8.0.2-6.1`
 - **Call Home Client**: `redislabs/call-home-client:8.0.2-6`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/8-0-6-releases/8-0-6-8-december2025.md
+++ b/content/operate/kubernetes/release-notes/8-0-6-releases/8-0-6-8-december2025.md
@@ -76,7 +76,7 @@ Any distribution not listed in the table is not supported for production workloa
 | **Amazon EKS** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | **Azure AKS** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | **Google GKE** |  |  | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| **Rancher REK2** | <span title="X icon">&#x274c;</span> | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| **Rancher RKE2** | <span title="X icon">&#x274c;</span> | <span title="X icon">&#x274c;</span> | <span title="Deprecation warning" class="font-serif">:warning:</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | **VMware TKG 2.5** |  |  |  |  |  |  |
 | **VMware VKS** |  |  |  | <span title="Supported">&#x2705;</span> |  |  |
 |  |  |  |  |  |  |  |
@@ -93,9 +93,9 @@ Any distribution not listed in the table is not supported for production workloa
 - **Redis Enterprise**: `redislabs/redis:8.0.6-54`
 - **Operator**: `redislabs/operator:8.0.6-8`
 - **Services Rigger**: `redislabs/k8s-controller:8.0.6-8`
-- **Callhome client**: `redislabs/re-call-home-client:8.0.6-8`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.6-8`
 
-### Openshift downloads
+### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.6-8.0`
 - **Call Home Client**: `redislabs/call-home-client:8.0.6-8`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only edits that correct headings and distribution names; no product behavior or configuration logic changes.
> 
> **Overview**
> Documentation cleanup across several Kubernetes release notes to standardize naming and correct typos.
> 
> This updates headings to `OpenShift downloads`, normalizes `Call Home Client`/OLM bundle label formatting, and fixes supported distribution table entries (e.g., `Azure AKS` and `Rancher RKE2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af73cedef32c50ff77f40a70bb9b6c0b78e6d107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->