### PR TITLE
k8s: Fixed Redis Enterprise download version in k8s 8.0.18-11 release notes

### DIFF
--- a/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026.md
@@ -74,7 +74,7 @@ The following table shows supported Kubernetes versions at the time of this rele
 
 ## Downloads
 
-- **Redis Enterprise**: `redislabs/redis:8.0.18-23.8` (`redislabs/redis:8.0.18-23.8.minimal` for minimal base image)
+- **Redis Enterprise**: `redislabs/redis:8.0.18-23.11` (`redislabs/redis:8.0.18-23.11.minimal` for minimal base image)
 - **Operator**: `redislabs/operator:8.0.18-11`
 - **Services Rigger**: `redislabs/k8s-controller:8.0.18-11`
 - **Callhome client**: `redislabs/re-call-home-client:8.0.18-11`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates a single download tag; no product code or behavior is affected.
> 
> **Overview**
> Fixes the `Redis Enterprise` download reference in the Kubernetes `8.0.18-11` release notes by updating the image tag from `redislabs/redis:8.0.18-23.8` to `redislabs/redis:8.0.18-23.11` (including the `.minimal` variant).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26d00d2043d7f956a704b06532ad1e3955246288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->