### PR TITLE
DEV: fix a few typos

### DIFF
--- a/content/develop/clients/lettuce/amr.md
+++ b/content/develop/clients/lettuce/amr.md
@@ -85,7 +85,7 @@ You can also add configuration to authenticate with a [service principal](#serv-
 or a [managed identity](#mgd-identity) as described in the sections below.
 
 When you have created your `TokenBasedRedisCredentialsProvider` instance, you may want to
-test it by obtaining a token, as shown in the folowing example:
+test it by obtaining a token, as shown in the following example:
 
 ```java
 // Test that the Entra ID credentials provider can resolve credentials.

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -148,7 +148,7 @@ client.hset('user', 'name', 'Bob', 'age', 20, 'description', 'I am a programmer'
 ```
 
 `node-redis` uses predefined formats for command arguments. These include specific
-classes for commmand options that generally don't correspond to the syntax
+classes for command options that generally don't correspond to the syntax
 of the CLI command. Internally, `node-redis` constructs the correct command using
 the method arguments you pass:
 

--- a/content/develop/clients/patterns/twitter-clone.md
+++ b/content/develop/clients/patterns/twitter-clone.md
@@ -283,7 +283,7 @@ This is the actual code:
     setcookie("auth",$authsecret,time()+3600*24*365);
     header("Location: index.php");
 
-This happens every time a user logs in, but we also need a function `isLoggedIn` in order to check if a given user is already authenticated or not. These are the logical steps preformed by the `isLoggedIn` function:
+This happens every time a user logs in, but we also need a function `isLoggedIn` in order to check if a given user is already authenticated or not. These are the logical steps performed by the `isLoggedIn` function:
 
  * Get the "auth" cookie from the user. If there is no cookie, the user is not logged in, of course. Let's call the value of the cookie `<authcookie>`.
  * Check if `<authcookie>` field in the `auths` Hash exists, and what the value (the user ID) is (1000 in the example).

--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -965,7 +965,7 @@ The program shows stats every second. In the first seconds the cache starts to b
     127000 Gets/sec | Hits: 50870 (40.06%) | Misses: 76130 (59.94%)
     124250 Gets/sec | Hits: 50147 (40.36%) | Misses: 74103 (59.64%)
 
-A miss rate of 59% may not be acceptable for certain use cases therefor
+A miss rate of 59% may not be acceptable for certain use cases;
 100MB of memory is not enough. Observe an example using a half gigabyte of memory. After several
 minutes the output stabilizes to the following figures:
 


### PR DESCRIPTION
Four typo fixes from @rohan5commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that correct spelling/grammar and a punctuation issue; no code or behavior changes.
> 
> **Overview**
> Fixes a handful of minor typos/wording issues across docs, including Entra ID/Lettuce auth guidance, the `node-redis` migration guide, the Twitter-clone pattern writeup, and `redis-cli` LRU test output text (spelling and punctuation corrections only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06b3819fa4ab826b7a68c6237990583f49e7945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->