### PR TITLE
Add redis-rb integration tile to /integrate page

### DIFF
--- a/content/integrate/redis-rb/_index.md
+++ b/content/integrate/redis-rb/_index.md
@@ -1,0 +1,36 @@
+---
+LinkTitle: redis-rb
+Title: Ruby client for Redis
+categories:
+- docs
+- integrate
+- oss
+- rs
+- rc
+description: Learn how to build with Redis and Ruby
+group: library
+stack: true
+summary: redis-rb is a Ruby client library for Redis.
+title: redis-rb
+type: integration
+weight: 6
+---
+
+Connect your Ruby application to a Redis database using the redis-rb client library.
+
+## Overview
+
+redis-rb is the recommended Ruby client for Redis, providing a simple and intuitive interface for interacting with Redis from Ruby applications. It supports all Redis commands and features, including connection pooling, pipelining, and Pub/Sub.
+
+## Key Features
+
+- **Full Redis Support**: Complete coverage of Redis commands and data types
+- **Connection Pooling**: Efficient connection management for concurrent applications
+- **Pipelining**: Batch commands for improved performance
+- **Pub/Sub**: Real-time messaging with Redis publish/subscribe
+- **Sentinel Support**: High availability with Redis Sentinel integration
+- **Redis Cluster**: Built-in support for Redis Cluster deployments
+
+## Getting Started
+
+Refer to the complete [Ruby guide]({{< relref "/develop/clients/ruby" >}}) to install, connect, and use redis-rb with detailed examples.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new integration tile/page; no code or runtime behavior is affected.
> 
> **Overview**
> Adds a new `content/integrate/redis-rb/_index.md` integration page for the `redis-rb` Ruby client, including front matter metadata (categories, grouping, weight) and a short overview/features section that links to the existing Ruby client guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb9e9725e1b4f03d372453ae520eaf2e6156d8e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->