### PR TITLE
Update nav and footer links to match redis.io

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -77,8 +77,7 @@
           <a class="hover:text-white" href="https://redis.io/compare/elasticache/">Redis vs Elasticache</a>
           <a class="hover:text-white" href="https://redis.io/compare/memcached/">Redis vs Memcached</a>
           <a class="hover:text-white" href="https://redis.io/compare/memorystore/">Redis vs Memory Store</a>
-          <a class="hover:text-white" href="https://redis.io/compare/community-edition/">Redis vs Source
-            Available</a>
+          <a class="hover:text-white" href="https://redis.io/compare/open-source">Redis vs. Open Source</a>
         </div>
       </div>
       <div>

--- a/layouts/partials/header/resources-dropdown.html
+++ b/layouts/partials/header/resources-dropdown.html
@@ -24,21 +24,25 @@
         class="mb-6 mt-12 border-b border-white border-opacity-30 pb-2 text-xs font-medium uppercase tracking-[2px] text-gray-300">
         Learn</h2>
       <ul class="grid grid-cols-3 gap-x-7 gap-y-3.5">
-        <li><a class="font-medium text-white hover:text-redis-red-500" href="https://redis.io/docs/">Docs</a>
-        </li>
         <li><a class="font-medium text-white hover:text-redis-red-500"
-            href="https://redis.io/commands/">Commands</a></li>
-        <li><a class="font-medium text-white hover:text-redis-red-500" href="https://redis.io/docs/latest/get-started/">Quick
-            starts</a></li>
+            href="https://redis.io/tutorials/">Tutorials</a></li>
         <li><a class="font-medium text-white hover:text-redis-red-500"
-            href="https://redis.io/learn/">Tutorials</a></li>
+            href="https://redis.io/docs/get-started/">Quick starts</a></li>
         <li><a class="font-medium text-white hover:text-redis-red-500"
-            href="https://university.redis.io/">University</a></li>
-        <li><a class="font-medium text-white hover:text-redis-red-500" href="https://redis.io/kb/">FAQs</a></li>
+            href="https://redis.io/docs/latest/commands/">Commands</a></li>
         <li><a class="font-medium text-white hover:text-redis-red-500"
-            href="https://redis.io/resources/">Resources</a></li>
-        <li><a class="font-medium text-white hover:text-redis-red-500" href="https://redis.io/blog/">Blog</a>
-        </li>
+            href="https://university.redis.io/academy">University</a></li>
+        <li><a class="font-medium text-white hover:text-redis-red-500"
+            href="https://support.redislabs.com">Knowledge Base</a></li>
+        <li><a class="font-medium text-white hover:text-redis-red-500"
+            href="https://redis.io/resources/">Resource Center</a></li>
+        <li><a class="font-medium text-white hover:text-redis-red-500" href="https://redis.io/blog/">Blog</a></li>
+        <li><a class="font-medium text-white hover:text-redis-red-500"
+            href="https://redis.io/demo-center/">Demo Center</a></li>
+        <li><a class="font-medium text-white hover:text-redis-red-500"
+            href="https://redis.io/dev/">Developer Hub</a></li>
+        <li><a class="font-medium text-white hover:text-redis-red-500"
+            href="https://redis.io/kb/">FAQs</a></li>
       </ul>
     </div>
   </div>
@@ -48,7 +52,7 @@
         Latest</h2>
       <ul class="space-y-4">
         <li><a class="font-medium text-white hover:text-redis-red-500"
-            href="https://redis.io/release/">Releases</a></li>
+            href="https://redis.io/new/">Releases</a></li>
         <li><a class="font-medium text-white hover:text-redis-red-500" href="https://redis.io/company/news/">News
             &amp; Updates</a></li>
       </ul>
@@ -56,7 +60,7 @@
     <div class="mt-auto">
       <h2 class="mb-6 pb-2 text-xs font-medium uppercase tracking-[2px] text-gray-300">See how it works</h2><a
         class="w-9/12 rounded border-redis-pen-600 bg-redis-red-700 px-6 py-4 text-redis-white-200 font-sans font-bold text-[16px] weight-[400] hover:bg-redis-pen-900"
