### PR TITLE
RS: Fix broken link syntax in Active-Active database creation docs.

### DIFF
--- a/content/operate/rs/7.22/databases/active-active/create.md
+++ b/content/operate/rs/7.22/databases/active-active/create.md
@@ -195,7 +195,7 @@ Active-Active databases support append-only file (AOF) persistence only. Snapsho
 
 - **Unauthenticated access** - You can access the database as the default user without providing credentials.
 
-- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}.
+- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}).
 
     If you also configure an access control list, connections can specify other users for authentication, and requests are allowed according to the Redis ACLs specified for that user.
 

--- a/content/operate/rs/7.4/databases/active-active/create.md
+++ b/content/operate/rs/7.4/databases/active-active/create.md
@@ -192,7 +192,7 @@ You cannot enable or turn off database clustering after the Active-Active databa
 
 - **Unauthenticated access** - You can access the database as the default user without providing credentials.
 
-- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}.
+- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}).
 
     If you also configure an access control list, connections can specify other users for authentication, and requests are allowed according to the Redis ACLs specified for that user.
 

--- a/content/operate/rs/7.8/databases/active-active/create.md
+++ b/content/operate/rs/7.8/databases/active-active/create.md
@@ -195,7 +195,7 @@ Active-Active databases support append-only file (AOF) persistence only. Snapsho
 
 - **Unauthenticated access** - You can access the database as the default user without providing credentials.
 
-- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}.
+- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}).
 
     If you also configure an access control list, connections can specify other users for authentication, and requests are allowed according to the Redis ACLs specified for that user.
 

--- a/content/operate/rs/databases/active-active/create.md
+++ b/content/operate/rs/databases/active-active/create.md
@@ -193,7 +193,7 @@ Active-Active databases support append-only file (AOF) persistence only. Snapsho
 
 - **Unauthenticated access** - You can access the database as the default user without providing credentials.
 
-- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}.
+- **Password-only authentication** - When you configure a password for your database's default user, all connections to the database must authenticate with the [AUTH command]({{< relref "/commands/auth" >}}).
 
     If you also configure an access control list, connections can specify other users for authentication, and requests are allowed according to the Redis ACLs specified for that user.
 


### PR DESCRIPTION
These links were missing a closing parenthesis, causing the anchor to not be created as a result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that corrects link syntax with no impact on product behavior.
> 
> **Overview**
> Fixes a broken `AUTH command` link in the **Access control** section of the Active-Active database creation docs by adding the missing closing `)`.
> 
> The correction is applied consistently across the versioned guides (`rs/7.4`, `rs/7.8`, `rs/7.22`) and the current `rs` documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1609a461b1492f74cc92563a9ed47f5dbfe3456a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->