### PR TITLE
DOC-6510 Rust hyperloglog examples

### DIFF
--- a/content/develop/clients/rust/prob.md
+++ b/content/develop/clients/rust/prob.md
@@ -1,0 +1,56 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Learn how to use HyperLogLog approximate cardinality with redis-rs.
+linkTitle: Probabilistic data types
+title: Probabilistic data types
+weight: 45
+---
+
+Redis supports several
+[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+that let you calculate values approximately rather than exactly.
+The `redis-rs` high-level command traits include support for
+[HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+cardinality estimation.
+
+{{< note >}}
+This page covers HyperLogLog because `redis-rs` provides high-level
+`pfadd`, `pfcount`, and `pfmerge` methods. Other probabilistic data types,
+such as Bloom filters, Count-min sketch, t-digest, and Top-K, can still be
+called with low-level Redis commands, but they don't currently have dedicated
+high-level `redis-rs` methods.
+{{< /note >}}
+
+## Set cardinality
+
+A HyperLogLog object calculates the approximate cardinality of a set. As you add
+items, the HyperLogLog tracks the number of distinct set members, but it doesn't
+let you retrieve those members or test whether a specific item was added.
+
+You can also merge two or more HyperLogLogs to find the approximate cardinality
+of the [union](https://en.wikipedia.org/wiki/Union_(set_theory)) of the sets
+they represent.
+
+{{< clients-example set="home_prob_dts" step="hyperloglog" lang_filter="Rust-Sync,Rust-Async" description="Set cardinality: Estimate distinct item count using HyperLogLog with minimal memory usage" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+The main benefit that HyperLogLogs offer is their very low memory usage. They
+can count up to 2^64 items with less than 1% standard error using a maximum
+12KB of memory.
+
+## More information
+
+See the following pages to learn more:
+
+- [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+- [`redis-rs` command trait](https://docs.rs/redis/latest/redis/trait.Commands.html)
+- [`redis-rs` async command trait](https://docs.rs/redis/latest/redis/trait.AsyncCommands.html)

--- a/local_examples/client-specific/rust-async/home_prob_dts.rs
+++ b/local_examples/client-specific/rust-async/home_prob_dts.rs
@@ -1,0 +1,65 @@
+// EXAMPLE: home_prob_dts
+#[cfg(test)]
+mod home_prob_dts_tests {
+    use redis::AsyncCommands;
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // STEP_START hyperloglog
+        // REMOVE_START
+        let _: Result<i32, _> = r.del(&["group:1", "group:2", "both_groups"]).await;
+        // REMOVE_END
+        let group1_added: bool = r
+            .pfadd("group:1", &["andy", "cameron", "david"])
+            .await
+            .expect("Failed to add items to group:1");
+        println!("{group1_added}"); // >>> true
+
+        let group1: usize = r.pfcount("group:1").await.expect("Failed to count group:1");
+        println!("{group1}"); // >>> 3
+
+        let group2_added: bool = r
+            .pfadd("group:2", &["kaitlyn", "michelle", "paolo", "rachel"])
+            .await
+            .expect("Failed to add items to group:2");
+        println!("{group2_added}"); // >>> true
+
+        let group2: usize = r.pfcount("group:2").await.expect("Failed to count group:2");
+        println!("{group2}"); // >>> 4
+
+        let _: () = r
+            .pfmerge("both_groups", &["group:1", "group:2"])
+            .await
+            .expect("Failed to merge HyperLogLogs");
+        println!("OK"); // >>> OK
+
+        let both_groups: usize = r
+            .pfcount("both_groups")
+            .await
+            .expect("Failed to count both_groups");
+        println!("{both_groups}"); // >>> 7
+
+        // STEP_END
+        // REMOVE_START
+        assert!(group1_added);
+        assert_eq!(group1, 3);
+        assert!(group2_added);
+        assert_eq!(group2, 4);
+        assert_eq!(both_groups, 7);
+        // REMOVE_END
+    }
+}

--- a/local_examples/client-specific/rust-sync/home_prob_dts.rs
+++ b/local_examples/client-specific/rust-sync/home_prob_dts.rs
@@ -1,0 +1,61 @@
+// EXAMPLE: home_prob_dts
+#[cfg(test)]
+mod home_prob_dts_tests {
+    use redis::Commands;
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // STEP_START hyperloglog
+        // REMOVE_START
+        let _: Result<i32, _> = r.del(&["group:1", "group:2", "both_groups"]);
+        // REMOVE_END
+        let group1_added: bool = r
+            .pfadd("group:1", &["andy", "cameron", "david"])
+            .expect("Failed to add items to group:1");
+        println!("{group1_added}"); // >>> true
+
+        let group1: usize = r.pfcount("group:1").expect("Failed to count group:1");
+        println!("{group1}"); // >>> 3
+
+        let group2_added: bool = r
+            .pfadd("group:2", &["kaitlyn", "michelle", "paolo", "rachel"])
+            .expect("Failed to add items to group:2");
+        println!("{group2_added}"); // >>> true
+
+        let group2: usize = r.pfcount("group:2").expect("Failed to count group:2");
+        println!("{group2}"); // >>> 4
+
+        let _: () = r
+            .pfmerge("both_groups", &["group:1", "group:2"])
+            .expect("Failed to merge HyperLogLogs");
+        println!("OK"); // >>> OK
+
+        let both_groups: usize = r
+            .pfcount("both_groups")
+            .expect("Failed to count both_groups");
+        println!("{both_groups}"); // >>> 7
+
+        // STEP_END
+        // REMOVE_START
+        assert!(group1_added);
+        assert_eq!(group1, 3);
+        assert!(group2_added);
+        assert_eq!(group2, 4);
+        assert_eq!(both_groups, 7);
+        // REMOVE_END
+    }
+}

--- a/local_examples/rust-async/dt-hll.rs
+++ b/local_examples/rust-async/dt-hll.rs
@@ -1,0 +1,61 @@
+// EXAMPLE: hll_tutorial
+#[cfg(test)]
+mod hll_tests {
+    use redis::AsyncCommands;
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // REMOVE_START
+        let _: Result<i32, _> = r.del(&["bikes", "commuter_bikes", "all_bikes"]).await;
+        // REMOVE_END
+        // STEP_START pfadd
+        let res1: bool = r
+            .pfadd("bikes", &["Hyperion", "Deimos", "Phoebe", "Quaoar"])
+            .await
+            .expect("Failed to add bikes");
+        println!("{res1}"); // >>> true
+
+        let res2: usize = r.pfcount("bikes").await.expect("Failed to count bikes");
+        println!("{res2}"); // >>> 4
+
+        let res3: bool = r
+            .pfadd("commuter_bikes", &["Salacia", "Mimas", "Quaoar"])
+            .await
+            .expect("Failed to add commuter bikes");
+        println!("{res3}"); // >>> true
+
+        let _: () = r
+            .pfmerge("all_bikes", &["bikes", "commuter_bikes"])
+            .await
+            .expect("Failed to merge HyperLogLogs");
+        println!("OK"); // >>> OK
+
+        let res5: usize = r
+            .pfcount("all_bikes")
+            .await
+            .expect("Failed to count all bikes");
+        println!("{res5}"); // >>> 6
+
+        // STEP_END
+        // REMOVE_START
+        assert!(res1);
+        assert_eq!(res2, 4);
+        assert!(res3);
+        assert_eq!(res5, 6);
+        // REMOVE_END
+    }
+}

--- a/local_examples/rust-sync/dt-hll.rs
+++ b/local_examples/rust-sync/dt-hll.rs
@@ -1,0 +1,55 @@
+// EXAMPLE: hll_tutorial
+#[cfg(test)]
+mod hll_tests {
+    use redis::Commands;
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // REMOVE_START
+        let _: Result<i32, _> = r.del(&["bikes", "commuter_bikes", "all_bikes"]);
+        // REMOVE_END
+        // STEP_START pfadd
+        let res1: bool = r
+            .pfadd("bikes", &["Hyperion", "Deimos", "Phoebe", "Quaoar"])
+            .expect("Failed to add bikes");
+        println!("{res1}"); // >>> true
+
+        let res2: usize = r.pfcount("bikes").expect("Failed to count bikes");
+        println!("{res2}"); // >>> 4
+
+        let res3: bool = r
+            .pfadd("commuter_bikes", &["Salacia", "Mimas", "Quaoar"])
+            .expect("Failed to add commuter bikes");
+        println!("{res3}"); // >>> true
+
+        let _: () = r
+            .pfmerge("all_bikes", &["bikes", "commuter_bikes"])
+            .expect("Failed to merge HyperLogLogs");
+        println!("OK"); // >>> OK
+
+        let res5: usize = r.pfcount("all_bikes").expect("Failed to count all bikes");
+        println!("{res5}"); // >>> 6
+
+        // STEP_END
+        // REMOVE_START
+        assert!(res1);
+        assert_eq!(res2, 4);
+        assert!(res3);
+        assert_eq!(res5, 6);
+        // REMOVE_END
+    }
+}


### PR DESCRIPTION
An omission from my previous PR that added data type examples: Rust doesn't support most of the probabilistic data types, but Hyperloglog is "built-in" (kind of), so it actually is supported. This PR adds Hyperloglog examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new documentation pages and example code only, with no changes to runtime application logic or security-sensitive paths.
> 
> **Overview**
> Adds a new Rust client docs page, `prob.md`, introducing probabilistic data types and documenting HyperLogLog cardinality estimation via `redis-rs` (`pfadd`, `pfcount`, `pfmerge`).
> 
> Includes new sync and async Rust example snippets (`home_prob_dts` and `dt-hll`) that demonstrate adding members, estimating counts, and merging HyperLogLogs for union cardinality, with test scaffolding and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9a7180ed97b7bd26e5ee78fb5efcacd87f2bb8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->