### PR TITLE
RS: Added SCH OSS cluster API support as an enhancement in RS 8.0.16-29 release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
@@ -89,7 +89,11 @@ For more information, see [Manage Active-Active databases]({{< relref "/operate/
     ]}
     ```
 
-- For [smart client handoffs]({{<relref "/operate/rs/clusters/configure/sch">}}), the delay between notifying clients and performing an operation is now configurable using the new `state_machine_smart_client_handoffs_delay_ms` cluster setting in the REST API.
+- For [smart client handoffs]({{<relref "/operate/rs/clusters/configure/sch">}}):
+
+    - Added smart client handoff support for databases with OSS cluster API enabled.
+
+    - The delay between notifying clients and performing an operation is now configurable using the new `state_machine_smart_client_handoffs_delay_ms` cluster setting in the REST API.
 
 ### Redis database versions
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that restructures the smart client handoff enhancement note and adds mention of OSS cluster API support; no product code or behavior changes.
> 
> **Overview**
> Updates the `8.0.16-29` Redis Software release notes to expand the *smart client handoffs* enhancement into a short subsection, explicitly calling out support for databases with OSS cluster API enabled and retaining the new configurable delay setting (`state_machine_smart_client_handoffs_delay_ms`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0d481b5d585fda03005ac15bd753551e9fa8e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->