### PR TITLE
Fix redisvl workflow

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -196,11 +196,19 @@ jobs:
 
           # Move numbered user-guide pages (except 01_getting_started) into how_to_guides/
           mkdir -p redis_vl_hugo/user_guide/how_to_guides/
+          moved_slugs_alt=""
           for f in ./redis_vl_hugo/user_guide/[0-9][0-9]_*.md; do
               [ -e "$f" ] || continue
               base=$(basename "$f")
               if [[ "$base" != 01_getting_started.md ]]; then
-                  mv "$f" "./redis_vl_hugo/user_guide/how_to_guides/${base}"
+                  moved="./redis_vl_hugo/user_guide/how_to_guides/${base}"
+                  mv "$f" "${moved}"
+                  # File moved one level deeper: bump '../' to '../../' in markdown links
+                  sed -E -i 's#\]\(\.\./#](../../#g' "${moved}"
+                  # Track moved slug (numeric prefix stripped) for later relref rewrites
+                  slug="${base%.md}"
+                  slug="${slug#[0-9][0-9]_}"
+                  moved_slugs_alt="${moved_slugs_alt:+${moved_slugs_alt}|}${slug}"
               fi
           done
 
@@ -217,11 +225,16 @@ jobs:
               # Replace https://docs.redisvl.com links
               sed -E -i 's#https://docs.redisvl.com/en/latest/.+/([^_]+).+\.html(\#[^)]+)#{{< relref "\1\2" >}}#g; s#https://docs.redisvl.com/en/latest/(.+)\.html#https://redis.io/docs/latest/develop/ai/redisvl/\1#g' "${markdown_page}"
 
-              # Replace .md and .ipynb links with relrefs, stripping numeric prefixes like 01_, 02_, etc.
-              sed -E -i 's#\]\(([^)]*/)([0-9]+_)?([^/)]+)\.(md|ipynb)\)#]({{< relref "\1\3" >}})#g' "${markdown_page}"
+              # Replace .md, .ipynb and .rst links with relrefs, stripping numeric prefixes like 01_, 02_, etc.
+              sed -E -i 's#\]\(([^)]*/)([0-9]+_)?([^/)]+)\.(md|ipynb|rst)\)#]({{< relref "\1\3" >}})#g' "${markdown_page}"
 
-              # Replace .md and .ipynb links without paths (same directory)
-              sed -E -i 's#\]\(([0-9]+_)?([^/)]+)\.(md|ipynb)\)#]({{< relref "\2" >}})#g' "${markdown_page}"
+              # Replace .md, .ipynb and .rst links without paths (same directory)
+              sed -E -i 's#\]\(([0-9]+_)?([^/)]+)\.(md|ipynb|rst)\)#]({{< relref "\2" >}})#g' "${markdown_page}"
+
+              # Bump relrefs to user_guide/<slug> -> user_guide/how_to_guides/<slug> for moved slugs
+              if [ -n "${moved_slugs_alt}" ]; then
+                  sed -E -i "s#relref \"((\\.\\./)*user_guide)/(${moved_slugs_alt})\"#relref \"\\1/how_to_guides/\\3\"#g" "${markdown_page}"
+              fi
 
               # Fix image paths from _static/ to proper Hugo path
               sed -E -i 's#!\[([^]]*)\]\(_static/([^)]+)\)#{{< image filename="/images/redisvl/\2" alt="\1" >}}#g' "${markdown_page}"

--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -217,11 +217,11 @@ jobs:
               # Replace https://docs.redisvl.com links
               sed -E -i 's#https://docs.redisvl.com/en/latest/.+/([^_]+).+\.html(\#[^)]+)#{{< relref "\1\2" >}}#g; s#https://docs.redisvl.com/en/latest/(.+)\.html#https://redis.io/docs/latest/develop/ai/redisvl/\1#g' "${markdown_page}"
 
