### PR TITLE
Minor fixes for older redisvl releases

### DIFF
--- a/content/develop/ai/redisvl/0.10.0/api/query.md
+++ b/content/develop/ai/redisvl/0.10.0/api/query.md
@@ -906,7 +906,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -947,7 +947,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -1967,7 +1967,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -2008,7 +2008,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.10.0/api/router.md
+++ b/content/develop/ai/redisvl/0.10.0/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.11.0/api/router.md
+++ b/content/develop/ai/redisvl/0.11.0/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.11.1/api/router.md
+++ b/content/develop/ai/redisvl/0.11.1/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.12.0/api/router.md
+++ b/content/develop/ai/redisvl/0.12.0/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.13.0/api/query.md
+++ b/content/develop/ai/redisvl/0.13.0/api/query.md
@@ -97,7 +97,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -110,7 +110,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -128,12 +128,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -187,7 +187,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -299,7 +299,7 @@ Set the USE_SEARCH_HISTORY parameter for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -355,7 +355,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -585,7 +585,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -598,7 +598,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -616,12 +616,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -675,7 +675,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -782,7 +782,7 @@ Set the USE_SEARCH_HISTORY parameter for the range query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -838,7 +838,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -1118,8 +1118,8 @@ Specify by which fields to group the aggregation.
   : aggregation module.
 
 * **Parameters:**
