### PR TITLE
DOC-6519 Ruby data type examples

### DIFF
--- a/local_examples/ruby/dt_hash.rb
+++ b/local_examples/ruby/dt_hash.rb
@@ -1,0 +1,102 @@
+# EXAMPLE: hash_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# REMOVE_START
+def assert_equal(expected, actual)
+  raise "Expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+end
+
+r.del('bike:1', 'bike:1:stats')
+# REMOVE_END
+
+# STEP_START set_get_all
+res1 = r.hset('bike:1', {
+  'model' => 'Deimos',
+  'brand' => 'Ergonom',
+  'type' => 'Enduro bikes',
+  'price' => 4972
+})
+puts res1 # 4
+
+res2 = r.hget('bike:1', 'model')
+puts res2 # Deimos
+
+res3 = r.hget('bike:1', 'price')
+puts res3 # 4972
+
+res4 = r.hgetall('bike:1')
+puts res4.inspect
+# {"model"=>"Deimos", "brand"=>"Ergonom", "type"=>"Enduro bikes", "price"=>"4972"}
+# STEP_END
+
+# REMOVE_START
+assert_equal(4, res1)
+assert_equal('Deimos', res2)
+assert_equal('4972', res3)
+assert_equal({
+  'model' => 'Deimos',
+  'brand' => 'Ergonom',
+  'type' => 'Enduro bikes',
+  'price' => '4972'
+}, res4)
+# REMOVE_END
+
+# STEP_START hmget
+res5 = r.hmget('bike:1', 'model', 'price', 'no-such-field')
+puts res5.inspect # ["Deimos", "4972", nil]
+# STEP_END
+
+# REMOVE_START
+assert_equal(['Deimos', '4972', nil], res5)
+# REMOVE_END
+
+# STEP_START hincrby
+res6 = r.hincrby('bike:1', 'price', 100)
+puts res6 # 5072
+
+res7 = r.hincrby('bike:1', 'price', -100)
+puts res7 # 4972
+# STEP_END
+
+# REMOVE_START
+assert_equal(5072, res6)
+assert_equal(4972, res7)
+# REMOVE_END
+
+# STEP_START incrby_get_mget
+res8 = r.hincrby('bike:1:stats', 'rides', 1)
+puts res8 # 1
+
+res9 = r.hincrby('bike:1:stats', 'rides', 1)
+puts res9 # 2
+
+res10 = r.hincrby('bike:1:stats', 'rides', 1)
+puts res10 # 3
+
+res11 = r.hincrby('bike:1:stats', 'crashes', 1)
+puts res11 # 1
+
+res12 = r.hincrby('bike:1:stats', 'owners', 1)
+puts res12 # 1
+
+res13 = r.hget('bike:1:stats', 'rides')
+puts res13 # 3
+
+res14 = r.hmget('bike:1:stats', 'owners', 'crashes')
+puts res14.inspect # ["1", "1"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res8)
+assert_equal(2, res9)
+assert_equal(3, res10)
+assert_equal(1, res11)
+assert_equal(1, res12)
+assert_equal('3', res13)
+assert_equal(['1', '1'], res14)
+r.close
+# REMOVE_END

--- a/local_examples/ruby/dt_hyperloglog.rb
+++ b/local_examples/ruby/dt_hyperloglog.rb
@@ -1,0 +1,41 @@
+# EXAMPLE: hll_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# REMOVE_START
+def assert_equal(expected, actual)
+  raise "Expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+end
+
+r.del('bikes', 'commuter_bikes', 'all_bikes')
+# REMOVE_END
+
+# STEP_START pfadd
+res1 = r.pfadd('bikes', ['Hyperion', 'Deimos', 'Phoebe', 'Quaoar'])
+puts res1 # true
+
+res2 = r.pfcount('bikes')
+puts res2 # 4
+
+res3 = r.pfadd('commuter_bikes', ['Salacia', 'Mimas', 'Quaoar'])
+puts res3 # true
+
+res4 = r.pfmerge('all_bikes', 'bikes', 'commuter_bikes')
+puts res4 # true
+
+res5 = r.pfcount('all_bikes')
+puts res5 # 6
+# STEP_END
+
+# REMOVE_START
+assert_equal(true, res1)
+assert_equal(4, res2)
+assert_equal(true, res3)
+assert_equal(true, res4)
+assert_equal(6, res5)
+r.del('bikes', 'commuter_bikes', 'all_bikes')
+r.close
+# REMOVE_END

