### PR TITLE
update Jedis ssl connect example to use recomended SslOptions

### DIFF
--- a/content/develop/clients/jedis/connect.md
+++ b/content/develop/clients/jedis/connect.md
@@ -105,11 +105,9 @@ package org.example;
 
 import redis.clients.jedis.*;
 
-import javax.net.ssl.*;
-import java.io.FileInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
-import java.security.KeyStore;
 
 public class Main {
 

--- a/content/develop/clients/jedis/connect.md
+++ b/content/develop/clients/jedis/connect.md
@@ -116,15 +116,16 @@ public class Main {
     public static void main(String[] args) throws GeneralSecurityException, IOException {
         HostAndPort address = new HostAndPort("my-redis-instance.cloud.redislabs.com", 6379);
 
-        SSLSocketFactory sslFactory = createSslSocketFactory(
-                "./truststore.jks",
-                "secret!", // use the password you specified for keytool command
-                "./redis-user-keystore.p12",
-                "secret!" // use the password you specified for openssl command
-        );
+        SslOptions sslOptions = SslOptions.builder()
+                .truststore(new File("./truststore.jks"), "secret!".toCharArray())
+                .trustStoreType("jks")
+                // optional: use if Redis requires client certificate
+                .keystore(new File("./redis-user-keystore.p12"), "secret!".toCharArray())
+                .keyStoreType("pkcs12")
+                .build();
 
         JedisClientConfig config = DefaultJedisClientConfig.builder()
-                .ssl(true).sslSocketFactory(sslFactory)
+                .sslOptions(sslOptions)
                 .user("default") // use your Redis user. More info https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/
                 .password("secret!") // use your Redis password
                 .build();
@@ -135,28 +136,6 @@ public class Main {
               .build();
         jedis.set("foo", "bar");
         System.out.println(jedis.get("foo")); // prints bar
-    }
-
-    private static SSLSocketFactory createSslSocketFactory(
-            String caCertPath, String caCertPassword, String userCertPath, String userCertPassword)
-            throws IOException, GeneralSecurityException {
-
-        KeyStore keyStore = KeyStore.getInstance("pkcs12");
-        keyStore.load(new FileInputStream(userCertPath), userCertPassword.toCharArray());
-
-        KeyStore trustStore = KeyStore.getInstance("jks");
-        trustStore.load(new FileInputStream(caCertPath), caCertPassword.toCharArray());
-
-        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance("X509");
-        trustManagerFactory.init(trustStore);
-
-        KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance("PKIX");
-        keyManagerFactory.init(keyStore, userCertPassword.toCharArray());
-
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null);
-
-        return sslContext.getSocketFactory();
     }
 }
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a code snippet; no runtime code is modified.
> 
> **Overview**
> Updates the Jedis TLS connection example in `content/develop/clients/jedis/connect.md` to use the recommended `SslOptions` API instead of manually constructing an `SSLSocketFactory`.
> 
> Removes the custom `createSslSocketFactory` helper and related imports, and shows configuring truststore/keystore types directly via the `SslOptions.builder()` passed into `DefaultJedisClientConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fce83ae0bf2040c1cefcd60eb9dd5a07beadacc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->