### PR TITLE
Update workflow to handle images

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -196,6 +196,9 @@ jobs:
 
               # Replace .md links without paths (same directory)
               sed -E -i 's#\]\(([0-9]+_)?([^/)]+)\.md\)#]({{< relref "\2" >}})#g' "${markdown_page}"
+
+              # Fix image paths from _static/ to proper Hugo path
+              sed -E -i 's#!\[([^]]*)\]\(_static/([^)]+)\)#{{< image filename="/images/redisvl/\2" alt="\1" >}}#g' "${markdown_page}"
           done
 
           # Fix links in api pages
@@ -321,6 +324,12 @@ jobs:
             rm -rf content/develop/ai/redisvl/concepts/*
 
             cp -r redis_vl_hugo/* content/develop/ai/redisvl/
+
+            # Copy images referenced by the markdown from _static/ to static/images/redisvl/
+            mkdir -p static/images/redisvl/
+            if [ -d "./redis-vl-python/docs/_static" ]; then
+                rsync -a ./redis-vl-python/docs/_static/ ./static/images/redisvl/ --exclude='*.yaml' --exclude='css'
+            fi
           else
             mkdir -p content/develop/ai/redisvl/${version}/
             cp -r redis_vl_hugo/* content/develop/ai/redisvl/${version}/
@@ -358,13 +367,14 @@ jobs:
           fi
 
           set +e
-          latest_redisvl_release_is_different=$(git diff content/develop/ai/redisvl/)
-          new_release=$(git ls-files --others --directory | grep content/develop/ai/redisvl/${release})
+          latest_redisvl_release_is_different=$(git diff content/develop/ai/redisvl/ static/images/redisvl/)
+          new_release=$(git ls-files --others --directory | grep -E 'content/develop/ai/redisvl/'${release}'|static/images/redisvl/')
 
           if [[ -n "$latest_redisvl_release_is_different" || -n "$new_release" ]]; then
             redisvl_change=true
 
             git add "content/develop/ai/redisvl/"
+            git add "static/images/redisvl/"
             git config user.email "177626021+redisdocsapp[bot]@users.noreply.github.com"
             git config user.name "redisdocsapp[bot]"
             git commit -m "Update for redisvl ${release}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the automated docs-sync workflow to rewrite image markup and commit new static assets, which could break documentation rendering or create unexpected diffs if the path/shortcode assumptions are wrong.
> 
> **Overview**
> Updates the RedisVL docs sync workflow to **properly handle images** produced by Sphinx.
> 
> Markdown processing now rewrites `![](_static/...)` references into the Hugo `{{< image >}}` shortcode pointing at `/images/redisvl/...`, and the sync job copies `redis-vl-python/docs/_static/` into `static/images/redisvl/` (excluding some non-image assets).
> 
> The PR detection/commit step is expanded to include `static/images/redisvl/` so image changes are pushed and included in the generated update PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1561142382f3054ed142f2e198ac722167227df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->