--- a/local_examples/ruby/dt_list.rb
+++ b/local_examples/ruby/dt_list.rb
@@ -1,0 +1,336 @@
+# EXAMPLE: list_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# REMOVE_START
+def assert_equal(expected, actual)
+  raise "Expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+end
+
+r.del('bikes:repairs', 'bikes:finished', 'new_bikes')
+# REMOVE_END
+
+# STEP_START queue
+res1 = r.lpush('bikes:repairs', 'bike:1')
+puts res1 # 1
+
+res2 = r.lpush('bikes:repairs', 'bike:2')
+puts res2 # 2
+
+res3 = r.rpop('bikes:repairs')
+puts res3 # bike:1
+
+res4 = r.rpop('bikes:repairs')
+puts res4 # bike:2
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res1)
+assert_equal(2, res2)
+assert_equal('bike:1', res3)
+assert_equal('bike:2', res4)
+# REMOVE_END
+
+# STEP_START stack
+res5 = r.lpush('bikes:repairs', 'bike:1')
+puts res5 # 1
+
+res6 = r.lpush('bikes:repairs', 'bike:2')
+puts res6 # 2
+
+res7 = r.lpop('bikes:repairs')
+puts res7 # bike:2
+
+res8 = r.lpop('bikes:repairs')
+puts res8 # bike:1
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res5)
+assert_equal(2, res6)
+assert_equal('bike:2', res7)
+assert_equal('bike:1', res8)
+# REMOVE_END
+
+# STEP_START llen
+res9 = r.llen('bikes:repairs')
+puts res9 # 0
+# STEP_END
+
+# REMOVE_START
+assert_equal(0, res9)
+# REMOVE_END
+
+# STEP_START lmove_lrange
+res10 = r.lpush('bikes:repairs', 'bike:1')
+puts res10 # 1
+
+res11 = r.lpush('bikes:repairs', 'bike:2')
+puts res11 # 2
+
+res12 = r.lmove('bikes:repairs', 'bikes:finished', 'LEFT', 'LEFT')
+puts res12 # bike:2
+
+res13 = r.lrange('bikes:repairs', 0, -1)
+puts res13.inspect # ["bike:1"]
+
+res14 = r.lrange('bikes:finished', 0, -1)
+puts res14.inspect # ["bike:2"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res10)
+assert_equal(2, res11)
+assert_equal('bike:2', res12)
+assert_equal(['bike:1'], res13)
+assert_equal(['bike:2'], res14)
+# REMOVE_END
+
+# STEP_START ltrim.1
+r.del('bikes:repairs')
+
+res15 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
+puts res15 # 5
+
+res16 = r.ltrim('bikes:repairs', 0, 2)
+puts res16 # OK
+
+res17 = r.lrange('bikes:repairs', 0, -1)
+puts res17.inspect # ["bike:1", "bike:2", "bike:3"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(5, res15)
+assert_equal('OK', res16)
+assert_equal(['bike:1', 'bike:2', 'bike:3'], res17)
+# REMOVE_END
+
+# STEP_START lpush_rpush
+r.del('bikes:repairs')
+
+res18 = r.rpush('bikes:repairs', 'bike:1')
+puts res18 # 1
+
+res19 = r.rpush('bikes:repairs', 'bike:2')
+puts res19 # 2
+
+res20 = r.lpush('bikes:repairs', 'bike:important_bike')
+puts res20 # 3
+
+res21 = r.lrange('bikes:repairs', 0, -1)
+puts res21.inspect # ["bike:important_bike", "bike:1", "bike:2"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res18)
+assert_equal(2, res19)
+assert_equal(3, res20)
+assert_equal(['bike:important_bike', 'bike:1', 'bike:2'], res21)
+# REMOVE_END
+
+# STEP_START variadic
+r.del('bikes:repairs')
+
+res22 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3'])
+puts res22 # 3
+
+res23 = r.lpush('bikes:repairs', ['bike:important_bike', 'bike:very_important_bike'])
+puts res23 # 5
+
+res24 = r.lrange('bikes:repairs', 0, -1)
+puts res24.inspect
+# ["bike:very_important_bike", "bike:important_bike", "bike:1", "bike:2", "bike:3"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res22)
+assert_equal(5, res23)
+assert_equal([
+  'bike:very_important_bike',
+  'bike:important_bike',
+  'bike:1',
+  'bike:2',
+  'bike:3'
+], res24)
+# REMOVE_END
+
+# STEP_START lpop_rpop
+r.del('bikes:repairs')
+
+res25 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3'])
+puts res25 # 3
+
+res26 = r.rpop('bikes:repairs')
+puts res26 # bike:3
+
+res27 = r.lpop('bikes:repairs')
+puts res27 # bike:1
+
+res28 = r.rpop('bikes:repairs')
+puts res28 # bike:2
+
+res29 = r.rpop('bikes:repairs')
+puts res29.inspect # nil
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res25)
+assert_equal('bike:3', res26)
+assert_equal('bike:1', res27)
+assert_equal('bike:2', res28)
+assert_equal(nil, res29)
+# REMOVE_END
+
+# STEP_START ltrim
+r.del('bikes:repairs')
+
+res30 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
+puts res30 # 5
+
+res31 = r.ltrim('bikes:repairs', 0, 2)
+puts res31 # OK
+
+res32 = r.lrange('bikes:repairs', 0, -1)
+puts res32.inspect # ["bike:1", "bike:2", "bike:3"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(5, res30)
+assert_equal('OK', res31)
+assert_equal(['bike:1', 'bike:2', 'bike:3'], res32)
+# REMOVE_END
+
+# STEP_START ltrim_end_of_list
+r.del('bikes:repairs')
+
+res33 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
+puts res33 # 5
+
+res34 = r.ltrim('bikes:repairs', -3, -1)
+puts res34 # OK
+
+res35 = r.lrange('bikes:repairs', 0, -1)
+puts res35.inspect # ["bike:3", "bike:4", "bike:5"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(5, res33)
+assert_equal('OK', res34)
+assert_equal(['bike:3', 'bike:4', 'bike:5'], res35)
+# REMOVE_END
+
+# STEP_START brpop
+r.del('bikes:repairs')
+
+res36 = r.rpush('bikes:repairs', ['bike:1', 'bike:2'])
+puts res36 # 2
+
+res37 = r.brpop('bikes:repairs', timeout: 1)
+puts res37.inspect # ["bikes:repairs", "bike:2"]
+
+res38 = r.brpop('bikes:repairs', timeout: 1)
+puts res38.inspect # ["bikes:repairs", "bike:1"]
+
+res39 = r.brpop('bikes:repairs', timeout: 1)
+puts res39.inspect # nil
+# STEP_END
+
+# REMOVE_START
+assert_equal(2, res36)
+assert_equal(['bikes:repairs', 'bike:2'], res37)
+assert_equal(['bikes:repairs', 'bike:1'], res38)
+assert_equal(nil, res39)
+r.del('bikes:repairs', 'new_bikes')
+# REMOVE_END
+
+# STEP_START rule_1
+res40 = r.del('new_bikes')
+puts res40 # 0
+
+res41 = r.lpush('new_bikes', ['bike:1', 'bike:2', 'bike:3'])
+puts res41 # 3
+# STEP_END
+
+# REMOVE_START
+assert_equal(0, res40)
+assert_equal(3, res41)
+# REMOVE_END
+
+# STEP_START rule_1.1
+r.del('new_bikes')
+
+res42 = r.set('new_bikes', 'bike:1')
+puts res42 # OK
+
+res43 = r.type('new_bikes')
+puts res43 # string
+
+wrong_type_error = nil
+begin
+  r.lpush('new_bikes', ['bike:2', 'bike:3'])
+rescue Redis::CommandError => e
+  wrong_type_error = e
+  puts e.message # WRONGTYPE Operation against a key holding the wrong kind of value
+end
+# STEP_END
+
+# REMOVE_START
+assert_equal('OK', res42)
+assert_equal('string', res43)
+raise 'Expected WRONGTYPE error' unless wrong_type_error&.message&.include?('WRONGTYPE')
+r.del('new_bikes')
+# REMOVE_END
+
+# STEP_START rule_2
+r.del('bikes:repairs')
+
+res44 = r.lpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3'])
+puts res44 # 3
+
+res45 = r.exists('bikes:repairs')
+puts res45 # 1
+
+res46 = r.lpop('bikes:repairs')
+puts res46 # bike:3
+
+res47 = r.lpop('bikes:repairs')
+puts res47 # bike:2
+
+res48 = r.lpop('bikes:repairs')
+puts res48 # bike:1
+
+res49 = r.exists('bikes:repairs')
+puts res49 # 0
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res44)
+assert_equal(1, res45)
+assert_equal('bike:3', res46)
+assert_equal('bike:2', res47)
+assert_equal('bike:1', res48)
+assert_equal(0, res49)
+# REMOVE_END
+
+# STEP_START rule_3
+r.del('bikes:repairs')
+
+res50 = r.del('bikes:repairs')
+puts res50 # 0
+
+res51 = r.llen('bikes:repairs')
+puts res51 # 0
+
+res52 = r.lpop('bikes:repairs')
+puts res52.inspect # nil
+# STEP_END
+
+# REMOVE_START
+assert_equal(0, res50)
+assert_equal(0, res51)
+assert_equal(nil, res52)
+r.close
+# REMOVE_END

