### PR TITLE
added video tutorial link to gcp marketplace page

### DIFF
--- a/content/operate/rc/cloud-integrations/gcp-marketplace/_index.md
+++ b/content/operate/rc/cloud-integrations/gcp-marketplace/_index.md
@@ -13,6 +13,10 @@ weight: 30
 
 You can use Google Cloud marketplace to subscribe to Redis Cloud. This lets you provision according to your needs and pay using your Google Cloud account.
 
+{{< video-link >}}
+See [Connecting Google Cloud Marketplace to Redis Cloud](https://www.youtube.com/watch?v=jo3e5VNye0E) for a short video tutorial.
+{{< /video-link >}}
+
 ## Subscribe to Redis Cloud using Google Cloud marketplace
 
 Here's how to subscribe to Redis Cloud with Google Cloud marketplace:


### PR DESCRIPTION
Added a callout with a link to a video tutorial on how to subscribe to Redis Cloud using Google Cloud marketplace.

YouTube: https://www.youtube.com/watch?v=jo3e5VNye0E

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new external YouTube link and uses an existing `video-link` shortcode.
> 
> **Overview**
> Adds a `video-link` callout to `content/operate/rc/cloud-integrations/gcp-marketplace/_index.md` linking to a YouTube tutorial on connecting Google Cloud Marketplace to Redis Cloud.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ea61410cff333f1a64183d387c3da2079d0b630. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->