### PR TITLE
RS: Added the REST API method to upgrade databases

### DIFF
--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
@@ -81,7 +81,8 @@ To upgrade a database:
 
 {{< multitabs id="upgrade-db"
     tab1="Cluster Manager UI"
-    tab2="rladmin" >}}
+    tab2="rladmin"
+    tab3="REST API" >}}
 
 1. Complete all [prerequisites](#upgrade-prerequisites) before starting the upgrade.
 
@@ -156,5 +157,23 @@ To upgrade a database:
     ```sh
     rladmin status databases extra all
     ```
+
+-tab-sep-
+
+1. Complete all [prerequisites](#upgrade-prerequisites) before starting the upgrade.
+
+1. Optionally, back up the database to minimize the risk of data loss.
+
+1. Use an [upgrade database]({{< relref "/operate/rs/references/rest-api/requests/bdbs/upgrade" >}}) REST API request. During the upgrade process, the database will restart without losing any data. Use the `preserve_roles` option to keep the database's current state, including primary shard placement, and prevent the cluster from becoming unbalanced.
+
+    ```sh
+    POST https://<host>:<port>/v1/bdbs/<database_id>/upgrade
+    {
+        "preserve_roles": true,
+        // Additional fields
+    }
+    ```
+
+    For additional database upgrade options, see the [request body]({{<relref "/operate/rs/references/rest-api/requests/bdbs/upgrade#request-body">}}) section of the database upgrade requests reference.
 
 {{< /multitabs >}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change that adds an additional, already-supported upgrade method; no product code or runtime behavior is modified.
> 
> **Overview**
> Adds a new **REST API** tab to the `Upgrade database` docs, documenting how to upgrade a database via `POST /v1/bdbs/<database_id>/upgrade` (including `preserve_roles`) and linking to the request body reference.
> 
> Updates the `multitabs` block to include this third option while keeping the existing UI and `rladmin` upgrade instructions intact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c759cb839210528f4974ef24d5300abd7d405bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->