### PR TITLE
K8s: DOC-6245 bug

### DIFF
--- a/content/embeds/k8s/rerc-raegan.md
+++ b/content/embeds/k8s/rerc-raegan.md
@@ -6,7 +6,7 @@ metadata:
 spec:
   recName: rec-arlington
   recNamespace: ns-virginia
-  apiFqdnUrl: test-example-api-rec-arlington-ns-virginia.example.com
-  dbFqdnSuffix: -example-cluster-rec-arlington-ns-virginia.example.com
+  apiFqdnUrl: api-rec-arlington-ns-virginia.example.com
+  dbFqdnSuffix: -db-rec-arlington-ns-virginia.example.com
   secretName: redis-enterprise-rerc-raegan
 ```

--- a/content/operate/kubernetes/7.4.6/active-active/create-reaadb.md
+++ b/content/operate/kubernetes/7.4.6/active-active/create-reaadb.md
@@ -65,8 +65,8 @@ For a list of example values used throughout this article, see the [Example valu
     spec:
       recName: rec-arlington
       recNamespace: ns-virginia
-      apiFqdnUrl: test-example-api-rec-arlington-ns-virginia.example.com
-      dbFqdnSuffix: -example-cluster-rec-arlington-ns-virginia.example.com
+      apiFqdnUrl: api-rec-arlington-ns-virginia.example.com
+      dbFqdnSuffix: -db-rec-arlington-ns-virginia.example.com
       secretName: redis-enterprise-rerc-reagan
     ```
 

--- a/content/operate/kubernetes/7.8.4/active-active/create-reaadb.md
+++ b/content/operate/kubernetes/7.8.4/active-active/create-reaadb.md
@@ -65,8 +65,8 @@ For a list of example values used throughout this article, see the [Example valu
     spec:
       recName: rec-arlington
       recNamespace: ns-virginia
-      apiFqdnUrl: test-example-api-rec-arlington-ns-virginia.example.com
-      dbFqdnSuffix: -example-cluster-rec-arlington-ns-virginia.example.com
+      apiFqdnUrl: api-rec-arlington-ns-virginia.example.com
+      dbFqdnSuffix: -db-rec-arlington-ns-virginia.example.com
       secretName: redis-enterprise-rerc-reagan
     ```
 

--- a/content/operate/kubernetes/7.8.6/active-active/create-reaadb.md
+++ b/content/operate/kubernetes/7.8.6/active-active/create-reaadb.md
@@ -65,8 +65,8 @@ For a list of example values used throughout this article, see the [Example valu
     spec:
       recName: rec-arlington
       recNamespace: ns-virginia
-      apiFqdnUrl: test-example-api-rec-arlington-ns-virginia.example.com
-      dbFqdnSuffix: -example-cluster-rec-arlington-ns-virginia.example.com
+      apiFqdnUrl: api-rec-arlington-ns-virginia.example.com
+      dbFqdnSuffix: -db-rec-arlington-ns-virginia.example.com
       secretName: redis-enterprise-rerc-reagan
     ```
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates example hostnames; no product code or behavior is modified.
> 
> **Overview**
> Updates the `RedisEnterpriseRemoteCluster` YAML examples to use the correct `apiFqdnUrl` and `dbFqdnSuffix` formats (removing the outdated `test-example-*` / `-example-cluster-*` values) in the shared embed (`rerc-raegan.md`) and the Active-Active "Create REAADB" docs for Kubernetes versions `7.4.6`, `7.8.4`, and `7.8.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 436f05e7115e69ae5062cc194fd03f2641ab662f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->