### PR TITLE
DOC-6508 JSON page and examples for Rust

### DIFF
--- a/content/develop/clients/rust/json.md
+++ b/content/develop/clients/rust/json.md
@@ -1,0 +1,117 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Learn how to store, read, and update JSON documents with redis-rs.
+linkTitle: JSON documents
+title: Work with JSON documents
+scope: example
+relatedPages:
+- /develop/data-types/json
+- /develop/data-types/json/path
+topics:
+- JSON
+- Rust
+weight: 30
+---
+
+This example shows how to work with a
+[JSON]({{< relref "/develop/data-types/json" >}})
+document from Rust using [`redis-rs`]({{< relref "/develop/clients/rust" >}}).
+It uses one `bike:1` document to demonstrate a simple workflow:
+create the document, read nested fields, update part of the document,
+and append data to an array.
+
+Unlike some of the other client examples in this section, this page focuses on
+Redis JSON commands directly rather than on Redis Search.
+
+## Install
+
+Add `serde_json` and enable the `json` feature for `redis`.
+If you want to use the async API, also enable a runtime integration such as `tokio-comp`.
+
+```toml
+[dependencies]
+serde_json = "1"
+
+# Sync API
+redis = { version = "1.0.4", features = ["json"] }
+
+# Async API with Tokio
+tokio = { version = "1", features = ["full"] }
+redis = { version = "1.0.4", features = ["json", "tokio-comp"] }
+```
+
+## Import the required crates
+
+The example uses `serde_json::json!()` to build the document and the
+`JsonCommands` or `JsonAsyncCommands` trait to access Redis JSON commands.
+
+{{< clients-example set="rust_home_json" step="import" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Import the Redis JSON traits and serde_json helpers needed to work with JSON documents in Rust" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Create some JSON data
+
+Create a sample document representing a bike listing.
+The nested `specs` and `inventory` objects and the `colors` array let you see how
+JSON paths work with more realistic data than a flat object.
+
+{{< clients-example set="rust_home_json" step="create_data" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Define a nested JSON document with objects and arrays using serde_json::json!" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Connect to Redis
+
+Connect to your Redis server in the usual way.
+See [Connect to the server]({{< relref "/develop/clients/rust" >}})
+for more connection options.
+
+{{< clients-example set="rust_home_json" step="connect" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Create a Redis client and open a sync or async connection from Rust" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Store and retrieve the document
+
+Use [`JSON.SET`]({{< relref "/commands/json.set" >}}) to store the whole document at the root path `$`.
+You can then retrieve the document again with [`JSON.GET`]({{< relref "/commands/json.get" >}}).
+
+{{< clients-example set="rust_home_json" step="set_get_doc" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Store a complete JSON document with JSON.SET and fetch it again with JSON.GET" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Read nested fields
+
+JSON paths let you retrieve only the parts of the document you need.
+This is useful when your application only needs a small subset of the data.
+
+{{< clients-example set="rust_home_json" step="get_fields" lang_filter="Rust-Sync,Rust-Async" description="Read nested data: Use JSON paths to retrieve selected fields and arrays without fetching the whole document" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Update part of the document
+
+You can update individual fields without replacing the whole document.
+The example below changes the stock count and then applies a price change with
+[`JSON.NUMINCRBY`]({{< relref "/commands/json.numincrby" >}}).
+
+{{< clients-example set="rust_home_json" step="update_fields" lang_filter="Rust-Sync,Rust-Async" description="Update nested values: Modify individual fields in place with JSON.SET and JSON.NUMINCRBY" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+## Append to an array
+
+You can also update arrays in place.
+This example adds another color to the bike and then retrieves the updated array.
+
+{{< clients-example set="rust_home_json" step="update_array" lang_filter="Rust-Sync,Rust-Async" description="Update arrays: Append new elements to a JSON array and read back the updated value" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+## More information
+
+See the following pages to learn more:
+
+- [JSON data type]({{< relref "/develop/data-types/json" >}})
+- [JSON path syntax]({{< relref "/develop/data-types/json/path" >}})
+- [`redis-rs` documentation](https://docs.rs/redis/latest/redis/)

--- a/data/command-api-mapping/JSON.ARRAPPEND.json
+++ b/data/command-api-mapping/JSON.ARRAPPEND.json
@@ -453,6 +453,58 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_arr_append(key: K, path: P, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to append after the last array element."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The array length after the append operation."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_arr_append(key: K, path: P, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to append after the last array element."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The array length after the append operation."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.ARRINDEX.json
+++ b/data/command-api-mapping/JSON.ARRINDEX.json
@@ -543,6 +543,126 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_arr_index(key: K, path: P, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to search for."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The index of the first matching element."
+        }
+      },
+      {
+        "signature": "json_arr_index_ss(key: K, path: P, value: &V, start: &isize, stop: &isize)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to search for."
+          },
+          {
+            "name": "start",
+            "type": "&isize",
+            "description": "The start offset for the search."
+          },
+          {
+            "name": "stop",
+            "type": "&isize",
+            "description": "The stop offset for the search."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The index of the first matching element in the requested range."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_arr_index(key: K, path: P, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to search for."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The index of the first matching element."
+        }
+      },
+      {
+        "signature": "json_arr_index_ss(key: K, path: P, value: &V, start: &isize, stop: &isize)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to search for."
+          },
+          {
+            "name": "start",
+            "type": "&isize",
+            "description": "The start offset for the search."
+          },
+          {
+            "name": "stop",
+            "type": "&isize",
+            "description": "The stop offset for the search."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The index of the first matching element in the requested range."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.ARRINSERT.json
+++ b/data/command-api-mapping/JSON.ARRINSERT.json
@@ -404,6 +404,68 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_arr_insert(key: K, path: P, index: i64, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "index",
+            "type": "i64",
+            "description": "The position before which to insert the new value."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to insert."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The array length after the insert operation."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_arr_insert(key: K, path: P, index: i64, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "index",
+            "type": "i64",
+            "description": "The position before which to insert the new value."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to insert."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The array length after the insert operation."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.ARRLEN.json
+++ b/data/command-api-mapping/JSON.ARRLEN.json
@@ -268,6 +268,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_arr_len(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The length of the JSON array at the requested path."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_arr_len(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The length of the JSON array at the requested path."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.ARRPOP.json
+++ b/data/command-api-mapping/JSON.ARRPOP.json
@@ -408,6 +408,58 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_arr_pop(key: K, path: P, index: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "index",
+            "type": "i64",
+            "description": "The index of the element to remove. Use -1 to pop from the end."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The removed JSON element."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_arr_pop(key: K, path: P, index: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "index",
+            "type": "i64",
+            "description": "The index of the element to remove. Use -1 to pop from the end."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The removed JSON element."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.ARRTRIM.json
+++ b/data/command-api-mapping/JSON.ARRTRIM.json
@@ -287,6 +287,68 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_arr_trim(key: K, path: P, start: i64, stop: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "start",
+            "type": "i64",
+            "description": "The inclusive start index to keep."
+          },
+          {
+            "name": "stop",
+            "type": "i64",
+            "description": "The inclusive stop index to keep."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The length of the array after trimming."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_arr_trim(key: K, path: P, start: i64, stop: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the target array."
+          },
+          {
+            "name": "start",
+            "type": "i64",
+            "description": "The inclusive start index to keep."
+          },
+          {
+            "name": "stop",
+            "type": "i64",
+            "description": "The inclusive stop index to keep."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The length of the array after trimming."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.CLEAR.json
+++ b/data/command-api-mapping/JSON.CLEAR.json
@@ -282,6 +282,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_clear(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the value or container to clear."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The number of values cleared."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_clear(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the value or container to clear."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The number of values cleared."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.DEL.json
+++ b/data/command-api-mapping/JSON.DEL.json
@@ -282,6 +282,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_del(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the value to delete."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The number of paths deleted."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_del(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the value to delete."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The number of paths deleted."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.GET.json
+++ b/data/command-api-mapping/JSON.GET.json
@@ -380,6 +380,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_get(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path or paths to retrieve."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The JSON value at the requested path."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_get(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path or paths to retrieve."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The JSON value at the requested path."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.MGET.json
+++ b/data/command-api-mapping/JSON.MGET.json
@@ -293,6 +293,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_mget(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key or keys holding the JSON documents to fetch."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to retrieve from each JSON document."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The JSON values found at the requested path across the requested keys."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_mget(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key or keys holding the JSON documents to fetch."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to retrieve from each JSON document."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The JSON values found at the requested path across the requested keys."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.MSET.json
+++ b/data/command-api-mapping/JSON.MSET.json
@@ -132,6 +132,38 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_mset(key_path_values: &[(K, P, V)])",
+        "params": [
+          {
+            "name": "key_path_values",
+            "type": "&[(K, P, V)]",
+            "description": "The key, path, and value tuples to set in a single call."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The status reply for the multi-set operation."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_mset(key_path_values: &[(K, P, V)])",
+        "params": [
+          {
+            "name": "key_path_values",
+            "type": "&[(K, P, V)]",
+            "description": "The key, path, and value tuples to set in a single call."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The status reply for the multi-set operation."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.NUMINCRBY.json
+++ b/data/command-api-mapping/JSON.NUMINCRBY.json
@@ -262,6 +262,58 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_num_incr_by(key: K, path: P, value: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the numeric value to increment."
+          },
+          {
+            "name": "value",
+            "type": "i64",
+            "description": "The amount to add to the numeric value."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The updated numeric value."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_num_incr_by(key: K, path: P, value: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the numeric value to increment."
+          },
+          {
+            "name": "value",
+            "type": "i64",
+            "description": "The amount to add to the numeric value."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The updated numeric value."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.OBJKEYS.json
+++ b/data/command-api-mapping/JSON.OBJKEYS.json
@@ -268,6 +268,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_obj_keys(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON object."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The keys contained in the JSON object at the requested path."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_obj_keys(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON object."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The keys contained in the JSON object at the requested path."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.OBJLEN.json
+++ b/data/command-api-mapping/JSON.OBJLEN.json
@@ -268,6 +268,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_obj_len(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON object."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The number of keys in the JSON object at the requested path."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_obj_len(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON object."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The number of keys in the JSON object at the requested path."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.SET.json
+++ b/data/command-api-mapping/JSON.SET.json
@@ -692,6 +692,58 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_set(key: K, path: P, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path where the JSON value should be stored."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to set."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The status reply for the set operation."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_set(key: K, path: P, value: &V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path where the JSON value should be stored."
+          },
+          {
+            "name": "value",
+            "type": "&V",
+            "description": "The JSON value to set."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The status reply for the set operation."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.STRAPPEND.json
+++ b/data/command-api-mapping/JSON.STRAPPEND.json
@@ -467,6 +467,58 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_str_append(key: K, path: P, value: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON string."
+          },
+          {
+            "name": "value",
+            "type": "V",
+            "description": "The JSON string fragment to append."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The string length after the append operation."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_str_append(key: K, path: P, value: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON string."
+          },
+          {
+            "name": "value",
+            "type": "V",
+            "description": "The JSON string fragment to append."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The string length after the append operation."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.STRLEN.json
+++ b/data/command-api-mapping/JSON.STRLEN.json
@@ -268,6 +268,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_str_len(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON string."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The length of the JSON string at the requested path."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_str_len(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the JSON string."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The length of the JSON string at the requested path."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.TOGGLE.json
+++ b/data/command-api-mapping/JSON.TOGGLE.json
@@ -212,6 +212,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_toggle(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the boolean value to toggle."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The toggled boolean value."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_toggle(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to the boolean value to toggle."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The toggled boolean value."
+        }
+      }
     ]
   }
 }

--- a/data/command-api-mapping/JSON.TYPE.json
+++ b/data/command-api-mapping/JSON.TYPE.json
@@ -268,6 +268,48 @@
           "description": ""
         }
       }
+    ],
+    "redis_rs_sync": [
+      {
+        "signature": "json_type(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to inspect."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The JSON type at the requested path."
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "json_type(key: K, path: P)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The key holding the JSON document."
+          },
+          {
+            "name": "path",
+            "type": "P",
+            "description": "The path to inspect."
+          }
+        ],
+        "returns": {
+          "type": "(RV)",
+          "description": "The JSON type at the requested path."
+        }
+      }
     ]
   }
 }

--- a/local_examples/client-specific/rust-async/home_json.rs
+++ b/local_examples/client-specific/rust-async/home_json.rs
@@ -1,0 +1,142 @@
+// EXAMPLE: rust_home_json
+#[cfg(test)]
+mod tests {
+    // STEP_START import
+    use redis::{cmd, AsyncCommands, JsonAsyncCommands};
+    use serde_json::json;
+    // STEP_END
+
+    #[tokio::test]
+    async fn run() {
+        // STEP_START create_data
+        let bike = json!({
+            "model": "Deimos",
+            "brand": "Ergonom",
+            "price": 4972,
+            "specs": {
+                "material": "carbon",
+                "weight": 8.7
+            },
+            "colors": ["black", "silver"],
+            "inventory": {
+                "in_stock": 12,
+                "warehouse": "w1"
+            }
+        });
+        // STEP_END
+
+        // STEP_START connect
+        let client =
+            redis::Client::open("redis://127.0.0.1").expect("Failed to create Redis client");
+        let mut r = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("Failed to connect to Redis");
+        // STEP_END
+
+        // REMOVE_START
+        let _: i32 = r.del("bike:1").await.expect("Failed to clean up key");
+        // REMOVE_END
+
+        // STEP_START set_get_doc
+        let stored: bool = r
+            .json_set("bike:1", "$", &bike)
+            .await
+            .expect("Failed to run JSON.SET");
+        println!("{}", if stored { "OK" } else { "(nil)" }); // >>> OK
+
+        let bike_json: String = r
+            .json_get("bike:1", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{bike_json}");
+        // >>> [{"model":"Deimos","brand":"Ergonom","price":4972,"specs":{"material":"carbon","weight":8.7},"colors":["black","silver"],"inventory":{"in_stock":12,"warehouse":"w1"}}]
+        // STEP_END
+
+        // REMOVE_START
+        assert!(stored);
+        assert_eq!(
+            bike_json,
+            r#"[{"brand":"Ergonom","colors":["black","silver"],"inventory":{"in_stock":12,"warehouse":"w1"},"model":"Deimos","price":4972,"specs":{"material":"carbon","weight":8.7}}]"#
+        );
+        // REMOVE_END
+
+        // STEP_START get_fields
+        let material: String = r
+            .json_get("bike:1", "$.specs.material")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{material}"); // >>> ["carbon"]
+
+        let colors: String = r
+            .json_get("bike:1", "$.colors")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{colors}"); // >>> [["black","silver"]]
+
+        let stock: String = r
+            .json_get("bike:1", "$.inventory.in_stock")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{stock}"); // >>> [12]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(material, r#"["carbon"]"#);
+        assert_eq!(colors, r#"[["black","silver"]]"#);
+        assert_eq!(stock, "[12]");
+        // REMOVE_END
+
+        // STEP_START update_fields
+        let stock_set: bool = r
+            .json_set("bike:1", "$.inventory.in_stock", &json!(8))
+            .await
+            .expect("Failed to update stock");
+        println!("{}", if stock_set { "OK" } else { "(nil)" }); // >>> OK
+
+        let new_price: String = cmd("JSON.NUMINCRBY")
+            .arg("bike:1")
+            .arg("$.price")
+            .arg(-500)
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{new_price}"); // >>> [4472]
+
+        let updated_fields: String = r
+            .json_get("bike:1", &["$.price", "$.inventory.in_stock"])
+            .await
+            .expect("Failed to read updated fields");
+        println!("{updated_fields}"); // >>> {"$.price":[4472],"$.inventory.in_stock":[8]}
+                                      // STEP_END
+
+        // REMOVE_START
+        assert!(stock_set);
+        assert_eq!(new_price, "[4472]");
+        assert!(
+            updated_fields == r#"{"$.price":[4472],"$.inventory.in_stock":[8]}"#
+                || updated_fields == r#"{"$.inventory.in_stock":[8],"$.price":[4472]}"#
+        );
+        // REMOVE_END
+
+        // STEP_START update_array
+        let _: redis::Value = cmd("JSON.ARRAPPEND")
+            .arg("bike:1")
+            .arg("$.colors")
+            .arg("\"red\"")
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.ARRAPPEND");
+
+        let updated_colors: String = r
+            .json_get("bike:1", "$.colors")
+            .await
+            .expect("Failed to read updated colors");
+        println!("{updated_colors}"); // >>> [["black","silver","red"]]
+                                      // STEP_END
+
+        // REMOVE_START
+        assert_eq!(updated_colors, r#"[["black","silver","red"]]"#);
+        // REMOVE_END
+    }
+}

--- a/local_examples/client-specific/rust-sync/home_json.rs
+++ b/local_examples/client-specific/rust-sync/home_json.rs
@@ -1,0 +1,127 @@
+// EXAMPLE: rust_home_json
+#[cfg(test)]
+mod tests {
+    // STEP_START import
+    use redis::{cmd, Commands, JsonCommands};
+    use serde_json::json;
+    // STEP_END
+
+    #[test]
+    fn run() {
+        // STEP_START create_data
+        let bike = json!({
+            "model": "Deimos",
+            "brand": "Ergonom",
+            "price": 4972,
+            "specs": {
+                "material": "carbon",
+                "weight": 8.7
+            },
+            "colors": ["black", "silver"],
+            "inventory": {
+                "in_stock": 12,
+                "warehouse": "w1"
+            }
+        });
+        // STEP_END
+
+        // STEP_START connect
+        let client =
+            redis::Client::open("redis://127.0.0.1").expect("Failed to create Redis client");
+        let mut r = client.get_connection().expect("Failed to connect to Redis");
+        // STEP_END
+
+        // REMOVE_START
+        let _: i32 = r.del("bike:1").expect("Failed to clean up key");
+        // REMOVE_END
+
+        // STEP_START set_get_doc
+        let stored: bool = r
+            .json_set("bike:1", "$", &bike)
+            .expect("Failed to run JSON.SET");
+        println!("{}", if stored { "OK" } else { "(nil)" }); // >>> OK
+
+        let bike_json: String = r.json_get("bike:1", "$").expect("Failed to run JSON.GET");
+        println!("{bike_json}");
+        // >>> [{"model":"Deimos","brand":"Ergonom","price":4972,"specs":{"material":"carbon","weight":8.7},"colors":["black","silver"],"inventory":{"in_stock":12,"warehouse":"w1"}}]
+        // STEP_END
+
+        // REMOVE_START
+        assert!(stored);
+        assert_eq!(
+            bike_json,
+            r#"[{"brand":"Ergonom","colors":["black","silver"],"inventory":{"in_stock":12,"warehouse":"w1"},"model":"Deimos","price":4972,"specs":{"material":"carbon","weight":8.7}}]"#
+        );
+        // REMOVE_END
+
+        // STEP_START get_fields
+        let material: String = r
+            .json_get("bike:1", "$.specs.material")
+            .expect("Failed to run JSON.GET");
+        println!("{material}"); // >>> ["carbon"]
+
+        let colors: String = r
+            .json_get("bike:1", "$.colors")
+            .expect("Failed to run JSON.GET");
+        println!("{colors}"); // >>> [["black","silver"]]
+
+        let stock: String = r
+            .json_get("bike:1", "$.inventory.in_stock")
+            .expect("Failed to run JSON.GET");
+        println!("{stock}"); // >>> [12]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(material, r#"["carbon"]"#);
+        assert_eq!(colors, r#"[["black","silver"]]"#);
+        assert_eq!(stock, "[12]");
+        // REMOVE_END
+
+        // STEP_START update_fields
+        let stock_set: bool = r
+            .json_set("bike:1", "$.inventory.in_stock", &json!(8))
+            .expect("Failed to update stock");
+        println!("{}", if stock_set { "OK" } else { "(nil)" }); // >>> OK
+
+        let new_price: String = cmd("JSON.NUMINCRBY")
+            .arg("bike:1")
+            .arg("$.price")
+            .arg(-500)
+            .query(&mut r)
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{new_price}"); // >>> [4472]
+
+        let updated_fields: String = r
+            .json_get("bike:1", &["$.price", "$.inventory.in_stock"])
+            .expect("Failed to read updated fields");
+        println!("{updated_fields}"); // >>> {"$.price":[4472],"$.inventory.in_stock":[8]}
+                                      // STEP_END
+
+        // REMOVE_START
+        assert!(stock_set);
+        assert_eq!(new_price, "[4472]");
+        assert!(
+            updated_fields == r#"{"$.price":[4472],"$.inventory.in_stock":[8]}"#
+                || updated_fields == r#"{"$.inventory.in_stock":[8],"$.price":[4472]}"#
+        );
+        // REMOVE_END
+
+        // STEP_START update_array
+        let _: redis::Value = cmd("JSON.ARRAPPEND")
+            .arg("bike:1")
+            .arg("$.colors")
+            .arg("\"red\"")
+            .query(&mut r)
+            .expect("Failed to run JSON.ARRAPPEND");
+
+        let updated_colors: String = r
+            .json_get("bike:1", "$.colors")
+            .expect("Failed to read updated colors");
+        println!("{updated_colors}"); // >>> [["black","silver","red"]]
+                                      // STEP_END
+
+        // REMOVE_START
+        assert_eq!(updated_colors, r#"[["black","silver","red"]]"#);
+        // REMOVE_END
+    }
+}

--- a/local_examples/rust-async/dt-json.rs
+++ b/local_examples/rust-async/dt-json.rs
@@ -1,0 +1,588 @@
+// EXAMPLE: json_tutorial
+#[cfg(test)]
+mod tests {
+    use redis::{cmd, AsyncCommands, JsonAsyncCommands, Value};
+    use serde_json::{json, Number, Value as JsonValue};
+
+    // HIDE_START
+    fn redis_value_to_json(value: &Value) -> JsonValue {
+        match value {
+            Value::Nil => JsonValue::Null,
+            Value::Int(number) => json!(number),
+            Value::BulkString(bytes) => {
+                let text = String::from_utf8(bytes.clone()).expect("Redis response was not UTF-8");
+                serde_json::from_str(&text).unwrap_or(JsonValue::String(text))
+            }
+            Value::Array(values) => {
+                JsonValue::Array(values.iter().map(redis_value_to_json).collect())
+            }
+            Value::SimpleString(text) => JsonValue::String(text.clone()),
+            Value::Okay => JsonValue::String("OK".to_string()),
+            Value::Double(number) => Number::from_f64(*number)
+                .map(JsonValue::Number)
+                .unwrap_or(JsonValue::Null),
+            Value::Boolean(flag) => JsonValue::Bool(*flag),
+            _ => JsonValue::String(format!("{value:?}")),
+        }
+    }
+
+    fn render_redis_value(value: &Value) -> String {
+        serde_json::to_string(&redis_value_to_json(value)).expect("Failed to render Redis value")
+    }
+
+    fn print_redis_value(value: &Value) {
+        println!("{}", render_redis_value(value));
+    }
+
+    fn print_set_result(result: bool) {
+        println!("{}", if result { "OK" } else { "(nil)" });
+    }
+
+    fn inventory_json() -> JsonValue {
+        json!({
+            "inventory": {
+                "mountain_bikes": [
+                    {
+                        "id": "bike:1",
+                        "model": "Phoebe",
+                        "description": "This is a mid-travel trail slayer that is a fantastic daily driver or one bike quiver. The Shimano Claris 8-speed groupset gives plenty of gear range to tackle hills and there's room for mudguards and a rack too.  This is the bike for the rider who wants trail manners with low fuss ownership.",
+                        "price": 1920,
+                        "specs": {"material": "carbon", "weight": 13.1},
+                        "colors": ["black", "silver"]
+                    },
+                    {
+                        "id": "bike:2",
+                        "model": "Quaoar",
+                        "description": "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.",
+                        "price": 2072,
+                        "specs": {"material": "aluminium", "weight": 7.9},
+                        "colors": ["black", "white"]
+                    },
+                    {
+                        "id": "bike:3",
+                        "model": "Weywot",
+                        "description": "This bike gives kids aged six years and older a durable and uberlight mountain bike for their first experience on tracks and easy cruising through forests and fields. A set of powerful Shimano hydraulic disc brakes provide ample stopping ability. If you're after a budget option, this is one of the best bikes you could get.",
+                        "price": 3264,
+                        "specs": {"material": "alloy", "weight": 13.8}
+                    }
+                ],
+                "commuter_bikes": [
+                    {
+                        "id": "bike:4",
+                        "model": "Salacia",
+                        "description": "This bike is a great option for anyone who just wants a bike to get about on With a slick-shifting Claris gears from Shimano's, this is a bike which doesn't break the bank and delivers craved performance.  It's for the rider who wants both efficiency and capability.",
+                        "price": 1475,
+                        "specs": {"material": "aluminium", "weight": 16.6},
+                        "colors": ["black", "silver"]
+                    },
+                    {
+                        "id": "bike:5",
+                        "model": "Mimas",
+                        "description": "A real joy to ride, this bike got very high scores in last years Bike of the year report. The carefully crafted 50-34 tooth chainset and 11-32 tooth cassette give an easy-on-the-legs bottom gear for climbing, and the high-quality Vittoria Zaffiro tires give balance and grip.It includes a low-step frame , our memory foam seat, bump-resistant shocks and conveniently placed thumb throttle. Put it all together and you get a bike that helps redefine what can be done for this price.",
+                        "price": 3941,
+                        "specs": {"material": "alloy", "weight": 11.6}
+                    }
+                ]
+            }
+        })
+    }
+    // HIDE_END
+
+    #[tokio::test]
+    async fn run() {
+        let client =
+            redis::Client::open("redis://127.0.0.1").expect("Failed to create Redis client");
+        let mut r = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("Failed to connect to Redis");
+
+        // REMOVE_START
+        let _: () = r.flushall().await.expect("Failed to flush Redis");
+        // REMOVE_END
+
+        // STEP_START set_get
+        let res1: bool = r
+            .json_set("bike", "$", &json!("Hyperion"))
+            .await
+            .expect("Failed to run JSON.SET");
+        print_set_result(res1); // >>> OK
+
+        let res2: String = r
+            .json_get("bike", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res2}"); // >>> ["Hyperion"]
+
+        let res3: Value = r
+            .json_type("bike", "$")
+            .await
+            .expect("Failed to run JSON.TYPE");
+        print_redis_value(&res3); // >>> ["string"]
+                                  // STEP_END
+
+        // REMOVE_START
+        assert!(res1);
+        assert_eq!(res2, r#"["Hyperion"]"#);
+        let rendered_type = render_redis_value(&res3);
+        assert!(rendered_type == r#"["string"]"# || rendered_type == r#"[["string"]]"#);
+        // REMOVE_END
+
+        // STEP_START str
+        let res4: Value = r
+            .json_str_len("bike", "$")
+            .await
+            .expect("Failed to run JSON.STRLEN");
+        print_redis_value(&res4); // >>> [8]
+
+        let res5: Value = r
+            .json_str_append("bike", "$", "\" (Enduro bikes)\"")
+            .await
+            .expect("Failed to run JSON.STRAPPEND");
+        print_redis_value(&res5); // >>> [23]
+
+        let res6: String = r
+            .json_get("bike", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res6}"); // >>> ["Hyperion (Enduro bikes)"]
+                            // STEP_END
+
+        // REMOVE_START
+        assert_eq!(render_redis_value(&res4), "[8]");
+        assert_eq!(render_redis_value(&res5), "[23]");
+        assert_eq!(res6, r#"["Hyperion (Enduro bikes)"]"#);
+        // REMOVE_END
+
+        // STEP_START num
+        let res7: bool = r
+            .json_set("crashes", "$", &json!(0))
+            .await
+            .expect("Failed to run JSON.SET");
+        print_set_result(res7); // >>> OK
+
+        let res8: String = cmd("JSON.NUMINCRBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(1)
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res8}"); // >>> [1]
+
+        let res9: String = cmd("JSON.NUMINCRBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(1.5)
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res9}"); // >>> [2.5]
+
+        let res10: String = cmd("JSON.NUMINCRBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(-0.75)
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res10}"); // >>> [1.75]
+
+        let res11: String = cmd("JSON.NUMMULTBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(24)
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.NUMMULTBY");
+        println!("{res11}"); // >>> [42.0]
+                             // STEP_END
+
+        // REMOVE_START
+        assert!(res7);
+        assert_eq!(res8, "[1]");
+        assert_eq!(res9, "[2.5]");
+        assert_eq!(res10, "[1.75]");
+        assert_eq!(res11, "[42.0]");
+        // REMOVE_END
+
+        // STEP_START arr
+        let res12: bool = r
+            .json_set("newbike", "$", &json!(["Deimos", {"crashes": 0}, null]))
+            .await
+            .expect("Failed to run JSON.SET");
+        print_set_result(res12); // >>> OK
+
+        let res13: String = r
+            .json_get("newbike", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res13}"); // >>> [["Deimos",{"crashes":0},null]]
+
+        let res14: String = r
+            .json_get("newbike", "$[1].crashes")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res14}"); // >>> [0]
+
+        let res15: i64 = r
+            .json_del("newbike", "$[-1]")
+            .await
+            .expect("Failed to run JSON.DEL");
+        println!("{res15}"); // >>> 1
+
+        let res16: String = r
+            .json_get("newbike", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res16}"); // >>> [["Deimos",{"crashes":0}]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert!(res12);
+        assert_eq!(res13, r#"[["Deimos",{"crashes":0},null]]"#);
+        assert_eq!(res14, "[0]");
+        assert_eq!(res15, 1);
+        assert_eq!(res16, r#"[["Deimos",{"crashes":0}]]"#);
+        // REMOVE_END
+
+        // STEP_START arr2
+        let res17: bool = r
+            .json_set("riders", "$", &json!([]))
+            .await
+            .expect("Failed to run JSON.SET");
+        print_set_result(res17); // >>> OK
+
+        let res18: Value = r
+            .json_arr_append("riders", "$", &json!("Norem"))
+            .await
+            .expect("Failed to run JSON.ARRAPPEND");
+        print_redis_value(&res18); // >>> [1]
+
+        let res19: String = r
+            .json_get("riders", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res19}"); // >>> [["Norem"]]
+
+        let res20: Value = cmd("JSON.ARRINSERT")
+            .arg("riders")
+            .arg("$")
+            .arg(1)
+            .arg("\"Prickett\"")
+            .arg("\"Royce\"")
+            .arg("\"Castilla\"")
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.ARRINSERT");
+        print_redis_value(&res20); // >>> [4]
+
+        let res21: String = r
+            .json_get("riders", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res21}"); // >>> [["Norem","Prickett","Royce","Castilla"]]
+
+        let res22: Value = r
+            .json_arr_trim("riders", "$", 1, 1)
+            .await
+            .expect("Failed to run JSON.ARRTRIM");
+        print_redis_value(&res22); // >>> [1]
+
+        let res23: String = r
+            .json_get("riders", "$")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res23}"); // >>> [["Prickett"]]
+
+        let res24: Value = r
+            .json_arr_pop("riders", "$", -1)
+            .await
+            .expect("Failed to run JSON.ARRPOP");
+        print_redis_value(&res24); // >>> ["Prickett"]
+
+        let res25: Value = r
+            .json_arr_pop("riders", "$", -1)
+            .await
+            .expect("Failed to run JSON.ARRPOP");
+        print_redis_value(&res25); // >>> [null]
+                                   // STEP_END
+
+        // REMOVE_START
+        assert!(res17);
+        assert_eq!(render_redis_value(&res18), "[1]");
+        assert_eq!(res19, r#"[["Norem"]]"#);
+        assert_eq!(render_redis_value(&res20), "[4]");
+        assert_eq!(res21, r#"[["Norem","Prickett","Royce","Castilla"]]"#);
+        assert_eq!(render_redis_value(&res22), "[1]");
+        assert_eq!(res23, r#"[["Prickett"]]"#);
+        assert_eq!(render_redis_value(&res24), r#"["Prickett"]"#);
+        assert_eq!(render_redis_value(&res25), "[null]");
+        // REMOVE_END
+
+        // STEP_START obj
+        let res26: bool = r
+            .json_set(
+                "bike:1",
+                "$",
+                &json!({"model": "Deimos", "brand": "Ergonom", "price": 4972}),
+            )
+            .await
+            .expect("Failed to run JSON.SET");
+        print_set_result(res26); // >>> OK
+
+        let res27: Value = r
+            .json_obj_len("bike:1", "$")
+            .await
+            .expect("Failed to run JSON.OBJLEN");
+        print_redis_value(&res27); // >>> [3]
+
+        let res28: Value = r
+            .json_obj_keys("bike:1", "$")
+            .await
+            .expect("Failed to run JSON.OBJKEYS");
+        print_redis_value(&res28); // >>> [["brand","model","price"]]
+                                   // STEP_END
+
+        // REMOVE_START
+        assert!(res26);
+        assert_eq!(render_redis_value(&res27), "[3]");
+        assert_eq!(render_redis_value(&res28), r#"[["brand","model","price"]]"#);
+        // REMOVE_END
+
+        // STEP_START set_bikes
+        let res29: bool = r
+            .json_set("bikes:inventory", "$", &inventory_json())
+            .await
+            .expect("Failed to run JSON.SET");
+        print_set_result(res29); // >>> OK
+                                 // STEP_END
+
+        // REMOVE_START
+        assert!(res29);
+        // REMOVE_END
+
+        // STEP_START get_bikes
+        let res30: String = r
+            .json_get("bikes:inventory", "$.inventory.*")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res30}");
+        // >>> [[{"id":"bike:1","model":"Phoebe","description":"This is a mid-travel trail slayer...
+        // STEP_END
+
+        // STEP_START get_mtnbikes
+        let res31: String = r
+            .json_get("bikes:inventory", "$.inventory.mountain_bikes[*].model")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res31}"); // >>> [["Phoebe","Quaoar","Weywot"]]
+
+        let res32: String = r
+            .json_get(
+                "bikes:inventory",
+                r#"$.inventory["mountain_bikes"][*].model"#,
+            )
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res32}"); // >>> [["Phoebe","Quaoar","Weywot"]]
+
+        let res33: String = r
+            .json_get("bikes:inventory", "$..mountain_bikes[*].model")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res33}"); // >>> [["Phoebe","Quaoar","Weywot"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res31, r#"["Phoebe","Quaoar","Weywot"]"#);
+        assert_eq!(res32, r#"["Phoebe","Quaoar","Weywot"]"#);
+        assert_eq!(res33, r#"["Phoebe","Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START get_models
+        let res34: String = r
+            .json_get("bikes:inventory", "$..model")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res34}"); // >>> [["Phoebe","Quaoar","Weywot","Salacia","Mimas"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res34, r#"["Salacia","Mimas","Phoebe","Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START get2mtnbikes
+        let res35: String = r
+            .json_get("bikes:inventory", "$..mountain_bikes[0:2].model")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res35}"); // >>> [["Phoebe","Quaoar"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res35, r#"["Phoebe","Quaoar"]"#);
+        // REMOVE_END
+
+        // STEP_START filter1
+        let res36: String = r
+            .json_get(
+                "bikes:inventory",
+                "$..mountain_bikes[?(@.price < 3000 && @.specs.weight < 10)]",
+            )
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res36}");
+        // >>> [[{"id":"bike:2","model":"Quaoar","description":"Redesigned for the 2020 model year...
+        // STEP_END
+
+        // STEP_START filter2
+        let res37: String = r
+            .json_get(
+                "bikes:inventory",
+                "$..[?(@.specs.material == 'alloy')].model",
+            )
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res37}"); // >>> [["Weywot","Mimas"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res37, r#"["Mimas","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START filter3
+        let res38: String = r
+            .json_get(
+                "bikes:inventory",
+                "$..[?(@.specs.material =~ '(?i)al')].model",
+            )
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res38}"); // >>> [["Quaoar","Weywot","Salacia","Mimas"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res38, r#"["Salacia","Mimas","Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START filter4
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[0].regex_pat",
+                &json!("(?i)al"),
+            )
+            .await
+            .expect("Failed to run JSON.SET");
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[1].regex_pat",
+                &json!("(?i)al"),
+            )
+            .await
+            .expect("Failed to run JSON.SET");
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[2].regex_pat",
+                &json!("(?i)al"),
+            )
+            .await
+            .expect("Failed to run JSON.SET");
+
+        let res39: String = r
+            .json_get(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model",
+            )
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res39}"); // >>> [["Quaoar","Weywot"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res39, r#"["Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START update_bikes
+        let res40: String = r
+            .json_get("bikes:inventory", "$..price")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res40}"); // >>> [1920,2072,3264,1475,3941]
+
+        let res41: String = cmd("JSON.NUMINCRBY")
+            .arg("bikes:inventory")
+            .arg("$..price")
+            .arg(-100)
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res41}"); // >>> [1820,1972,3164,1375,3841]
+
+        let res42: String = cmd("JSON.NUMINCRBY")
+            .arg("bikes:inventory")
+            .arg("$..price")
+            .arg(100)
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res42}"); // >>> [1920,2072,3264,1475,3941]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res40, "[1475,3941,1920,2072,3264]");
+        assert_eq!(res41, "[1375,3841,1820,1972,3164]");
+        assert_eq!(res42, "[1475,3941,1920,2072,3264]");
+        // REMOVE_END
+
+        // STEP_START update_filters1
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.*[?(@.price<2000)].price",
+                &json!(1500),
+            )
+            .await
+            .expect("Failed to run JSON.SET");
+
+        let res43: String = r
+            .json_get("bikes:inventory", "$..price")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res43}"); // >>> [1500,2072,3264,1500,3941]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res43, "[1500,3941,1500,2072,3264]");
+        // REMOVE_END
+
+        // STEP_START update_filters2
+        let res44: Value = cmd("JSON.ARRAPPEND")
+            .arg("bikes:inventory")
+            .arg("$.inventory.*[?(@.price<2000)].colors")
+            .arg("\"pink\"")
+            .query_async(&mut r)
+            .await
+            .expect("Failed to run JSON.ARRAPPEND");
+        print_redis_value(&res44); // >>> [3,3]
+
+        let res45: String = r
+            .json_get("bikes:inventory", "$..[*].colors")
+            .await
+            .expect("Failed to run JSON.GET");
+        println!("{res45}");
+        // >>> [["black","silver","pink"],["black","white"],["black","silver","pink"]]
+        // STEP_END
+
+        // REMOVE_START
+        assert_eq!(render_redis_value(&res44), "[3,3]");
+        assert_eq!(
+            res45,
+            r#"[["black","silver","pink"],["black","silver","pink"],["black","white"]]"#
+        );
+        // REMOVE_END
+    }
+}

--- a/local_examples/rust-sync/dt-json.rs
+++ b/local_examples/rust-sync/dt-json.rs
@@ -1,0 +1,520 @@
+// EXAMPLE: json_tutorial
+#[cfg(test)]
+mod tests {
+    use redis::{cmd, Commands, JsonCommands, Value};
+    use serde_json::{json, Number, Value as JsonValue};
+
+    // HIDE_START
+    fn redis_value_to_json(value: &Value) -> JsonValue {
+        match value {
+            Value::Nil => JsonValue::Null,
+            Value::Int(number) => json!(number),
+            Value::BulkString(bytes) => {
+                let text = String::from_utf8(bytes.clone()).expect("Redis response was not UTF-8");
+                serde_json::from_str(&text).unwrap_or(JsonValue::String(text))
+            }
+            Value::Array(values) => {
+                JsonValue::Array(values.iter().map(redis_value_to_json).collect())
+            }
+            Value::SimpleString(text) => JsonValue::String(text.clone()),
+            Value::Okay => JsonValue::String("OK".to_string()),
+            Value::Double(number) => Number::from_f64(*number)
+                .map(JsonValue::Number)
+                .unwrap_or(JsonValue::Null),
+            Value::Boolean(flag) => JsonValue::Bool(*flag),
+            _ => JsonValue::String(format!("{value:?}")),
+        }
+    }
+
+    fn render_redis_value(value: &Value) -> String {
+        serde_json::to_string(&redis_value_to_json(value)).expect("Failed to render Redis value")
+    }
+
+    fn print_redis_value(value: &Value) {
+        println!("{}", render_redis_value(value));
+    }
+
+    fn print_set_result(result: bool) {
+        println!("{}", if result { "OK" } else { "(nil)" });
+    }
+
+    fn inventory_json() -> JsonValue {
+        json!({
+            "inventory": {
+                "mountain_bikes": [
+                    {
+                        "id": "bike:1",
+                        "model": "Phoebe",
+                        "description": "This is a mid-travel trail slayer that is a fantastic daily driver or one bike quiver. The Shimano Claris 8-speed groupset gives plenty of gear range to tackle hills and there's room for mudguards and a rack too.  This is the bike for the rider who wants trail manners with low fuss ownership.",
+                        "price": 1920,
+                        "specs": {"material": "carbon", "weight": 13.1},
+                        "colors": ["black", "silver"]
+                    },
+                    {
+                        "id": "bike:2",
+                        "model": "Quaoar",
+                        "description": "Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.",
+                        "price": 2072,
+                        "specs": {"material": "aluminium", "weight": 7.9},
+                        "colors": ["black", "white"]
+                    },
+                    {
+                        "id": "bike:3",
+                        "model": "Weywot",
+                        "description": "This bike gives kids aged six years and older a durable and uberlight mountain bike for their first experience on tracks and easy cruising through forests and fields. A set of powerful Shimano hydraulic disc brakes provide ample stopping ability. If you're after a budget option, this is one of the best bikes you could get.",
+                        "price": 3264,
+                        "specs": {"material": "alloy", "weight": 13.8}
+                    }
+                ],
+                "commuter_bikes": [
+                    {
+                        "id": "bike:4",
+                        "model": "Salacia",
+                        "description": "This bike is a great option for anyone who just wants a bike to get about on With a slick-shifting Claris gears from Shimano's, this is a bike which doesn't break the bank and delivers craved performance.  It's for the rider who wants both efficiency and capability.",
+                        "price": 1475,
+                        "specs": {"material": "aluminium", "weight": 16.6},
+                        "colors": ["black", "silver"]
+                    },
+                    {
+                        "id": "bike:5",
+                        "model": "Mimas",
+                        "description": "A real joy to ride, this bike got very high scores in last years Bike of the year report. The carefully crafted 50-34 tooth chainset and 11-32 tooth cassette give an easy-on-the-legs bottom gear for climbing, and the high-quality Vittoria Zaffiro tires give balance and grip.It includes a low-step frame , our memory foam seat, bump-resistant shocks and conveniently placed thumb throttle. Put it all together and you get a bike that helps redefine what can be done for this price.",
+                        "price": 3941,
+                        "specs": {"material": "alloy", "weight": 11.6}
+                    }
+                ]
+            }
+        })
+    }
+    // HIDE_END
+
+    #[test]
+    fn run() {
+        let client =
+            redis::Client::open("redis://127.0.0.1").expect("Failed to create Redis client");
+        let mut r = client.get_connection().expect("Failed to connect to Redis");
+
+        // REMOVE_START
+        let _: () = r.flushall().expect("Failed to flush Redis");
+        // REMOVE_END
+
+        // STEP_START set_get
+        let res1: bool = r
+            .json_set("bike", "$", &json!("Hyperion"))
+            .expect("Failed to run JSON.SET");
+        print_set_result(res1); // >>> OK
+
+        let res2: String = r.json_get("bike", "$").expect("Failed to run JSON.GET");
+        println!("{res2}"); // >>> ["Hyperion"]
+
+        let res3: Value = r.json_type("bike", "$").expect("Failed to run JSON.TYPE");
+        print_redis_value(&res3); // >>> ["string"]
+                                  // STEP_END
+
+        // REMOVE_START
+        assert!(res1);
+        assert_eq!(res2, r#"["Hyperion"]"#);
+        let rendered_type = render_redis_value(&res3);
+        assert!(rendered_type == r#"["string"]"# || rendered_type == r#"[["string"]]"#);
+        // REMOVE_END
+
+        // STEP_START str
+        let res4: Value = r
+            .json_str_len("bike", "$")
+            .expect("Failed to run JSON.STRLEN");
+        print_redis_value(&res4); // >>> [8]
+
+        let res5: Value = r
+            .json_str_append("bike", "$", "\" (Enduro bikes)\"")
+            .expect("Failed to run JSON.STRAPPEND");
+        print_redis_value(&res5); // >>> [23]
+
+        let res6: String = r.json_get("bike", "$").expect("Failed to run JSON.GET");
+        println!("{res6}"); // >>> ["Hyperion (Enduro bikes)"]
+                            // STEP_END
+
+        // REMOVE_START
+        assert_eq!(render_redis_value(&res4), "[8]");
+        assert_eq!(render_redis_value(&res5), "[23]");
+        assert_eq!(res6, r#"["Hyperion (Enduro bikes)"]"#);
+        // REMOVE_END
+
+        // STEP_START num
+        let res7: bool = r
+            .json_set("crashes", "$", &json!(0))
+            .expect("Failed to run JSON.SET");
+        print_set_result(res7); // >>> OK
+
+        let res8: String = cmd("JSON.NUMINCRBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(1)
+            .query(&mut r)
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res8}"); // >>> [1]
+
+        let res9: String = cmd("JSON.NUMINCRBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(1.5)
+            .query(&mut r)
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res9}"); // >>> [2.5]
+
+        let res10: String = cmd("JSON.NUMINCRBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(-0.75)
+            .query(&mut r)
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res10}"); // >>> [1.75]
+
+        let res11: String = cmd("JSON.NUMMULTBY")
+            .arg("crashes")
+            .arg("$")
+            .arg(24)
+            .query(&mut r)
+            .expect("Failed to run JSON.NUMMULTBY");
+        println!("{res11}"); // >>> [42.0]
+                             // STEP_END
+
+        // REMOVE_START
+        assert!(res7);
+        assert_eq!(res8, "[1]");
+        assert_eq!(res9, "[2.5]");
+        assert_eq!(res10, "[1.75]");
+        assert_eq!(res11, "[42.0]");
+        // REMOVE_END
+
+        // STEP_START arr
+        let res12: bool = r
+            .json_set("newbike", "$", &json!(["Deimos", {"crashes": 0}, null]))
+            .expect("Failed to run JSON.SET");
+        print_set_result(res12); // >>> OK
+
+        let res13: String = r.json_get("newbike", "$").expect("Failed to run JSON.GET");
+        println!("{res13}"); // >>> [["Deimos",{"crashes":0},null]]
+
+        let res14: String = r
+            .json_get("newbike", "$[1].crashes")
+            .expect("Failed to run JSON.GET");
+        println!("{res14}"); // >>> [0]
+
+        let res15: i64 = r
+            .json_del("newbike", "$[-1]")
+            .expect("Failed to run JSON.DEL");
+        println!("{res15}"); // >>> 1
+
+        let res16: String = r.json_get("newbike", "$").expect("Failed to run JSON.GET");
+        println!("{res16}"); // >>> [["Deimos",{"crashes":0}]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert!(res12);
+        assert_eq!(res13, r#"[["Deimos",{"crashes":0},null]]"#);
+        assert_eq!(res14, "[0]");
+        assert_eq!(res15, 1);
+        assert_eq!(res16, r#"[["Deimos",{"crashes":0}]]"#);
+        // REMOVE_END
+
+        // STEP_START arr2
+        let res17: bool = r
+            .json_set("riders", "$", &json!([]))
+            .expect("Failed to run JSON.SET");
+        print_set_result(res17); // >>> OK
+
+        let res18: Value = r
+            .json_arr_append("riders", "$", &json!("Norem"))
+            .expect("Failed to run JSON.ARRAPPEND");
+        print_redis_value(&res18); // >>> [1]
+
+        let res19: String = r.json_get("riders", "$").expect("Failed to run JSON.GET");
+        println!("{res19}"); // >>> [["Norem"]]
+
+        let res20: Value = cmd("JSON.ARRINSERT")
+            .arg("riders")
+            .arg("$")
+            .arg(1)
+            .arg("\"Prickett\"")
+            .arg("\"Royce\"")
+            .arg("\"Castilla\"")
+            .query(&mut r)
+            .expect("Failed to run JSON.ARRINSERT");
+        print_redis_value(&res20); // >>> [4]
+
+        let res21: String = r.json_get("riders", "$").expect("Failed to run JSON.GET");
+        println!("{res21}"); // >>> [["Norem","Prickett","Royce","Castilla"]]
+
+        let res22: Value = r
+            .json_arr_trim("riders", "$", 1, 1)
+            .expect("Failed to run JSON.ARRTRIM");
+        print_redis_value(&res22); // >>> [1]
+
+        let res23: String = r.json_get("riders", "$").expect("Failed to run JSON.GET");
+        println!("{res23}"); // >>> [["Prickett"]]
+
+        let res24: Value = r
+            .json_arr_pop("riders", "$", -1)
+            .expect("Failed to run JSON.ARRPOP");
+        print_redis_value(&res24); // >>> ["Prickett"]
+
+        let res25: Value = r
+            .json_arr_pop("riders", "$", -1)
+            .expect("Failed to run JSON.ARRPOP");
+        print_redis_value(&res25); // >>> [null]
+                                   // STEP_END
+
+        // REMOVE_START
+        assert!(res17);
+        assert_eq!(render_redis_value(&res18), "[1]");
+        assert_eq!(res19, r#"[["Norem"]]"#);
+        assert_eq!(render_redis_value(&res20), "[4]");
+        assert_eq!(res21, r#"[["Norem","Prickett","Royce","Castilla"]]"#);
+        assert_eq!(render_redis_value(&res22), "[1]");
+        assert_eq!(res23, r#"[["Prickett"]]"#);
+        assert_eq!(render_redis_value(&res24), r#"["Prickett"]"#);
+        assert_eq!(render_redis_value(&res25), "[null]");
+        // REMOVE_END
+
+        // STEP_START obj
+        let res26: bool = r
+            .json_set(
+                "bike:1",
+                "$",
+                &json!({"model": "Deimos", "brand": "Ergonom", "price": 4972}),
+            )
+            .expect("Failed to run JSON.SET");
+        print_set_result(res26); // >>> OK
+
+        let res27: Value = r
+            .json_obj_len("bike:1", "$")
+            .expect("Failed to run JSON.OBJLEN");
+        print_redis_value(&res27); // >>> [3]
+
+        let res28: Value = r
+            .json_obj_keys("bike:1", "$")
+            .expect("Failed to run JSON.OBJKEYS");
+        print_redis_value(&res28); // >>> [["brand","model","price"]]
+                                   // STEP_END
+
+        // REMOVE_START
+        assert!(res26);
+        assert_eq!(render_redis_value(&res27), "[3]");
+        assert_eq!(render_redis_value(&res28), r#"[["brand","model","price"]]"#);
+        // REMOVE_END
+
+        // STEP_START set_bikes
+        let res29: bool = r
+            .json_set("bikes:inventory", "$", &inventory_json())
+            .expect("Failed to run JSON.SET");
+        print_set_result(res29); // >>> OK
+                                 // STEP_END
+
+        // REMOVE_START
+        assert!(res29);
+        // REMOVE_END
+
+        // STEP_START get_bikes
+        let res30: String = r
+            .json_get("bikes:inventory", "$.inventory.*")
+            .expect("Failed to run JSON.GET");
+        println!("{res30}");
+        // >>> [[{"id":"bike:1","model":"Phoebe","description":"This is a mid-travel trail slayer...
+        // STEP_END
+
+        // STEP_START get_mtnbikes
+        let res31: String = r
+            .json_get("bikes:inventory", "$.inventory.mountain_bikes[*].model")
+            .expect("Failed to run JSON.GET");
+        println!("{res31}"); // >>> [["Phoebe","Quaoar","Weywot"]]
+
+        let res32: String = r
+            .json_get(
+                "bikes:inventory",
+                r#"$.inventory["mountain_bikes"][*].model"#,
+            )
+            .expect("Failed to run JSON.GET");
+        println!("{res32}"); // >>> [["Phoebe","Quaoar","Weywot"]]
+
+        let res33: String = r
+            .json_get("bikes:inventory", "$..mountain_bikes[*].model")
+            .expect("Failed to run JSON.GET");
+        println!("{res33}"); // >>> [["Phoebe","Quaoar","Weywot"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res31, r#"["Phoebe","Quaoar","Weywot"]"#);
+        assert_eq!(res32, r#"["Phoebe","Quaoar","Weywot"]"#);
+        assert_eq!(res33, r#"["Phoebe","Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START get_models
+        let res34: String = r
+            .json_get("bikes:inventory", "$..model")
+            .expect("Failed to run JSON.GET");
+        println!("{res34}"); // >>> [["Phoebe","Quaoar","Weywot","Salacia","Mimas"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res34, r#"["Salacia","Mimas","Phoebe","Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START get2mtnbikes
+        let res35: String = r
+            .json_get("bikes:inventory", "$..mountain_bikes[0:2].model")
+            .expect("Failed to run JSON.GET");
+        println!("{res35}"); // >>> [["Phoebe","Quaoar"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res35, r#"["Phoebe","Quaoar"]"#);
+        // REMOVE_END
+
+        // STEP_START filter1
+        let res36: String = r
+            .json_get(
+                "bikes:inventory",
+                "$..mountain_bikes[?(@.price < 3000 && @.specs.weight < 10)]",
+            )
+            .expect("Failed to run JSON.GET");
+        println!("{res36}");
+        // >>> [[{"id":"bike:2","model":"Quaoar","description":"Redesigned for the 2020 model year...
+        // STEP_END
+
+        // STEP_START filter2
+        let res37: String = r
+            .json_get(
+                "bikes:inventory",
+                "$..[?(@.specs.material == 'alloy')].model",
+            )
+            .expect("Failed to run JSON.GET");
+        println!("{res37}"); // >>> [["Weywot","Mimas"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res37, r#"["Mimas","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START filter3
+        let res38: String = r
+            .json_get(
+                "bikes:inventory",
+                "$..[?(@.specs.material =~ '(?i)al')].model",
+            )
+            .expect("Failed to run JSON.GET");
+        println!("{res38}"); // >>> [["Quaoar","Weywot","Salacia","Mimas"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res38, r#"["Salacia","Mimas","Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START filter4
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[0].regex_pat",
+                &json!("(?i)al"),
+            )
+            .expect("Failed to run JSON.SET");
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[1].regex_pat",
+                &json!("(?i)al"),
+            )
+            .expect("Failed to run JSON.SET");
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[2].regex_pat",
+                &json!("(?i)al"),
+            )
+            .expect("Failed to run JSON.SET");
+
+        let res39: String = r
+            .json_get(
+                "bikes:inventory",
+                "$.inventory.mountain_bikes[?(@.specs.material =~ @.regex_pat)].model",
+            )
+            .expect("Failed to run JSON.GET");
+        println!("{res39}"); // >>> [["Quaoar","Weywot"]]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res39, r#"["Quaoar","Weywot"]"#);
+        // REMOVE_END
+
+        // STEP_START update_bikes
+        let res40: String = r
+            .json_get("bikes:inventory", "$..price")
+            .expect("Failed to run JSON.GET");
+        println!("{res40}"); // >>> [1920,2072,3264,1475,3941]
+
+        let res41: String = cmd("JSON.NUMINCRBY")
+            .arg("bikes:inventory")
+            .arg("$..price")
+            .arg(-100)
+            .query(&mut r)
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res41}"); // >>> [1820,1972,3164,1375,3841]
+
+        let res42: String = cmd("JSON.NUMINCRBY")
+            .arg("bikes:inventory")
+            .arg("$..price")
+            .arg(100)
+            .query(&mut r)
+            .expect("Failed to run JSON.NUMINCRBY");
+        println!("{res42}"); // >>> [1920,2072,3264,1475,3941]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res40, "[1475,3941,1920,2072,3264]");
+        assert_eq!(res41, "[1375,3841,1820,1972,3164]");
+        assert_eq!(res42, "[1475,3941,1920,2072,3264]");
+        // REMOVE_END
+
+        // STEP_START update_filters1
+        let _: bool = r
+            .json_set(
+                "bikes:inventory",
+                "$.inventory.*[?(@.price<2000)].price",
+                &json!(1500),
+            )
+            .expect("Failed to run JSON.SET");
+
+        let res43: String = r
+            .json_get("bikes:inventory", "$..price")
+            .expect("Failed to run JSON.GET");
+        println!("{res43}"); // >>> [1500,2072,3264,1500,3941]
+                             // STEP_END
+
+        // REMOVE_START
+        assert_eq!(res43, "[1500,3941,1500,2072,3264]");
+        // REMOVE_END
+
+        // STEP_START update_filters2
+        let res44: Value = cmd("JSON.ARRAPPEND")
+            .arg("bikes:inventory")
+            .arg("$.inventory.*[?(@.price<2000)].colors")
+            .arg("\"pink\"")
+            .query(&mut r)
+            .expect("Failed to run JSON.ARRAPPEND");
+        print_redis_value(&res44); // >>> [3,3]
+
+        let res45: String = r
+            .json_get("bikes:inventory", "$..[*].colors")
+            .expect("Failed to run JSON.GET");
+        println!("{res45}");
+        // >>> [["black","silver","pink"],["black","white"],["black","silver","pink"]]
+        // STEP_END
+
+        // REMOVE_START
+        assert_eq!(render_redis_value(&res44), "[3,3]");
+        assert_eq!(
+            res45,
+            r#"[["black","silver","pink"],["black","silver","pink"],["black","white"]]"#
+        );
+        // REMOVE_END
+    }
+}


### PR DESCRIPTION
Rust doesn't support Redis search yet, but a JSON example is very useful to have, so this is example is a bit different to the JSON examples for the other clients. Also added Rust examples for the JSON data type pages and added the command to API mappings for the Rust JSON commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/data updates that don’t affect runtime behavior; main risk is incorrect example output or API signature mismatches in the new command-to-client mappings.
> 
> **Overview**
> Adds a new Rust client docs page, `content/develop/clients/rust/json.md`, documenting a simple end-to-end RedisJSON workflow (create, read nested paths, update fields, append to arrays) for both sync and async `redis-rs`.
> 
> Introduces new runnable Rust example sources for `rust_home_json` and for the `json_tutorial` used by the JSON data type pages (`local_examples/rust-{sync,async}/dt-json.rs`), covering common JSON string/number/array/object operations and JSONPath queries.
> 
> Extends multiple `data/command-api-mapping/JSON.*.json` files to include `redis_rs_sync` and `redis_rs_async` API signatures/params/returns for RedisJSON commands (e.g., `JSON.GET`, `JSON.SET`, array ops, object ops, numeric ops).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e72872cce06affb45691bd5a2220f7cef62ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->