### PR TITLE
DEV: update build docs

### DIFF
--- a/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-8.md
+++ b/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-8.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on AlmaLinux/Rocky Linux 8.10
 weight: 5
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running AlmaLinux and Rocky Linux 8.10.
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running AlmaLinux 8.10 or Rocky Linux 8.10.
 
 {{< note >}}
 Docker images used to produce these build notes:
@@ -41,8 +41,6 @@ Clean the package metadata, enable required repositories, and install developmen
 
 ```bash
 sudo dnf clean all
-
-# Add GoReleaser repo
 sudo tee /etc/yum.repos.d/goreleaser.repo > /dev/null <<EOF
 [goreleaser]
 name=GoReleaser
@@ -50,16 +48,15 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0
 EOF
-
 sudo dnf update -y
 sudo dnf groupinstall "Development Tools" -y
 sudo dnf config-manager --set-enabled powertools
 sudo dnf install -y epel-release
 ```
 
-## 2. Install required packages
+## 2. Install required dependencies
 
-Install the build dependencies, Python 3.11, and supporting tools:
+Update your package lists and install the necessary development tools and libraries:
 
 ```bash
 sudo dnf install -y --nobest --skip-broken \
@@ -105,18 +102,15 @@ Install CMake 3.25.1 manually:
 ```bash
 CMAKE_VERSION=3.25.1
 ARCH=$(uname -m)
-
 if [ "$ARCH" = "x86_64" ]; then
   CMAKE_FILE=cmake-${CMAKE_VERSION}-linux-x86_64.sh
 else
   CMAKE_FILE=cmake-${CMAKE_VERSION}-linux-aarch64.sh
 fi
-
 wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_FILE}
 chmod +x ${CMAKE_FILE}
 ./${CMAKE_FILE} --skip-license --prefix=/usr/local --exclude-subdir
 rm ${CMAKE_FILE}
-
 cmake --version
 ```
 
@@ -128,7 +122,7 @@ Copy the tar(1) file to `/usr/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd /usr/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -145,25 +139,24 @@ rm redis-<version>.tar.gz
 
 ## 5. Build Redis
 
-Enable the GCC toolset and build Redis with support for TLS and modules:
+Enable the GCC toolset, set the necessary environment variables, and build Redis with TLS and module support:
 
 ```bash
 source /etc/profile.d/gcc-toolset-13.sh
 cd /usr/src/redis-<version>
-
 export BUILD_TLS=yes
 export BUILD_WITH_MODULES=yes
 export INSTALL_RUST_TOOLCHAIN=yes
 export DISABLE_WERRORS=yes
-
 make -j "$(nproc)" all
 ```
 
-## 6. (Optional) Verify the installation
+## 6. (Optional) Verify the build
 
-Check the installed Redis server and CLI versions:
+Check the built Redis server and CLI versions:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server --version
 ./src/redis-cli --version
 ```
@@ -173,12 +166,14 @@ Check the installed Redis server and CLI versions:
 To start Redis, use the following command:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server redis-full.conf
 ```
 
-To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
+To validate that the available modules have been installed, run the [`INFO`]({{< relref "/commands/info" >}}) command and look for lines similar to the following:
 
-```
+```bash
+cd /usr/src/redis-<version>
 ./src/redis-cli INFO
 ...
 # Modules
@@ -193,7 +188,7 @@ module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
 
 ## 8. (Optional) Install Redis to its default location
 
-```
+```bash
 cd /usr/src/redis-<version>
 sudo make install
 ```

--- a/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-9.md
+++ b/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-9.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on AlmaLinux/Rocky Linux 9.5
 weight: 10
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running AlmaLinux and Rocky Linux 9.5.
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running AlmaLinux 9.5 or Rocky Linux 9.5.
 
 {{< note >}}
 Docker images used to produce these build notes:
@@ -37,7 +37,7 @@ dnf install sudo -y
 ```
 {{< /note >}}
 
-Enable the GoReleaser repository and install required packages:
+Clean the package metadata, enable required repositories, and install development tools:
 
 ```bash
 sudo tee /etc/yum.repos.d/goreleaser.repo > /dev/null <<EOF
@@ -47,15 +47,14 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0
 EOF
-
 sudo dnf clean all
 sudo dnf makecache
 sudo dnf update -y
 ```
 
-## 2. Install required packages
+## 2. Install required dependencies
 
