### PR TITLE
RS: Copied A-A clustering limitation to the planning doc

### DIFF
--- a/content/operate/rs/databases/active-active/planning.md
+++ b/content/operate/rs/databases/active-active/planning.md
@@ -86,6 +86,7 @@ Active-Active databases have the following limitations:
 - The `UNLINK` command is a blocking command for all types of keys.
 - Cross slot multi commands (such as `MSET`) are not supported with Active-Active databases.
 - The hashing policy can't be changed after database creation.
+- Database clustering cannot be enabled or turned off after database creation.
 - Active-Active databases cannot be configured as Redis Flex deployments.
 - Active-Active databases handle replication internally and do not support the `redis.set_repl()` function in Lua scripts.
 - If you enabled the default database password during the creation of an Active-Active database, you should not turn off the default database password because it could prevent the removal of participating database instances.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a missing limitation; no product or runtime behavior is modified.
> 
> **Overview**
> Updates the Active-Active planning documentation to explicitly state that **database clustering cannot be enabled or disabled after database creation**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit befdda92085b6f3992e304d5bfa45f8dadf2dca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->