### PR TITLE
Add support for redisvl grid doc pages

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -121,22 +121,26 @@ jobs:
               fi
 
 
-              # Inject weight property for index pages to preserve order
-              case "${title}" in
-                  "Overview")
-                      echo "weight: 3" >> _tmp ;;
-                  "Concepts")
-                      echo "weight: 3" >> _tmp ;;
-                  "User Guides")
-                      echo "weight: 4" >> _tmp ;;
-                  "RedisVL API")
-                      echo "weight: 5" >> _tmp ;;
-              esac
-
-              # For user guides, strip the leading numbers from filename and use them for weight
+              # Compute weight: filename-based prefix first, then override via title for top-level pages
+              weight=""
               f=$(basename "${src}")
               if [[ "$f" =~ ^([0-9][0-9])_(.+) ]]; then
-                  echo "weight: ${BASH_REMATCH[1]}" >> _tmp
+                  weight="${BASH_REMATCH[1]}"
+              fi
+              case "${title}" in
+                  "Overview") weight=3 ;;
+                  "Concepts") weight=3 ;;
+                  "User Guides") weight=4 ;;
+                  "Guides") weight=4 ;;
+                  "RedisVL API") weight=5 ;;
+                  "Installation") weight=1 ;;
+                  "Getting Started") weight=2 ;;
+                  "How-To Guides") weight=3 ;;
+                  "The RedisVL CLI") weight=4 ;;
+                  "Use Cases") weight=5 ;;
+              esac
+              if [ -n "${weight}" ]; then
+                  echo "weight: ${weight}" >> _tmp
               fi
 
               # For _index.md files, add hideListLinks property
@@ -177,6 +181,28 @@ jobs:
           if [ -d "./${build_folder}/markdown/concepts" ]; then
               rsync -a ./${build_folder}/markdown/concepts/ ./redis_vl_hugo/concepts/ --exclude=index.md
           fi
+
+          # Copy how_to_guides markdown files if they exist
+          if [ -d "./${build_folder}/markdown/user_guide/how_to_guides" ]; then
+              mkdir -p redis_vl_hugo/user_guide/how_to_guides/
+              rsync -a ./${build_folder}/markdown/user_guide/how_to_guides/ ./redis_vl_hugo/user_guide/how_to_guides/ --exclude=index.md
+          fi
+
+          # Copy use_cases markdown files if they exist
+          if [ -d "./${build_folder}/markdown/user_guide/use_cases" ]; then
+              mkdir -p redis_vl_hugo/user_guide/use_cases/
+              rsync -a ./${build_folder}/markdown/user_guide/use_cases/ ./redis_vl_hugo/user_guide/use_cases/ --exclude=index.md
+          fi
+
+          # Move numbered user-guide pages (except 01_getting_started) into how_to_guides/
+          mkdir -p redis_vl_hugo/user_guide/how_to_guides/
+          for f in ./redis_vl_hugo/user_guide/[0-9][0-9]_*.md; do
+              [ -e "$f" ] || continue
+              base=$(basename "$f")
+              if [[ "$base" != 01_getting_started.md ]]; then
+                  mv "$f" "./redis_vl_hugo/user_guide/how_to_guides/${base}"
+              fi
+          done
 
           # Format markdown files
           shopt -s globstar
@@ -282,34 +308,84 @@ jobs:
 
           # Format _index.md pages
           cp ./${build_folder}/markdown/api/index.md ./redis_vl_hugo/api/_index.md
-          cp ./${build_folder}/markdown/user_guide/index.md ./redis_vl_hugo/user_guide/_index.md
 
           index_markdown_pages=(
               ./redis_vl_hugo/api/_index.md
-              ./redis_vl_hugo/user_guide/_index.md
           )