--- a/local_examples/ruby/dt_sets.rb
+++ b/local_examples/ruby/dt_sets.rb
@@ -1,0 +1,182 @@
+# EXAMPLE: sets_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# REMOVE_START
+def assert_equal(expected, actual)
+  raise "Expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+end
+
+def assert_same_members(expected, actual)
+  assert_equal(expected.sort, actual.sort)
+end
+
+r.del('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
+# REMOVE_END
+
+# STEP_START sadd
+res1 = r.sadd('bikes:racing:france', ['bike:1'])
+puts res1 # 1
+
+res2 = r.sadd('bikes:racing:france', ['bike:1'])
+puts res2 # 0
+
+res3 = r.sadd('bikes:racing:france', ['bike:2', 'bike:3'])
+puts res3 # 2
+
+res4 = r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
+puts res4 # 2
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res1)
+assert_equal(0, res2)
+assert_equal(2, res3)
+assert_equal(2, res4)
+# REMOVE_END
+
+# STEP_START sismember
+# HIDE_START
+r.del('bikes:racing:france', 'bikes:racing:usa')
+r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
+r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
+# HIDE_END
+res5 = r.sismember('bikes:racing:usa', 'bike:1')
+puts res5 # true
+
+res6 = r.sismember('bikes:racing:usa', 'bike:2')
+puts res6 # false
+# STEP_END
+
+# REMOVE_START
+assert_equal(true, res5)
+assert_equal(false, res6)
+# REMOVE_END
+
+# STEP_START sinter
+# HIDE_START
+r.del('bikes:racing:france', 'bikes:racing:usa')
+r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
+r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
+# HIDE_END
+res7 = r.sinter('bikes:racing:france', 'bikes:racing:usa')
+puts res7.inspect # ["bike:1"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(['bike:1'], res7)
+# REMOVE_END
+
+# STEP_START scard
+# HIDE_START
+r.del('bikes:racing:france')
+r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
+# HIDE_END
+res8 = r.scard('bikes:racing:france')
+puts res8 # 3
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res8)
+# REMOVE_END
+
+# STEP_START sadd_smembers
+r.del('bikes:racing:france')
+
+res9 = r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
+puts res9 # 3
+
+res10 = r.smembers('bikes:racing:france')
+puts res10.sort.inspect # ["bike:1", "bike:2", "bike:3"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res9)
+assert_same_members(['bike:1', 'bike:2', 'bike:3'], res10)
+# REMOVE_END
+
+# STEP_START smismember
+res11 = r.sismember('bikes:racing:france', 'bike:1')
+puts res11 # true
+
+res12 = r.smismember('bikes:racing:france', 'bike:2', 'bike:3', 'bike:4')
+puts res12.inspect # [true, true, false]
+# STEP_END
+
+# REMOVE_START
+assert_equal(true, res11)
+assert_equal([true, true, false], res12)
+# REMOVE_END
+
+# STEP_START sdiff
+r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
+r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
+
+res13 = r.sdiff('bikes:racing:france', 'bikes:racing:usa')
+puts res13.sort.inspect # ["bike:2", "bike:3"]
+# STEP_END
+
+# REMOVE_START
+assert_same_members(['bike:2', 'bike:3'], res13)
+# REMOVE_END
+
+# STEP_START multisets
+r.del('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
+
+r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
+r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
+r.sadd('bikes:racing:italy', ['bike:1', 'bike:2', 'bike:3', 'bike:4'])
+
+res14 = r.sinter('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
+puts res14.inspect # ["bike:1"]
+
+res15 = r.sunion('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
+puts res15.sort.inspect # ["bike:1", "bike:2", "bike:3", "bike:4"]
+
+res16 = r.sdiff('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
+puts res16.inspect # []
+
+res17 = r.sdiff('bikes:racing:france', 'bikes:racing:usa')
+puts res17.sort.inspect # ["bike:2", "bike:3"]
+
+res18 = r.sdiff('bikes:racing:usa', 'bikes:racing:france')
+puts res18.inspect # ["bike:4"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(['bike:1'], res14)
+assert_same_members(['bike:1', 'bike:2', 'bike:3', 'bike:4'], res15)
+assert_equal([], res16)
+assert_same_members(['bike:2', 'bike:3'], res17)
+assert_equal(['bike:4'], res18)
+# REMOVE_END
+
+# STEP_START srem
+r.del('bikes:racing:france')
+
+r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
+
+res19 = r.srem('bikes:racing:france', ['bike:1'])
+puts res19 # 1
+
+res20 = r.spop('bikes:racing:france')
+puts res20 # bike:3, for example
+
+res21 = r.smembers('bikes:racing:france')
+puts res21.sort.inspect # Remaining members, in no particular order
+
+res22 = r.srandmember('bikes:racing:france')
+puts res22 # bike:4, for example
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res19)
+raise 'Expected SPOP to return one member' unless res20
+raise 'Expected three members after SREM and SPOP' unless res21.length == 3
+raise 'Expected popped member to be removed' if res21.include?(res20)
+raise 'Expected random member to come from the set' unless res21.include?(res22)
+r.close
+# REMOVE_END

--- a/local_examples/ruby/dt_sorted_sets.rb
+++ b/local_examples/ruby/dt_sorted_sets.rb
@@ -1,0 +1,158 @@
+# EXAMPLE: ss_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# REMOVE_START
+def assert_equal(expected, actual)
+  raise "Expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+end
+
+r.del('racer_scores')
+# REMOVE_END
+
+# STEP_START zadd
+res1 = r.zadd('racer_scores', [[10, 'Norem']])
+puts res1 # 1
+
+res2 = r.zadd('racer_scores', [[12, 'Castilla']])
+puts res2 # 1
+
+res3 = r.zadd('racer_scores', [
+  [8, 'Sam-Bodden'],
+  [10, 'Royce'],
+  [6, 'Ford'],
+  [14, 'Prickett'],
+  [12, 'Castilla']
+])
+puts res3 # 4
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res1)
+assert_equal(1, res2)
+assert_equal(4, res3)
+assert_equal(6, r.zcard('racer_scores'))
+# REMOVE_END
+
+# STEP_START zrange
+res4 = r.zrange('racer_scores', 0, -1)
+puts res4.inspect # ["Ford", "Sam-Bodden", "Norem", "Royce", "Castilla", "Prickett"]
+
+res5 = r.zrevrange('racer_scores', 0, -1)
+puts res5.inspect # ["Prickett", "Castilla", "Royce", "Norem", "Sam-Bodden", "Ford"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(['Ford', 'Sam-Bodden', 'Norem', 'Royce', 'Castilla', 'Prickett'], res4)
+assert_equal(['Prickett', 'Castilla', 'Royce', 'Norem', 'Sam-Bodden', 'Ford'], res5)
+# REMOVE_END
+
+# STEP_START zrange_withscores
+res6 = r.zrange('racer_scores', 0, -1, with_scores: true)
+puts res6.inspect
+# [["Ford", 6.0], ["Sam-Bodden", 8.0], ["Norem", 10.0], ["Royce", 10.0],
+#  ["Castilla", 12.0], ["Prickett", 14.0]]
+# STEP_END
+
+# REMOVE_START
+assert_equal([
+  ['Ford', 6.0],
+  ['Sam-Bodden', 8.0],
+  ['Norem', 10.0],
+  ['Royce', 10.0],
+  ['Castilla', 12.0],
+  ['Prickett', 14.0]
+], res6)
+# REMOVE_END
+
+# STEP_START zrangebyscore
+res7 = r.zrangebyscore('racer_scores', '-inf', 10)
+puts res7.inspect # ["Ford", "Sam-Bodden", "Norem", "Royce"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(['Ford', 'Sam-Bodden', 'Norem', 'Royce'], res7)
+# REMOVE_END
+
+# STEP_START zremrangebyscore
+res8 = r.zrem('racer_scores', ['Castilla'])
+puts res8 # 1
+
+res9 = r.zremrangebyscore('racer_scores', '-inf', 9)
+puts res9 # 2
+
+res10 = r.zrange('racer_scores', 0, -1)
+puts res10.inspect # ["Norem", "Royce", "Prickett"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res8)
+assert_equal(2, res9)
+assert_equal(['Norem', 'Royce', 'Prickett'], res10)
+# REMOVE_END
+
+# STEP_START zrank
+res11 = r.zrank('racer_scores', 'Norem')
+puts res11 # 0
+
+res12 = r.zrevrank('racer_scores', 'Norem')
+puts res12 # 2
+# STEP_END
+
+# REMOVE_START
+assert_equal(0, res11)
+assert_equal(2, res12)
+# REMOVE_END
+
+# STEP_START zadd_lex
+res13 = r.zadd('racer_scores', [
+  [0, 'Norem'],
+  [0, 'Sam-Bodden'],
+  [0, 'Royce'],
+  [0, 'Ford'],
+  [0, 'Prickett'],
+  [0, 'Castilla']
+])
+puts res13 # 3
+
+res14 = r.zrange('racer_scores', 0, -1)
+puts res14.inspect # ["Castilla", "Ford", "Norem", "Prickett", "Royce", "Sam-Bodden"]
+
+res15 = r.zrangebylex('racer_scores', '[A', '[L')
+puts res15.inspect # ["Castilla", "Ford"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res13)
+assert_equal(['Castilla', 'Ford', 'Norem', 'Prickett', 'Royce', 'Sam-Bodden'], res14)
+assert_equal(['Castilla', 'Ford'], res15)
+# REMOVE_END
+
+# STEP_START leaderboard
+res16 = r.zadd('racer_scores', [[100, 'Wood']])
+puts res16 # 1
+
+res17 = r.zadd('racer_scores', [[100, 'Henshaw']])
+puts res17 # 1
+
+res18 = r.zadd('racer_scores', [[150, 'Henshaw']])
+puts res18 # 0
+
+res19 = r.zincrby('racer_scores', 50, 'Wood')
+puts res19 # 150.0
+
+res20 = r.zincrby('racer_scores', 50, 'Henshaw')
+puts res20 # 200.0
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res16)
+assert_equal(1, res17)
+assert_equal(0, res18)
+assert_equal(150.0, res19)
+assert_equal(200.0, res20)
+r.close
+# REMOVE_END

--- a/local_examples/ruby/dt_stream.rb
+++ b/local_examples/ruby/dt_stream.rb
@@ -1,0 +1,520 @@
+# EXAMPLE: stream_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# REMOVE_START
+r.del('race:france', 'race:italy', 'race:usa', 'mystream')
+# REMOVE_END
+
+# STEP_START xadd
+res1 = r.xadd('race:france', {
+  'rider' => 'Castilla',
+  'speed' => 30.2,
+  'position' => 1,
+  'location_id' => 1
+})
+puts res1 # 1692632086370-0, for example
+
+res2 = r.xadd('race:france', {
+  'rider' => 'Norem',
+  'speed' => 28.8,
+  'position' => 3,
+  'location_id' => 1
+})
+puts res2 # 1692632094485-0, for example
+
+res3 = r.xadd('race:france', {
+  'rider' => 'Prickett',
+  'speed' => 29.7,
+  'position' => 2,
+  'location_id' => 1
+})
+puts res3 # 1692632102976-0, for example
+# STEP_END
+
+# REMOVE_START
+raise 'Expected three stream IDs' unless [res1, res2, res3].all? { |id| id.match?(/\A\d+-\d+\z/) }
+raise 'Expected three entries' unless r.xlen('race:france') == 3
+# REMOVE_END
+
+# STEP_START xrange
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {
+  'rider' => 'Castilla',
+  'speed' => '30.2',
+  'position' => '1',
+  'location_id' => '1'
+}, id: '1692632086370-0')
+r.xadd('race:france', {
+  'rider' => 'Norem',
+  'speed' => '28.8',
+  'position' => '3',
+  'location_id' => '1'
+}, id: '1692632094485-0')
+r.xadd('race:france', {
+  'rider' => 'Prickett',
+  'speed' => '29.7',
+  'position' => '2',
+  'location_id' => '1'
+}, id: '1692632102976-0')
+r.xadd('race:france', {
+  'rider' => 'Castilla',
+  'speed' => '29.9',
+  'position' => '1',
+  'location_id' => '2'
+}, id: '1692632147973-0')
+# HIDE_END
+res4 = r.xrange('race:france', '1692632086370-0', '+', count: 2)
+puts res4.inspect
+# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+#  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected two entries' unless res4.length == 2
+raise 'Expected first fixed ID' unless res4[0][0] == '1692632086370-0'
+raise 'Expected second fixed ID' unless res4[1][0] == '1692632094485-0'
+# REMOVE_END
+
+# STEP_START xread_block
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {'rider' => 'Castilla'}, id: '1692632086370-0')
+# HIDE_END
+res5 = r.xread(['race:france'], ['$'], count: 100, block: 300)
+puts res5.inspect # {}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected empty result when XREAD times out' unless res5.empty?
+# REMOVE_END
+
+# STEP_START xadd_2
+res6 = r.xadd('race:france', {
+  'rider' => 'Castilla',
+  'speed' => 29.9,
+  'position' => 1,
+  'location_id' => 2
+})
+puts res6 # 1692632147973-0, for example
+# STEP_END
+
+# REMOVE_START
+raise 'Expected a stream ID' unless res6.match?(/\A\d+-\d+\z/)
+# REMOVE_END
+
+# STEP_START xlen
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {'rider' => 'Castilla'}, id: '1692632086370-0')
+r.xadd('race:france', {'rider' => 'Norem'}, id: '1692632094485-0')
+r.xadd('race:france', {'rider' => 'Prickett'}, id: '1692632102976-0')
+r.xadd('race:france', {'rider' => 'Castilla'}, id: '1692632147973-0')
+# HIDE_END
+res7 = r.xlen('race:france')
+puts res7 # 4
+# STEP_END
+
+# REMOVE_START
+raise 'Expected four stream entries' unless res7 == 4
+# REMOVE_END
+
+# STEP_START xadd_id
+# HIDE_START
+r.del('race:usa')
+# HIDE_END
+res8 = r.xadd('race:usa', {'racer' => 'Castilla'}, id: '0-1')
+puts res8 # 0-1
+
+res9 = r.xadd('race:usa', {'racer' => 'Norem'}, id: '0-2')
+puts res9 # 0-2
+# STEP_END
+
+# REMOVE_START
+raise 'Expected 0-1' unless res8 == '0-1'
+raise 'Expected 0-2' unless res9 == '0-2'
+# REMOVE_END
+
+# STEP_START xadd_bad_id
+begin
+  r.xadd('race:usa', {'racer' => 'Prickett'}, id: '0-1')
+rescue Redis::CommandError => e
+  puts e.message
+  # ERR The ID specified in XADD is equal or smaller than the target stream top item
+end
+# STEP_END
+
+# REMOVE_START
+begin
+  r.xadd('race:usa', {'racer' => 'Prickett'}, id: '0-1')
+  raise 'Expected XADD to reject a non-increasing ID'
+rescue Redis::CommandError => e
+  raise 'Expected WRONGID error' unless e.message.include?('equal or smaller')
+end
+# REMOVE_END
+
+# STEP_START xadd_7
+# HIDE_START
+r.del('race:usa')
+r.xadd('race:usa', {'racer' => 'Castilla'}, id: '0-1')
+r.xadd('race:usa', {'racer' => 'Norem'}, id: '0-2')
+# HIDE_END
+res10 = r.xadd('race:usa', {'racer' => 'Prickett'}, id: '0-*')
+puts res10 # 0-3
+# STEP_END
+
+# REMOVE_START
+raise 'Expected Redis to generate the sequence number' unless res10 == '0-3'
+# REMOVE_END
+
+# STEP_START xrange_all
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '30.2', 'position' => '1', 'location_id' => '1'}, id: '1692632086370-0')
+r.xadd('race:france', {'rider' => 'Norem', 'speed' => '28.8', 'position' => '3', 'location_id' => '1'}, id: '1692632094485-0')
+r.xadd('race:france', {'rider' => 'Prickett', 'speed' => '29.7', 'position' => '2', 'location_id' => '1'}, id: '1692632102976-0')
+r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '1', 'location_id' => '2'}, id: '1692632147973-0')
+# HIDE_END
+res11 = r.xrange('race:france', '-', '+')
+puts res11.inspect
+# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+#  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}],
+#  ["1692632102976-0", {"rider"=>"Prickett", "speed"=>"29.7", "position"=>"2", "location_id"=>"1"}],
+#  ["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected all four entries' unless res11.length == 4
+# REMOVE_END
+
+# STEP_START xrange_time
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '30.2', 'position' => '1', 'location_id' => '1'}, id: '1692632086370-0')
+r.xadd('race:france', {'rider' => 'Norem', 'speed' => '28.8', 'position' => '3', 'location_id' => '1'}, id: '1692632094485-0')
+# HIDE_END
+res12 = r.xrange('race:france', '1692632086369', '1692632086371')
+puts res12.inspect
+# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected one entry in time range' unless res12.length == 1
+raise 'Expected Castilla entry' unless res12[0][1]['rider'] == 'Castilla'
+# REMOVE_END
+
+# STEP_START xrange_step_1
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '30.2', 'position' => '1', 'location_id' => '1'}, id: '1692632086370-0')
+r.xadd('race:france', {'rider' => 'Norem', 'speed' => '28.8', 'position' => '3', 'location_id' => '1'}, id: '1692632094485-0')
+r.xadd('race:france', {'rider' => 'Prickett', 'speed' => '29.7', 'position' => '2', 'location_id' => '1'}, id: '1692632102976-0')
+r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '1', 'location_id' => '2'}, id: '1692632147973-0')
+# HIDE_END
+res13 = r.xrange('race:france', '-', '+', count: 2)
+puts res13.inspect
+# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+#  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected first page of two entries' unless res13.map(&:first) == ['1692632086370-0', '1692632094485-0']
+# REMOVE_END
+
+# STEP_START xrange_step_2
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '30.2', 'position' => '1', 'location_id' => '1'}, id: '1692632086370-0')
+r.xadd('race:france', {'rider' => 'Norem', 'speed' => '28.8', 'position' => '3', 'location_id' => '1'}, id: '1692632094485-0')
+r.xadd('race:france', {'rider' => 'Prickett', 'speed' => '29.7', 'position' => '2', 'location_id' => '1'}, id: '1692632102976-0')
+r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '1', 'location_id' => '2'}, id: '1692632147973-0')
+# HIDE_END
+res14 = r.xrange('race:france', '(1692632094485-0', '+', count: 2)
+puts res14.inspect
+# [["1692632102976-0", {"rider"=>"Prickett", "speed"=>"29.7", "position"=>"2", "location_id"=>"1"}],
+#  ["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected second page of two entries' unless res14.map(&:first) == ['1692632102976-0', '1692632147973-0']
+# REMOVE_END
+
+# STEP_START xrange_empty
+res15 = r.xrange('race:france', '(1692632147973-0', '+', count: 2)
+puts res15.inspect # []
+# STEP_END
+
+# REMOVE_START
+raise 'Expected no more entries' unless res15.empty?
+# REMOVE_END
+
+# STEP_START xrevrange
+res16 = r.xrevrange('race:france', '+', '-', count: 1)
+puts res16.inspect
+# [["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected newest entry' unless res16.length == 1 && res16[0][0] == '1692632147973-0'
+# REMOVE_END
+
+# STEP_START xread
+res17 = r.xread(['race:france'], ['0'], count: 2)
+puts res17.inspect
+# {"race:france"=>[["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+#                  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected two XREAD entries' unless res17['race:france'].length == 2
+# REMOVE_END
+
+# STEP_START xgroup_create
+# HIDE_START
+r.del('race:france')
+r.xadd('race:france', {'rider' => 'Castilla'}, id: '1692632086370-0')
+# HIDE_END
+res18 = r.xgroup(:create, 'race:france', 'france_riders', '$')
+puts res18 # OK
+# STEP_END
+
+# REMOVE_START
+raise 'Expected OK' unless res18 == 'OK'
+# REMOVE_END
+
+# STEP_START xgroup_create_mkstream
+# HIDE_START
+r.del('race:italy')
+# HIDE_END
+res19 = r.xgroup(:create, 'race:italy', 'italy_riders', '$', mkstream: true)
+puts res19 # OK
+# STEP_END
+
+# REMOVE_START
+raise 'Expected OK' unless res19 == 'OK'
+# REMOVE_END
+
+# STEP_START xgroup_read
+# HIDE_START
+r.del('race:italy')
+r.xgroup(:create, 'race:italy', 'italy_riders', '$', mkstream: true)
+# HIDE_END
+r.xadd('race:italy', {'rider' => 'Castilla'}, id: '1692632639151-0')
+r.xadd('race:italy', {'rider' => 'Royce'}, id: '1692632647899-0')
+r.xadd('race:italy', {'rider' => 'Sam-Bodden'}, id: '1692632662819-0')
+r.xadd('race:italy', {'rider' => 'Prickett'}, id: '1692632670501-0')
+r.xadd('race:italy', {'rider' => 'Norem'}, id: '1692632678249-0')
+
+res20 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['>'], count: 1)
+puts res20.inspect
+# {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected Alice to receive Castilla' unless res20['race:italy'][0][0] == '1692632639151-0'
+# REMOVE_END
+
+# STEP_START xgroup_read_id
+res21 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['0'], count: 1)
+puts res21.inspect
+# {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected pending Castilla message' unless res21['race:italy'][0][0] == '1692632639151-0'
+# REMOVE_END
+
+# STEP_START xack
+res22 = r.xack('race:italy', 'italy_riders', '1692632639151-0')
+puts res22 # 1
+
+res23 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['0'])
+puts res23.inspect
+# {"race:italy"=>[]}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected one acknowledged message' unless res22 == 1
+raise 'Expected no pending messages for Alice' unless res23['race:italy'].empty?
+# REMOVE_END
+
+# STEP_START xgroup_read_bob
+res24 = r.xreadgroup('italy_riders', 'Bob', ['race:italy'], ['>'], count: 2)
+puts res24.inspect
+# {"race:italy"=>[["1692632647899-0", {"rider"=>"Royce"}],
+#                 ["1692632662819-0", {"rider"=>"Sam-Bodden"}]]}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected Bob to receive two messages' unless res24['race:italy'].map(&:first) == ['1692632647899-0', '1692632662819-0']
+# REMOVE_END
+
+# STEP_START xpending
+res25 = r.xpending('race:italy', 'italy_riders')
+puts res25.inspect
+# {"size"=>2, "min_entry_id"=>"1692632647899-0", "max_entry_id"=>"1692632662819-0", "consumers"=>{"Bob"=>"2"}}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected two pending messages' unless res25['size'] == 2
+raise 'Expected Bob pending messages' unless res25['consumers']['Bob'] == '2'
+# REMOVE_END
+
+# STEP_START xpending_plus_minus
+res26 = r.xpending('race:italy', 'italy_riders', '-', '+', 10)
+puts res26.inspect
+# STEP_END
+
+# REMOVE_START
+raise 'Expected pending details' unless res26.map { |entry| entry['entry_id'] } == ['1692632647899-0', '1692632662819-0']
+raise 'Expected Bob ownership' unless res26.all? { |entry| entry['consumer'] == 'Bob' }
+# REMOVE_END
+
+# STEP_START xrange_pending
+res27 = r.xrange('race:italy', '1692632647899-0', '1692632647899-0')
+puts res27.inspect
+# [["1692632647899-0", {"rider"=>"Royce"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected Royce pending entry' unless res27[0][1]['rider'] == 'Royce'
+# REMOVE_END
+
+# STEP_START xclaim
+res28 = r.xclaim('race:italy', 'italy_riders', 'Alice', 0, '1692632647899-0')
+puts res28.inspect
+# [["1692632647899-0", {"rider"=>"Royce"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected Alice to claim Royce' unless res28[0][0] == '1692632647899-0'
+# REMOVE_END
+
+# STEP_START xautoclaim
+res29 = r.xautoclaim('race:italy', 'italy_riders', 'Alice', 0, '0-0', count: 1)
+puts res29.inspect
+# {"next"=>"1692632662819-0", "entries"=>[["1692632647899-0", {"rider"=>"Royce"}]]}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected autoclaim result' unless res29['entries'].length == 1
+# REMOVE_END
+
+# STEP_START xautoclaim_cursor
+res30 = r.xautoclaim('race:italy', 'italy_riders', 'Lora', 0, res29['next'], count: 1)
+puts res30.inspect
+# {"next"=>"0-0", "entries"=>[["1692632662819-0", {"rider"=>"Sam-Bodden"}]]}
+# STEP_END
+
+# REMOVE_START
+raise 'Expected cursor autoclaim result' unless res30.key?('entries')
+# REMOVE_END
+
+# STEP_START xinfo
+res31 = r.xinfo(:stream, 'race:italy')
+puts res31.inspect
+# STEP_END
+
+# REMOVE_START
+raise 'Expected five stream entries' unless res31['length'] == 5
+raise 'Expected one consumer group' unless res31['groups'] == 1
+# REMOVE_END
+
+# STEP_START xinfo_groups
+res32 = r.xinfo(:groups, 'race:italy')
+puts res32.inspect
+# STEP_END
+
+# REMOVE_START
+raise 'Expected italy_riders group' unless res32[0]['name'] == 'italy_riders'
+# REMOVE_END
+
+# STEP_START xinfo_consumers
+res33 = r.xinfo(:consumers, 'race:italy', 'italy_riders')
+puts res33.inspect
+# STEP_END
+
+# REMOVE_START
+consumer_names = res33.map { |consumer| consumer['name'] }
+raise 'Expected Alice consumer' unless consumer_names.include?('Alice')
+raise 'Expected Bob consumer' unless consumer_names.include?('Bob')
+# REMOVE_END
+
+# STEP_START maxlen
+# HIDE_START
+r.del('race:italy')
+r.xadd('race:italy', {'rider' => 'Castilla'}, id: '1692632639151-0')
+r.xadd('race:italy', {'rider' => 'Royce'}, id: '1692632647899-0')
+r.xadd('race:italy', {'rider' => 'Sam-Bodden'}, id: '1692632662819-0')
+r.xadd('race:italy', {'rider' => 'Prickett'}, id: '1692632670501-0')
+r.xadd('race:italy', {'rider' => 'Norem'}, id: '1692632678249-0')
+# HIDE_END
+r.xadd('race:italy', {'rider' => 'Jones'}, id: '1692633189161-0', maxlen: 2)
+r.xadd('race:italy', {'rider' => 'Wood'}, id: '1692633198206-0', maxlen: 2)
+r.xadd('race:italy', {'rider' => 'Henshaw'}, id: '1692633208557-0', maxlen: 2)
+
+res34 = r.xlen('race:italy')
+puts res34 # 2
+
+res35 = r.xrange('race:italy', '-', '+')
+puts res35.inspect
+# [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected stream trimmed to two entries' unless res34 == 2
+raise 'Expected Wood and Henshaw' unless res35.map { |entry| entry[1]['rider'] } == ['Wood', 'Henshaw']
+# REMOVE_END
+
+# STEP_START xtrim
+res36 = r.xtrim('race:italy', 10, approximate: false)
+puts res36 # 0
+# STEP_END
+
+# REMOVE_START
+raise 'Expected no entries trimmed' unless res36 == 0
+# REMOVE_END
+
+# STEP_START xtrim2
+# HIDE_START
+r.del('mystream')
+1.upto(10) do |n|
+  r.xadd('mystream', {'field' => 'value'}, id: "#{n}-0")
+end
+# HIDE_END
+res37 = r.xtrim('mystream', 10, approximate: true)
+puts res37 # 0
+# STEP_END
+
+# REMOVE_START
+raise 'Expected no entries trimmed' unless res37 == 0
+# REMOVE_END
+
+# STEP_START xdel
+# HIDE_START
+r.del('race:italy')
+r.xadd('race:italy', {'rider' => 'Wood'}, id: '1692633198206-0')
+r.xadd('race:italy', {'rider' => 'Henshaw'}, id: '1692633208557-0')
+# HIDE_END
+res38 = r.xrange('race:italy', '-', '+', count: 2)
+puts res38.inspect
+# [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
+
+res39 = r.xdel('race:italy', '1692633208557-0')
+puts res39 # 1
+
+res40 = r.xrange('race:italy', '-', '+', count: 2)
+puts res40.inspect
+# [["1692633198206-0", {"rider"=>"Wood"}]]
+# STEP_END
+
+# REMOVE_START
+raise 'Expected two entries before deletion' unless res38.length == 2
+raise 'Expected one deleted entry' unless res39 == 1
+raise 'Expected only Wood after deletion' unless res40.length == 1 && res40[0][1]['rider'] == 'Wood'
+r.close
+# REMOVE_END

