### PR TITLE
DOC-6536 link to Snowflake source prep from rel notes

### DIFF
--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -22,7 +22,7 @@ weight: 971
 
 ### Snowflake and Source Integration
 
-- **Snowflake source support for Helm installations (Preview)**: RDI now supports Snowflake as a source in Helm-based installations, including capture from multiple schemas in a single pipeline. Regular preview terms apply. Snowflake sources are not yet supported for VM installations. RDI can also use well-known root CA certificates from the system truststore, reducing the need for manual certificate configuration for cloud-hosted source databases.
+- **Snowflake source support for Helm installations (Preview)**: RDI now supports [Snowflake]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/snowflake" >}}) as a source in Helm-based installations, including capture from multiple schemas in a single pipeline. Regular preview terms apply. Snowflake sources are not yet supported for VM installations. RDI can also use well-known root CA certificates from the system truststore, reducing the need for manual certificate configuration for cloud-hosted source databases.
 - **Collector resource reservation controls**: A new `sources.advanced.resources` section lets you control memory and CPU reservation for the collector.
 - **CDC-readiness validation in API v2**: RDI API v2 can optionally validate whether MariaDB, MySQL, PostgreSQL, SQL Server, Oracle, and MongoDB sources are ready for CDC as part of pipeline validation. This is available on pipeline create, update, and patch requests by using the `validate_cdc` query parameter, including dry-run requests. Spanner and Snowflake sources are not supported for this validation. The validation is available through API v2 only; the CLI and Redis Insight do not expose it yet.
 


### PR DESCRIPTION
Requested in a Slack chat.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only change that updates a single release-notes bullet to add an internal link; no product logic or configuration behavior changes.
> 
> **Overview**
> Adds an internal `relref` link to the Snowflake preparation documentation in the 1.18.0 RDI release notes, replacing the previously unlinked “Snowflake” mention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7209e690f19f7ef41348e7ea204ebd00bc17b33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->