-              # Replace .md links with relrefs, stripping numeric prefixes like 01_, 02_, etc.
-              sed -E -i 's#\]\(([^)]*/)([0-9]+_)?([^/)]+)\.md\)#]({{< relref "\1\3" >}})#g' "${markdown_page}"
+              # Replace .md and .ipynb links with relrefs, stripping numeric prefixes like 01_, 02_, etc.
+              sed -E -i 's#\]\(([^)]*/)([0-9]+_)?([^/)]+)\.(md|ipynb)\)#]({{< relref "\1\3" >}})#g' "${markdown_page}"
 
-              # Replace .md links without paths (same directory)
-              sed -E -i 's#\]\(([0-9]+_)?([^/)]+)\.md\)#]({{< relref "\2" >}})#g' "${markdown_page}"
+              # Replace .md and .ipynb links without paths (same directory)
+              sed -E -i 's#\]\(([0-9]+_)?([^/)]+)\.(md|ipynb)\)#]({{< relref "\2" >}})#g' "${markdown_page}"
 
               # Fix image paths from _static/ to proper Hugo path
               sed -E -i 's#!\[([^]]*)\]\(_static/([^)]+)\)#{{< image filename="/images/redisvl/\2" alt="\1" >}}#g' "${markdown_page}"
@@ -313,9 +313,10 @@ jobs:
               ./redis_vl_hugo/api/_index.md
           )
 
-          # Fetch an upstream MyST landing page (local clone preferred, GitHub fallback) and
-          # convert its grid-card directives into Hugo HTML cards via build/redisvl_grid_to_cards.py.
-          # Falls back to copying the post-Sphinx markdown if the upstream source can't be obtained.
+          # Fetch an upstream MyST landing page from the local clone (already checked out at
+          # the requested tag) and convert its grid-card directives into Hugo HTML cards via
+          # build/redisvl_grid_to_cards.py. Falls back to copying the post-Sphinx markdown if
+          # the upstream source isn't present in this release.
           fetch_landing_source() {
               local rel_path="$1"
               local out_path="$2"
@@ -323,11 +324,6 @@ jobs:
                   cp "./redis-vl-python/docs/${rel_path}" "${out_path}"
                   return 0
               fi
-              for ref in "v${version}" "${version}" "main"; do
-                  if curl -fsSL "https://raw.githubusercontent.com/redis/redis-vl-python/${ref}/docs/${rel_path}" -o "${out_path}"; then
-                      return 0
-                  fi
-              done
               return 1
           }
 
@@ -339,12 +335,14 @@ jobs:
               local tmp_src
               tmp_src=$(mktemp)
               if fetch_landing_source "${rel_path}" "${tmp_src}"; then
+                  mkdir -p "$(dirname "${hugo_dest}")"
                   python3 build/redisvl_grid_to_cards.py "${tmp_src}" "${hugo_dest}" --context "${context}"
                   rm -f "${tmp_src}"
                   return 0
               fi
               rm -f "${tmp_src}"
               if [ -n "${fallback}" ] && [ -f "${fallback}" ]; then
+                  mkdir -p "$(dirname "${hugo_dest}")"
                   cp "${fallback}" "${hugo_dest}"
                   return 0
               fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the docs-sync workflow’s file moves and regex-based link rewriting, which can impact large portions of generated documentation and potentially introduce broken links if patterns misfire.
> 
> **Overview**
> Improves the `redisvl_docs_sync` workflow’s Hugo-prep step by **moving numbered user guide pages into `how_to_guides/` while updating relative links** and rewriting affected `relref`s to point at the new location.
> 
> Extends link normalization to convert `.md`, `.ipynb`, and `.rst` links into Hugo `relref`s, and tightens landing-page generation to **only use the locally checked-out MyST sources** (no GitHub raw fallback) while ensuring destination directories exist before writing outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cda5ab7db717dd07144e7512076e740e03b3181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->