### PR TITLE
DOC-6520 added note about MariaDB binlog config

### DIFF
--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -1,7 +1,7 @@
 | Database | Versions | AWS RDS  Versions | GCP SQL Versions |
 | :-- | :-- | :-- | :-- |
 | Oracle | 19c, 21c, 23ai (LogMiner only) | 19c, 21c | - |
-| MariaDB | 10.5, 11.4.x, 11.7.x | 10.4 to 10.11, 11.4.3 | - |
+| MariaDB | 10.5, 11.4.x, 11.7.x | 10.4 to 10.11 | - |
 | MongoDB | 6.0, 7.0, 8.0 | - | - |
 | MySQL | 5.7, 8.0.x, 8.4.x, 9.0, 9.1 | 8.0.x | 8.0 |
 | PostgreSQL | 10, 11, 12, 13, 14, 15, 16, 17  | 11, 12, 13, 14, 15, 16 | 15 |

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/my-sql-mariadb.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/my-sql-mariadb.md
@@ -99,6 +99,20 @@ binlog_row_image            = FULL
 binlog_expire_logs_seconds  = 864000
 ```
 
+For MariaDB, also add the following server configuration settings:
+
+```
+log_bin_compress            = 0
+
+# Required for MariaDB 11.4 and later.
+binlog_legacy_event_pos     = 1
+```
+
+RDI doesn't support binary log compression, so you must set
+`log_bin_compress` to `0`. For MariaDB 11.4 and later, you must also set
+`binlog_legacy_event_pos` to `1` to prevent RDI collector crash loops after
+the MariaDB server restarts.
+
 You can run the query above again to check that `log-bin` is now `ON`.
 
 {{< note >}}If you are using [Amazon RDS for MySQL](https://aws.amazon.com/rds/mysql/) then


### PR DESCRIPTION
Requested from a Slack thread. Note that both the Cloud docs and the on-prem docs refer to this same page for source DB configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is potential user misconfiguration if the new MariaDB settings are inaccurate for certain versions.
> 
> **Overview**
> Clarifies MariaDB source DB setup for RDI by adding required binlog configuration guidance: disable binary log compression via `log_bin_compress=0` and (for MariaDB 11.4+) set `binlog_legacy_event_pos=1` to avoid collector crash loops after server restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea43e2b01f21ac109ad15ac3d3861a88c2042c72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->