-  * **fields** (*str* *|* *List* *[* *str* *]*)
-  * **reducers** (*Reducer*)
+  * **fields** (*List* *[* *str* *]*)
+  * **reducers** (*Reducer* *|* *List* *[* *Reducer* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -1484,7 +1484,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -1497,7 +1497,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -1515,12 +1515,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -1574,7 +1574,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -1623,7 +1623,7 @@ Set or update the text weights for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -1679,7 +1679,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -1779,7 +1779,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -1792,7 +1792,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -1810,12 +1810,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -1869,7 +1869,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -1903,7 +1903,7 @@ Set the filter expression for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -1959,7 +1959,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -2030,7 +2030,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -2043,7 +2043,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -2061,12 +2061,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -2120,7 +2120,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -2154,7 +2154,7 @@ Set the filter expression for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -2210,7 +2210,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -2361,8 +2361,8 @@ Specify by which fields to group the aggregation.
   : aggregation module.
 
 * **Parameters:**
-  * **fields** (*str* *|* *List* *[* *str* *]*)
-  * **reducers** (*Reducer*)
+  * **fields** (*List* *[* *str* *]*)
+  * **reducers** (*Reducer* *|* *List* *[* *Reducer* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.13.0/api/reranker.md
+++ b/content/develop/ai/redisvl/0.13.0/api/reranker.md
@@ -78,7 +78,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -167,7 +167,7 @@ in a manner that is potentially more relevant to the query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -269,7 +269,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.13.0/api/router.md
+++ b/content/develop/ai/redisvl/0.13.0/api/router.md
@@ -150,7 +150,7 @@ Get references for an existing route route.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.13.0/api/vectorizer.md
+++ b/content/develop/ai/redisvl/0.13.0/api/vectorizer.md
@@ -104,7 +104,7 @@ Initialize the Hugging Face text vectorizer.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.13.0/overview/installation.md
+++ b/content/develop/ai/redisvl/0.13.0/overview/installation.md
@@ -55,7 +55,7 @@ offering
 
 1. [Redis Cloud](https://redis.io/cloud), a fully managed cloud offering
 2. [Redis Stack](https://redis.io/docs/getting-started/install-stack/docker/), a local docker image for testing and development
-3. [Redis Enterprise](https://redis.com/redis-enterprise/), a commercial self-hosted
+3. [Redis Software](https://redis.com/redis-enterprise/), a commercial self-hosted
 
 ### Redis Cloud
 
@@ -73,11 +73,11 @@ docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:lat
 
 This will also spin up the [Redis Insight GUI](https://redis.io/insight/) at `http://localhost:8001`.
 
-### Redis Enterprise (self-hosted)
+### Redis Software (self-hosted)
 
-Redis Enterprise is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
+Redis Software is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
 
-If you are considering a self-hosted Redis Enterprise deployment on Kubernetes, there is the [Redis Enterprise Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Enterprise cluster on Kubernetes.
+If you are considering a self-hosted Redis Software deployment on Kubernetes, there is the [Redis Software Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Software cluster on Kubernetes.
 
 ### Redis Sentinel
 

--- a/content/develop/ai/redisvl/0.13.0/user_guide/getting_started.md
+++ b/content/develop/ai/redisvl/0.13.0/user_guide/getting_started.md
@@ -304,7 +304,7 @@ query = VectorQuery(
 )
 ```
 
-See the [SVS-VAMANA guide](09_svs_vamana.ipynb) and [Advanced Queries guide](11_advanced_queries.ipynb) for more details on runtime parameters.
+See the [SVS-VAMANA guide]({{< relref "svs_vamana" >}}) and [Advanced Queries guide]({{< relref "advanced_queries" >}}) for more details on runtime parameters.
 
 ### Executing queries
 With our `VectorQuery` object defined above, we can execute the query over the `SearchIndex` using the `query` method.

--- a/content/develop/ai/redisvl/0.13.0/user_guide/hash_vs_json.md
+++ b/content/develop/ai/redisvl/0.13.0/user_guide/hash_vs_json.md
@@ -13,7 +13,7 @@ In this notebook, we will demonstrate how to use RedisVL with both [Hash](https:
 
 Before running this notebook, be sure to
 1. Have installed ``redisvl`` and have that environment active for this notebook.
-2. Have a running Redis Stack or Redis Enterprise instance with RediSearch > 2.4 activated.
+2. Have a running Redis Stack or Redis Software instance with RediSearch > 2.4 activated.
 
 For example, you can run [Redis Stack](https://redis.io/docs/install/install-stack/) locally with Docker:
 

--- a/content/develop/ai/redisvl/0.13.0/user_guide/hybrid_queries.md
+++ b/content/develop/ai/redisvl/0.13.0/user_guide/hybrid_queries.md
@@ -152,7 +152,7 @@ v = VectorQuery(
 )
 ```
 
-These parameters can be adjusted at query time without rebuilding the index. See the [Advanced Queries guide](11_advanced_queries.ipynb) for more details.
+These parameters can be adjusted at query time without rebuilding the index. See the [Advanced Queries guide]({{< relref "advanced_queries" >}}) for more details.
 
 
 ```python

--- a/content/develop/ai/redisvl/0.13.2/api/query.md
+++ b/content/develop/ai/redisvl/0.13.2/api/query.md
@@ -97,7 +97,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -110,7 +110,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -128,12 +128,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -187,7 +187,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -299,7 +299,7 @@ Set the USE_SEARCH_HISTORY parameter for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -355,7 +355,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -585,7 +585,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -598,7 +598,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -616,12 +616,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -675,7 +675,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -782,7 +782,7 @@ Set the USE_SEARCH_HISTORY parameter for the range query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -838,7 +838,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -1118,8 +1118,8 @@ Specify by which fields to group the aggregation.
   : aggregation module.
 
 * **Parameters:**
-  * **fields** (*str* *|* *List* *[* *str* *]*)
-  * **reducers** (*Reducer*)
+  * **fields** (*List* *[* *str* *]*)
+  * **reducers** (*Reducer* *|* *List* *[* *Reducer* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -1484,7 +1484,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -1497,7 +1497,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -1515,12 +1515,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -1574,7 +1574,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -1623,7 +1623,7 @@ Set or update the text weights for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -1679,7 +1679,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -1779,7 +1779,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -1792,7 +1792,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -1810,12 +1810,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -1869,7 +1869,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -1903,7 +1903,7 @@ Set the filter expression for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -1959,7 +1959,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -2030,7 +2030,7 @@ Add a dialect field to the query.
 
 #### `expander(expander)`
 
-Add an expander field to the query.
+Add a expander field to the query.
 
 - **expander** - the name of the expander
 
@@ -2043,7 +2043,7 @@ Add an expander field to the query.
 
 Match only documents where the query terms appear in
 the same order in the document.
-i.e., for the query "hello world", we do not match "world hello"
+i.e. for the query "hello world", we do not match "world hello"
 
 * **Return type:**
   *Query*
@@ -2061,12 +2061,12 @@ Analyze the query as being in the specified language.
 
 Limit the search to specific TEXT fields only.
 
-- **fields**: Each element should be a string, case sensitive field name
+- **fields**: A list of strings, case sensitive field names
 
 from the defined schema.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *Query*
 
@@ -2120,7 +2120,7 @@ Set the fields to return with search results.
 
 * **Parameters:**
   * **\*fields** – Variable number of field names to return.
-  * **skip_decode** (*List* *[* *str* *]*  *|* *str* *|* *None*) – Optional field name or list of field names that should not be
+  * **skip_decode** (*str* *|* *List* *[* *str* *]*  *|* *None*) – Optional field name or list of field names that should not be
     decoded. Useful for binary data like embeddings.
 * **Returns:**
   Returns the query object for method chaining.
@@ -2154,7 +2154,7 @@ Set the filter expression for the query.
 
 #### `slop(slop)`
 
-Allow a maximum of N intervening non-matched terms between
+Allow a maximum of N intervening non matched terms between
 phrase terms (0 means exact phrase).
 
 * **Parameters:**
@@ -2210,7 +2210,7 @@ overrides the timeout parameter of the module
 
 #### `verbatim()`
 
-Set the query to be verbatim, i.e., use no query expansion
+Set the query to be verbatim, i.e. use no query expansion
 or stemming.
 
 * **Return type:**
@@ -2361,8 +2361,8 @@ Specify by which fields to group the aggregation.
   : aggregation module.
 
 * **Parameters:**
-  * **fields** (*str* *|* *List* *[* *str* *]*)
-  * **reducers** (*Reducer*)
+  * **fields** (*List* *[* *str* *]*)
+  * **reducers** (*Reducer* *|* *List* *[* *Reducer* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.13.2/api/reranker.md
+++ b/content/develop/ai/redisvl/0.13.2/api/reranker.md
@@ -78,7 +78,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -167,7 +167,7 @@ in a manner that is potentially more relevant to the query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -269,7 +269,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.13.2/api/router.md
+++ b/content/develop/ai/redisvl/0.13.2/api/router.md
@@ -150,7 +150,7 @@ Get references for an existing route route.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.13.2/api/vectorizer.md
+++ b/content/develop/ai/redisvl/0.13.2/api/vectorizer.md
@@ -104,7 +104,7 @@ Initialize the Hugging Face text vectorizer.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.13.2/overview/installation.md
+++ b/content/develop/ai/redisvl/0.13.2/overview/installation.md
@@ -55,7 +55,7 @@ offering
 
 1. [Redis Cloud](https://redis.io/cloud), a fully managed cloud offering
 2. [Redis Stack](https://redis.io/docs/getting-started/install-stack/docker/), a local docker image for testing and development
-3. [Redis Enterprise](https://redis.com/redis-enterprise/), a commercial self-hosted
+3. [Redis Software](https://redis.com/redis-enterprise/), a commercial self-hosted
 
 ### Redis Cloud
 
@@ -73,11 +73,11 @@ docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:lat
 
 This will also spin up the [Redis Insight GUI](https://redis.io/insight/) at `http://localhost:8001`.
 
-### Redis Enterprise (self-hosted)
+### Redis Software (self-hosted)
 
-Redis Enterprise is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
+Redis Software is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
 
-If you are considering a self-hosted Redis Enterprise deployment on Kubernetes, there is the [Redis Enterprise Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Enterprise cluster on Kubernetes.
+If you are considering a self-hosted Redis Software deployment on Kubernetes, there is the [Redis Software Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Software cluster on Kubernetes.
 
 ### Redis Sentinel
 

--- a/content/develop/ai/redisvl/0.13.2/user_guide/getting_started.md
+++ b/content/develop/ai/redisvl/0.13.2/user_guide/getting_started.md
@@ -304,7 +304,7 @@ query = VectorQuery(
 )
 ```
 
-See the [SVS-VAMANA guide](09_svs_vamana.ipynb) and [Advanced Queries guide](11_advanced_queries.ipynb) for more details on runtime parameters.
+See the [SVS-VAMANA guide]({{< relref "svs_vamana" >}}) and [Advanced Queries guide]({{< relref "advanced_queries" >}}) for more details on runtime parameters.
 
 ### Executing queries
 With our `VectorQuery` object defined above, we can execute the query over the `SearchIndex` using the `query` method.

--- a/content/develop/ai/redisvl/0.13.2/user_guide/hash_vs_json.md
+++ b/content/develop/ai/redisvl/0.13.2/user_guide/hash_vs_json.md
@@ -13,7 +13,7 @@ In this notebook, we will demonstrate how to use RedisVL with both [Hash](https:
 
 Before running this notebook, be sure to
 1. Have installed ``redisvl`` and have that environment active for this notebook.
-2. Have a running Redis Stack or Redis Enterprise instance with RediSearch > 2.4 activated.
+2. Have a running Redis Stack or Redis Software instance with RediSearch > 2.4 activated.
 
 For example, you can run [Redis Stack](https://redis.io/docs/install/install-stack/) locally with Docker:
 

--- a/content/develop/ai/redisvl/0.13.2/user_guide/hybrid_queries.md
+++ b/content/develop/ai/redisvl/0.13.2/user_guide/hybrid_queries.md
@@ -152,7 +152,7 @@ v = VectorQuery(
 )
 ```
 
-These parameters can be adjusted at query time without rebuilding the index. See the [Advanced Queries guide](11_advanced_queries.ipynb) for more details.
+These parameters can be adjusted at query time without rebuilding the index. See the [Advanced Queries guide]({{< relref "advanced_queries" >}}) for more details.
 
 
 ```python

--- a/content/develop/ai/redisvl/0.6.0/api/router.md
+++ b/content/develop/ai/redisvl/0.6.0/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.7.0/api/query.md
+++ b/content/develop/ai/redisvl/0.7.0/api/query.md
@@ -834,7 +834,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -875,7 +875,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.7.0/api/reranker.md
+++ b/content/develop/ai/redisvl/0.7.0/api/reranker.md
@@ -78,7 +78,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -167,7 +167,7 @@ in a manner that is potentially more relevant to the query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -269,7 +269,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.7.0/api/router.md
+++ b/content/develop/ai/redisvl/0.7.0/api/router.md
@@ -150,7 +150,7 @@ Get references for an existing route route.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.7.0/api/vectorizer.md
+++ b/content/develop/ai/redisvl/0.7.0/api/vectorizer.md
@@ -79,7 +79,7 @@ Initialize the Hugging Face text vectorizer.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.7.0/overview/installation.md
+++ b/content/develop/ai/redisvl/0.7.0/overview/installation.md
@@ -55,7 +55,7 @@ offering
 
 1. [Redis Cloud](https://redis.io/cloud), a fully managed cloud offering
 2. [Redis Stack](https://redis.io/docs/getting-started/install-stack/docker/), a local docker image for testing and development
-3. [Redis Enterprise](https://redis.com/redis-enterprise/), a commercial self-hosted
+3. [Redis Software](https://redis.com/redis-enterprise/), a commercial self-hosted
 
 ### Redis Cloud
 
@@ -73,8 +73,8 @@ docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:lat
 
 This will also spin up the [Redis Insight GUI](https://redis.io/insight/) at `http://localhost:8001`.
 
-### Redis Enterprise (self-hosted)
+### Redis Software (self-hosted)
 
-Redis Enterprise is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
+Redis Software is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
 
-If you are considering a self-hosted Redis Enterprise deployment on Kubernetes, there is the [Redis Enterprise Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Enterprise cluster on Kubernetes.
+If you are considering a self-hosted Redis Software deployment on Kubernetes, there is the [Redis Software Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Software cluster on Kubernetes.

--- a/content/develop/ai/redisvl/0.7.0/user_guide/hash_vs_json.md
+++ b/content/develop/ai/redisvl/0.7.0/user_guide/hash_vs_json.md
@@ -13,7 +13,7 @@ In this notebook, we will demonstrate how to use RedisVL with both [Hash](https:
 
 Before running this notebook, be sure to
 1. Have installed ``redisvl`` and have that environment active for this notebook.
-2. Have a running Redis Stack or Redis Enterprise instance with RediSearch > 2.4 activated.
+2. Have a running Redis Stack or Redis Software instance with RediSearch > 2.4 activated.
 
 For example, you can run [Redis Stack](https://redis.io/docs/install/install-stack/) locally with Docker:
 

--- a/content/develop/ai/redisvl/0.8.0/api/query.md
+++ b/content/develop/ai/redisvl/0.8.0/api/query.md
@@ -834,7 +834,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -875,7 +875,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.8.0/api/router.md
+++ b/content/develop/ai/redisvl/0.8.0/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.8.1/api/query.md
+++ b/content/develop/ai/redisvl/0.8.1/api/query.md
@@ -834,7 +834,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -875,7 +875,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.8.1/api/router.md
+++ b/content/develop/ai/redisvl/0.8.1/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.8.2/api/query.md
+++ b/content/develop/ai/redisvl/0.8.2/api/query.md
@@ -834,7 +834,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -875,7 +875,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.8.2/api/router.md
+++ b/content/develop/ai/redisvl/0.8.2/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.9.0/api/query.md
+++ b/content/develop/ai/redisvl/0.9.0/api/query.md
@@ -906,7 +906,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -947,7 +947,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.9.0/api/router.md
+++ b/content/develop/ai/redisvl/0.9.0/api/router.md
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.9.1/api/query.md
+++ b/content/develop/ai/redisvl/0.9.1/api/query.md
@@ -906,7 +906,7 @@ returned in addition to any others implicitly specified.
 Otherwise, fields should be given in the format of @field.
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 
@@ -947,7 +947,7 @@ AggregateRequest()            .group_by("@customer", r.sum("@paid").alias(FIELDN
 ``
 
 * **Parameters:**
-  **fields** (*str*)
+  **fields** (*List* *[* *str* *]*)
 * **Return type:**
   *AggregateRequest*
 

--- a/content/develop/ai/redisvl/0.9.1/api/reranker.md
+++ b/content/develop/ai/redisvl/0.9.1/api/reranker.md
@@ -78,7 +78,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -167,7 +167,7 @@ in a manner that is potentially more relevant to the query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -269,7 +269,7 @@ query’s context.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.9.1/api/router.md
+++ b/content/develop/ai/redisvl/0.9.1/api/router.md
@@ -150,7 +150,7 @@ Get references for an existing route route.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 
@@ -368,7 +368,7 @@ The matched route name.
 
 ## Distance Aggregation Method
 
-### `class DistanceAggregationMethod(value, names=<not given>, *values, module=None, qualname=None, type=None, start=1, boundary=None)`
+### `class DistanceAggregationMethod(value, names=None, *, module=None, qualname=None, type=None, start=1, boundary=None)`
 
 Enumeration for distance aggregation methods.
 

--- a/content/develop/ai/redisvl/0.9.1/api/vectorizer.md
+++ b/content/develop/ai/redisvl/0.9.1/api/vectorizer.md
@@ -79,7 +79,7 @@ Initialize the Hugging Face text vectorizer.
 
 #### `model_post_init(context, /)`
 
-This function is meant to behave like a BaseModel method to initialize private attributes.
+This function is meant to behave like a BaseModel method to initialise private attributes.
 
 It takes context as an argument since that’s what pydantic-core passes when calling it.
 

--- a/content/develop/ai/redisvl/0.9.1/overview/installation.md
+++ b/content/develop/ai/redisvl/0.9.1/overview/installation.md
@@ -55,7 +55,7 @@ offering
 
 1. [Redis Cloud](https://redis.io/cloud), a fully managed cloud offering
 2. [Redis Stack](https://redis.io/docs/getting-started/install-stack/docker/), a local docker image for testing and development
-3. [Redis Enterprise](https://redis.com/redis-enterprise/), a commercial self-hosted
+3. [Redis Software](https://redis.com/redis-enterprise/), a commercial self-hosted
 
 ### Redis Cloud
 
@@ -73,11 +73,11 @@ docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 redis/redis-stack:lat
 
 This will also spin up the [Redis Insight GUI](https://redis.io/insight/) at `http://localhost:8001`.
 
-### Redis Enterprise (self-hosted)
+### Redis Software (self-hosted)
 
-Redis Enterprise is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
+Redis Software is a commercial offering that can be self-hosted. You can download the latest version [here](https://redis.io/downloads/).
 
-If you are considering a self-hosted Redis Enterprise deployment on Kubernetes, there is the [Redis Enterprise Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Enterprise cluster on Kubernetes.
+If you are considering a self-hosted Redis Software deployment on Kubernetes, there is the [Redis Software Operator](https://docs.redis.com/latest/kubernetes/) for Kubernetes. This will allow you to easily deploy and manage a Redis Software cluster on Kubernetes.
 
 ### Redis Sentinel
 

--- a/content/develop/ai/redisvl/0.9.1/user_guide/hash_vs_json.md
+++ b/content/develop/ai/redisvl/0.9.1/user_guide/hash_vs_json.md
@@ -13,7 +13,7 @@ In this notebook, we will demonstrate how to use RedisVL with both [Hash](https:
 
 Before running this notebook, be sure to
 1. Have installed ``redisvl`` and have that environment active for this notebook.
-2. Have a running Redis Stack or Redis Enterprise instance with RediSearch > 2.4 activated.
+2. Have a running Redis Stack or Redis Software instance with RediSearch > 2.4 activated.
 
 For example, you can run [Redis Stack](https://redis.io/docs/install/install-stack/) locally with Docker:
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes across multiple versioned RedisVL pages; low risk aside from potential broken formatting/links in generated docs.
> 
> **Overview**
> Updates versioned RedisVL docs to better match actual API signatures and terminology.
> 
> Fixes several API reference parameter types (notably `fields`/`reducers` now documented as lists/unions where appropriate), tweaks autogenerated enum/class signatures, and makes minor wording/grammar adjustments.
> 
> Renames “Redis Enterprise” to “Redis Software” in installation/user-guide pages and converts some notebook-style links to Hugo `relref` links (e.g., `svs_vamana`, `advanced_queries`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038e30c8a90a57fe219efc5351ef11512f310e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->