### PR TITLE
RS: Updated note about global config changes in A-A planning

### DIFF
--- a/content/operate/rs/databases/active-active/planning.md
+++ b/content/operate/rs/databases/active-active/planning.md
@@ -25,7 +25,7 @@ You need at least [two participating clusters]({{< relref "/operate/rs/clusters/
 If an Active-Active database [runs on flash memory]({{<relref "/operate/rs/databases/flash">}}), you cannot add participating clusters that run on RAM only.
 {{</note>}}
 
-Changes made from the Cluster Manager UI to an Active-Active database configuration only apply to the cluster you are editing. For global configuration changes across all clusters, use the `crdb-cli` command-line utility.
+For Redis Software versions earlier than 8.0.16, changes made from the Cluster Manager UI to an Active-Active database configuration only apply to the cluster you are editing. For global configuration changes across all clusters, use the `crdb-cli` command-line utility. As of Redis Software version 8.0.16, the Cluster Manager UI supports both global and local configuration changes for Active-Active databases.
 
 ## Memory limits
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only wording change with no impact on runtime behavior; risk is limited to potential reader confusion if the version cutoff is incorrect.
> 
> **Overview**
> Updates the Active-Active planning docs to clarify that **Cluster Manager UI configuration changes were local-only before Redis Software 8.0.16**, and that **8.0.16+ supports both global and local configuration changes** (otherwise directing users to `crdb-cli` for global changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f727e51241c5f16371ac99ccec5f4ec91fcccdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->