-Install build dependencies, GCC toolset, Python, and utilities:
+Update your package lists and install the necessary development tools and libraries:
 
 ```bash
 sudo dnf install -y --nobest --skip-broken \
@@ -98,23 +97,20 @@ echo "source /etc/profile.d/gcc-toolset-13.sh" | sudo tee -a /etc/bashrc
 
 ## 3. Install CMake
 
-Install CMake version 3.25.1 manually:
+Install CMake 3.25.1 manually:
 
 ```bash
 CMAKE_VERSION=3.25.1
 ARCH=$(uname -m)
-
 if [ "$ARCH" = "x86_64" ]; then
   CMAKE_FILE=cmake-${CMAKE_VERSION}-linux-x86_64.sh
 else
   CMAKE_FILE=cmake-${CMAKE_VERSION}-linux-aarch64.sh
 fi
-
 wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/${CMAKE_FILE}
 chmod +x ${CMAKE_FILE}
 ./${CMAKE_FILE} --skip-license --prefix=/usr/local --exclude-subdir
 rm ${CMAKE_FILE}
-
 cmake --version
 ```
 
@@ -126,7 +122,7 @@ Copy the tar(1) file to `/usr/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd /usr/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -143,25 +139,24 @@ rm redis-<version>.tar.gz
 
 ## 5. Build Redis
 
-Enable the GCC toolset and compile Redis with TLS and module support:
+Enable the GCC toolset, set the necessary environment variables, and build Redis with TLS and module support:
 
 ```bash
 source /etc/profile.d/gcc-toolset-13.sh
 cd /usr/src/redis-<version>
-
 export BUILD_TLS=yes
 export BUILD_WITH_MODULES=yes
 export INSTALL_RUST_TOOLCHAIN=yes
 export DISABLE_WERRORS=yes
-
 make -j "$(nproc)" all
 ```
 
-## 6. (Optional) Verify the installation
+## 6. (Optional) Verify the build
 
-Check that Redis was installed successfully:
+Check the built Redis server and CLI versions:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server --version
 ./src/redis-cli --version
 ```
@@ -171,12 +166,14 @@ Check that Redis was installed successfully:
 To start Redis, use the following command:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server redis-full.conf
 ```
 
-To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
+To validate that the available modules have been installed, run the [`INFO`]({{< relref "/commands/info" >}}) command and look for lines similar to the following:
 
-```
+```bash
+cd /usr/src/redis-<version>
 ./src/redis-cli INFO
 ...
 # Modules
@@ -191,7 +188,7 @@ module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
 
 ## 8. (Optional) Install Redis to its default location
 
-```
+```bash
 cd /usr/src/redis-<version>
 sudo make install
 ```

--- a/content/operate/oss_and_stack/install/build-stack/debian-bookworm.md
+++ b/content/operate/oss_and_stack/install/build-stack/debian-bookworm.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on Debian 12 (Bookworm)
 weight: 15
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running Debian 12 (Bookworm).
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running Debian 12 (Bookworm).
 
 {{< note >}}
 Docker images used to produce these build notes:
@@ -19,7 +19,7 @@ Docker images used to produce these build notes:
 
 ## 1. Install required dependencies
 
-First, update your package lists and install the development tools and libraries needed to build Redis:
+Update your package lists and install the development tools and libraries:
 
 ```bash
 apt-get update
@@ -55,7 +55,7 @@ Copy the tar(1) file to `/usr/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd /usr/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -70,10 +70,9 @@ tar xvf redis-<version>.tar.gz
 rm redis-<version>.tar.gz
 ```
 
-
 ## 3. Build Redis
 
-Set the appropriate environment variables to enable TLS, modules, and other build options, then compile and install Redis:
+Set the necessary environment variables and build Redis with TLS and module support:
 
 ```bash
 cd /usr/src/redis-<version>
@@ -81,17 +80,15 @@ export BUILD_TLS=yes
 export BUILD_WITH_MODULES=yes
 export INSTALL_RUST_TOOLCHAIN=yes
 export DISABLE_WERRORS=yes
-
 make -j "$(nproc)" all
 ```
 
-This builds the Redis server, CLI, and any included modules.
-
 ## 4. (Optional) Verify the installation
 
-You can confirm that Redis has been built and installed successfully by checking the version:
+Check the built Redis server and CLI versions:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server --version
 ./src/redis-cli --version
 ```
@@ -101,12 +98,14 @@ You can confirm that Redis has been built and installed successfully by checking
 To start Redis, use the following command:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server redis-full.conf
 ```
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 
-```
+```bash
+cd /usr/src/redis-<version>
 ./src/redis-cli INFO
 ...
 # Modules
