### PR TITLE
K8s: fix bug 6142

### DIFF
--- a/content/operate/kubernetes/networking/routes.md
+++ b/content/operate/kubernetes/networking/routes.md
@@ -28,7 +28,7 @@ OpenShift routes allow requests to be routed to the database or cluster API from
 
    * **Name**: Choose any name you want as the first part of your generated hostname
    * **Hostname**: Leave blank
-   * **Path**: Leave as is ("/")
+   * **Path**: Leave blank
    * **Service**: Select the service for the database you want to access
    * **TLS Termination**: Choose "passthrough"
    * **Insecure Traffic**: Select "None"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that updates OpenShift route creation instructions; no runtime behavior is modified.
> 
> **Overview**
> Updates the OpenShift route creation guide to instruct users to leave the **Path** field blank (instead of using `/`), aligning the docs with the expected configuration for external database access via passthrough routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b9f0d9806d60a6fe2a88e4daac30cec5f5b095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->