+
+          # Fetch an upstream MyST landing page (local clone preferred, GitHub fallback) and
+          # convert its grid-card directives into Hugo HTML cards via build/redisvl_grid_to_cards.py.
+          # Falls back to copying the post-Sphinx markdown if the upstream source can't be obtained.
+          fetch_landing_source() {
+              local rel_path="$1"
+              local out_path="$2"
+              if [ -f "./redis-vl-python/docs/${rel_path}" ]; then
+                  cp "./redis-vl-python/docs/${rel_path}" "${out_path}"
+                  return 0
+              fi
+              for ref in "v${version}" "${version}" "main"; do
+                  if curl -fsSL "https://raw.githubusercontent.com/redis/redis-vl-python/${ref}/docs/${rel_path}" -o "${out_path}"; then
+                      return 0
+                  fi
+              done
+              return 1
+          }
+
+          transform_landing() {
+              local rel_path="$1"
+              local hugo_dest="$2"
+              local context="$3"
+              local fallback="$4"
+              local tmp_src
+              tmp_src=$(mktemp)
+              if fetch_landing_source "${rel_path}" "${tmp_src}"; then
+                  python3 build/redisvl_grid_to_cards.py "${tmp_src}" "${hugo_dest}" --context "${context}"
+                  rm -f "${tmp_src}"
+                  return 0
+              fi
+              rm -f "${tmp_src}"
+              if [ -n "${fallback}" ] && [ -f "${fallback}" ]; then
+                  cp "${fallback}" "${hugo_dest}"
+                  return 0
+              fi
+              return 1
+          }
+
+          if transform_landing "user_guide/index.md" "./redis_vl_hugo/user_guide/_index.md" "user_guide" "./${build_folder}/markdown/user_guide/index.md"; then
+              index_markdown_pages+=(./redis_vl_hugo/user_guide/_index.md)
+          fi
 
           if [ -f "./${build_folder}/markdown/overview/index.md" ]; then
               cp ./${build_folder}/markdown/overview/index.md ./redis_vl_hugo/overview/_index.md
               index_markdown_pages+=(./redis_vl_hugo/overview/_index.md)
           fi
-          if [ -f "./${build_folder}/markdown/concepts/index.md" ]; then
-              cp ./${build_folder}/markdown/concepts/index.md ./redis_vl_hugo/concepts/_index.md
-              index_markdown_pages+=(./redis_vl_hugo/concepts/_index.md)
+
+          if [ -d "./redis_vl_hugo/concepts" ]; then
+              if transform_landing "concepts/index.md" "./redis_vl_hugo/concepts/_index.md" "concepts" "./${build_folder}/markdown/concepts/index.md"; then
+                  index_markdown_pages+=(./redis_vl_hugo/concepts/_index.md)
+              fi
+          fi
+
+          if transform_landing "user_guide/how_to_guides/index.md" "./redis_vl_hugo/user_guide/how_to_guides/_index.md" "how_to_guides" "./${build_folder}/markdown/user_guide/how_to_guides/index.md"; then
+              index_markdown_pages+=(./redis_vl_hugo/user_guide/how_to_guides/_index.md)
+          fi
+
+          if transform_landing "user_guide/use_cases/index.md" "./redis_vl_hugo/user_guide/use_cases/_index.md" "use_cases" "./${build_folder}/markdown/user_guide/use_cases/index.md"; then
+              index_markdown_pages+=(./redis_vl_hugo/user_guide/use_cases/_index.md)
           fi
 
           for index_markdown_page in "${index_markdown_pages[@]}"; do
               format "${index_markdown_page}"
 
-              # Fix relrefs by removing .md extension and references to numbered pages
-              sed -E -i 's/\.md/\//g; s/\([0-9]{2}_/\(/g; s/\/index\//\//g' "${index_markdown_page}"
+              # Fix relrefs by removing .md extension and references to numbered pages (with or without a path prefix)
+              sed -E -i 's/\.md/\//g; s/\(([^)]*\/)?([0-9]{2}_)/(\1/g; s/\/index\//\//g' "${index_markdown_page}"
           done
 
-          # Rename user guides to strip leading numbers from filename
-          user_guides=(./redis_vl_hugo/user_guide/*.md)
+          # Rename user guides to strip leading numbers from filename (top level and how_to_guides)
+          user_guides=(./redis_vl_hugo/user_guide/**/*.md)
           for user_guide in "${user_guides[@]}"; do
               if [[ ! "$user_guide" =~ _index.md$ ]]; then
-                  renamed_user_guide=$(sed 's|[0-9]\+_||' <<<${user_guide})
+                  renamed_user_guide=$(sed 's|/[0-9]\+_|/|' <<<${user_guide})
                   if [ "${user_guide}" != "${renamed_user_guide}" ]; then
                       mv ${user_guide} ${renamed_user_guide}
                   fi