@@ -121,7 +120,7 @@ module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
 
 ## 6. (Optional) Install Redis to its default location
 
-```
-cd /usr/src/redis-version
+```bash
+cd /usr/src/redis-<version>
 sudo make install
 ```

--- a/content/operate/oss_and_stack/install/build-stack/debian-bullseye.md
+++ b/content/operate/oss_and_stack/install/build-stack/debian-bullseye.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on Debian 11 (Bullseye)
 weight: 20
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running Debian 11 (Bullseye).
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running Debian 11 (Bullseye).
 
 {{< note >}}
 Docker images used to produce these build notes:
@@ -19,7 +19,7 @@ Docker images used to produce these build notes:
 
 ## 1. Install required dependencies
 
-First, update your package lists and install the development tools and libraries needed to build Redis:
+Update your package lists and install the development tools and libraries:
 
 ```bash
 apt-get update
@@ -55,7 +55,7 @@ Copy the tar(1) file to `/usr/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd /usr/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -72,7 +72,7 @@ rm redis-<version>.tar.gz
 
 ## 3. Build Redis
 
-Set the appropriate environment variables to enable TLS, modules, and other build options, then compile and install Redis:
+Set the necessary environment variables and build Redis with TLS and module support:
 
 ```bash
 cd /usr/src/redis-<version>
@@ -80,17 +80,15 @@ export BUILD_TLS=yes
 export BUILD_WITH_MODULES=yes
 export INSTALL_RUST_TOOLCHAIN=yes
 export DISABLE_WERRORS=yes
-
 make -j "$(nproc)" all
 ```
 
-This builds the Redis server, CLI, and any included modules.
-
 ## 4. (Optional) Verify the installation
 
-You can confirm that Redis has been built and installed successfully by checking the version:
+Check the built Redis server and CLI versions:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server --version
 ./src/redis-cli --version
 ```
@@ -100,12 +98,14 @@ You can confirm that Redis has been built and installed successfully by checking
 To start Redis, use the following command:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server redis-full.conf
 ```
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 
-```
+```bash
+cd /usr/src/redis-<version>
 ./src/redis-cli INFO
 ...
 # Modules
@@ -120,7 +120,7 @@ module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
 
 ## 6. (Optional) Install Redis to its default location
 
-```
+```bash
 cd /usr/src/redis-<version>
 sudo make install
 ```

