### PR TITLE
AWS now supports PrivateLink for AZ euc1-az2

### DIFF
--- a/content/operate/rc/security/aws-privatelink.md
+++ b/content/operate/rc/security/aws-privatelink.md
@@ -40,7 +40,6 @@ Be aware of the following limitations when using PrivateLink with Redis Cloud:
     - `usw1-az2`
     - `apne1-az3`
     - `apne2-az2`
-    - `euc1-az2`
     - `euw1-az4`
     - `cac1-az3`
     - `ilc1-az2`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change removing `euc1-az2` from the list of unsupported Amazon VPC Lattice availability zones; no product code or behavior changes.
> 
> **Overview**
> Updates the AWS PrivateLink docs to reflect that availability zone `euc1-az2` is no longer listed as unsupported for Amazon VPC Lattice/PrivateLink Resource Endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e4dc0d1d4e80831eed5bf46c6422876e23021c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->