--- a/local_examples/ruby/dt_string.rb
+++ b/local_examples/ruby/dt_string.rb
@@ -1,0 +1,64 @@
+# EXAMPLE: set_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# STEP_START set_get
+res1 = r.set('bike:1', 'Deimos')
+puts res1 # OK
+
+res2 = r.get('bike:1')
+puts res2 # Deimos
+# STEP_END
+
+# REMOVE_START
+raise "Expected 'OK'" unless res1 == 'OK'
+raise "Expected 'Deimos'" unless res2 == 'Deimos'
+# REMOVE_END
+
+# STEP_START setnx_xx
+res3 = r.set('bike:1', 'bike', nx: true)
+puts res3 # false
+
+puts r.get('bike:1') # Deimos
+
+res4 = r.set('bike:1', 'bike', xx: true)
+puts res4 # true
+# STEP_END
+
+# REMOVE_START
+raise 'Expected SET NX to fail' unless res3 == false
+raise 'Expected SET XX to succeed' unless res4 == true
+raise "Expected 'bike'" unless r.get('bike:1') == 'bike'
+# REMOVE_END
+
+# STEP_START mset
+res5 = r.mset('bike:1', 'Deimos', 'bike:2', 'Ares', 'bike:3', 'Vanth')
+puts res5 # OK
+
+res6 = r.mget('bike:1', 'bike:2', 'bike:3')
+puts res6.inspect # ["Deimos", "Ares", "Vanth"]
+# STEP_END
+
+# REMOVE_START
+raise "Expected 'OK'" unless res5 == 'OK'
+raise 'Expected all bike names' unless res6 == ['Deimos', 'Ares', 'Vanth']
+# REMOVE_END
+
+# STEP_START incr
+r.set('total_crashes', 0)
+
+res7 = r.incr('total_crashes')
+puts res7 # 1
+
+res8 = r.incrby('total_crashes', 10)
+puts res8 # 11
+# STEP_END
+
+# REMOVE_START
+raise 'Expected 1' unless res7 == 1
+raise 'Expected 11' unless res8 == 11
+r.close
+# REMOVE_END


### PR DESCRIPTION
Everyone's favourite language now has a full set of code examples for the data types it supports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new Ruby-only example scripts for Redis data types; no production logic changes, with minimal risk beyond potential documentation/example correctness.
> 
> **Overview**
> Adds a new set of Ruby example scripts under `local_examples/ruby/` demonstrating Redis operations for **strings, hashes, lists, sets, sorted sets, streams, and HyperLogLog**.
> 
> Each example includes setup/teardown and inline assertions (via `REMOVE_START` blocks) to validate command behavior and expected outputs for the tutorial steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9c4c3dd52b53c9702c8422c0797a51c17dc1cd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->