### PR TITLE
RS: Usernames must contain ASCII characters only

### DIFF
--- a/content/operate/rs/security/access-control/create-users.md
+++ b/content/operate/rs/security/access-control/create-users.md
@@ -28,11 +28,13 @@ To add a user to the cluster:
 
 1. Enter the name, email, and password of the new user.
 
-    {{<image filename="images/rs/screenshots/access-control/7-22-updates/create-user-panel.png" alt="Create user panel with fields for username, email, password, and alerts.">}}
-
     {{< note >}}
-To use [single sign-on (SSO)]({{< relref "/operate/rs/security/access-control/saml-sso" >}}), users must have email addresses.
+- Usernames must contain ASCII characters only.
+
+- To use [single sign-on (SSO)]({{< relref "/operate/rs/security/access-control/saml-sso" >}}), users must have email addresses.
     {{< /note >}}
+
+    {{<image filename="images/rs/screenshots/access-control/7-22-updates/create-user-panel.png" alt="Create user panel with fields for username, email, password, and alerts.">}}
 
 1. Select the **Alerts** the user should receive by email:
 

--- a/content/operate/rs/security/access-control/saml-sso.md
+++ b/content/operate/rs/security/access-control/saml-sso.md
@@ -216,7 +216,7 @@ Redis Software only supports SP-initiated logout, where the user logs out from t
     |-------------------------------------------|-------------|
     | firstName | User's first name |
     | lastName | User's last name |
-    | email | User's email address (used as the username in the Redis Software Cluster Manager UI) |
+    | email | User's email address (used as the username in the Redis Software Cluster Manager UI and must contain ASCII characters only.) |
     | redisRoleMapping | String array that includes the role UID for role-based access control in Redis Software. Only used for just-in-time (JIT) user provisioning. If a user already exists in Redis Software, this attribute is ignored and their existing roles are preserved. |
 
     {{<note>}}
@@ -338,7 +338,7 @@ PUT https://<host>:<port>/v1/cluster/sso
 
 After single sign-on is activated for Redis Software, you can create new Redis Software users on the identity provider side using just-in-time (JIT) provisioning.
 
-1. In the identity provider's admin console, create a new user profile with a valid email address. See your identity provider's documentation for detailed instructions.
+1. In the identity provider's admin console, create a new user profile with a valid email address that contains ASCII characters only. See your identity provider's documentation for detailed instructions.
 
 1. Configure the `redisRoleMapping` and assign a Redis Software role UID to the user.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording/layout changes; no product behavior or security logic is modified.
> 
> **Overview**
> Clarifies in the `Create users` docs that **usernames must contain ASCII characters only**, and adjusts the placement of the create-user screenshot relative to the note.
> 
> Updates the `SAML SSO` docs to reflect the same ASCII-only constraint for the `email` attribute (used as the Cluster Manager username) and for JIT-provisioned users created in the IdP.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ab3222553612f117d736bbcec2979a46d96af27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->