--- a/build/redisvl_grid_to_cards.py
+++ b/build/redisvl_grid_to_cards.py
@@ -26,13 +26,17 @@ def convert_link(link, context):
     link = re.sub(r"/index$", "", link)
     parts = ["" if p == "" else re.sub(r"^[0-9]+_", "", p) for p in link.split("/")]
     link = "/".join(parts)
+    # Files that remain at the user_guide/ level (parent of how_to_guides and
+    # use_cases). Links to these targets must keep the ../ prefix; everything
+    # else under ../ is a former NN_ guide that has been moved into how_to_guides/.
+    user_guide_top_level = ("getting_started", "installation", "cli")
     if context == "how_to_guides" and link.startswith("../"):
         rest = link[3:]
-        if rest and not rest.startswith("cli"):
+        if rest and rest not in user_guide_top_level:
             link = rest
     elif context == "use_cases" and link.startswith("../"):
         rest = link[3:]
-        if rest and rest not in ("getting_started", "installation", "cli"):
+        if rest and rest not in user_guide_top_level:
             link = "../how_to_guides/" + rest
     if link and not link.endswith("/"):
         link = link + "/"

--- a/build/redisvl_grid_to_cards.py
+++ b/build/redisvl_grid_to_cards.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Convert MyST grid-card directives in upstream redisvl markdown to Hugo-friendly HTML cards.
+
+Reads a source markdown file, strips upstream YAML frontmatter and `{toctree}` blocks,
+replaces `::::{grid} N` ... `::::` blocks with HTML grids, and rewrites markdown link
+targets to match the Hugo destination paths produced by redisvlscript.sh.
+"""
+import argparse
+import re
+from pathlib import Path
+
+GRID_CLASSES = "grid grid-cols-1 md:grid-cols-2 gap-4 my-6"
+CARD_CLASSES = (
+    "block p-5 border border-redis-pen-300 rounded-lg "
+    "hover:border-redis-red-500 hover:shadow-md transition-all duration-200 "
+    "no-underline hover:no-underline"
+)
+STATIC_CARD_CLASSES = "p-5 border border-redis-pen-300 rounded-lg"
+
+
+def convert_link(link, context):
+    """Map an upstream link target to a Hugo-relative URL."""
+    if link.startswith(("http://", "https://", "#", "/")):
+        return link
+    link = re.sub(r"\.(md|ipynb)$", "", link)
+    link = re.sub(r"/index$", "", link)
+    parts = ["" if p == "" else re.sub(r"^[0-9]+_", "", p) for p in link.split("/")]
+    link = "/".join(parts)
+    if context == "how_to_guides" and link.startswith("../"):
+        rest = link[3:]
+        if rest and not rest.startswith("cli"):
+            link = rest
+    elif context == "use_cases" and link.startswith("../"):
+        rest = link[3:]
+        if rest and rest not in ("getting_started", "installation", "cli"):
+            link = "../how_to_guides/" + rest
+    if link and not link.endswith("/"):
+        link = link + "/"
+    return link
+
+
+def render_inline(text, context):
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+
+    def link_repl(m):
+        return f'<a href="{convert_link(m.group(2), context)}">{m.group(1)}</a>'
+
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", link_repl, text)
+    text = text.replace(" -- ", " — ")
+    return text
+
+
+def render_body(lines, context):
+    out, paragraph, in_list = [], [], False
+
+    def flush_paragraph():
+        nonlocal paragraph
+        if paragraph:
+            out.append("<p>" + render_inline(" ".join(paragraph), context) + "</p>")
+            paragraph = []
+
+    for line in lines:
+        line = line.rstrip()
+        if line.startswith("- ") or line.startswith("* "):
+            flush_paragraph()
+            if not in_list:
+                out.append("<ul>")
+                in_list = True
+            out.append("<li>" + render_inline(line[2:], context) + "</li>")
+        elif not line.strip():
+            flush_paragraph()
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+        else:
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+            paragraph.append(line)
+    flush_paragraph()
+    if in_list:
+        out.append("</ul>")
+    return "\n".join(out)
+
+
+def parse_grid(lines, start_idx, context):
+    cards = []
+    i = start_idx + 1
+    while i < len(lines) and lines[i].rstrip() != "::::":
+        line = lines[i].rstrip()
+        if line.startswith(":::{grid-item-card}"):
+            title = line[len(":::{grid-item-card}"):].strip()
+            link, body, footer, in_footer = None, [], [], False
+            i += 1
+            while i < len(lines) and lines[i].rstrip() != ":::":
+                cline = lines[i].rstrip()
+                if cline.startswith(":link:"):
+                    link = cline[len(":link:"):].strip()
+                elif cline.startswith(":link-type:") or cline.startswith(":gutter:"):
+                    pass
+                elif cline.strip() == "+++":
+                    in_footer = True
+                else:
+                    (footer if in_footer else body).append(cline)
+                i += 1
+            while body and not body[0].strip():
+                body.pop(0)
+            while body and not body[-1].strip():
+                body.pop()
+            cards.append((title, link, body, footer))
+        i += 1
+    out = [f'<div class="{GRID_CLASSES}">']
+    for title, link, body, footer in cards:
+        body_html = render_body(body, context)
+        footer_html = ""
+        if footer:
+            text = " ".join(l.strip() for l in footer if l.strip())
+            if text:
+                footer_html = f'<p class="text-sm opacity-75 mt-3">{render_inline(text, context)}</p>'
+        title_html = render_inline(title, context)
+        if link:
+            href = convert_link(link, context)
+            out.append(
+                f'<a href="{href}" class="{CARD_CLASSES}">'
+                f'<h3 class="mt-0 mb-2">{title_html}</h3>{body_html}{footer_html}</a>'
+            )
+        else:
+            out.append(
+                f'<div class="{STATIC_CARD_CLASSES}">'
+                f'<h3 class="mt-0 mb-2">{title_html}</h3>{body_html}{footer_html}</div>'
+            )
+    out.append("</div>")
+    return "\n".join(out), i
+
+
+
+def strip_frontmatter(text):
+    if text.startswith("---\n"):
+        end = text.find("\n---\n", 4)
+        if end != -1:
+            return text[end + 5:]
+    return text
+
+
+def transform(text, context):
+    text = strip_frontmatter(text)
+    lines = text.splitlines()
+    out, i = [], 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.rstrip()
+        if stripped.startswith("::::{grid}"):
+            html, end = parse_grid(lines, i, context)
+            out.append(html)
+            i = end + 1
+            continue
+        if stripped.startswith(":::{grid-item-card}") or stripped in (":::", "::::"):
+            i += 1
+            continue
+        if stripped.startswith(":gutter:") or stripped.startswith(":link:") or stripped.startswith(":link-type:"):
+            i += 1
+            continue
+        if stripped.startswith("```{toctree}"):
+            i += 1
+            while i < len(lines) and not lines[i].rstrip().startswith("```"):
+                i += 1
+            i += 1
+            continue
+        # Rewrite markdown links outside grid blocks too (tables, paragraphs).
+        rewritten = re.sub(
+            r"\[([^\]]+)\]\(([^)]+)\)",
+            lambda m: f"[{m.group(1)}]({convert_link(m.group(2), context)})",
+            line,
+        )
+        out.append(rewritten)
+        i += 1
+    return "\n".join(out).strip() + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", help="Path to upstream MyST markdown file")
+    parser.add_argument("destination", help="Path to write the transformed Hugo markdown")
+    parser.add_argument(
+        "--context",
+        choices=("concepts", "user_guide", "how_to_guides", "use_cases"),
+        required=True,
+        help="Page context controlling relative link rewriting",
+    )
+    args = parser.parse_args()
+    text = Path(args.source).read_text(encoding="utf-8")
+    Path(args.destination).write_text(transform(text, args.context), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the docs sync workflow’s content layout/weighting and link rewriting, which could reorder sections or break navigation paths if assumptions about upstream file structure change.
> 
> **Overview**
> Adds support for upstream RedisVL *grid-card* landing pages by introducing `build/redisvl_grid_to_cards.py`, which converts MyST `grid`/`grid-item-card` directives into Hugo-friendly HTML cards while stripping frontmatter/toctree blocks and rewriting links.
> 
> Updates the `redisvl_docs_sync` workflow to (1) fetch upstream landing-page sources (local clone or GitHub raw) and transform them into `_index.md` files for `user_guide`, `concepts`, `how_to_guides`, and `use_cases`, (2) copy and reorganize guide content into `how_to_guides/` and `use_cases/`, and (3) adjust frontmatter `weight` computation and relref/link cleanup to match the new structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ea76cf9085be71ccf0bd87f4bb4f816af8a0a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->