-        href="https://redis.io/demo-center/"><span>Visit Demo Center</span></a>
+        href="https://redis.io/dev/"><span>Visit our Developer Hub</span></a>
     </div>
   </div>
 </div>

--- a/layouts/partials/header/resources-mobile.html
+++ b/layouts/partials/header/resources-mobile.html
@@ -18,20 +18,25 @@
             <h2 class="pb-2 text-xs uppercase tracking-[2px] text-gray-300">Learn</h2>
             <ul>
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
-                        href="https://redis.io/docs/">Docs</a></li>
+                        href="https://redis.io/tutorials/">Tutorials</a></li>
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
-                        href="https://redis.io/commands/">Commands</a></li>
-                <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white" href="https://redis.io/docs/latest/get-started/">Quick
-                        starts</a></li>
+                        href="https://redis.io/docs/get-started/">Quick starts</a></li>
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
-                        href="https://redis.io/learn/">Tutorials</a></li>
+                        href="https://redis.io/docs/latest/commands/">Commands</a></li>
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
-                        href="https://university.redis.io/">University</a></li>
-                <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white" href="https://redis.io/kb/">FAQs</a></li>
+                        href="https://university.redis.io/academy">University</a></li>
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
-                        href="https://redis.io/resources/">Resources</a></li>
+                        href="https://support.redislabs.com">Knowledge Base</a></li>
+                <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
+                        href="https://redis.io/resources/">Resource Center</a></li>
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
                         href="https://redis.io/blog/">Blog</a></li>
+                <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
+                        href="https://redis.io/demo-center/">Demo Center</a></li>
+                <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
+                        href="https://redis.io/dev/">Developer Hub</a></li>
+                <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
+                        href="https://redis.io/kb/">FAQs</a></li>
             </ul>
         </div>
     </div>
@@ -40,7 +45,7 @@
             <h2 class="pb-2 text-xs uppercase tracking-[2px] text-gray-300">Latest</h2>
             <ul class="space-y-4">
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
-                        href="https://redis.io/release/">Releases</a></li>
+                        href="https://redis.io/new/">Releases</a></li>
                 <li class="active:text-redis-red-500"><a class="block w-full py-4 text-white"
                         href="https://redis.io/company/news/">News &amp; Updates</a></li>
             </ul>
@@ -51,7 +56,7 @@
             <h2 class="mb-6 pb-2 text-xs uppercase tracking-[2px] text-gray-300">See how it works</h2>
             <div class="flex text-center"><a
                     class="w-full rounded border border-redis-pen-600 bg-redis-red-700 py-4 text-redis-white-200 font-sans font-bold active:bg-redis-pen-900 active:text-white"
-                    href="https://redis.io/demo-center/">Visit Demo Center</a></div>
+                    href="https://redis.io/dev/">Visit our Developer Hub</a></div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- Footer: update community edition compare link to /compare/open-source with new title
- Resources menu: sync Learn section links/labels with redis.io nav (Tutorials, Commands, University, Knowledge Base, Resource Center, Demo Center, Developer Hub, FAQs)
- Resources menu: update Releases link from /release/ to /new/
- Resources menu: update CTA button from "Visit Demo Center" to "Visit our Developer Hub"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: template-only updates to link URLs/labels; primary risk is broken or incorrect external navigation targets.
> 
> **Overview**
> Updates site navigation links to match redis.io.
> 
> In the footer, replaces the "Redis vs Source Available" compare link with `Redis vs. Open Source` pointing to `/compare/open-source`. In the Resources menus (desktop + mobile), refreshes the Learn section link set/order (e.g., `Tutorials`, `Quick starts`, `Commands`, `University`, `Knowledge Base`, `Resource Center`, `Demo Center`, `Developer Hub`, `FAQs`), updates Releases to `/new/`, and changes the CTA to point to the Developer Hub.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca26678fc5990f7b2eb952e891dafd651d094c19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->