### PR TITLE
[RDI] Add RDI 1.18.0 release notes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,7 +56,7 @@ rdi_redis_gears_version = "1.2.6"
 rdi_debezium_server_version = "2.3.0.Final"
 rdi_db_types = "cassandra|mysql|oracle|postgresql|sqlserver"
 rdi_cli_latest = "latest"
-rdi_current_version = "1.16.2"
+rdi_current_version = "1.18.0"
 
 
 [params.clientsConfig]

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -83,21 +83,25 @@ the structure of the JSON data is invalid or if there is a fatal bug in the tran
 job then RDI can't transform the data. When this happens, RDI will store the original data
 in a "dead letter queue" along with a message to say why it was rejected. The dead letter
 queue is stored as a capped stream in the RDI staging database. You can see its contents
-with Redis Insight or with the 
+with Redis Insight or with the
 [`redis-di get-rejected`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-get-rejected" >}})
 command from the CLI.
-
 
 ## Can I use RDI without persistence enabled?
 
 By default, RDI requires persistence to be enabled on the RDI database. This ensures that RDI can recover both its configuration and the last known state if the cluster crashes.
 
 If you don't have permissions to use persistence due to compliance or other reasons, you can disable
-the persistence check on the RDI database (Helm installation only). If you do this, RDI will not be 
+the persistence check on the RDI database (Helm installation only). If you do this, RDI will not be
 able to recover from a crash, and you will have to perform a new deploy to reinitialize the pipeline.
 
-To disable the persistence check, set the `aofRequired` value to `false` in the `operator->prerequisiteChecks`
+To disable the persistence check, set the `aofRequired` value to `false` in the `operator.prerequisiteChecks`
 section of the `values.yaml` file.
 
-This option is available in RDI 1.16.2 and later.
+```yaml
+operator:
+  prerequisiteChecks:
+    aofRequired: false
+```
 
+This option is available in RDI 1.16.2 and later.

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -25,7 +25,9 @@ It also lets you _transform_ the data from relational tables into convenient and
 
 ## What's New in 1.18.0
 
-No breaking changes are called out in this release.
+### Breaking Changes
+
+- **`rdi-metrics-exporter` moved to the data plane**: The `rdi-metrics-exporter` is now deployed by the pipeline Helm chart (managed by the operator) instead of the main RDI Helm chart, and is only rendered when `processors.type` is `classic`. Helm values previously under the top-level `rdiMetricsExporter:` block must be moved under `operator.dataPlane.metricsExporter:` in your custom values file. During the upgrade, Helm deletes the control-plane copy of the exporter resources before the operator recreates them under the pipeline release, resulting in a brief (seconds) gap in Prometheus scraping that does not affect the data path. ([RDSC-5004](https://redislabs.atlassian.net/browse/RDSC-5004))
 
 ### Snowflake and Source Integration
 

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -6,32 +6,23 @@ categories:
 - operate
 - rs
 description: |
-  Snowflake source support for Helm installations, including multi-schema capture and system truststore support.
-  New API v2 DLQ inspection, flush-target, and CDC-readiness validation endpoints.
+  Preview for Snowflake source support for Helm installations, including multi-schema capture and system truststore support.
+  New API v2 endpoints for DLQ inspection, flushing the target database, and CDC-readiness validation.
   Better deployment reliability, new validation and resource controls, and security refreshes across core images.
 linkTitle: 1.18.0 (April 2026)
 toc: 'true'
 weight: 971
 ---
 
-RDI's mission is to help Redis customers sync Redis Enterprise with live data from their slow disk-based databases to:
-
-- Meet the required speed and scale of read queries and provide an excellent and predictable user experience.
-- Save resources and time when building pipelines and coding data transformations.
-- Reduce the total cost of ownership by saving money on expensive database read replicas.
-
-RDI keeps the Redis cache up to date with changes in the primary database, using a [_Change Data Capture (CDC)_](https://en.wikipedia.org/wiki/Change_data_capture) mechanism.
-It also lets you _transform_ the data from relational tables into convenient and fast data structures that match your app's requirements. You specify the transformations using a configuration system, so no coding is required.
-
 ## What's New in 1.18.0
 
-### Breaking Changes
+### Compatibility Notes
 
 - **`rdi-metrics-exporter` moved to the data plane**: The `rdi-metrics-exporter` is now deployed by the pipeline Helm chart (managed by the operator) instead of the main RDI Helm chart. Helm values previously under the top-level `rdiMetricsExporter:` block must be moved under `operator.dataPlane.metricsExporter:` in your custom values file. During the upgrade, there will be a brief (seconds) gap in Prometheus scraping that does not affect the data path. The exporter is not deployed for Flink-based pipelines.
 
 ### Snowflake and Source Integration
 
-- **Snowflake source support for Helm installations**: RDI now supports Snowflake as a source in Helm-based installations, including capture from multiple schemas in a single pipeline. Snowflake sources are not yet supported for VM installations. RDI can also use well-known root CA certificates from the system truststore, reducing the need for manual certificate configuration for cloud-hosted source databases.
+- **Snowflake source support for Helm installations (Preview)**: RDI now supports Snowflake as a source in Helm-based installations, including capture from multiple schemas in a single pipeline. Regular preview terms apply. Snowflake sources are not yet supported for VM installations. RDI can also use well-known root CA certificates from the system truststore, reducing the need for manual certificate configuration for cloud-hosted source databases.
 - **Collector resource reservation controls**: A new `sources.advanced.resources` section lets you control memory and CPU reservation for the collector.
 - **CDC-readiness validation in API v2**: RDI API v2 can optionally validate whether MariaDB, MySQL, PostgreSQL, SQL Server, Oracle, and MongoDB sources are ready for CDC as part of pipeline validation. This is available on pipeline create, update, and patch requests by using the `validate_cdc` query parameter, including dry-run requests. Spanner and Snowflake sources are not supported for this validation. The validation is available through API v2 only; the CLI and Redis Insight do not expose it yet.
 

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -1,0 +1,72 @@
+---
+Title: Redis Data Integration release notes 1.18.0 (April 2026)
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: |
+  Snowflake source support for Helm installations, including multi-schema capture and improved health reporting.
+  New API v2 DLQ inspection and flush-target endpoints, plus automated TypeScript SDK generation.
+  Better deployment reliability, new validation and resource controls, and security refreshes across core images.
+linkTitle: 1.18.0 (April 2026)
+toc: 'true'
+weight: 971
+---
+
+RDI's mission is to help Redis customers sync Redis Enterprise with live data from their slow disk-based databases to:
+
+- Meet the required speed and scale of read queries and provide an excellent and predictable user experience.
+- Save resources and time when building pipelines and coding data transformations.
+- Reduce the total cost of ownership by saving money on expensive database read replicas.
+
+RDI keeps the Redis cache up to date with changes in the primary database, using a [_Change Data Capture (CDC)_](https://en.wikipedia.org/wiki/Change_data_capture) mechanism.
+It also lets you _transform_ the data from relational tables into convenient and fast data structures that match your app's requirements. You specify the transformations using a configuration system, so no coding is required.
+
+## What's New in 1.18.0
+
+No breaking changes are called out in this release.
+
+### Snowflake and Source Integration
+
+- **Snowflake source support for Helm installations**: RDI now supports Snowflake as a source in Helm-based installations. Status, state, and component health are now reported correctly for Snowflake sources. Snowflake sources are not yet supported for VM installations.
+- **Snowflake multi-schema capture**: In Helm-based installations, Snowflake sources can now capture from multiple schemas in a single pipeline.
+- **System truststore support**: RDI can optionally use well-known root CA certificates from the system truststore, reducing the need for manual certificate configuration for cloud-hosted source databases.
+- **Collector resource reservation controls**: A new `sources.advanced.resources` section lets you control memory and CPU reservation for the collector.
+- **CDC-readiness validation in API v2**: RDI API v2 can optionally validate whether a source database is ready for CDC as part of pipeline validation. This is available on pipeline create, update, and patch requests by using the `validate_cdc` query parameter, including dry-run requests. If validation fails, the API returns validation errors instead of applying the change. Coverage is still limited in this release and will expand over time.
+
+### RDI API and SDK
+
+- **DLQ inspection endpoints in API v2**: RDI API v2 now exposes endpoints to inspect Dead Letter Queue (DLQ) data programmatically:
+  - `GET /api/v2/pipelines/{name}/dlqs` lists tables that currently have DLQ records with their counts.
+  - `GET /api/v2/pipelines/{name}/dlqs/{full_table_name}` returns the DLQ count for a specific table.
+  - `GET /api/v2/pipelines/{name}/dlqs/{full_table_name}/records` returns DLQ records for a specific table with pagination, sort order control, and optional field projection.
+- **Flush target endpoint in API v2**: Added `POST /api/v2/pipelines/{name}/flush-target/{target_name}` so you can flush a target Redis database through the API.
+- **Automated TypeScript SDK generation**: RDI now supports automated generation of the TypeScript SDK from the latest OpenAPI definition, helping keep the SDK aligned with the API.
+
+### Operations and Reliability
+
+- **Optional AOF prerequisite check disablement**: A new `operator.prerequisiteChecks` section in the Helm values file lets you disable the AOF prerequisite check when the RDI database does not have AOF enabled. Use this carefully, because disabling the check can lead to data loss in some failure scenarios. For example:
+
+  ```yaml
+  # prerequisiteChecks:
+    # Set to `false` to allow RDI deployment without AOF persistence on the RDI Redis database.
+    # Note: Disabling AOF persistence means data durability is not ensured across full cluster outages.
+    # This may affect streamed data, deployed configurations, and offsets.
+    # This option should only be used in environments where disk persistence cannot be enabled due to policy constraints.
+    # Defaults to `true` for backward compatibility and data durability.
+    # aofRequired: true
+  ```
+
+- **More reliable deploy task completion**: Fixed an issue where the operator could mark a deploy task as completed before the new pipeline was fully deployed, which could lead to incorrect pipeline status reporting.
+- **Safer collector property handling**: Fixed a `NullPointerException` in the collector API when intercepted connection property maps contained null values or resolved to null. Null maps are now rejected earlier with a clear error instead of failing later in the pipeline.
+- **Reloader image configuration for Helm installations**: The Helm chart's bundled Reloader controller, which watches ConfigMaps and Secrets and triggers rolling upgrades when they change, now defaults to `docker.io/redis/reloader` and can be configured explicitly with `reloader.reloader.deployment.image.name`. This fixes a gap where the Reloader image could still default to `ghcr.io/stakater/reloader` instead of following the Redis-hosted image convention used elsewhere in the chart. This is especially useful for private-registry and mirrored-image deployments, where users previously had to edit the `rdi-reloader` Deployment manually after installation.
+
+### Security Updates
+
+- **Security refresh across operator, collector API, and Fluentd images**: Refreshed dependencies and base packages to reduce Critical and High findings in the operator, collector API, and Fluentd images.
+- **Dependency upgrades for CVE remediation**: Updated key dependencies including Spring Boot, Spring Framework, Spring Security, Netty, Kafka clients, MySQL Connector/J, containerd, `golang.org/x/crypto`, and Stakater Reloader.
+
+## Limitations
+
+RDI can write data to a Redis Active-Active database. However, it doesn't support writing data to two or more Active-Active replicas. Writing data from RDI to several Active-Active replicas could easily harm data integrity as RDI is not synchronous with the source database commits.

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -6,8 +6,8 @@ categories:
 - operate
 - rs
 description: |
-  Snowflake source support for Helm installations, including multi-schema capture and improved health reporting.
-  New API v2 DLQ inspection and flush-target endpoints, plus automated TypeScript SDK generation.
+  Snowflake source support for Helm installations, including multi-schema capture and system truststore support.
+  New API v2 DLQ inspection, flush-target, and CDC-readiness validation endpoints.
   Better deployment reliability, new validation and resource controls, and security refreshes across core images.
 linkTitle: 1.18.0 (April 2026)
 toc: 'true'
@@ -27,48 +27,30 @@ It also lets you _transform_ the data from relational tables into convenient and
 
 ### Breaking Changes
 
-- **`rdi-metrics-exporter` moved to the data plane**: The `rdi-metrics-exporter` is now deployed by the pipeline Helm chart (managed by the operator) instead of the main RDI Helm chart, and is only rendered when `processors.type` is `classic`. Helm values previously under the top-level `rdiMetricsExporter:` block must be moved under `operator.dataPlane.metricsExporter:` in your custom values file. During the upgrade, Helm deletes the control-plane copy of the exporter resources before the operator recreates them under the pipeline release, resulting in a brief (seconds) gap in Prometheus scraping that does not affect the data path. ([RDSC-5004](https://redislabs.atlassian.net/browse/RDSC-5004))
+- **`rdi-metrics-exporter` moved to the data plane**: The `rdi-metrics-exporter` is now deployed by the pipeline Helm chart (managed by the operator) instead of the main RDI Helm chart. Helm values previously under the top-level `rdiMetricsExporter:` block must be moved under `operator.dataPlane.metricsExporter:` in your custom values file. During the upgrade, there will be a brief (seconds) gap in Prometheus scraping that does not affect the data path. The exporter is not deployed for Flink-based pipelines.
 
 ### Snowflake and Source Integration
 
-- **Snowflake source support for Helm installations**: RDI now supports Snowflake as a source in Helm-based installations. Status, state, and component health are now reported correctly for Snowflake sources. Snowflake sources are not yet supported for VM installations.
-- **Snowflake multi-schema capture**: In Helm-based installations, Snowflake sources can now capture from multiple schemas in a single pipeline.
-- **System truststore support**: RDI can optionally use well-known root CA certificates from the system truststore, reducing the need for manual certificate configuration for cloud-hosted source databases.
+- **Snowflake source support for Helm installations**: RDI now supports Snowflake as a source in Helm-based installations, including capture from multiple schemas in a single pipeline. Snowflake sources are not yet supported for VM installations. RDI can also use well-known root CA certificates from the system truststore, reducing the need for manual certificate configuration for cloud-hosted source databases.
 - **Collector resource reservation controls**: A new `sources.advanced.resources` section lets you control memory and CPU reservation for the collector.
-- **CDC-readiness validation in API v2**: RDI API v2 can optionally validate whether a source database is ready for CDC as part of pipeline validation. This is available on pipeline create, update, and patch requests by using the `validate_cdc` query parameter, including dry-run requests. If validation fails, the API returns validation errors instead of applying the change. Coverage is still limited in this release and will expand over time.
+- **CDC-readiness validation in API v2**: RDI API v2 can optionally validate whether MariaDB, MySQL, PostgreSQL, SQL Server, Oracle, and MongoDB sources are ready for CDC as part of pipeline validation. This is available on pipeline create, update, and patch requests by using the `validate_cdc` query parameter, including dry-run requests. Spanner and Snowflake sources are not supported for this validation. The validation is available through API v2 only; the CLI and Redis Insight do not expose it yet.
 
-### RDI API and SDK
+### RDI API
 
 - **DLQ inspection endpoints in API v2**: RDI API v2 now exposes endpoints to inspect Dead Letter Queue (DLQ) data programmatically:
   - `GET /api/v2/pipelines/{name}/dlqs` lists tables that currently have DLQ records with their counts.
   - `GET /api/v2/pipelines/{name}/dlqs/{full_table_name}` returns the DLQ count for a specific table.
   - `GET /api/v2/pipelines/{name}/dlqs/{full_table_name}/records` returns DLQ records for a specific table with pagination, sort order control, and optional field projection.
 - **Flush target endpoint in API v2**: Added `POST /api/v2/pipelines/{name}/flush-target/{target_name}` so you can flush a target Redis database through the API.
-- **Automated TypeScript SDK generation**: RDI now supports automated generation of the TypeScript SDK from the latest OpenAPI definition, helping keep the SDK aligned with the API.
 
 ### Operations and Reliability
 
-- **Optional AOF prerequisite check disablement**: A new `operator.prerequisiteChecks` section in the Helm values file lets you disable the AOF prerequisite check when the RDI database does not have AOF enabled. Use this carefully, because disabling the check can lead to data loss in some failure scenarios. For example:
-
-  ```yaml
-  # prerequisiteChecks:
-    # Set to `false` to allow RDI deployment without AOF persistence on the RDI Redis database.
-    # Note: Disabling AOF persistence means data durability is not ensured across full cluster outages.
-    # This may affect streamed data, deployed configurations, and offsets.
-    # This option should only be used in environments where disk persistence cannot be enabled due to policy constraints.
-    # Defaults to `true` for backward compatibility and data durability.
-    # aofRequired: true
-  ```
-
+- **Optional AOF prerequisite check disablement**: For Helm installations, the `operator.prerequisiteChecks` section in the Helm values file lets you disable the AOF prerequisite check when the RDI database does not have AOF enabled. AOF should only be disabled after careful consideration, because disabling the check can lead to data loss in some failure scenarios. See [Can I use RDI without persistence enabled?]({{< relref "/integrate/redis-data-integration/faq#can-i-use-rdi-without-persistence-enabled" >}}).
 - **More reliable deploy task completion**: Fixed an issue where the operator could mark a deploy task as completed before the new pipeline was fully deployed, which could lead to incorrect pipeline status reporting.
-- **Safer collector property handling**: Fixed a `NullPointerException` in the collector API when intercepted connection property maps contained null values or resolved to null. Null maps are now rejected earlier with a clear error instead of failing later in the pipeline.
-- **Reloader image configuration for Helm installations**: The Helm chart's bundled Reloader controller, which watches ConfigMaps and Secrets and triggers rolling upgrades when they change, now defaults to `docker.io/redis/reloader` and can be configured explicitly with `reloader.reloader.deployment.image.name`. This fixes a gap where the Reloader image could still default to `ghcr.io/stakater/reloader` instead of following the Redis-hosted image convention used elsewhere in the chart. This is especially useful for private-registry and mirrored-image deployments, where users previously had to edit the `rdi-reloader` Deployment manually after installation.
+- **Fewer pipeline component restarts**: Fixed an issue where deploying a changed pipeline configuration would cause pipeline components that were not affected by the change to be restarted as well.
+- **Safer collector API property handling**: Fixed an issue in the collector API when connection property maps contained null values or resolved to null. Such cases are now rejected with a clear error.
+- **Reloader image configuration for Helm installations**: The Helm chart's bundled Reloader controller, which watches ConfigMaps and Secrets and triggers rolling upgrades when they change, now defaults to `docker.io/redis/reloader` and can be configured explicitly with `reloader.reloader.deployment.image.name`. This is especially useful for private-registry and mirrored-image deployments.
 
 ### Security Updates
 
-- **Security refresh across operator, collector API, and Fluentd images**: Refreshed dependencies and base packages to reduce Critical and High findings in the operator, collector API, and Fluentd images.
-- **Dependency upgrades for CVE remediation**: Updated key dependencies including Spring Boot, Spring Framework, Spring Security, Netty, Kafka clients, MySQL Connector/J, containerd, `golang.org/x/crypto`, and Stakater Reloader.
-
-## Limitations
-
-RDI can write data to a Redis Active-Active database. However, it doesn't support writing data to two or more Active-Active replicas. Writing data from RDI to several Active-Active replicas could easily harm data integrity as RDI is not synchronous with the source database commits.
+- **Security updates across RDI images**: Updated third-party images, dependencies, and base packages to remove Critical and High CVEs in RDI images, including the operator, collector API, Fluentd, and Reloader images.


### PR DESCRIPTION
## What changed

Adds the RDI 1.18.0 release-notes page under `content/integrate/redis-data-integration/release-notes/`.

The page covers:

- Snowflake source support for Helm installations, including multi-schema capture
- API v2 additions for CDC-readiness validation, DLQ inspection, and flush-target
- operational updates such as the optional AOF prerequisite-check disablement and reloader image configuration
- security refreshes across operator, collector API, and Fluentd images

## Why this changed

The docs repo was missing the 1.18.0 RDI release-notes entry. The source changelog also needed product-facing wording and a few scope clarifications, including:

- Snowflake support applies to Helm installations, not VM installs
- CDC-readiness validation is exposed through API v2
- the DLQ section should call out the actual API endpoints
- the reloader note should explain the Helm/private-registry impact

## User impact

Users will see the 1.18.0 release notes in the RDI release-notes index with clearer guidance on feature scope, API surface, and operational caveats.

## Root cause

The release-notes page had not yet been added to the docs repo for this version.

## Validation

- Reviewed the new Markdown page in place
- Ran `git diff --cached --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes (new release notes and small FAQ/config updates) with no impact on runtime code paths.
> 
> **Overview**
> Updates the docs site RDI version marker from `1.16.2` to `1.18.0` in `config.toml`.
> 
> Adds a new `rdi-1-18-0` release-notes page documenting 1.18.0 changes (Snowflake source preview for Helm, API v2 additions for DLQ/flush-target/CDC validation, reliability and Helm config updates, and security refreshes), and tweaks the FAQ to clarify the Helm `operator.prerequisiteChecks.aofRequired` setting with a concrete YAML example and minor formatting fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40b18faa8da1431600715f1394d25f8a0c0d0e69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->