### PR TITLE
Only copy redisvl architecture diagram

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -325,10 +325,10 @@ jobs:
 
             cp -r redis_vl_hugo/* content/develop/ai/redisvl/
 
-            # Copy images referenced by the markdown from _static/ to static/images/redisvl/
-            mkdir -p static/images/redisvl/
-            if [ -d "./redis-vl-python/docs/_static" ]; then
-                rsync -a ./redis-vl-python/docs/_static/ ./static/images/redisvl/ --exclude='*.yaml' --exclude='css'
+            # Copy the architecture diagram referenced by the markdown to static/images/redisvl/
+            if [ -f "./redis-vl-python/docs/_static/redisvl-architecture.svg" ]; then
+                mkdir -p static/images/redisvl/
+                cp ./redis-vl-python/docs/_static/redisvl-architecture.svg ./static/images/redisvl/redisvl-architecture.svg
             fi
           else
             mkdir -p content/develop/ai/redisvl/${version}/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only changes which static assets are copied during the docs sync workflow, potentially affecting documentation images but not runtime code.
> 
> **Overview**
> The `redisvl_docs_sync` GitHub Action now copies only `redisvl-architecture.svg` from `redis-vl-python/docs/_static` into `static/images/redisvl/` when syncing the *latest* RedisVL docs.
> 
> This replaces the previous behavior that `rsync`’d the entire `_static` directory, reducing the chance of publishing unrelated or stale static assets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec9e56a2201038a7bd9b8b0ffb881813b624bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->