### PR TITLE
DOC-6510 Rust data type examples

### DIFF
--- a/local_examples/rust-async/dt-list.rs
+++ b/local_examples/rust-async/dt-list.rs
@@ -1,0 +1,569 @@
+// EXAMPLE: list_tutorial
+#[cfg(test)]
+mod tests {
+    use redis::{AsyncCommands, Direction, ValueType};
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    fn print_optional_string(value: Option<String>) {
+        match value {
+            Some(value) => println!("{value}"),
+            None => println!("(nil)"),
+        }
+    }
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().await.expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START queue
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:1").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:2").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START stack
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:1").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:2").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START llen
+        if let Ok(res) = r.llen("bikes:repairs").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START lmove_lrange
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:1").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:2").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .lmove(
+                "bikes:repairs",
+                "bikes:finished",
+                Direction::Left,
+                Direction::Left,
+            )
+            .await
+        {
+            let res: String = res;
+            println!("{res}"); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, "bike:2");
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:1"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:finished", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:2"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:2"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START ltrim.1
+        if let Ok(res) = r.del("bikes:repairs").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .rpush(
+                "bikes:repairs",
+                &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"],
+            )
+            .await
+        {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.ltrim("bikes:repairs", 0, 2).await {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START lpush_rpush
+        let _: usize = r.del("bikes:repairs").await.unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", "bike:1").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpush("bikes:repairs", "bike:2").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:important_bike").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:important_bike", "bike:1", "bike:2"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:important_bike", "bike:1", "bike:2"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START variadic
+        let _: usize = r.del("bikes:repairs").await.unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2", "bike:3"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .lpush("bikes:repairs", &["bike:important_bike", "bike:very_important_bike"])
+            .await
+        {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["bike:very_important_bike", "bike:important_bike", "bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&[
+                    "bike:very_important_bike",
+                    "bike:important_bike",
+                    "bike:1",
+                    "bike:2",
+                    "bike:3",
+                ])
+            );
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START lpop_rpop
+        let _: usize = r.del("bikes:repairs").await.unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2", "bike:3"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:3
+            // REMOVE_START
+            assert_eq!(res, Some("bike:3".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> (nil)
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START ltrim
+        if let Ok(res) = r
+            .rpush(
+                "bikes:repairs",
+                &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"],
+            )
+            .await
+        {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.ltrim("bikes:repairs", 0, 2).await {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START ltrim_end_of_list
+        let _: usize = r.del("bikes:repairs").await.unwrap_or(0);
+
+        if let Ok(res) = r
+            .rpush(
+                "bikes:repairs",
+                &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"],
+            )
+            .await
+        {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.ltrim("bikes:repairs", -3, -1).await {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:3", "bike:4", "bike:5"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:3", "bike:4", "bike:5"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START brpop
+        let _: usize = r.del("bikes:repairs").await.unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.brpop("bikes:repairs", 1.0).await {
+            let res: Option<[String; 2]> = res;
+            println!("{res:?}"); // >>> Some(["bikes:repairs", "bike:2"])
+            // REMOVE_START
+            assert_eq!(res, Some(["bikes:repairs".to_string(), "bike:2".to_string()]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.brpop("bikes:repairs", 1.0).await {
+            let res: Option<[String; 2]> = res;
+            println!("{res:?}"); // >>> Some(["bikes:repairs", "bike:1"])
+            // REMOVE_START
+            assert_eq!(res, Some(["bikes:repairs".to_string(), "bike:1".to_string()]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.brpop("bikes:repairs", 1.0).await {
+            let res: Option<[String; 2]> = res;
+            println!("{res:?}"); // >>> None
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START rule_1
+        if let Ok(res) = r.del("new_bikes").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("new_bikes", &["bike:1", "bike:2", "bike:3"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START rule_1.1
+        if let Ok(res) = r.del("new_bikes").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.set("new_bikes", "bike:1").await {
+            let res: String = res;
+            println!("{res}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.key_type("new_bikes").await {
+            let res: ValueType = res;
+            let res: String = res.into();
+            println!("{res}"); // >>> string
+            // REMOVE_START
+            assert_eq!(res, "string");
+            // REMOVE_END
+        }
+
+        let res: redis::RedisResult<usize> = r.lpush("new_bikes", &["bike:2", "bike:3"]).await;
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if let Some((_, tail)) = msg.split_once("WRONGTYPE ") {
+                    println!("WRONGTYPE {tail}");
+                } else {
+                    println!("{msg}");
+                }
+                // REMOVE_START
+                assert!(msg.contains("WRONGTYPE"));
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START rule_2
+        // HIDE_START
+        let _: usize = r.rpush("bikes:repairs", "bike:placeholder").await.unwrap_or(0);
+        // HIDE_END
+        if let Ok(res) = r.del("bikes:repairs").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", &["bike:1", "bike:2", "bike:3"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.exists("bikes:repairs").await {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 1
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:3
+            // REMOVE_START
+            assert_eq!(res, Some("bike:3".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.exists("bikes:repairs").await {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 0
+            // REMOVE_START
+            assert!(!res);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START rule_3
+        if let Ok(res) = r.del("bikes:repairs").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.llen("bikes:repairs").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None).await {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> (nil)
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-async/dt-sets.rs
+++ b/local_examples/rust-async/dt-sets.rs
@@ -1,0 +1,293 @@
+// EXAMPLE: sets_tutorial
+#[cfg(test)]
+mod tests {
+    use redis::AsyncCommands;
+    use std::collections::HashSet;
+
+    fn sorted(mut values: Vec<String>) -> Vec<String> {
+        values.sort();
+        values
+    }
+
+    fn sorted_set(values: HashSet<String>) -> Vec<String> {
+        sorted(values.into_iter().collect())
+    }
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => {
+                match client.get_multiplexed_async_connection().await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        println!("Failed to connect to Redis: {e}");
+                        return;
+                    }
+                }
+            }
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().await.expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START sadd
+        if let Ok(res) = r.sadd("bikes:racing:france", "bike:1").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sadd("bikes:racing:france", "bike:1").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sadd("bikes:racing:france", &["bike:2", "bike:3"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sadd("bikes:racing:usa", &["bike:1", "bike:4"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sismember
+        if let Ok(res) = r.sismember("bikes:racing:usa", "bike:1").await {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 1
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sismember("bikes:racing:usa", "bike:2").await {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 0
+            // REMOVE_START
+            assert!(!res);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sinter
+        if let Ok(res) = r.sinter(["bikes:racing:france", "bikes:racing:usa"]).await {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START scard
+        if let Ok(res) = r.scard("bikes:racing:france").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sadd_smembers
+        let _: usize = r.del("bikes:racing:france").await.unwrap_or(0);
+
+        if let Ok(res) = r.sadd("bikes:racing:france", &["bike:1", "bike:2", "bike:3"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.smembers("bikes:racing:france").await {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START smismember
+        if let Ok(res) = r.sismember("bikes:racing:france", "bike:1").await {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 1
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .smismember("bikes:racing:france", &["bike:2", "bike:3", "bike:4"])
+            .await
+        {
+            let res: Vec<bool> = res;
+            let res: Vec<i32> = res.into_iter().map(i32::from).collect();
+            println!("{res:?}"); // >>> [1, 1, 0]
+            // REMOVE_START
+            assert_eq!(res, vec![1, 1, 0]);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sdiff
+        let _: usize = r.del("bikes:racing:france").await.unwrap_or(0);
+        let _: usize = r.del("bikes:racing:usa").await.unwrap_or(0);
+        let _: usize = r
+            .sadd("bikes:racing:france", &["bike:1", "bike:2", "bike:3"])
+            .await
+            .unwrap_or(0);
+        let _: usize = r
+            .sadd("bikes:racing:usa", &["bike:1", "bike:4"])
+            .await
+            .unwrap_or(0);
+
+        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]).await {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START multisets
+        let _: usize = r
+            .del(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+            .await
+            .unwrap_or(0);
+        let _: usize = r
+            .sadd("bikes:racing:france", &["bike:1", "bike:2", "bike:3"])
+            .await
+            .unwrap_or(0);
+        let _: usize = r
+            .sadd("bikes:racing:usa", &["bike:1", "bike:4"])
+            .await
+            .unwrap_or(0);
+        let _: usize = r
+            .sadd("bikes:racing:italy", &["bike:1", "bike:2", "bike:3", "bike:4"])
+            .await
+            .unwrap_or(0);
+
+        if let Ok(res) = r
+            .sinter(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+            .await
+        {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .sunion(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+            .await
+        {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3", "bike:4"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3", "bike:4"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .sdiff(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+            .await
+        {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> []
+            // REMOVE_START
+            assert!(res.is_empty());
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]).await {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sdiff(["bikes:racing:usa", "bikes:racing:france"]).await {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:4"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:4"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START srem
+        let _: usize = r.del("bikes:racing:france").await.unwrap_or(0);
+        let _: usize = r
+            .sadd(
+                "bikes:racing:france",
+                &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"],
+            )
+            .await
+            .unwrap_or(0);
+
+        if let Ok(res) = r.srem("bikes:racing:france", "bike:1").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.spop("bikes:racing:france").await {
+            let res: Option<String> = res;
+            match res {
+                Some(res) => println!("{res}"), // >>> bike:3 (for example)
+                None => println!("(nil)"),
+            }
+        }
+
+        if let Ok(res) = r.smembers("bikes:racing:france").await {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:2", "bike:4", "bike:5"] (for example)
+        }
+
+        if let Ok(res) = r.srandmember("bikes:racing:france").await {
+            let res: Option<String> = res;
+            match res {
+                Some(res) => println!("{res}"), // >>> bike:4 (for example)
+                None => println!("(nil)"),
+            }
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-async/dt-sets.rs
+++ b/local_examples/rust-async/dt-sets.rs
@@ -91,7 +91,7 @@ mod tests {
         // STEP_END
 
         // STEP_START sinter
-        if let Ok(res) = r.sinter(["bikes:racing:france", "bikes:racing:usa"]).await {
+        if let Ok(res) = r.sinter(&["bikes:racing:france", "bikes:racing:usa"]).await {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:1"]
@@ -166,7 +166,7 @@ mod tests {
             .await
             .unwrap_or(0);
 
-        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]).await {
+        if let Ok(res) = r.sdiff(&["bikes:racing:france", "bikes:racing:usa"]).await {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:2", "bike:3"]
@@ -195,7 +195,7 @@ mod tests {
             .unwrap_or(0);
 
         if let Ok(res) = r
-            .sinter(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+            .sinter(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
             .await
         {
             let res: HashSet<String> = res;
@@ -207,7 +207,7 @@ mod tests {
         }
 
         if let Ok(res) = r
-            .sunion(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+            .sunion(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
             .await
         {
             let res: HashSet<String> = res;
@@ -219,7 +219,7 @@ mod tests {
         }
 
         if let Ok(res) = r
-            .sdiff(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+            .sdiff(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
             .await
         {
             let res: HashSet<String> = res;
@@ -230,7 +230,7 @@ mod tests {
             // REMOVE_END
         }
 
-        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]).await {
+        if let Ok(res) = r.sdiff(&["bikes:racing:france", "bikes:racing:usa"]).await {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:2", "bike:3"]
@@ -239,7 +239,7 @@ mod tests {
             // REMOVE_END
         }
 
-        if let Ok(res) = r.sdiff(["bikes:racing:usa", "bikes:racing:france"]).await {
+        if let Ok(res) = r.sdiff(&["bikes:racing:usa", "bikes:racing:france"]).await {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:4"]

--- a/local_examples/rust-async/dt-sorted-sets.rs
+++ b/local_examples/rust-async/dt-sorted-sets.rs
@@ -1,0 +1,264 @@
+// EXAMPLE: ss_tutorial
+#[cfg(test)]
+mod tests {
+    use redis::AsyncCommands;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    fn score_pairs(values: &[(&str, f64)]) -> Vec<(String, f64)> {
+        values
+            .iter()
+            .map(|(member, score)| (member.to_string(), *score))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().await.expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START zadd
+        if let Ok(res) = r.zadd("racer_scores", "Norem", 10).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zadd("racer_scores", "Castilla", 12).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .zadd_multiple(
+                "racer_scores",
+                &[
+                    (8, "Sam-Bodden"),
+                    (10, "Royce"),
+                    (6, "Ford"),
+                    (14, "Prickett"),
+                    (12, "Castilla"),
+                ],
+            )
+            .await
+        {
+            let res: usize = res;
+            println!("{res}"); // >>> 4
+            // REMOVE_START
+            assert_eq!(res, 4);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrange
+        if let Ok(res) = r.zrange("racer_scores", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["Ford", "Sam-Bodden", "Norem", "Royce", "Castilla", "Prickett"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&["Ford", "Sam-Bodden", "Norem", "Royce", "Castilla", "Prickett"])
+            );
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrevrange("racer_scores", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["Prickett", "Castilla", "Royce", "Norem", "Sam-Bodden", "Ford"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&["Prickett", "Castilla", "Royce", "Norem", "Sam-Bodden", "Ford"])
+            );
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrange_withscores
+        if let Ok(res) = r.zrange_withscores("racer_scores", 0, -1).await {
+            let res: Vec<(String, f64)> = res;
+            println!("{res:?}");
+            // >>> [("Ford", 6.0), ("Sam-Bodden", 8.0), ("Norem", 10.0), ("Royce", 10.0), ("Castilla", 12.0), ("Prickett", 14.0)]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                score_pairs(&[
+                    ("Ford", 6.0),
+                    ("Sam-Bodden", 8.0),
+                    ("Norem", 10.0),
+                    ("Royce", 10.0),
+                    ("Castilla", 12.0),
+                    ("Prickett", 14.0),
+                ])
+            );
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrangebyscore
+        if let Ok(res) = r.zrangebyscore("racer_scores", "-inf", 10).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["Ford", "Sam-Bodden", "Norem", "Royce"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["Ford", "Sam-Bodden", "Norem", "Royce"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zremrangebyscore
+        if let Ok(res) = r.zrem("racer_scores", "Castilla").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrembyscore("racer_scores", "-inf", 9).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrange("racer_scores", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["Norem", "Royce", "Prickett"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["Norem", "Royce", "Prickett"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrank
+        if let Ok(res) = r.zrank("racer_scores", "Norem").await {
+            let res: Option<usize> = res;
+            if let Some(res) = res {
+                println!("{res}"); // >>> 0
+                // REMOVE_START
+                assert_eq!(res, 0);
+                // REMOVE_END
+            }
+        }
+
+        if let Ok(res) = r.zrevrank("racer_scores", "Norem").await {
+            let res: Option<usize> = res;
+            if let Some(res) = res {
+                println!("{res}"); // >>> 2
+                // REMOVE_START
+                assert_eq!(res, 2);
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START zadd_lex
+        if let Ok(res) = r
+            .zadd_multiple(
+                "racer_scores",
+                &[
+                    (0, "Norem"),
+                    (0, "Sam-Bodden"),
+                    (0, "Royce"),
+                    (0, "Ford"),
+                    (0, "Prickett"),
+                    (0, "Castilla"),
+                ],
+            )
+            .await
+        {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrange("racer_scores", 0, -1).await {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["Castilla", "Ford", "Norem", "Prickett", "Royce", "Sam-Bodden"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&["Castilla", "Ford", "Norem", "Prickett", "Royce", "Sam-Bodden"])
+            );
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrangebylex("racer_scores", "[A", "[L").await {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["Castilla", "Ford"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["Castilla", "Ford"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START leaderboard
+        if let Ok(res) = r.zadd("racer_scores", "Wood", 100).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zadd("racer_scores", "Henshaw", 100).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zadd("racer_scores", "Henshaw", 150).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zincr("racer_scores", "Wood", 50).await {
+            let res: f64 = res;
+            println!("{res}"); // >>> 150
+            // REMOVE_START
+            assert_eq!(res, 150.0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zincr("racer_scores", "Henshaw", 50).await {
+            let res: f64 = res;
+            println!("{res}"); // >>> 200
+            // REMOVE_START
+            assert_eq!(res, 200.0);
+            // REMOVE_END
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-async/dt-stream.rs
+++ b/local_examples/rust-async/dt-stream.rs
@@ -1,0 +1,1113 @@
+// EXAMPLE: stream_tutorial
+#[cfg(test)]
+mod tests {
+    use redis::{
+        streams::{
+            StreamAutoClaimOptions, StreamInfoConsumersReply, StreamInfoGroupsReply,
+            StreamInfoStreamReply, StreamMaxlen, StreamPendingCountReply, StreamPendingReply,
+            StreamRangeReply, StreamReadOptions, StreamReadReply, StreamTrimmingMode, StreamTrimOptions,
+        },
+        AsyncCommands,
+    };
+    use tokio::time::{sleep, Duration};
+
+    async fn delete_keys(r: &mut redis::aio::MultiplexedConnection, keys: &[&str]) {
+        let _: usize = r.del(keys).await.unwrap_or(0);
+    }
+
+    async fn add_france_fixed(r: &mut redis::aio::MultiplexedConnection) {
+        delete_keys(r, &["race:france"]).await;
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632086370-0",
+                &[
+                    ("rider", "Castilla"),
+                    ("speed", "30.2"),
+                    ("position", "1"),
+                    ("location_id", "1"),
+                ],
+            )
+            .await
+            .expect("add france 1");
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632094485-0",
+                &[
+                    ("rider", "Norem"),
+                    ("speed", "28.8"),
+                    ("position", "3"),
+                    ("location_id", "1"),
+                ],
+            )
+            .await
+            .expect("add france 2");
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632102976-0",
+                &[
+                    ("rider", "Prickett"),
+                    ("speed", "29.7"),
+                    ("position", "2"),
+                    ("location_id", "1"),
+                ],
+            )
+            .await
+            .expect("add france 3");
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632147973-0",
+                &[
+                    ("rider", "Castilla"),
+                    ("speed", "29.9"),
+                    ("position", "1"),
+                    ("location_id", "2"),
+                ],
+            )
+            .await
+            .expect("add france 4");
+    }
+
+    async fn seed_usa_fixed(r: &mut redis::aio::MultiplexedConnection) {
+        delete_keys(r, &["race:usa"]).await;
+        let _: Option<String> = r
+            .xadd("race:usa", "0-1", &[("racer", "Castilla")])
+            .await
+            .expect("add usa 1");
+        let _: Option<String> = r
+            .xadd("race:usa", "0-2", &[("racer", "Norem")])
+            .await
+            .expect("add usa 2");
+    }
+
+    async fn seed_italy_group_base(r: &mut redis::aio::MultiplexedConnection) {
+        delete_keys(r, &["race:italy"]).await;
+        let _: () = r
+            .xgroup_create_mkstream("race:italy", "italy_riders", "$")
+            .await
+            .expect("create italy group");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632639151-0", &[("rider", "Castilla")])
+            .await
+            .expect("add italy 1");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632647899-0", &[("rider", "Royce")])
+            .await
+            .expect("add italy 2");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632662819-0", &[("rider", "Sam-Bodden")])
+            .await
+            .expect("add italy 3");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632670501-0", &[("rider", "Prickett")])
+            .await
+            .expect("add italy 4");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632678249-0", &[("rider", "Norem")])
+            .await
+            .expect("add italy 5");
+    }
+
+    async fn seed_italy_alice_pending(r: &mut redis::aio::MultiplexedConnection) {
+        seed_italy_group_base(r).await;
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice").count(1);
+        let _: Option<StreamReadReply> = r
+            .xread_options(&["race:italy"], &[">"], &opts)
+            .await
+            .expect("alice read pending");
+    }
+
+    async fn seed_italy_after_ack(r: &mut redis::aio::MultiplexedConnection) {
+        seed_italy_alice_pending(r).await;
+        let _: usize = r
+            .xack("race:italy", "italy_riders", &["1692632639151-0"])
+            .await
+            .expect("ack first italy message");
+    }
+
+    async fn seed_italy_bob_pending(r: &mut redis::aio::MultiplexedConnection) {
+        seed_italy_after_ack(r).await;
+        let opts = StreamReadOptions::default().group("italy_riders", "Bob").count(2);
+        let _: Option<StreamReadReply> = r
+            .xread_options(&["race:italy"], &[">"], &opts)
+            .await
+            .expect("bob read pending");
+    }
+
+    async fn seed_italy_info_state(r: &mut redis::aio::MultiplexedConnection) {
+        seed_italy_bob_pending(r).await;
+        sleep(Duration::from_millis(5)).await;
+        let _: redis::streams::StreamClaimReply = r
+            .xclaim("race:italy", "italy_riders", "Alice", 1, &["1692632647899-0"])
+            .await
+            .expect("alice claim");
+        sleep(Duration::from_millis(5)).await;
+        let _: redis::streams::StreamClaimReply = r
+            .xclaim("race:italy", "italy_riders", "Lora", 1, &["1692632662819-0"])
+            .await
+            .expect("lora claim");
+    }
+
+    async fn seed_trim_stream(r: &mut redis::aio::MultiplexedConnection) {
+        delete_keys(r, &["mystream"]).await;
+        for id in ["1-0", "2-0", "3-0", "4-0", "5-0", "6-0", "7-0", "8-0", "9-0", "10-0"] {
+            let _: Option<String> = r
+                .xadd("mystream", id, &[("field", "value")])
+                .await
+                .expect("seed mystream");
+        }
+    }
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().await.expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START xadd
+        let res1: Option<String> = r
+            .xadd(
+                "race:france",
+                "*",
+                &[
+                    ("rider", "Castilla"),
+                    ("speed", "30.2"),
+                    ("position", "1"),
+                    ("location_id", "1"),
+                ],
+            )
+            .await
+            .expect("xadd 1");
+        let res1 = res1.expect("missing stream id");
+        println!("{res1}"); // >>> 1692632086370-0
+
+        let res2: Option<String> = r
+            .xadd(
+                "race:france",
+                "*",
+                &[
+                    ("rider", "Norem"),
+                    ("speed", "28.8"),
+                    ("position", "3"),
+                    ("location_id", "1"),
+                ],
+            )
+            .await
+            .expect("xadd 2");
+        let res2 = res2.expect("missing stream id");
+        println!("{res2}"); // >>> 1692632094485-0
+
+        let res3: Option<String> = r
+            .xadd(
+                "race:france",
+                "*",
+                &[
+                    ("rider", "Prickett"),
+                    ("speed", "29.7"),
+                    ("position", "2"),
+                    ("location_id", "1"),
+                ],
+            )
+            .await
+            .expect("xadd 3");
+        let res3 = res3.expect("missing stream id");
+        println!("{res3}"); // >>> 1692632102976-0
+        // STEP_END
+        // REMOVE_START
+        let parse = |id: &str| {
+            let (ms, seq) = id.split_once('-').expect("invalid stream id");
+            (
+                ms.parse::<u64>().expect("invalid stream id millis"),
+                seq.parse::<u64>().expect("invalid stream id seq"),
+            )
+        };
+        assert!(parse(&res1) < parse(&res2));
+        assert!(parse(&res2) < parse(&res3));
+        // REMOVE_END
+
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        // STEP_START xrange
+        if let Ok(res) = r.xrange_count("race:france", "1692632086370-0", "+", 2).await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")])]
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        // STEP_START xread_block
+        let opts = StreamReadOptions::default().count(100).block(300);
+        if let Ok(res) = r.xread_options(&["race:france"], &["$"], &opts).await {
+            let res: Option<StreamReadReply> = res;
+            println!("{res:?}"); // >>> None
+        }
+        // STEP_END
+
+        // STEP_START xadd_2
+        if let Ok(res) = r
+            .xadd(
+                "race:france",
+                "*",
+                &[
+                    ("rider", "Castilla"),
+                    ("speed", "29.9"),
+                    ("position", "1"),
+                    ("location_id", "2"),
+                ],
+            )
+            .await
+        {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 1692632147973-0
+        }
+        // STEP_END
+
+        // STEP_START xlen
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xlen("race:france").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 4
+        }
+        // STEP_END
+
+        // STEP_START xadd_id
+        // HIDE_START
+        delete_keys(&mut r, &["race:usa"]).await;
+        // HIDE_END
+        if let Ok(res) = r.xadd("race:usa", "0-1", &[("racer", "Castilla")]).await {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 0-1
+        }
+        if let Ok(res) = r.xadd("race:usa", "0-2", &[("racer", "Norem")]).await {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 0-2
+        }
+        // STEP_END
+
+        // STEP_START xadd_bad_id
+        let res: redis::RedisResult<Option<String>> =
+            r.xadd("race:usa", "0-1", &[("racer", "Prickett")]).await;
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                println!("{msg}");
+                // >>> An error was signalled by the server - ResponseError: The ID specified in XADD is equal or smaller than the target stream top item
+            }
+        }
+        // STEP_END
+
+        // STEP_START xadd_7
+        // HIDE_START
+        seed_usa_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xadd("race:usa", "0-*", &[("racer", "Prickett")]).await {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 0-3
+        }
+        // STEP_END
+
+        // STEP_START xrange_all
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xrange_all("race:france").await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")]), ("1692632102976-0", [("rider", "Prickett"), ("speed", "29.7"), ("position", "2"), ("location_id", "1")]), ("1692632147973-0", [("rider", "Castilla"), ("speed", "29.9"), ("position", "1"), ("location_id", "2")])]
+        }
+        // STEP_END
+
+        // STEP_START xrange_time
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xrange("race:france", "1692632086369", "1692632086371").await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")])]
+        }
+        // STEP_END
+
+        // STEP_START xrange_step_1
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xrange_count("race:france", "-", "+", 2).await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")])]
+        }
+        // STEP_END
+
+        // STEP_START xrange_step_2
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xrange_count("race:france", "(1692632094485-0", "+", 2).await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632102976-0", [("rider", "Prickett"), ("speed", "29.7"), ("position", "2"), ("location_id", "1")]), ("1692632147973-0", [("rider", "Castilla"), ("speed", "29.9"), ("position", "1"), ("location_id", "2")])]
+        }
+        // STEP_END
+
+        // STEP_START xrange_empty
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xrange_count("race:france", "(1692632147973-0", "+", 2).await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> []
+        }
+        // STEP_END
+
+        // STEP_START xrevrange
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xrevrange_count("race:france", "+", "-", 1).await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632147973-0", [("rider", "Castilla"), ("speed", "29.9"), ("position", "1"), ("location_id", "2")])]
+        }
+        // STEP_END
+
+        // STEP_START xread
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        let opts = StreamReadOptions::default().count(2);
+        if let Ok(res) = r.xread_options(&["race:france"], &["0"], &opts).await {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("xread should return data")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![
+                                        ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                                        ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                                        ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                                        (
+                                            "location_id".to_string(),
+                                            entry.get::<String>("location_id").expect("missing location_id"),
+                                        ),
+                                    ],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:france", [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")])])]
+        }
+        // STEP_END
+
+        // STEP_START xgroup_create
+        // HIDE_START
+        add_france_fixed(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r.xgroup_create("race:france", "france_riders", "$").await {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+        // STEP_END
+
+        // STEP_START xgroup_create_mkstream
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]).await;
+        // HIDE_END
+        if let Ok(res) = r.xgroup_create_mkstream("race:italy", "italy_riders", "$").await {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+        // STEP_END
+
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]).await;
+        let _: () = r
+            .xgroup_create_mkstream("race:italy", "italy_riders", "$")
+            .await
+            .expect("create italy group");
+        // HIDE_END
+        // STEP_START xgroup_read
+        let italy_1: Option<String> = r
+            .xadd("race:italy", "1692632639151-0", &[("rider", "Castilla")])
+            .await
+            .expect("italy1");
+        let italy_1 = italy_1.expect("missing stream id");
+        println!("{italy_1}"); // >>> 1692632639151-0
+        let italy_2: Option<String> = r
+            .xadd("race:italy", "1692632647899-0", &[("rider", "Royce")])
+            .await
+            .expect("italy2");
+        let italy_2 = italy_2.expect("missing stream id");
+        println!("{italy_2}"); // >>> 1692632647899-0
+        let italy_3: Option<String> = r
+            .xadd("race:italy", "1692632662819-0", &[("rider", "Sam-Bodden")])
+            .await
+            .expect("italy3");
+        let italy_3 = italy_3.expect("missing stream id");
+        println!("{italy_3}"); // >>> 1692632662819-0
+        let italy_4: Option<String> = r
+            .xadd("race:italy", "1692632670501-0", &[("rider", "Prickett")])
+            .await
+            .expect("italy4");
+        let italy_4 = italy_4.expect("missing stream id");
+        println!("{italy_4}"); // >>> 1692632670501-0
+        let italy_5: Option<String> = r
+            .xadd("race:italy", "1692632678249-0", &[("rider", "Norem")])
+            .await
+            .expect("italy5");
+        let italy_5 = italy_5.expect("missing stream id");
+        println!("{italy_5}"); // >>> 1692632678249-0
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice").count(1);
+        if let Ok(res) = r.xread_options(&["race:italy"], &[">"], &opts).await {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("xgroup read should return data")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:italy", [("1692632639151-0", [("rider", "Castilla")])])]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_alice_pending(&mut r).await;
+        // HIDE_END
+        // STEP_START xgroup_read_id
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice");
+        if let Ok(res) = r.xread_options(&["race:italy"], &["0"], &opts).await {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("xgroup history")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:italy", [("1692632639151-0", [("rider", "Castilla")])])]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_alice_pending(&mut r).await;
+        // HIDE_END
+        // STEP_START xack
+        if let Ok(res) = r.xack("race:italy", "italy_riders", &["1692632639151-0"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+        }
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice");
+        if let Ok(res) = r.xread_options(&["race:italy"], &["0"], &opts).await {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("xgroup history")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("race:italy", [])]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_after_ack(&mut r).await;
+        // HIDE_END
+        // STEP_START xgroup_read_bob
+        let opts = StreamReadOptions::default().group("italy_riders", "Bob").count(2);
+        if let Ok(res) = r.xread_options(&["race:italy"], &[">"], &opts).await {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("bob should receive data")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:italy", [("1692632647899-0", [("rider", "Royce")]), ("1692632662819-0", [("rider", "Sam-Bodden")])])]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r).await;
+        // HIDE_END
+        // STEP_START xpending
+        if let Ok(res) = r.xpending("race:italy", "italy_riders").await {
+            let res: StreamPendingReply = res;
+            let view = match res {
+                StreamPendingReply::Empty => None,
+                StreamPendingReply::Data(data) => Some((
+                    data.count,
+                    data.start_id.clone(),
+                    data.end_id.clone(),
+                    data.consumers
+                        .iter()
+                        .map(|consumer| (consumer.name.clone(), consumer.pending))
+                        .collect::<Vec<_>>(),
+                )),
+            }
+            .expect("pending summary");
+            println!("{view:?}");
+            // >>> (2, "1692632647899-0", "1692632662819-0", [("Bob", 2)])
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r).await;
+        sleep(Duration::from_millis(5)).await;
+        // HIDE_END
+        // STEP_START xpending_plus_minus
+        if let Ok(res) = r.xpending_count("race:italy", "italy_riders", "-", "+", 10).await {
+            let res: StreamPendingCountReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        entry.consumer.clone(),
+                        entry.last_delivered_ms,
+                        entry.times_delivered,
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632647899-0", "Bob", 5, 1), ("1692632662819-0", "Bob", 5, 1)]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r).await;
+        // HIDE_END
+        // STEP_START xrange_pending
+        if let Ok(res) = r.xrange("race:italy", "1692632647899-0", "1692632647899-0").await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("1692632647899-0", [("rider", "Royce")])]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r).await;
+        sleep(Duration::from_millis(5)).await;
+        // HIDE_END
+        // STEP_START xclaim
+        if let Ok(res) = r
+            .xclaim("race:italy", "italy_riders", "Alice", 1, &["1692632647899-0"])
+            .await
+        {
+            let res: redis::streams::StreamClaimReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("1692632647899-0", [("rider", "Royce")])]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r).await;
+        sleep(Duration::from_millis(5)).await;
+        // HIDE_END
+        // STEP_START xautoclaim
+        let opts = StreamAutoClaimOptions::default().count(1);
+        if let Ok(res) = r
+            .xautoclaim_options("race:italy", "italy_riders", "Alice", 1, "0-0", opts)
+            .await
+        {
+            let res: redis::streams::StreamAutoClaimReply = res;
+            let claimed: Vec<_> = res
+                .claimed
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{:?}", (res.next_stream_id.clone(), &claimed));
+            // >>> ("1692632662819-0", [("1692632647899-0", [("rider", "Royce")])])
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r).await;
+        sleep(Duration::from_millis(5)).await;
+        let first_opts = StreamAutoClaimOptions::default().count(1);
+        let _: redis::streams::StreamAutoClaimReply = r
+            .xautoclaim_options("race:italy", "italy_riders", "Alice", 1, "0-0", first_opts)
+            .await
+            .expect("first autoclaim");
+        // HIDE_END
+        // STEP_START xautoclaim_cursor
+        let next_opts = StreamAutoClaimOptions::default().count(1);
+        if let Ok(res) = r
+            .xautoclaim_options(
+                "race:italy",
+                "italy_riders",
+                "Lora",
+                1,
+                "(1692632647899-0",
+                next_opts,
+            )
+            .await
+        {
+            let res: redis::streams::StreamAutoClaimReply = res;
+            let claimed: Vec<_> = res
+                .claimed
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{:?}", (res.next_stream_id.clone(), &claimed));
+            // >>> ("0-0", [("1692632662819-0", [("rider", "Sam-Bodden")])])
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_info_state(&mut r).await;
+        // HIDE_END
+        // STEP_START xinfo
+        if let Ok(res) = r.xinfo_stream("race:italy").await {
+            let res: StreamInfoStreamReply = res;
+            let view = (
+                res.length,
+                res.radix_tree_keys,
+                res.groups,
+                res.last_generated_id.clone(),
+                res.first_entry.id.clone(),
+                res.last_entry.id.clone(),
+            );
+            println!("{view:?}");
+            // >>> (5, 1, 1, "1692632678249-0", "1692632639151-0", "1692632678249-0")
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_info_state(&mut r).await;
+        // HIDE_END
+        // STEP_START xinfo_groups
+        if let Ok(res) = r.xinfo_groups("race:italy").await {
+            let res: StreamInfoGroupsReply = res;
+            let view: Vec<_> = res
+                .groups
+                .iter()
+                .map(|group| {
+                    (
+                        group.name.clone(),
+                        group.consumers,
+                        group.pending,
+                        group.last_delivered_id.clone(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("italy_riders", 3, 2, "1692632662819-0")]
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_info_state(&mut r).await;
+        // HIDE_END
+        // STEP_START xinfo_consumers
+        if let Ok(res) = r.xinfo_consumers("race:italy", "italy_riders").await {
+            let res: StreamInfoConsumersReply = res;
+            let mut view: Vec<_> = res
+                .consumers
+                .iter()
+                .map(|consumer| (consumer.name.clone(), consumer.pending, consumer.idle))
+                .collect();
+            view.sort_by(|a, b| a.0.cmp(&b.0));
+            println!("{view:?}");
+            // >>> [("Alice", 1, 5), ("Bob", 0, 5), ("Lora", 1, 5)]
+        }
+        // STEP_END
+
+        // STEP_START maxlen
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]).await;
+        // HIDE_END
+        let max1: Option<String> = r
+            .xadd_maxlen("race:italy", StreamMaxlen::Equals(2), "1-0", &[("rider", "Jones")])
+            .await
+            .expect("maxlen add 1");
+        let max1 = max1.expect("missing stream id");
+        println!("{max1}"); // >>> 1-0
+        let max2: Option<String> = r
+            .xadd_maxlen("race:italy", StreamMaxlen::Equals(2), "2-0", &[("rider", "Wood")])
+            .await
+            .expect("maxlen add 2");
+        let max2 = max2.expect("missing stream id");
+        println!("{max2}"); // >>> 2-0
+        let max3: Option<String> = r
+            .xadd_maxlen("race:italy", StreamMaxlen::Equals(2), "3-0", &[("rider", "Henshaw")])
+            .await
+            .expect("maxlen add 3");
+        let max3 = max3.expect("missing stream id");
+        println!("{max3}"); // >>> 3-0
+        if let Ok(res) = r.xlen("race:italy").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+        }
+        if let Ok(res) = r.xrange_all("race:italy").await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("2-0", [("rider", "Wood")]), ("3-0", [("rider", "Henshaw")])]
+        }
+        // STEP_END
+
+        // STEP_START xtrim
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]).await;
+        let _: Option<String> = r.xadd("race:italy", "1-0", &[("rider", "Wood")]).await.expect("trim seed 1");
+        let _: Option<String> = r.xadd("race:italy", "2-0", &[("rider", "Henshaw")]).await.expect("trim seed 2");
+        // HIDE_END
+        if let Ok(res) = r.xtrim("race:italy", StreamMaxlen::Equals(10)).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+        }
+        // STEP_END
+
+        // STEP_START xtrim2
+        // HIDE_START
+        seed_trim_stream(&mut r).await;
+        // HIDE_END
+        if let Ok(res) = r
+            .xtrim_options(
+                "mystream",
+                &StreamTrimOptions::maxlen(StreamTrimmingMode::Approx, 10),
+            )
+            .await
+        {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+        }
+        // STEP_END
+
+        // STEP_START xdel
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]).await;
+        let _: Option<String> = r.xadd("race:italy", "2-0", &[("rider", "Wood")]).await.expect("xdel seed 1");
+        let _: Option<String> = r.xadd("race:italy", "3-0", &[("rider", "Henshaw")]).await.expect("xdel seed 2");
+        // HIDE_END
+        if let Ok(res) = r.xrange_count("race:italy", "-", "+", 2).await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("2-0", [("rider", "Wood")]), ("3-0", [("rider", "Henshaw")])]
+        }
+        if let Ok(res) = r.xdel("race:italy", &["3-0"]).await {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+        }
+        if let Ok(res) = r.xrange_count("race:italy", "-", "+", 2).await {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("2-0", [("rider", "Wood")])]
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-async/dt-vecsets.rs
+++ b/local_examples/rust-async/dt-vecsets.rs
@@ -1,0 +1,631 @@
+// EXAMPLE: vecset_tutorial
+#[cfg(all(test, feature = "vector-sets"))]
+mod tests {
+    use redis::{
+        cmd, AsyncCommands, EmbeddingInput, VAddOptions, VSimOptions, Value, VectorAddInput,
+        VectorQuantization, VectorSimilaritySearchInput,
+    };
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().await.expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START vadd
+        if let Ok(res) = r
+            .vadd(
+                "points",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[1.0, 1.0])),
+                "pt:A",
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .vadd(
+                "points",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[-1.0, -1.0])),
+                "pt:B",
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .vadd(
+                "points",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[-1.0, 1.0])),
+                "pt:C",
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .vadd(
+                "points",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[1.0, -1.0])),
+                "pt:D",
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r
+            .vadd(
+                "points",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[1.0, 0.0])),
+                "pt:E",
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        let res: String = cmd("TYPE")
+            .arg("points")
+            .query_async(&mut r)
+            .await
+            .expect("TYPE points should succeed");
+        println!("{res}"); // >>> vectorset
+        // REMOVE_START
+        assert_eq!(res, "vectorset");
+        // REMOVE_END
+        // STEP_END
+
+        // STEP_START vcardvdim
+        if let Ok(res) = r.vcard("points").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vdim("points").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vemb
+        if let Ok(res) = r.vemb("points", "pt:A").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [0.9999999403953552, 0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] - 1.0).abs() < 0.001);
+            assert!((res[1] - 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:B").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [-0.9999999403953552, -0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] + 1.0).abs() < 0.001);
+            assert!((res[1] + 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:C").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [-0.9999999403953552, 0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] + 1.0).abs() < 0.001);
+            assert!((res[1] - 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:D").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [0.9999999403953552, -0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] - 1.0).abs() < 0.001);
+            assert!((res[1] + 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:E").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}"); // >>> [1.0, 0.0]
+            // REMOVE_START
+            assert!((res[0] - 1.0).abs() < 0.001);
+            assert!(res[1].abs() < 0.001);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START attr
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:A")
+            .arg("{\"name\":\"Point A\",\"description\":\"First point added\"}")
+            .query_async(&mut r)
+            .await
+            .expect("VSETATTR should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        if let Ok(res) = r.vgetattr("points", "pt:A").await {
+            let res: Option<String> = res;
+            println!(
+                "{}",
+                res.clone().unwrap_or_else(|| "None".to_string())
+            );
+            // >>> {"name":"Point A","description":"First point added"}
+            // REMOVE_START
+            assert_eq!(
+                res,
+                Some("{\"name\":\"Point A\",\"description\":\"First point added\"}".to_string())
+            );
+            // REMOVE_END
+        }
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:A")
+            .arg("")
+            .query_async(&mut r)
+            .await
+            .expect("VSETATTR clear should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        if let Ok(res) = r.vgetattr("points", "pt:A").await {
+            let res: Option<String> = res;
+            println!(
+                "{}",
+                res.clone().unwrap_or_else(|| "None".to_string())
+            ); // >>> None
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vrem
+        if let Ok(res) = r
+            .vadd(
+                "points",
+                VectorAddInput::Values(EmbeddingInput::String(&["0", "0"])),
+                "pt:F",
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vcard("points").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 6
+            // REMOVE_START
+            assert_eq!(res, 6);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vrem("points", "pt:F").await {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vcard("points").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vsim_basic
+        if let Ok(res) = r
+            .vsim(
+                "points",
+                VectorSimilaritySearchInput::Values(EmbeddingInput::Float64(&[0.9, 0.1])),
+            )
+            .await
+        {
+            let res: Value = res;
+            if let Value::Array(items) = res {
+                let view: Vec<String> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                        Value::SimpleString(s) => s,
+                        other => panic!("Unexpected VSIM item: {other:?}"),
+                    })
+                    .collect();
+                println!("{view:?}");
+                // >>> ["pt:E", "pt:A", "pt:D", "pt:C", "pt:B"]
+                // REMOVE_START
+                assert_eq!(
+                    view,
+                    vec![
+                        "pt:E".to_string(),
+                        "pt:A".to_string(),
+                        "pt:D".to_string(),
+                        "pt:C".to_string(),
+                        "pt:B".to_string()
+                    ]
+                );
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START vsim_options
+        let opts = VSimOptions::default().set_with_scores(true).set_count(4);
+        if let Ok(res) = r
+            .vsim_options("points", VectorSimilaritySearchInput::Element("pt:A"), &opts)
+            .await
+        {
+            let res: Value = res;
+            let mut view: Vec<(String, f64)> = match res {
+                Value::Array(items) => items
+                    .chunks(2)
+                    .map(|chunk| {
+                        let member = match &chunk[0] {
+                            Value::BulkString(bytes) => {
+                                String::from_utf8(bytes.clone()).expect("utf8")
+                            }
+                            Value::SimpleString(s) => s.clone(),
+                            other => panic!("Unexpected member format: {other:?}"),
+                        };
+                        let score = match &chunk[1] {
+                            Value::BulkString(bytes) => String::from_utf8(bytes.clone())
+                                .expect("utf8")
+                                .parse::<f64>()
+                                .expect("score"),
+                            Value::SimpleString(s) => s.parse::<f64>().expect("score"),
+                            Value::Double(v) => *v,
+                            Value::Int(v) => *v as f64,
+                            other => panic!("Unexpected score format: {other:?}"),
+                        };
+                        (member, score)
+                    })
+                    .collect(),
+                Value::Map(items) => items
+                    .into_iter()
+                    .map(|(member, score)| {
+                        let member = match member {
+                            Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                            Value::SimpleString(s) => s,
+                            other => panic!("Unexpected member format: {other:?}"),
+                        };
+                        let score = match score {
+                            Value::BulkString(bytes) => String::from_utf8(bytes)
+                                .expect("utf8")
+                                .parse::<f64>()
+                                .expect("score"),
+                            Value::SimpleString(s) => s.parse::<f64>().expect("score"),
+                            Value::Double(v) => v,
+                            Value::Int(v) => v as f64,
+                            other => panic!("Unexpected score format: {other:?}"),
+                        };
+                        (member, score)
+                    })
+                    .collect(),
+                other => panic!("Unexpected VSIM WITHSCORES response: {other:?}"),
+            };
+            view.sort_by(|a, b| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| b.0.cmp(&a.0))
+            });
+            println!("{view:?}");
+            // >>> [("pt:A", 1.0), ("pt:E", 0.8535534143447876), ("pt:D", 0.5), ("pt:C", 0.5)]
+            // REMOVE_START
+            assert_eq!(view.len(), 4);
+            assert_eq!(view[0].0, "pt:A");
+            assert!((view[0].1 - 1.0).abs() < 0.001);
+            assert_eq!(view[1].0, "pt:E");
+            assert!(view[1].1 > 0.85 && view[1].1 < 0.86);
+            assert_eq!(view[2], ("pt:D".to_string(), 0.5));
+            assert_eq!(view[3], ("pt:C".to_string(), 0.5));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vsim_filter
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:A")
+            .arg("{\"size\":\"large\",\"price\":18.99}")
+            .query_async(&mut r)
+            .await
+            .expect("VSETATTR A should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:B")
+            .arg("{\"size\":\"large\",\"price\":35.99}")
+            .query_async(&mut r)
+            .await
+            .expect("VSETATTR B should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:C")
+            .arg("{\"size\":\"large\",\"price\":25.99}")
+            .query_async(&mut r)
+            .await
+            .expect("VSETATTR C should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:D")
+            .arg("{\"size\":\"small\",\"price\":21.00}")
+            .query_async(&mut r)
+            .await
+            .expect("VSETATTR D should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:E")
+            .arg("{\"size\":\"small\",\"price\":17.75}")
+            .query_async(&mut r)
+            .await
+            .expect("VSETATTR E should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let opts = VSimOptions::default().set_filter_expression(".size == \"large\"");
+        if let Ok(res) = r
+            .vsim_options("points", VectorSimilaritySearchInput::Element("pt:A"), &opts)
+            .await
+        {
+            let res: Value = res;
+            if let Value::Array(items) = res {
+                let view: Vec<String> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                        Value::SimpleString(s) => s,
+                        other => panic!("Unexpected VSIM item: {other:?}"),
+                    })
+                    .collect();
+                println!("{view:?}");
+                // >>> ["pt:A", "pt:C", "pt:B"]
+                // REMOVE_START
+                assert_eq!(
+                    view,
+                    vec!["pt:A".to_string(), "pt:C".to_string(), "pt:B".to_string()]
+                );
+                // REMOVE_END
+            }
+        }
+
+        let opts = VSimOptions::default()
+            .set_filter_expression(".size == \"large\" && .price > 20.00");
+        if let Ok(res) = r
+            .vsim_options("points", VectorSimilaritySearchInput::Element("pt:A"), &opts)
+            .await
+        {
+            let res: Value = res;
+            if let Value::Array(items) = res {
+                let view: Vec<String> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                        Value::SimpleString(s) => s,
+                        other => panic!("Unexpected VSIM item: {other:?}"),
+                    })
+                    .collect();
+                println!("{view:?}");
+                // >>> ["pt:C", "pt:B"]
+                // REMOVE_START
+                assert_eq!(view, vec!["pt:C".to_string(), "pt:B".to_string()]);
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START add_quant
+        let opts = VAddOptions::default().set_quantization(VectorQuantization::Q8);
+        if let Ok(res) = r
+            .vadd_options(
+                "quantSetQ8",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[1.262185, 1.958231])),
+                "quantElement",
+                &opts,
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("quantSetQ8", "quantElement").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [1.2643694877624512, 1.958230972290039]
+            // REMOVE_START
+            assert!((res[0] - 1.2643694877624512).abs() < 0.001);
+            assert!((res[1] - 1.958230972290039).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        let opts = VAddOptions::default().set_quantization(VectorQuantization::NoQuant);
+        if let Ok(res) = r
+            .vadd_options(
+                "quantSetNoQ",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[1.262185, 1.958231])),
+                "quantElement",
+                &opts,
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("quantSetNoQ", "quantElement").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [1.262184977531433, 1.958230972290039]
+            // REMOVE_START
+            assert!((res[0] - 1.262184977531433).abs() < 0.001);
+            assert!((res[1] - 1.958230972290039).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        let opts = VAddOptions::default().set_quantization(VectorQuantization::Bin);
+        if let Ok(res) = r
+            .vadd_options(
+                "quantSetBin",
+                VectorAddInput::Values(EmbeddingInput::Float64(&[1.262185, 1.958231])),
+                "quantElement",
+                &opts,
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("quantSetBin", "quantElement").await {
+            let res: Vec<f64> = res;
+            println!("{res:?}"); // >>> [1.0, 1.0]
+            // REMOVE_START
+            assert_eq!(res, vec![1.0, 1.0]);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START add_reduce
+        let values: Vec<f64> = (0..300).map(|i| i as f64 / 299.0).collect();
+
+        if let Ok(res) = r
+            .vadd(
+                "setNotReduced",
+                VectorAddInput::Values(EmbeddingInput::Float64(&values)),
+                "element",
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vdim("setNotReduced").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 300
+            // REMOVE_START
+            assert_eq!(res, 300);
+            // REMOVE_END
+        }
+
+        let opts = VAddOptions::default().set_reduction_dimension(100);
+        if let Ok(res) = r
+            .vadd_options(
+                "setReduced",
+                VectorAddInput::Values(EmbeddingInput::Float64(&values)),
+                "element",
+                &opts,
+            )
+            .await
+        {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vdim("setReduced").await {
+            let res: usize = res;
+            println!("{res}"); // >>> 100
+            // REMOVE_START
+            assert_eq!(res, 100);
+            // REMOVE_END
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-sync/dt-list.rs
+++ b/local_examples/rust-sync/dt-list.rs
@@ -1,0 +1,545 @@
+// EXAMPLE: list_tutorial
+#[cfg(test)]
+mod list_tests {
+    use redis::{Commands, Direction, ValueType};
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    fn print_optional_string(value: Option<String>) {
+        match value {
+            Some(value) => println!("{value}"),
+            None => println!("(nil)"),
+        }
+    }
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START queue
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:1") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:2") {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START stack
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:1") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:2") {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START llen
+        if let Ok(res) = r.llen("bikes:repairs") {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START lmove_lrange
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:1") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:2") {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lmove(
+            "bikes:repairs",
+            "bikes:finished",
+            Direction::Left,
+            Direction::Left,
+        ) {
+            let res: String = res;
+            println!("{res}"); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, "bike:2");
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:1"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:finished", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:2"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:2"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START ltrim.1
+        if let Ok(res) = r.del("bikes:repairs") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.ltrim("bikes:repairs", 0, 2) {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START lpush_rpush
+        let _: usize = r.del("bikes:repairs").unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", "bike:1") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpush("bikes:repairs", "bike:2") {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", "bike:important_bike") {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:important_bike", "bike:1", "bike:2"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:important_bike", "bike:1", "bike:2"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START variadic
+        let _: usize = r.del("bikes:repairs").unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2", "bike:3"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", &["bike:important_bike", "bike:very_important_bike"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["bike:very_important_bike", "bike:important_bike", "bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&[
+                    "bike:very_important_bike",
+                    "bike:important_bike",
+                    "bike:1",
+                    "bike:2",
+                    "bike:3",
+                ])
+            );
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START lpop_rpop
+        let _: usize = r.del("bikes:repairs").unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2", "bike:3"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:3
+            // REMOVE_START
+            assert_eq!(res, Some("bike:3".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.rpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> (nil)
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START ltrim
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.ltrim("bikes:repairs", 0, 2) {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START ltrim_end_of_list
+        let _: usize = r.del("bikes:repairs").unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.ltrim("bikes:repairs", -3, -1) {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+
+        if let Ok(res) = r.lrange("bikes:repairs", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["bike:3", "bike:4", "bike:5"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:3", "bike:4", "bike:5"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START brpop
+        let _: usize = r.del("bikes:repairs").unwrap_or(0);
+
+        if let Ok(res) = r.rpush("bikes:repairs", &["bike:1", "bike:2"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.brpop("bikes:repairs", 1.0) {
+            let res: Option<[String; 2]> = res;
+            println!("{res:?}"); // >>> Some(["bikes:repairs", "bike:2"])
+            // REMOVE_START
+            assert_eq!(res, Some(["bikes:repairs".to_string(), "bike:2".to_string()]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.brpop("bikes:repairs", 1.0) {
+            let res: Option<[String; 2]> = res;
+            println!("{res:?}"); // >>> Some(["bikes:repairs", "bike:1"])
+            // REMOVE_START
+            assert_eq!(res, Some(["bikes:repairs".to_string(), "bike:1".to_string()]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.brpop("bikes:repairs", 1.0) {
+            let res: Option<[String; 2]> = res;
+            println!("{res:?}"); // >>> None
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START rule_1
+        if let Ok(res) = r.del("new_bikes") {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("new_bikes", &["bike:1", "bike:2", "bike:3"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START rule_1.1
+        if let Ok(res) = r.del("new_bikes") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.set("new_bikes", "bike:1") {
+            let res: String = res;
+            println!("{res}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.key_type("new_bikes") {
+            let res: ValueType = res;
+            let res: String = res.into();
+            println!("{res}"); // >>> string
+            // REMOVE_START
+            assert_eq!(res, "string");
+            // REMOVE_END
+        }
+
+        let res: redis::RedisResult<usize> = r.lpush("new_bikes", &["bike:2", "bike:3"]);
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if let Some((_, tail)) = msg.split_once("WRONGTYPE ") {
+                    println!("WRONGTYPE {tail}");
+                } else {
+                    println!("{msg}");
+                }
+                // REMOVE_START
+                assert!(msg.contains("WRONGTYPE"));
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START rule_2
+        // HIDE_START
+        let _: usize = r.rpush("bikes:repairs", "bike:placeholder").unwrap_or(0);
+        // HIDE_END
+        if let Ok(res) = r.del("bikes:repairs") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpush("bikes:repairs", &["bike:1", "bike:2", "bike:3"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.exists("bikes:repairs") {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 1
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:3
+            // REMOVE_START
+            assert_eq!(res, Some("bike:3".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:2
+            // REMOVE_START
+            assert_eq!(res, Some("bike:2".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> bike:1
+            // REMOVE_START
+            assert_eq!(res, Some("bike:1".to_string()));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.exists("bikes:repairs") {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 0
+            // REMOVE_START
+            assert!(!res);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START rule_3
+        if let Ok(res) = r.del("bikes:repairs") {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.llen("bikes:repairs") {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.lpop("bikes:repairs", None) {
+            let res: Option<String> = res;
+            print_optional_string(res.clone()); // >>> (nil)
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-sync/dt-sets.rs
+++ b/local_examples/rust-sync/dt-sets.rs
@@ -1,0 +1,262 @@
+// EXAMPLE: sets_tutorial
+#[cfg(test)]
+mod sets_tests {
+    use redis::Commands;
+    use std::collections::HashSet;
+
+    fn sorted(mut values: Vec<String>) -> Vec<String> {
+        values.sort();
+        values
+    }
+
+    fn sorted_set(values: HashSet<String>) -> Vec<String> {
+        sorted(values.into_iter().collect())
+    }
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => {
+                match client.get_connection() {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        println!("Failed to connect to Redis: {e}");
+                        return;
+                    }
+                }
+            }
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START sadd
+        if let Ok(res) = r.sadd("bikes:racing:france", "bike:1") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sadd("bikes:racing:france", "bike:1") {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sadd("bikes:racing:france", &["bike:2", "bike:3"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sadd("bikes:racing:usa", &["bike:1", "bike:4"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sismember
+        if let Ok(res) = r.sismember("bikes:racing:usa", "bike:1") {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 1
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sismember("bikes:racing:usa", "bike:2") {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 0
+            // REMOVE_START
+            assert!(!res);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sinter
+        if let Ok(res) = r.sinter(["bikes:racing:france", "bikes:racing:usa"]) {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START scard
+        if let Ok(res) = r.scard("bikes:racing:france") {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sadd_smembers
+        let _: usize = r.del("bikes:racing:france").unwrap_or(0);
+
+        if let Ok(res) = r.sadd("bikes:racing:france", &["bike:1", "bike:2", "bike:3"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.smembers("bikes:racing:france") {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START smismember
+        if let Ok(res) = r.sismember("bikes:racing:france", "bike:1") {
+            let res: bool = res;
+            println!("{}", i32::from(res)); // >>> 1
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.smismember("bikes:racing:france", &["bike:2", "bike:3", "bike:4"]) {
+            let res: Vec<bool> = res;
+            let res: Vec<i32> = res.into_iter().map(i32::from).collect();
+            println!("{res:?}"); // >>> [1, 1, 0]
+            // REMOVE_START
+            assert_eq!(res, vec![1, 1, 0]);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START sdiff
+        let _: usize = r.del("bikes:racing:france").unwrap_or(0);
+        let _: usize = r.del("bikes:racing:usa").unwrap_or(0);
+        let _: usize = r.sadd("bikes:racing:france", &["bike:1", "bike:2", "bike:3"]).unwrap_or(0);
+        let _: usize = r.sadd("bikes:racing:usa", &["bike:1", "bike:4"]).unwrap_or(0);
+
+        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]) {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START multisets
+        let _: usize = r.del(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"]).unwrap_or(0);
+        let _: usize = r.sadd("bikes:racing:france", &["bike:1", "bike:2", "bike:3"]).unwrap_or(0);
+        let _: usize = r.sadd("bikes:racing:usa", &["bike:1", "bike:4"]).unwrap_or(0);
+        let _: usize = r.sadd("bikes:racing:italy", &["bike:1", "bike:2", "bike:3", "bike:4"]).unwrap_or(0);
+
+        if let Ok(res) = r.sinter(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"]) {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sunion(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"]) {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3", "bike:4"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:1", "bike:2", "bike:3", "bike:4"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"]) {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> []
+            // REMOVE_START
+            assert!(res.is_empty());
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]) {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:2", "bike:3"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:2", "bike:3"]));
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.sdiff(["bikes:racing:usa", "bikes:racing:france"]) {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:4"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["bike:4"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START srem
+        let _: usize = r.del("bikes:racing:france").unwrap_or(0);
+        let _: usize = r
+            .sadd(
+                "bikes:racing:france",
+                &["bike:1", "bike:2", "bike:3", "bike:4", "bike:5"],
+            )
+            .unwrap_or(0);
+
+        if let Ok(res) = r.srem("bikes:racing:france", "bike:1") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.spop("bikes:racing:france") {
+            let res: Option<String> = res;
+            match res {
+                Some(res) => println!("{res}"), // >>> bike:3 (for example)
+                None => println!("(nil)"),
+            }
+        }
+
+        if let Ok(res) = r.smembers("bikes:racing:france") {
+            let res: HashSet<String> = res;
+            let res = sorted_set(res);
+            println!("{res:?}"); // >>> ["bike:2", "bike:4", "bike:5"] (for example)
+        }
+
+        if let Ok(res) = r.srandmember("bikes:racing:france") {
+            let res: Option<String> = res;
+            match res {
+                Some(res) => println!("{res}"), // >>> bike:4 (for example)
+                None => println!("(nil)"),
+            }
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-sync/dt-sets.rs
+++ b/local_examples/rust-sync/dt-sets.rs
@@ -91,7 +91,7 @@ mod sets_tests {
         // STEP_END
 
         // STEP_START sinter
-        if let Ok(res) = r.sinter(["bikes:racing:france", "bikes:racing:usa"]) {
+        if let Ok(res) = r.sinter(&["bikes:racing:france", "bikes:racing:usa"]) {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:1"]
@@ -157,7 +157,7 @@ mod sets_tests {
         let _: usize = r.sadd("bikes:racing:france", &["bike:1", "bike:2", "bike:3"]).unwrap_or(0);
         let _: usize = r.sadd("bikes:racing:usa", &["bike:1", "bike:4"]).unwrap_or(0);
 
-        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]) {
+        if let Ok(res) = r.sdiff(&["bikes:racing:france", "bikes:racing:usa"]) {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:2", "bike:3"]
@@ -173,7 +173,9 @@ mod sets_tests {
         let _: usize = r.sadd("bikes:racing:usa", &["bike:1", "bike:4"]).unwrap_or(0);
         let _: usize = r.sadd("bikes:racing:italy", &["bike:1", "bike:2", "bike:3", "bike:4"]).unwrap_or(0);
 
-        if let Ok(res) = r.sinter(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"]) {
+        if let Ok(res) =
+            r.sinter(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+        {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:1"]
@@ -182,7 +184,9 @@ mod sets_tests {
             // REMOVE_END
         }
 
-        if let Ok(res) = r.sunion(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"]) {
+        if let Ok(res) =
+            r.sunion(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+        {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:1", "bike:2", "bike:3", "bike:4"]
@@ -191,7 +195,9 @@ mod sets_tests {
             // REMOVE_END
         }
 
-        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"]) {
+        if let Ok(res) =
+            r.sdiff(&["bikes:racing:france", "bikes:racing:usa", "bikes:racing:italy"])
+        {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> []
@@ -200,7 +206,7 @@ mod sets_tests {
             // REMOVE_END
         }
 
-        if let Ok(res) = r.sdiff(["bikes:racing:france", "bikes:racing:usa"]) {
+        if let Ok(res) = r.sdiff(&["bikes:racing:france", "bikes:racing:usa"]) {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:2", "bike:3"]
@@ -209,7 +215,7 @@ mod sets_tests {
             // REMOVE_END
         }
 
-        if let Ok(res) = r.sdiff(["bikes:racing:usa", "bikes:racing:france"]) {
+        if let Ok(res) = r.sdiff(&["bikes:racing:usa", "bikes:racing:france"]) {
             let res: HashSet<String> = res;
             let res = sorted_set(res);
             println!("{res:?}"); // >>> ["bike:4"]

--- a/local_examples/rust-sync/dt-sorted-sets.rs
+++ b/local_examples/rust-sync/dt-sorted-sets.rs
@@ -1,0 +1,258 @@
+// EXAMPLE: ss_tutorial
+#[cfg(test)]
+mod sorted_set_tests {
+    use redis::Commands;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    fn score_pairs(values: &[(&str, f64)]) -> Vec<(String, f64)> {
+        values
+            .iter()
+            .map(|(member, score)| (member.to_string(), *score))
+            .collect()
+    }
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START zadd
+        if let Ok(res) = r.zadd("racer_scores", "Norem", 10) {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zadd("racer_scores", "Castilla", 12) {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zadd_multiple(
+            "racer_scores",
+            &[
+                (8, "Sam-Bodden"),
+                (10, "Royce"),
+                (6, "Ford"),
+                (14, "Prickett"),
+                (12, "Castilla"),
+            ],
+        ) {
+            let res: usize = res;
+            println!("{res}"); // >>> 4
+            // REMOVE_START
+            assert_eq!(res, 4);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrange
+        if let Ok(res) = r.zrange("racer_scores", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["Ford", "Sam-Bodden", "Norem", "Royce", "Castilla", "Prickett"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&["Ford", "Sam-Bodden", "Norem", "Royce", "Castilla", "Prickett"])
+            );
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrevrange("racer_scores", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["Prickett", "Castilla", "Royce", "Norem", "Sam-Bodden", "Ford"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&["Prickett", "Castilla", "Royce", "Norem", "Sam-Bodden", "Ford"])
+            );
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrange_withscores
+        if let Ok(res) = r.zrange_withscores("racer_scores", 0, -1) {
+            let res: Vec<(String, f64)> = res;
+            println!("{res:?}");
+            // >>> [("Ford", 6.0), ("Sam-Bodden", 8.0), ("Norem", 10.0), ("Royce", 10.0), ("Castilla", 12.0), ("Prickett", 14.0)]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                score_pairs(&[
+                    ("Ford", 6.0),
+                    ("Sam-Bodden", 8.0),
+                    ("Norem", 10.0),
+                    ("Royce", 10.0),
+                    ("Castilla", 12.0),
+                    ("Prickett", 14.0),
+                ])
+            );
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrangebyscore
+        if let Ok(res) = r.zrangebyscore("racer_scores", "-inf", 10) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["Ford", "Sam-Bodden", "Norem", "Royce"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["Ford", "Sam-Bodden", "Norem", "Royce"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zremrangebyscore
+        if let Ok(res) = r.zrem("racer_scores", "Castilla") {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrembyscore("racer_scores", "-inf", 9) {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrange("racer_scores", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["Norem", "Royce", "Prickett"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["Norem", "Royce", "Prickett"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START zrank
+        if let Ok(res) = r.zrank("racer_scores", "Norem") {
+            let res: Option<usize> = res;
+            if let Some(res) = res {
+                println!("{res}"); // >>> 0
+                // REMOVE_START
+                assert_eq!(res, 0);
+                // REMOVE_END
+            }
+        }
+
+        if let Ok(res) = r.zrevrank("racer_scores", "Norem") {
+            let res: Option<usize> = res;
+            if let Some(res) = res {
+                println!("{res}"); // >>> 2
+                // REMOVE_START
+                assert_eq!(res, 2);
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START zadd_lex
+        if let Ok(res) = r.zadd_multiple(
+            "racer_scores",
+            &[
+                (0, "Norem"),
+                (0, "Sam-Bodden"),
+                (0, "Royce"),
+                (0, "Ford"),
+                (0, "Prickett"),
+                (0, "Castilla"),
+            ],
+        ) {
+            let res: usize = res;
+            println!("{res}"); // >>> 3
+            // REMOVE_START
+            assert_eq!(res, 3);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrange("racer_scores", 0, -1) {
+            let res: Vec<String> = res;
+            println!("{res:?}");
+            // >>> ["Castilla", "Ford", "Norem", "Prickett", "Royce", "Sam-Bodden"]
+            // REMOVE_START
+            assert_eq!(
+                res,
+                strings(&["Castilla", "Ford", "Norem", "Prickett", "Royce", "Sam-Bodden"])
+            );
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zrangebylex("racer_scores", "[A", "[L") {
+            let res: Vec<String> = res;
+            println!("{res:?}"); // >>> ["Castilla", "Ford"]
+            // REMOVE_START
+            assert_eq!(res, strings(&["Castilla", "Ford"]));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START leaderboard
+        if let Ok(res) = r.zadd("racer_scores", "Wood", 100) {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zadd("racer_scores", "Henshaw", 100) {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zadd("racer_scores", "Henshaw", 150) {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zincr("racer_scores", "Wood", 50) {
+            let res: f64 = res;
+            println!("{res}"); // >>> 150
+            // REMOVE_START
+            assert_eq!(res, 150.0);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.zincr("racer_scores", "Henshaw", 50) {
+            let res: f64 = res;
+            println!("{res}"); // >>> 200
+            // REMOVE_START
+            assert_eq!(res, 200.0);
+            // REMOVE_END
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-sync/dt-stream.rs
+++ b/local_examples/rust-sync/dt-stream.rs
@@ -1,0 +1,1227 @@
+// EXAMPLE: stream_tutorial
+#[cfg(test)]
+mod stream_tests {
+    use redis::{
+        streams::{
+            StreamAutoClaimOptions, StreamInfoConsumersReply, StreamInfoGroupsReply,
+            StreamInfoStreamReply, StreamMaxlen, StreamPendingCountReply, StreamPendingReply,
+            StreamRangeReply, StreamReadOptions, StreamReadReply, StreamTrimmingMode,
+            StreamTrimOptions,
+        },
+        Commands,
+    };
+    use std::{thread::sleep, time::Duration};
+
+    fn delete_keys(r: &mut redis::Connection, keys: &[&str]) {
+        let _: usize = r.del(keys).unwrap_or(0);
+    }
+
+    fn add_france_fixed(r: &mut redis::Connection) {
+        delete_keys(r, &["race:france"]);
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632086370-0",
+                &[
+                    ("rider", "Castilla"),
+                    ("speed", "30.2"),
+                    ("position", "1"),
+                    ("location_id", "1"),
+                ],
+            )
+            .expect("add france 1");
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632094485-0",
+                &[
+                    ("rider", "Norem"),
+                    ("speed", "28.8"),
+                    ("position", "3"),
+                    ("location_id", "1"),
+                ],
+            )
+            .expect("add france 2");
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632102976-0",
+                &[
+                    ("rider", "Prickett"),
+                    ("speed", "29.7"),
+                    ("position", "2"),
+                    ("location_id", "1"),
+                ],
+            )
+            .expect("add france 3");
+        let _: Option<String> = r
+            .xadd(
+                "race:france",
+                "1692632147973-0",
+                &[
+                    ("rider", "Castilla"),
+                    ("speed", "29.9"),
+                    ("position", "1"),
+                    ("location_id", "2"),
+                ],
+            )
+            .expect("add france 4");
+    }
+
+    fn seed_usa_fixed(r: &mut redis::Connection) {
+        delete_keys(r, &["race:usa"]);
+        let _: Option<String> = r
+            .xadd("race:usa", "0-1", &[("racer", "Castilla")])
+            .expect("add usa 1");
+        let _: Option<String> = r
+            .xadd("race:usa", "0-2", &[("racer", "Norem")])
+            .expect("add usa 2");
+    }
+
+    fn seed_italy_group_base(r: &mut redis::Connection) {
+        delete_keys(r, &["race:italy"]);
+        let _: () = r
+            .xgroup_create_mkstream("race:italy", "italy_riders", "$")
+            .expect("create italy group");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632639151-0", &[("rider", "Castilla")])
+            .expect("add italy 1");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632647899-0", &[("rider", "Royce")])
+            .expect("add italy 2");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632662819-0", &[("rider", "Sam-Bodden")])
+            .expect("add italy 3");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632670501-0", &[("rider", "Prickett")])
+            .expect("add italy 4");
+        let _: Option<String> = r
+            .xadd("race:italy", "1692632678249-0", &[("rider", "Norem")])
+            .expect("add italy 5");
+    }
+
+    fn seed_italy_alice_pending(r: &mut redis::Connection) {
+        seed_italy_group_base(r);
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice").count(1);
+        let _: Option<StreamReadReply> = r
+            .xread_options(&["race:italy"], &[">"], &opts)
+            .expect("alice read pending");
+    }
+
+    fn seed_italy_after_ack(r: &mut redis::Connection) {
+        seed_italy_alice_pending(r);
+        let _: usize = r
+            .xack("race:italy", "italy_riders", &["1692632639151-0"])
+            .expect("ack first italy message");
+    }
+
+    fn seed_italy_bob_pending(r: &mut redis::Connection) {
+        seed_italy_after_ack(r);
+        let opts = StreamReadOptions::default().group("italy_riders", "Bob").count(2);
+        let _: Option<StreamReadReply> = r
+            .xread_options(&["race:italy"], &[">"], &opts)
+            .expect("bob read pending");
+    }
+
+    fn seed_italy_info_state(r: &mut redis::Connection) {
+        seed_italy_bob_pending(r);
+        sleep(Duration::from_millis(5));
+        let _: redis::streams::StreamClaimReply = r
+            .xclaim("race:italy", "italy_riders", "Alice", 1, &["1692632647899-0"])
+            .expect("alice claim");
+        sleep(Duration::from_millis(5));
+        let _: redis::streams::StreamClaimReply = r
+            .xclaim("race:italy", "italy_riders", "Lora", 1, &["1692632662819-0"])
+            .expect("lora claim");
+    }
+
+    fn seed_trim_stream(r: &mut redis::Connection) {
+        delete_keys(r, &["mystream"]);
+        for id in ["1-0", "2-0", "3-0", "4-0", "5-0", "6-0", "7-0", "8-0", "9-0", "10-0"] {
+            let _: Option<String> = r
+                .xadd("mystream", id, &[("field", "value")])
+                .expect("seed mystream");
+        }
+    }
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START xadd
+        let res1 = {
+            let res: Option<String> = r
+                .xadd(
+                    "race:france",
+                    "*",
+                    &[
+                        ("rider", "Castilla"),
+                        ("speed", "30.2"),
+                        ("position", "1"),
+                        ("location_id", "1"),
+                    ],
+                )
+                .expect("xadd 1");
+            res.expect("missing stream id")
+        };
+        println!("{res1}"); // >>> 1692632086370-0
+
+        let res2 = {
+            let res: Option<String> = r
+                .xadd(
+                    "race:france",
+                    "*",
+                    &[
+                        ("rider", "Norem"),
+                        ("speed", "28.8"),
+                        ("position", "3"),
+                        ("location_id", "1"),
+                    ],
+                )
+                .expect("xadd 2");
+            res.expect("missing stream id")
+        };
+        println!("{res2}"); // >>> 1692632094485-0
+
+        let res3 = {
+            let res: Option<String> = r
+                .xadd(
+                    "race:france",
+                    "*",
+                    &[
+                        ("rider", "Prickett"),
+                        ("speed", "29.7"),
+                        ("position", "2"),
+                        ("location_id", "1"),
+                    ],
+                )
+                .expect("xadd 3");
+            res.expect("missing stream id")
+        };
+        println!("{res3}"); // >>> 1692632102976-0
+        // STEP_END
+        // REMOVE_START
+        let parse = |id: &str| {
+            let (ms, seq) = id.split_once('-').expect("invalid stream id");
+            (
+                ms.parse::<u64>().expect("invalid stream id millis"),
+                seq.parse::<u64>().expect("invalid stream id seq"),
+            )
+        };
+        assert!(parse(&res1) < parse(&res2));
+        assert!(parse(&res2) < parse(&res3));
+        // REMOVE_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xrange
+        if let Ok(res) = r.xrange_count("race:france", "1692632086370-0", "+", 2) {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 2);
+            assert_eq!(view[0].0, "1692632086370-0");
+            assert_eq!(view[1].0, "1692632094485-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xread_block
+        let opts = StreamReadOptions::default().count(100).block(300);
+        if let Ok(res) = r.xread_options(&["race:france"], &["$"], &opts) {
+            let res: Option<StreamReadReply> = res;
+            println!("{res:?}"); // >>> None
+            // REMOVE_START
+            assert!(res.is_none());
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START xadd_2
+        if let Ok(res) = r.xadd(
+            "race:france",
+            "*",
+            &[
+                ("rider", "Castilla"),
+                ("speed", "29.9"),
+                ("position", "1"),
+                ("location_id", "2"),
+            ],
+        ) {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 1692632147973-0
+            // REMOVE_START
+            let (ms, seq) = res.split_once('-').expect("invalid stream id");
+            let _ = (
+                ms.parse::<u64>().expect("invalid stream id millis"),
+                seq.parse::<u64>().expect("invalid stream id seq"),
+            );
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xlen
+        if let Ok(res) = r.xlen("race:france") {
+            let res: usize = res;
+            println!("{res}"); // >>> 4
+            // REMOVE_START
+            assert_eq!(res, 4);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        delete_keys(&mut r, &["race:usa"]);
+        // HIDE_END
+        // STEP_START xadd_id
+        if let Ok(res) = r.xadd("race:usa", "0-1", &[("racer", "Castilla")]) {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 0-1
+            // REMOVE_START
+            assert_eq!(res, "0-1");
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.xadd("race:usa", "0-2", &[("racer", "Norem")]) {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 0-2
+            // REMOVE_START
+            assert_eq!(res, "0-2");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START xadd_bad_id
+        let res: redis::RedisResult<Option<String>> =
+            r.xadd("race:usa", "0-1", &[("racer", "Prickett")]);
+        match res {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                println!("{msg}");
+                // >>> An error was signalled by the server - ResponseError: The ID specified in XADD is equal or smaller than the target stream top item
+                // REMOVE_START
+                assert!(msg.contains("equal or smaller"));
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_usa_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xadd_7
+        if let Ok(res) = r.xadd("race:usa", "0-*", &[("racer", "Prickett")]) {
+            let res: Option<String> = res;
+            let res = res.expect("missing stream id");
+            println!("{res}"); // >>> 0-3
+            // REMOVE_START
+            assert_eq!(res, "0-3");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xrange_all
+        if let Ok(res) = r.xrange_all("race:france") {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")]), ("1692632102976-0", [("rider", "Prickett"), ("speed", "29.7"), ("position", "2"), ("location_id", "1")]), ("1692632147973-0", [("rider", "Castilla"), ("speed", "29.9"), ("position", "1"), ("location_id", "2")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 4);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xrange_time
+        if let Ok(res) = r.xrange("race:france", "1692632086369", "1692632086371") {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 1);
+            assert_eq!(view[0].0, "1692632086370-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xrange_step_1
+        if let Ok(res) = r.xrange_count("race:france", "-", "+", 2) {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 2);
+            assert_eq!(view[1].0, "1692632094485-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xrange_step_2
+        if let Ok(res) = r.xrange_count("race:france", "(1692632094485-0", "+", 2) {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632102976-0", [("rider", "Prickett"), ("speed", "29.7"), ("position", "2"), ("location_id", "1")]), ("1692632147973-0", [("rider", "Castilla"), ("speed", "29.9"), ("position", "1"), ("location_id", "2")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 2);
+            assert_eq!(view[0].0, "1692632102976-0");
+            assert_eq!(view[1].0, "1692632147973-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xrange_empty
+        if let Ok(res) = r.xrange_count("race:france", "(1692632147973-0", "+", 2) {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> []
+            // REMOVE_START
+            assert!(view.is_empty());
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xrevrange
+        if let Ok(res) = r.xrevrange_count("race:france", "+", "-", 1) {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![
+                            ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                            ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                            ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                            (
+                                "location_id".to_string(),
+                                entry.get::<String>("location_id").expect("missing location_id"),
+                            ),
+                        ],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632147973-0", [("rider", "Castilla"), ("speed", "29.9"), ("position", "1"), ("location_id", "2")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 1);
+            assert_eq!(view[0].0, "1692632147973-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xread
+        let opts = StreamReadOptions::default().count(2);
+        if let Ok(res) = r.xread_options(&["race:france"], &["0"], &opts) {
+            let res: Option<StreamReadReply> = res;
+            let reply = res.expect("xread should return data");
+            let view: Vec<_> = reply
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![
+                                        ("rider".to_string(), entry.get::<String>("rider").expect("missing rider")),
+                                        ("speed".to_string(), entry.get::<String>("speed").expect("missing speed")),
+                                        ("position".to_string(), entry.get::<String>("position").expect("missing position")),
+                                        (
+                                            "location_id".to_string(),
+                                            entry.get::<String>("location_id").expect("missing location_id"),
+                                        ),
+                                    ],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:france", [("1692632086370-0", [("rider", "Castilla"), ("speed", "30.2"), ("position", "1"), ("location_id", "1")]), ("1692632094485-0", [("rider", "Norem"), ("speed", "28.8"), ("position", "3"), ("location_id", "1")])])]
+            // REMOVE_START
+            assert_eq!(view.len(), 1);
+            assert_eq!(view[0].1.len(), 2);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        add_france_fixed(&mut r);
+        // HIDE_END
+        // STEP_START xgroup_create
+        if let Ok(res) = r.xgroup_create("race:france", "france_riders", "$") {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+        // STEP_END
+
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]);
+        // HIDE_END
+        // STEP_START xgroup_create_mkstream
+        if let Ok(res) = r.xgroup_create_mkstream("race:italy", "italy_riders", "$") {
+            let res: () = res;
+            let _ = res;
+            println!("OK"); // >>> OK
+        }
+        // STEP_END
+
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]);
+        let _: () = r
+            .xgroup_create_mkstream("race:italy", "italy_riders", "$")
+            .expect("create italy group");
+        // HIDE_END
+        // STEP_START xgroup_read
+        let italy_1: Option<String> = r
+            .xadd("race:italy", "1692632639151-0", &[("rider", "Castilla")])
+            .expect("italy1");
+        let italy_1 = italy_1.expect("missing stream id");
+        println!("{italy_1}"); // >>> 1692632639151-0
+        let italy_2: Option<String> = r
+            .xadd("race:italy", "1692632647899-0", &[("rider", "Royce")])
+            .expect("italy2");
+        let italy_2 = italy_2.expect("missing stream id");
+        println!("{italy_2}"); // >>> 1692632647899-0
+        let italy_3: Option<String> = r
+            .xadd("race:italy", "1692632662819-0", &[("rider", "Sam-Bodden")])
+            .expect("italy3");
+        let italy_3 = italy_3.expect("missing stream id");
+        println!("{italy_3}"); // >>> 1692632662819-0
+        let italy_4: Option<String> = r
+            .xadd("race:italy", "1692632670501-0", &[("rider", "Prickett")])
+            .expect("italy4");
+        let italy_4 = italy_4.expect("missing stream id");
+        println!("{italy_4}"); // >>> 1692632670501-0
+        let italy_5: Option<String> = r
+            .xadd("race:italy", "1692632678249-0", &[("rider", "Norem")])
+            .expect("italy5");
+        let italy_5 = italy_5.expect("missing stream id");
+        println!("{italy_5}"); // >>> 1692632678249-0
+
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice").count(1);
+        if let Ok(res) = r.xread_options(&["race:italy"], &[">"], &opts) {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("xgroup read should return data")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:italy", [("1692632639151-0", [("rider", "Castilla")])])]
+            // REMOVE_START
+            assert_eq!(view[0].1[0].0, "1692632639151-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_alice_pending(&mut r);
+        // HIDE_END
+        // STEP_START xgroup_read_id
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice");
+        if let Ok(res) = r.xread_options(&["race:italy"], &["0"], &opts) {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("xgroup history")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:italy", [("1692632639151-0", [("rider", "Castilla")])])]
+            // REMOVE_START
+            assert_eq!(view[0].1[0].0, "1692632639151-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_alice_pending(&mut r);
+        // HIDE_END
+        // STEP_START xack
+        if let Ok(res) = r.xack("race:italy", "italy_riders", &["1692632639151-0"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        let opts = StreamReadOptions::default().group("italy_riders", "Alice");
+        if let Ok(res) = r.xread_options(&["race:italy"], &["0"], &opts) {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("xgroup history")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("race:italy", [])]
+            // REMOVE_START
+            assert!(view[0].1.is_empty());
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_after_ack(&mut r);
+        // HIDE_END
+        // STEP_START xgroup_read_bob
+        let opts = StreamReadOptions::default().group("italy_riders", "Bob").count(2);
+        if let Ok(res) = r.xread_options(&["race:italy"], &[">"], &opts) {
+            let res: Option<StreamReadReply> = res;
+            let view: Vec<_> = res
+                .expect("bob should receive data")
+                .keys
+                .iter()
+                .map(|stream| {
+                    (
+                        stream.key.clone(),
+                        stream
+                            .ids
+                            .iter()
+                            .map(|entry| {
+                                (
+                                    entry.id.clone(),
+                                    vec![(
+                                        "rider".to_string(),
+                                        entry.get::<String>("rider").expect("missing rider"),
+                                    )],
+                                )
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("race:italy", [("1692632647899-0", [("rider", "Royce")]), ("1692632662819-0", [("rider", "Sam-Bodden")])])]
+            // REMOVE_START
+            assert_eq!(view[0].1.len(), 2);
+            assert_eq!(view[0].1[0].0, "1692632647899-0");
+            assert_eq!(view[0].1[1].0, "1692632662819-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r);
+        // HIDE_END
+        // STEP_START xpending
+        if let Ok(res) = r.xpending("race:italy", "italy_riders") {
+            let res: StreamPendingReply = res;
+            let view = match res {
+                StreamPendingReply::Empty => None,
+                StreamPendingReply::Data(data) => Some((
+                    data.count,
+                    data.start_id.clone(),
+                    data.end_id.clone(),
+                    data.consumers
+                        .iter()
+                        .map(|consumer| (consumer.name.clone(), consumer.pending))
+                        .collect::<Vec<_>>(),
+                )),
+            }
+            .expect("pending summary");
+            println!("{view:?}");
+            // >>> (2, "1692632647899-0", "1692632662819-0", [("Bob", 2)])
+            // REMOVE_START
+            assert_eq!(view.0, 2);
+            assert_eq!(view.1, "1692632647899-0");
+            assert_eq!(view.2, "1692632662819-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r);
+        sleep(Duration::from_millis(5));
+        // HIDE_END
+        // STEP_START xpending_plus_minus
+        if let Ok(res) = r.xpending_count("race:italy", "italy_riders", "-", "+", 10) {
+            let res: StreamPendingCountReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        entry.consumer.clone(),
+                        entry.last_delivered_ms,
+                        entry.times_delivered,
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("1692632647899-0", "Bob", 5, 1), ("1692632662819-0", "Bob", 5, 1)]
+            // REMOVE_START
+            assert_eq!(view.len(), 2);
+            assert_eq!(view[0].0, "1692632647899-0");
+            assert_eq!(view[1].0, "1692632662819-0");
+            assert_eq!(view[0].1, "Bob");
+            assert_eq!(view[0].3, 1);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r);
+        // HIDE_END
+        // STEP_START xrange_pending
+        if let Ok(res) = r.xrange("race:italy", "1692632647899-0", "1692632647899-0") {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("1692632647899-0", [("rider", "Royce")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 1);
+            assert_eq!(view[0].0, "1692632647899-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r);
+        sleep(Duration::from_millis(5));
+        // HIDE_END
+        // STEP_START xclaim
+        if let Ok(res) = r.xclaim("race:italy", "italy_riders", "Alice", 1, &["1692632647899-0"]) {
+            let res: redis::streams::StreamClaimReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("1692632647899-0", [("rider", "Royce")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 1);
+            assert_eq!(view[0].0, "1692632647899-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r);
+        sleep(Duration::from_millis(5));
+        // HIDE_END
+        // STEP_START xautoclaim
+        let opts = StreamAutoClaimOptions::default().count(1);
+        if let Ok(res) = r.xautoclaim_options("race:italy", "italy_riders", "Alice", 1, "0-0", opts) {
+            let res: redis::streams::StreamAutoClaimReply = res;
+            let claimed: Vec<_> = res
+                .claimed
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{:?}", (res.next_stream_id.clone(), &claimed));
+            // >>> ("1692632662819-0", [("1692632647899-0", [("rider", "Royce")])])
+            // REMOVE_START
+            assert_eq!(claimed.len(), 1);
+            assert_eq!(claimed[0].0, "1692632647899-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_bob_pending(&mut r);
+        sleep(Duration::from_millis(5));
+        let first_opts = StreamAutoClaimOptions::default().count(1);
+        let _: redis::streams::StreamAutoClaimReply = r
+            .xautoclaim_options("race:italy", "italy_riders", "Alice", 1, "0-0", first_opts)
+            .expect("first autoclaim");
+        // HIDE_END
+        // STEP_START xautoclaim_cursor
+        let next_opts = StreamAutoClaimOptions::default().count(1);
+        if let Ok(res) = r.xautoclaim_options(
+            "race:italy",
+            "italy_riders",
+            "Lora",
+            1,
+            "(1692632647899-0",
+            next_opts,
+        ) {
+            let res: redis::streams::StreamAutoClaimReply = res;
+            let claimed: Vec<_> = res
+                .claimed
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{:?}", (res.next_stream_id.clone(), &claimed));
+            // >>> ("0-0", [("1692632662819-0", [("rider", "Sam-Bodden")])])
+            // REMOVE_START
+            assert_eq!(claimed.len(), 1);
+            assert_eq!(claimed[0].0, "1692632662819-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_info_state(&mut r);
+        // HIDE_END
+        // STEP_START xinfo
+        if let Ok(res) = r.xinfo_stream("race:italy") {
+            let res: StreamInfoStreamReply = res;
+            let view = (
+                res.length,
+                res.radix_tree_keys,
+                res.groups,
+                res.last_generated_id.clone(),
+                res.first_entry.id.clone(),
+                res.last_entry.id.clone(),
+            );
+            println!("{view:?}");
+            // >>> (5, 1, 1, "1692632678249-0", "1692632639151-0", "1692632678249-0")
+            // REMOVE_START
+            assert_eq!(view.0, 5);
+            assert_eq!(view.2, 1);
+            assert_eq!(view.4, "1692632639151-0");
+            assert_eq!(view.5, "1692632678249-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_info_state(&mut r);
+        // HIDE_END
+        // STEP_START xinfo_groups
+        if let Ok(res) = r.xinfo_groups("race:italy") {
+            let res: StreamInfoGroupsReply = res;
+            let view: Vec<_> = res
+                .groups
+                .iter()
+                .map(|group| {
+                    (
+                        group.name.clone(),
+                        group.consumers,
+                        group.pending,
+                        group.last_delivered_id.clone(),
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("italy_riders", 3, 2, "1692632662819-0")]
+            // REMOVE_START
+            assert_eq!(view.len(), 1);
+            assert_eq!(view[0].0, "italy_riders");
+            assert_eq!(view[0].1, 3);
+            assert_eq!(view[0].2, 2);
+            assert_eq!(view[0].3, "1692632662819-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // HIDE_START
+        seed_italy_info_state(&mut r);
+        // HIDE_END
+        // STEP_START xinfo_consumers
+        if let Ok(res) = r.xinfo_consumers("race:italy", "italy_riders") {
+            let res: StreamInfoConsumersReply = res;
+            let mut view: Vec<_> = res
+                .consumers
+                .iter()
+                .map(|consumer| (consumer.name.clone(), consumer.pending, consumer.idle))
+                .collect();
+            view.sort_by(|a, b| a.0.cmp(&b.0));
+            println!("{view:?}");
+            // >>> [("Alice", 1, 5), ("Bob", 0, 5), ("Lora", 1, 5)]
+            // REMOVE_START
+            assert_eq!(view.len(), 3);
+            assert_eq!(view[0].0, "Alice");
+            assert_eq!(view[0].1, 1);
+            assert_eq!(view[1].0, "Bob");
+            assert_eq!(view[2].0, "Lora");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START maxlen
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]);
+        // HIDE_END
+        let max1: Option<String> = r
+            .xadd_maxlen("race:italy", StreamMaxlen::Equals(2), "1-0", &[("rider", "Jones")])
+            .expect("maxlen add 1");
+        let max1 = max1.expect("missing stream id");
+        println!("{max1}"); // >>> 1-0
+        let max2: Option<String> = r
+            .xadd_maxlen("race:italy", StreamMaxlen::Equals(2), "2-0", &[("rider", "Wood")])
+            .expect("maxlen add 2");
+        let max2 = max2.expect("missing stream id");
+        println!("{max2}"); // >>> 2-0
+        let max3: Option<String> = r
+            .xadd_maxlen("race:italy", StreamMaxlen::Equals(2), "3-0", &[("rider", "Henshaw")])
+            .expect("maxlen add 3");
+        let max3 = max3.expect("missing stream id");
+        println!("{max3}"); // >>> 3-0
+
+        if let Ok(res) = r.xlen("race:italy") {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.xrange_all("race:italy") {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}");
+            // >>> [("2-0", [("rider", "Wood")]), ("3-0", [("rider", "Henshaw")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 2);
+            assert_eq!(view[0].0, "2-0");
+            assert_eq!(view[1].0, "3-0");
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START xtrim
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]);
+        let _: Option<String> = r.xadd("race:italy", "1-0", &[("rider", "Wood")]).expect("trim seed 1");
+        let _: Option<String> = r.xadd("race:italy", "2-0", &[("rider", "Henshaw")]).expect("trim seed 2");
+        // HIDE_END
+        if let Ok(res) = r.xtrim("race:italy", StreamMaxlen::Equals(10)) {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START xtrim2
+        // HIDE_START
+        seed_trim_stream(&mut r);
+        // HIDE_END
+        if let Ok(res) = r.xtrim_options(
+            "mystream",
+            &StreamTrimOptions::maxlen(StreamTrimmingMode::Approx, 10),
+        ) {
+            let res: usize = res;
+            println!("{res}"); // >>> 0
+            // REMOVE_START
+            assert_eq!(res, 0);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START xdel
+        // HIDE_START
+        delete_keys(&mut r, &["race:italy"]);
+        let _: Option<String> = r.xadd("race:italy", "2-0", &[("rider", "Wood")]).expect("xdel seed 1");
+        let _: Option<String> = r.xadd("race:italy", "3-0", &[("rider", "Henshaw")]).expect("xdel seed 2");
+        // HIDE_END
+        if let Ok(res) = r.xrange_count("race:italy", "-", "+", 2) {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("2-0", [("rider", "Wood")]), ("3-0", [("rider", "Henshaw")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.xdel("race:italy", &["3-0"]) {
+            let res: usize = res;
+            println!("{res}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.xrange_count("race:italy", "-", "+", 2) {
+            let res: StreamRangeReply = res;
+            let view: Vec<_> = res
+                .ids
+                .iter()
+                .map(|entry| {
+                    (
+                        entry.id.clone(),
+                        vec![(
+                            "rider".to_string(),
+                            entry.get::<String>("rider").expect("missing rider"),
+                        )],
+                    )
+                })
+                .collect();
+            println!("{view:?}"); // >>> [("2-0", [("rider", "Wood")])]
+            // REMOVE_START
+            assert_eq!(view.len(), 1);
+            assert_eq!(view[0].0, "2-0");
+            // REMOVE_END
+        }
+        // STEP_END
+    }
+}

--- a/local_examples/rust-sync/dt-vecsets.rs
+++ b/local_examples/rust-sync/dt-vecsets.rs
@@ -1,0 +1,584 @@
+// EXAMPLE: vecset_tutorial
+#[cfg(all(test, feature = "vector-sets"))]
+mod vecset_tests {
+    use redis::{
+        cmd, Commands, EmbeddingInput, VAddOptions, VSimOptions, Value, VectorAddInput,
+        VectorQuantization, VectorSimilaritySearchInput,
+    };
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+        // REMOVE_START
+        let _: () = r.flushall().expect("Failed to flushall");
+        // REMOVE_END
+
+        // STEP_START vadd
+        if let Ok(res) = r.vadd(
+            "points",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[1.0, 1.0])),
+            "pt:A",
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vadd(
+            "points",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[-1.0, -1.0])),
+            "pt:B",
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vadd(
+            "points",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[-1.0, 1.0])),
+            "pt:C",
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vadd(
+            "points",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[1.0, -1.0])),
+            "pt:D",
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vadd(
+            "points",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[1.0, 0.0])),
+            "pt:E",
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        let res: String = cmd("TYPE")
+            .arg("points")
+            .query(&mut r)
+            .expect("TYPE points should succeed");
+        println!("{res}"); // >>> vectorset
+        // REMOVE_START
+        assert_eq!(res, "vectorset");
+        // REMOVE_END
+        // STEP_END
+
+        // STEP_START vcardvdim
+        if let Ok(res) = r.vcard("points") {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vdim("points") {
+            let res: usize = res;
+            println!("{res}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res, 2);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vemb
+        if let Ok(res) = r.vemb("points", "pt:A") {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [0.9999999403953552, 0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] - 1.0).abs() < 0.001);
+            assert!((res[1] - 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:B") {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [-0.9999999403953552, -0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] + 1.0).abs() < 0.001);
+            assert!((res[1] + 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:C") {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [-0.9999999403953552, 0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] + 1.0).abs() < 0.001);
+            assert!((res[1] - 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:D") {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [0.9999999403953552, -0.9999999403953552]
+            // REMOVE_START
+            assert!((res[0] - 1.0).abs() < 0.001);
+            assert!((res[1] + 1.0).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("points", "pt:E") {
+            let res: Vec<f64> = res;
+            println!("{res:?}"); // >>> [1.0, 0.0]
+            // REMOVE_START
+            assert!((res[0] - 1.0).abs() < 0.001);
+            assert!(res[1].abs() < 0.001);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START attr
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:A")
+            .arg("{\"name\":\"Point A\",\"description\":\"First point added\"}")
+            .query(&mut r)
+            .expect("VSETATTR should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        if let Ok(res) = r.vgetattr("points", "pt:A") {
+            let res: Option<String> = res;
+            println!(
+                "{}",
+                res.clone().unwrap_or_else(|| "None".to_string())
+            );
+            // >>> {"name":"Point A","description":"First point added"}
+            // REMOVE_START
+            assert_eq!(
+                res,
+                Some("{\"name\":\"Point A\",\"description\":\"First point added\"}".to_string())
+            );
+            // REMOVE_END
+        }
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:A")
+            .arg("")
+            .query(&mut r)
+            .expect("VSETATTR clear should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        if let Ok(res) = r.vgetattr("points", "pt:A") {
+            let res: Option<String> = res;
+            println!(
+                "{}",
+                res.clone().unwrap_or_else(|| "None".to_string())
+            ); // >>> None
+            // REMOVE_START
+            assert_eq!(res, None);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vrem
+        if let Ok(res) = r.vadd(
+            "points",
+            VectorAddInput::Values(EmbeddingInput::String(&["0", "0"])),
+            "pt:F",
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vcard("points") {
+            let res: usize = res;
+            println!("{res}"); // >>> 6
+            // REMOVE_START
+            assert_eq!(res, 6);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vrem("points", "pt:F") {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vcard("points") {
+            let res: usize = res;
+            println!("{res}"); // >>> 5
+            // REMOVE_START
+            assert_eq!(res, 5);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vsim_basic
+        if let Ok(res) = r.vsim(
+            "points",
+            VectorSimilaritySearchInput::Values(EmbeddingInput::Float64(&[0.9, 0.1])),
+        ) {
+            let res: Value = res;
+            if let Value::Array(items) = res {
+                let view: Vec<String> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                        Value::SimpleString(s) => s,
+                        other => panic!("Unexpected VSIM item: {other:?}"),
+                    })
+                    .collect();
+                println!("{view:?}");
+                // >>> ["pt:E", "pt:A", "pt:D", "pt:C", "pt:B"]
+                // REMOVE_START
+                assert_eq!(
+                    view,
+                    vec![
+                        "pt:E".to_string(),
+                        "pt:A".to_string(),
+                        "pt:D".to_string(),
+                        "pt:C".to_string(),
+                        "pt:B".to_string()
+                    ]
+                );
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START vsim_options
+        let opts = VSimOptions::default().set_with_scores(true).set_count(4);
+        if let Ok(res) =
+            r.vsim_options("points", VectorSimilaritySearchInput::Element("pt:A"), &opts)
+        {
+            let res: Value = res;
+            let mut view: Vec<(String, f64)> = match res {
+                Value::Array(items) => items
+                    .chunks(2)
+                    .map(|chunk| {
+                        let member = match &chunk[0] {
+                            Value::BulkString(bytes) => {
+                                String::from_utf8(bytes.clone()).expect("utf8")
+                            }
+                            Value::SimpleString(s) => s.clone(),
+                            other => panic!("Unexpected member format: {other:?}"),
+                        };
+                        let score = match &chunk[1] {
+                            Value::BulkString(bytes) => String::from_utf8(bytes.clone())
+                                .expect("utf8")
+                                .parse::<f64>()
+                                .expect("score"),
+                            Value::SimpleString(s) => s.parse::<f64>().expect("score"),
+                            Value::Double(v) => *v,
+                            Value::Int(v) => *v as f64,
+                            other => panic!("Unexpected score format: {other:?}"),
+                        };
+                        (member, score)
+                    })
+                    .collect(),
+                Value::Map(items) => items
+                    .into_iter()
+                    .map(|(member, score)| {
+                        let member = match member {
+                            Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                            Value::SimpleString(s) => s,
+                            other => panic!("Unexpected member format: {other:?}"),
+                        };
+                        let score = match score {
+                            Value::BulkString(bytes) => String::from_utf8(bytes)
+                                .expect("utf8")
+                                .parse::<f64>()
+                                .expect("score"),
+                            Value::SimpleString(s) => s.parse::<f64>().expect("score"),
+                            Value::Double(v) => v,
+                            Value::Int(v) => v as f64,
+                            other => panic!("Unexpected score format: {other:?}"),
+                        };
+                        (member, score)
+                    })
+                    .collect(),
+                other => panic!("Unexpected VSIM WITHSCORES response: {other:?}"),
+            };
+            view.sort_by(|a, b| {
+                b.1.partial_cmp(&a.1)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| b.0.cmp(&a.0))
+            });
+            println!("{view:?}");
+            // >>> [("pt:A", 1.0), ("pt:E", 0.8535534143447876), ("pt:D", 0.5), ("pt:C", 0.5)]
+            // REMOVE_START
+            assert_eq!(view.len(), 4);
+            assert_eq!(view[0].0, "pt:A");
+            assert!((view[0].1 - 1.0).abs() < 0.001);
+            assert_eq!(view[1].0, "pt:E");
+            assert!(view[1].1 > 0.85 && view[1].1 < 0.86);
+            assert_eq!(view[2], ("pt:D".to_string(), 0.5));
+            assert_eq!(view[3], ("pt:C".to_string(), 0.5));
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START vsim_filter
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:A")
+            .arg("{\"size\":\"large\",\"price\":18.99}")
+            .query(&mut r)
+            .expect("VSETATTR A should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:B")
+            .arg("{\"size\":\"large\",\"price\":35.99}")
+            .query(&mut r)
+            .expect("VSETATTR B should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:C")
+            .arg("{\"size\":\"large\",\"price\":25.99}")
+            .query(&mut r)
+            .expect("VSETATTR C should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:D")
+            .arg("{\"size\":\"small\",\"price\":21.00}")
+            .query(&mut r)
+            .expect("VSETATTR D should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let res: bool = cmd("VSETATTR")
+            .arg("points")
+            .arg("pt:E")
+            .arg("{\"size\":\"small\",\"price\":17.75}")
+            .query(&mut r)
+            .expect("VSETATTR E should succeed");
+        println!("{res}"); // >>> true
+        // REMOVE_START
+        assert!(res);
+        // REMOVE_END
+
+        let opts = VSimOptions::default().set_filter_expression(".size == \"large\"");
+        if let Ok(res) =
+            r.vsim_options("points", VectorSimilaritySearchInput::Element("pt:A"), &opts)
+        {
+            let res: Value = res;
+            if let Value::Array(items) = res {
+                let view: Vec<String> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                        Value::SimpleString(s) => s,
+                        other => panic!("Unexpected VSIM item: {other:?}"),
+                    })
+                    .collect();
+                println!("{view:?}");
+                // >>> ["pt:A", "pt:C", "pt:B"]
+                // REMOVE_START
+                assert_eq!(
+                    view,
+                    vec!["pt:A".to_string(), "pt:C".to_string(), "pt:B".to_string()]
+                );
+                // REMOVE_END
+            }
+        }
+
+        let opts = VSimOptions::default()
+            .set_filter_expression(".size == \"large\" && .price > 20.00");
+        if let Ok(res) =
+            r.vsim_options("points", VectorSimilaritySearchInput::Element("pt:A"), &opts)
+        {
+            let res: Value = res;
+            if let Value::Array(items) = res {
+                let view: Vec<String> = items
+                    .into_iter()
+                    .map(|item| match item {
+                        Value::BulkString(bytes) => String::from_utf8(bytes).expect("utf8"),
+                        Value::SimpleString(s) => s,
+                        other => panic!("Unexpected VSIM item: {other:?}"),
+                    })
+                    .collect();
+                println!("{view:?}");
+                // >>> ["pt:C", "pt:B"]
+                // REMOVE_START
+                assert_eq!(view, vec!["pt:C".to_string(), "pt:B".to_string()]);
+                // REMOVE_END
+            }
+        }
+        // STEP_END
+
+        // STEP_START add_quant
+        let opts = VAddOptions::default().set_quantization(VectorQuantization::Q8);
+        if let Ok(res) = r.vadd_options(
+            "quantSetQ8",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[1.262185, 1.958231])),
+            "quantElement",
+            &opts,
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("quantSetQ8", "quantElement") {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [1.2643694877624512, 1.958230972290039]
+            // REMOVE_START
+            assert!((res[0] - 1.2643694877624512).abs() < 0.001);
+            assert!((res[1] - 1.958230972290039).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        let opts = VAddOptions::default().set_quantization(VectorQuantization::NoQuant);
+        if let Ok(res) = r.vadd_options(
+            "quantSetNoQ",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[1.262185, 1.958231])),
+            "quantElement",
+            &opts,
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("quantSetNoQ", "quantElement") {
+            let res: Vec<f64> = res;
+            println!("{res:?}");
+            // >>> [1.262184977531433, 1.958230972290039]
+            // REMOVE_START
+            assert!((res[0] - 1.262184977531433).abs() < 0.001);
+            assert!((res[1] - 1.958230972290039).abs() < 0.001);
+            // REMOVE_END
+        }
+
+        let opts = VAddOptions::default().set_quantization(VectorQuantization::Bin);
+        if let Ok(res) = r.vadd_options(
+            "quantSetBin",
+            VectorAddInput::Values(EmbeddingInput::Float64(&[1.262185, 1.958231])),
+            "quantElement",
+            &opts,
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vemb("quantSetBin", "quantElement") {
+            let res: Vec<f64> = res;
+            println!("{res:?}"); // >>> [1.0, 1.0]
+            // REMOVE_START
+            assert_eq!(res, vec![1.0, 1.0]);
+            // REMOVE_END
+        }
+        // STEP_END
+
+        // STEP_START add_reduce
+        let values: Vec<f64> = (0..300).map(|i| i as f64 / 299.0).collect();
+
+        if let Ok(res) = r.vadd(
+            "setNotReduced",
+            VectorAddInput::Values(EmbeddingInput::Float64(&values)),
+            "element",
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vdim("setNotReduced") {
+            let res: usize = res;
+            println!("{res}"); // >>> 300
+            // REMOVE_START
+            assert_eq!(res, 300);
+            // REMOVE_END
+        }
+
+        let opts = VAddOptions::default().set_reduction_dimension(100);
+        if let Ok(res) = r.vadd_options(
+            "setReduced",
+            VectorAddInput::Values(EmbeddingInput::Float64(&values)),
+            "element",
+            &opts,
+        ) {
+            let res: bool = res;
+            println!("{res}"); // >>> true
+            // REMOVE_START
+            assert!(res);
+            // REMOVE_END
+        }
+
+        if let Ok(res) = r.vdim("setReduced") {
+            let res: usize = res;
+            println!("{res}"); // >>> 100
+            // REMOVE_START
+            assert_eq!(res, 100);
+            // REMOVE_END
+        }
+        // STEP_END
+    }
+}


### PR DESCRIPTION
These were considered low priority originally but it seems reasonable to add them now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to new `local_examples` test/example files and do not modify library or production code, but they add many Redis-integration tests that depend on local Redis availability/features.
> 
> **Overview**
> Adds a new set of Rust **sync** and **async** data-type tutorial examples under `local_examples/`, implemented as runnable tests that connect to a local Redis and print/assert expected outputs.
> 
> Coverage includes list operations, set operations, sorted sets/leaderboards, extensive stream commands (groups, pending/claim/autoclaim, trimming/deletion), and vector set examples (guarded by the `vector-sets` feature) including similarity search, filtering, quantization, and dimensionality reduction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e368bca81297b96911ebdc802dae4cd3d65f63d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->