--- a/content/operate/oss_and_stack/install/build-stack/macos-13-14.md
+++ b/content/operate/oss_and_stack/install/build-stack/macos-13-14.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on macOS 13 (Ventura) and macOS 14 (Sonom
 weight: 50
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running macOS 13 (Ventura) and macOS 14 (Sonoma).
+Follow the steps below to build and run Redis Open Source with all data structuresfrom its source code on a system running macOS 13 (Ventura) and macOS 14 (Sonoma).
 
 ## 1. Install homebrew
 
@@ -17,7 +17,7 @@ If Homebrew isn't already installed, follow the installation instructions on the
 
 ## 2. Install required packages
 
-```
+```bash
 export HOMEBREW_NO_AUTO_UPDATE=1
 brew update
 brew install coreutils
@@ -35,7 +35,7 @@ brew install wget
 
 Rust is required to build the JSON package.
 
-```
+```bash
 RUST_INSTALLER=rust-1.80.1-$(if [ "$(uname -m)" = "arm64" ]; then echo "aarch64"; else echo "x86_64"; fi)-apple-darwin
 wget --quiet -O ${RUST_INSTALLER}.tar.xz https://static.rust-lang.org/dist/${RUST_INSTALLER}.tar.xz
 tar -xf ${RUST_INSTALLER}.tar.xz
@@ -48,7 +48,7 @@ The Redis source code is available from [the Redis GitHub site](https://github.c
 
 Create a directory for the src, for example `~/src`.
 
-```
+```bash
 mkdir ~/src
 ```
 
@@ -56,7 +56,7 @@ Copy the tar(1) file to `~/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd ~/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -66,13 +66,14 @@ Replace `<version>` with the three-digit Redis release number, for example `8.0.
 Extract the source:
 
 ```bash
+cd ~/src
 tar xvf redis-<version>.tar.gz
 rm redis-<version>.tar.gz
 ```
 
 ## 5. Build Redis
 
-```
+```bash
 cd ~/src/redis-<version>
 export HOMEBREW_PREFIX="$(brew --prefix)"
 export BUILD_WITH_MODULES=yes
@@ -81,7 +82,6 @@ export DISABLE_WERRORS=yes
 PATH="$HOMEBREW_PREFIX/opt/libtool/libexec/gnubin:$HOMEBREW_PREFIX/opt/llvm@18/bin:$HOMEBREW_PREFIX/opt/make/libexec/gnubin:$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$HOMEBREW_PREFIX/opt/coreutils/libexec/gnubin:$PATH"
 export LDFLAGS="-L$HOMEBREW_PREFIX/opt/llvm@18/lib"
 export CPPFLAGS="-I$HOMEBREW_PREFIX/opt/llvm@18/include"
-          
 mkdir -p build_dir/etc
 make -C redis-8.0 -j "$(nproc)" all OS=macos
 make -C redis-8.0 install PREFIX=$(pwd)/build_dir OS=macos
@@ -92,6 +92,7 @@ make -C redis-8.0 install PREFIX=$(pwd)/build_dir OS=macos
 Check the installed Redis server and CLI versions:
 
 ```bash
+cd ~/src/redis-<version>
 build_dir/bin/redis-server --version
 build_dir/bin/redis-cli --version
 ```
@@ -101,6 +102,7 @@ build_dir/bin/redis-cli --version
 To start Redis, use the following command:
 
 ```bash
+cd ~/src/redis-<version>
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 build_dir/bin/redis-server redis-full.conf
@@ -108,7 +110,7 @@ build_dir/bin/redis-server redis-full.conf
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 
-```
+```bash
 build_dir/bin/redis-cli INFO
 ...
 # Modules

--- a/content/operate/oss_and_stack/install/build-stack/macos-13-14.md
+++ b/content/operate/oss_and_stack/install/build-stack/macos-13-14.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on macOS 13 (Ventura) and macOS 14 (Sonom
 weight: 50
 ---
 
-Follow the steps below to build and run Redis Open Source with all data structuresfrom its source code on a system running macOS 13 (Ventura) and macOS 14 (Sonoma).
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running macOS 13 (Ventura) and macOS 14 (Sonoma).
 
 ## 1. Install homebrew
 

--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-focal.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-focal.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on Ubuntu 20.04 (Focal)
 weight: 25
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running Ubuntu 20.04 (Focal).
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running Ubuntu 20.04 (Focal).
 
 {{< note >}}
 Docker images used to produce these build notes:
@@ -77,7 +77,7 @@ Copy the tar(1) file to `/usr/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd /usr/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -94,7 +94,7 @@ rm redis-<version>.tar.gz
 
 ## 5. Build Redis
 
-Set the necessary environment variables and compile Redis:
+Set the necessary environment variables, and build Redis with TLS and module support:
 
 ```bash
 cd /usr/src/redis-<version>
@@ -102,15 +102,15 @@ export BUILD_TLS=yes
 export BUILD_WITH_MODULES=yes
 export INSTALL_RUST_TOOLCHAIN=yes
 export DISABLE_WERRORS=yes
-
 make -j "$(nproc)" all
 ```
 
 ## 6. (Optional) Verify the installation
 
-Confirm the Redis installation:
+Check the built Redis server and CLI versions:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server --version
 ./src/redis-cli --version
 ```
@@ -120,12 +120,14 @@ Confirm the Redis installation:
 To start Redis, use the following command:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server redis-full.conf
 ```
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 
 ```
+cd /usr/src/redis-<version>
 ./src/redis-cli INFO
 ...
 # Modules

--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-jammy.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-jammy.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on Ubuntu 22.04 (Jammy)
 weight: 30
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running Ubuntu 22.04 (Jammy).
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running Ubuntu 22.04 (Jammy).
 
 {{< note >}}
 Docker images used to produce these build notes:
@@ -18,7 +18,7 @@ Docker images used to produce these build notes:
 
 ## 1. Install required dependencies
 
-First, update your package lists and install the development tools and libraries needed to build Redis:
+Update your package lists and install the necessary development tools and libraries:
 
 ```bash
 apt-get update
@@ -68,7 +68,7 @@ Copy the tar(1) file to `/usr/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd /usr/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -85,7 +85,7 @@ rm redis-<version>.tar.gz
 
 ## 4. Build Redis
 
-Set the appropriate environment variables to enable TLS, modules, and other build options, then compile and install Redis:
+Set the necessary environment variables, and build Redis with TLS and module support:
 
 ```bash
 cd /usr/src/redis-<version>
@@ -93,17 +93,15 @@ export BUILD_TLS=yes
 export BUILD_WITH_MODULES=yes
 export INSTALL_RUST_TOOLCHAIN=yes
 export DISABLE_WERRORS=yes
-
 make -j "$(nproc)" all
 ```
 
-This builds the Redis server, CLI, and any included modules.
-
 ## 5. (Optional) Verify the installation
 
-You can confirm that Redis has been built and installed successfully by checking the version:
+Check the built Redis server and CLI versions:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server --version
 ./src/redis-cli --version
 ```
@@ -113,12 +111,14 @@ You can confirm that Redis has been built and installed successfully by checking
 To start Redis, use the following command:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server redis-full.conf
 ```
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 
-```
+```bash
+cd /usr/src/redis-<version>
 ./src/redis-cli INFO
 ...
 # Modules
@@ -133,7 +133,7 @@ module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
 
 ## 7. (Optional) Install Redis to its default location
 
-```
+```bash
 cd /usr/src/redis-<version>
 sudo make install
 ```

--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-noble.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-noble.md
@@ -9,7 +9,7 @@ title: Build and run Redis Open Source on Ubuntu 24.04 (Noble)
 weight: 35
 ---
 
-Follow the steps below to build and run Redis Open Source from its source code on a system running Ubuntu 24.04 (Noble).
+Follow the steps below to build and run Redis Open Source with all data structures from its source code on a system running Ubuntu 24.04 (Noble).
 
 {{< note >}}
 Docker images used to produce these build notes:
@@ -18,7 +18,7 @@ Docker images used to produce these build notes:
 
 ## 1. Install required dependencies
 
-First, update your package lists and install the development tools and libraries needed to build Redis:
+Update your package lists and install the necessary development tools and libraries:
 
 ```bash
 apt-get update
@@ -54,7 +54,7 @@ Copy the tar(1) file to `/usr/src`.
 
 Alternatively, you can download the file directly using the `wget` command, as shown below.
 
-```
+```bash
 cd /usr/src
 wget -O redis-<version>.tar.gz https://github.com/redis/redis/archive/refs/tags/<version>.tar.gz
 ```
@@ -71,7 +71,7 @@ rm redis-<version>.tar.gz
 
 ## 3. Build Redis
 
-Set the appropriate environment variables to enable TLS, modules, and other build options, then compile and install Redis:
+Set the necessary environment variables, and build Redis with TLS and module support:
 
 ```bash
 cd /usr/src/redis-<version>
@@ -79,17 +79,15 @@ export BUILD_TLS=yes
 export BUILD_WITH_MODULES=yes
 export INSTALL_RUST_TOOLCHAIN=yes
 export DISABLE_WERRORS=yes
-
 make -j "$(nproc)" all
 ```
 
-This builds the Redis server, CLI, and any included modules.
-
 ## 4. (Optional) Verify the installation
 
-You can confirm that Redis has been built and installed successfully by checking the version:
+Check the built Redis server and CLI versions:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server --version
 ./src/redis-cli --version
 ```
@@ -99,12 +97,14 @@ You can confirm that Redis has been built and installed successfully by checking
 To start Redis, use the following command:
 
 ```bash
+cd /usr/src/redis-<version>
 ./src/redis-server redis-full.conf
 ```
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 
-```
+```bash
+cd /usr/src/redis-<version>
 ./src/redis-cli INFO
 ...
 # Modules
@@ -119,7 +119,7 @@ module:name=vectorset,ver=1,api=1,filters=0,usedby=[],using=[],options=[]
 
 ## 6. (Optional) Install Redis to its default location
 
-```
+```bash
 cd /usr/src/redis-<version>
 sudo make install
 ```


### PR DESCRIPTION
This ticket was originally aimed at 8.8 changes, but as of yet there are none. This set of changes merely brings the docs pages up to date with the build docs in redis/redis:README.md.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits across OS build guides; no product or runtime behavior changes, with low risk limited to potential instruction accuracy/regressions.
> 
> **Overview**
> Updates the build-from-source docs for AlmaLinux/Rocky, Debian, Ubuntu, and macOS to reflect building Redis Open Source **with all data structures** (modules enabled) and to align wording with the upstream build notes.
> 
> Cleans up and standardizes the command snippets and flow (e.g., consistent `bash` code fences, adding missing `cd /usr/src/redis-<version>`/`cd ~/src/redis-<version>` before build/verify/start steps, and renaming “Verify the installation” to “Verify the build”), plus minor link formatting fixes (notably the `INFO` relref syntax on Alma/Rocky pages).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ce7e1f8c40098297a87dc32c9a3d8ba19ba7da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->