### PR TITLE
DEV: (cmds) update array data type information

### DIFF
--- a/content/commands/argrep.md
+++ b/content/commands/argrep.md
@@ -1,0 +1,191 @@
+---
+acl_categories:
+- '@array'
+arguments:
+- key_spec_index: 0
+  name: key
+  type: key
+- name: start
+  type: string
+- name: end
+  type: string
+- arguments:
+  - arguments:
+    - name: exact
+      token: EXACT
+      type: pure-token
+    - name: string
+      type: string
+    name: exact
+    type: block
+  - arguments:
+    - name: match
+      token: MATCH
+      type: pure-token
+    - name: string
+      type: string
+    name: match
+    type: block
+  - arguments:
+    - name: glob
+      token: GLOB
+      type: pure-token
+    - name: pattern
+      type: string
+    name: glob
+    type: block
+  - arguments:
+    - name: re
+      token: RE
+      type: pure-token
+    - name: pattern
+      type: string
+    name: re
+    type: block
+  multiple: true
+  name: predicate
+  type: oneof
+- arguments:
+  - name: and
+    token: AND
+    type: pure-token
+  - name: or
+    token: OR
+    type: pure-token
+  - name: limit
+    token: LIMIT
+    type: integer
+  - name: withvalues
+    token: WITHVALUES
+    type: pure-token
+  - name: nocase
+    token: NOCASE
+    type: pure-token
+  multiple: true
+  name: options
+  optional: true
+  type: oneof
+arity: -6
+bannerText: Array is a new data type that is currently in preview and may be subject to change.
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+complexity: O(P * C) where P is the number of visited positions in touched slices
+  and C is the cost of evaluating the predicates on one existing element.
+description: Searches array elements in a range using textual predicates.
+group: array
+hidden: false
+key_specs:
+- begin_search:
+    index:
+      pos: 1
+  find_keys:
+    range:
+      lastkey: 0
+      limit: 0
+      step: 1
+  flags:
+  - ro
+  - access
+linkTitle: ARGREP
+reply_schema:
+  description: Array of matching indexes, or flat index-value pairs when WITHVALUES
+    is used.
+  items:
+    oneOf:
+    - description: Index of a matching element
+      type: integer
+    - description: Matching value when WITHVALUES is used
+      type: string
+  type: array
+since: 8.8.0
+summary: Searches array elements in a range using textual predicates.
+syntax_fmt: "ARGREP key start end\n \
+  \ <EXACT string | MATCH string | GLOB pattern | RE pattern [...]>\n \
+  \ [AND | OR | LIMIT\_limit | WITHVALUES | NOCASE [...]]"
+title: ARGREP
+---
+Searches array elements in a range using textual predicates and returns the indices of the matching elements. Empty slots in the range are skipped.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+The name of the key that holds the array.
+
+</details>
+
+<details open><summary><code>start</code></summary>
+
+The zero-based integer index at which to begin searching. The special value `-` denotes the first index of the array. If `start` is greater than `end`, matches are returned in reverse index order.
+
+</details>
+
+<details open><summary><code>end</code></summary>
+
+The zero-based integer index at which to stop searching (inclusive). The special value `+` denotes the last index of the array.
+
+</details>
+
+<details open><summary><code>predicate</code></summary>
+
+One or more textual predicates to evaluate against each non-empty element in the range. Each predicate is one of:
+
+- **`EXACT string`** — Matches elements whose value is exactly equal to `string`.
+- **`MATCH string`** — Matches elements whose value contains `string` as a substring.
+- **`GLOB pattern`** — Matches elements whose value matches the glob-style `pattern` (with `*`, `?`, and `[...]` wildcards), the same syntax used by [`KEYS`]({{< relref "/commands/keys" >}}) and [`SCAN`]({{< relref "/commands/scan" >}}) `MATCH`.
+- **`RE pattern`** — Matches elements whose value matches the regular expression `pattern`.
+
+When more than one predicate is supplied, use the `AND` or `OR` option to control how they are combined. The default is `OR`.
+
+</details>
+
+## Optional arguments
+
+<details open><summary><code>options</code></summary>
+
+Zero or more of the following modifiers:
+
+- **`AND`** — Combine multiple predicates with logical AND. An element matches only if every predicate matches.
+- **`OR`** — Combine multiple predicates with logical OR. An element matches if any predicate matches. This is the default.
+- **`LIMIT limit`** — Stop after `limit` matches have been collected. `limit` must be a positive integer. When omitted, all matches in the range are returned.
+- **`WITHVALUES`** — In addition to each matching index, return the matching value. The reply becomes a flat list of alternating index-value pairs.
+- **`NOCASE`** — Perform case-insensitive comparisons for `EXACT`, `MATCH`, `GLOB`, and `RE`.
+
+</details>
+
+## Examples
+
+{{% redis-cli %}}
+ARMSET log 0 "boot: ok" 1 "warn: disk" 2 "ERROR: cpu" 3 "info: ready" 4 "error: net"
+ARGREP log - + MATCH "error" NOCASE
+ARGREP log - + MATCH "error" NOCASE WITHVALUES
+ARGREP log 0 4 GLOB "warn:*" OR GLOB "error:*"
+ARGREP log 0 4 RE "^[A-Za-z]+: (cpu|net)$" NOCASE WITHVALUES
+ARGREP log 0 4 EXACT "info: ready"
+ARGREP log - + MATCH "error" NOCASE LIMIT 1
+{{% /redis-cli %}}
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays): Indices of the matching elements, in the same order in which the range is traversed (ascending when `start <= end`, descending when `start > end`). When `WITHVALUES` is given, a flat array of alternating index-value pairs: `[idx1, val1, idx2, val2, ...]`. An empty array is returned when the key does not exist or no element matches.
+
+-tab-sep-
+
+[Array reply](../../develop/reference/protocol-spec#arrays): Indices of the matching elements, in the same order in which the range is traversed (ascending when `start <= end`, descending when `start > end`). When `WITHVALUES` is given, a flat array of alternating index-value pairs: `[idx1, val1, idx2, val2, ...]`. An empty array is returned when the key does not exist or no element matches.
+
+{{< /multitabs >}}
+

--- a/content/commands/arseek.md
+++ b/content/commands/arseek.md
@@ -23,7 +23,7 @@ command_flags:
 - WRITE
 - FAST
 complexity: O(1)
-description: Sets the ARINSERT cursor to a specific index.
+description: Sets the ARINSERT / ARRING cursor to a specific index.
 function: arseekCommand
 group: array
 hidden: false
@@ -44,11 +44,11 @@ reply_schema:
   description: 1 if the cursor was set, 0 if the key does not exist.
   type: integer
 since: 8.8.0
-summary: Sets the ARINSERT cursor to a specific index.
+summary: Sets the ARINSERT / ARRING cursor to a specific index.
 syntax_fmt: ARSEEK key index
 title: ARSEEK
 ---
-Sets the ARINSERT cursor to a specific index.
+Sets the ARINSERT / ARRING cursor to a specific index.
 
 ## Required arguments
 

--- a/content/develop/data-types/arrays.md
+++ b/content/develop/data-types/arrays.md
@@ -189,9 +189,18 @@ Deleting the last remaining element removes the key entirely.
 ...
 ```
 
+## Configuration
+
+The following configuration parameters affect array behavior:
+- `array-slice-size`
+- `array-sparse-kmax`
+- `array-sparse-kmin`
+
+See the [Redis configuration page]({{< relref "/operate/oss_and_stack/oss/config" >}}) for details.
+
 ## Performance
 
-Most array commands are O(1), including [`ARSET`]({{< relref "/commands/arset" >}}), [`ARGET`]({{< relref "/commands/arget" >}}), [`ARDEL`]({{< relref "/commands/ardel" >}}), [`ARINSERT`]({{< relref "/commands/arinsert" >}}), [`ARNEXT`]({{< relref "/commands/arnext" >}}), [`ARSEEK`]({{< relref "/commands/arseek" >}}), [`ARCOUNT`]({{< relref "/commands/arcount" >}}), and [`ARLEN`]({{< relref "/commands/arlen" >}}). Operations that touch N elements—such as [`ARGETRANGE`]({{< relref "/commands/argetrange" >}}), [`ARSCAN`]({{< relref "/commands/arscan" >}}), [`ARDELRANGE`]({{< relref "/commands/ardelrange" >}}), [`AROP`]({{< relref "/commands/arop" >}}), and [`ARLASTITEMS`]({{< relref "/commands/arlastitems" >}})—are O(N). The underlying sliced-array encoding handles both dense and sparse access patterns efficiently, so large index gaps consume very little memory.
+Most array commands are O(1), including [`ARSET`]({{< relref "/commands/arset" >}}), [`ARGET`]({{< relref "/commands/arget" >}}), [`ARDEL`]({{< relref "/commands/ardel" >}}), [`ARINSERT`]({{< relref "/commands/arinsert" >}}), [`ARNEXT`]({{< relref "/commands/arnext" >}}), [`ARSEEK`]({{< relref "/commands/arseek" >}}), [`ARCOUNT`]({{< relref "/commands/arcount" >}}), and [`ARLEN`]({{< relref "/commands/arlen" >}}). Operations that touch N elements—such as [`ARGETRANGE`]({{< relref "/commands/argetrange" >}}), [`ARSCAN`]({{< relref "/commands/arscan" >}}), [`ARDELRANGE`]({{< relref "/commands/ardelrange" >}}), [`AROP`]({{< relref "/commands/arop" >}}), and [`ARLASTITEMS`]({{< relref "/commands/arlastitems" >}})—are O(N). The underlying sliced-array encoding handles both dense and sparse access patterns efficiently, so large index gaps consume very little memory. The [`ARGREP`]({{< relref "/commands/argrep" >}}) command has the following complexity: O(P * C) where P is the number of visited positions in touched slices and C is the cost of evaluating the predicates on one existing element
 
 ## Limits
 

--- a/content/develop/pubsub/keyspace-notifications.md
+++ b/content/develop/pubsub/keyspace-notifications.md
@@ -83,6 +83,7 @@ following table:
     h     Hash commands
     z     Sorted set commands
     t     Stream commands
+    a     Array commands
     d     Module key type events
     x     Expired events (events generated every time a key expires)
     e     Evicted events (events generated when a key is evicted for maxmemory)
@@ -90,7 +91,7 @@ following table:
     n     New key events generated whenever a new key is created (Note: not included in the 'A' class)
     o     Overwritten events generated every time a key is overwritten (Note: not included in the 'A' class)
     c     Type-changed events generated every time a key's type changes (Note: not included in the 'A' class)
-    A     Alias for "g$lshztdxe", so that the "AKE" string means all the events except "m", "n", "o" and "c".
+    A     Alias for "g$lshztdxea", so that the "AKE" string means all the events except "m", "n", "o" and "c".
 
 At least `K` or `E` should be present in the string, otherwise no event
 will be delivered regardless of the rest of the string.

--- a/static/images/railroad/argrep.svg
+++ b/static/images/railroad/argrep.svg
@@ -1,0 +1,105 @@
+<svg class="railroad-diagram" height="207" viewBox="0 0 1331.5 207" width="1331.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 38v20m10 -20v20m-10 -10h20"></path></g><path d="M40 48h10"></path><g>
+<path d="M50 48h0.0"></path><path d="M1281.5 48h0.0"></path><g class="terminal ">
+<path d="M50.0 48h0.0"></path><path d="M121.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="37"></rect><text x="85.5" y="52">ARGREP</text></g><path d="M121.0 48h10"></path><path d="M131.0 48h10"></path><g class="non-terminal ">
+<path d="M141.0 48h0.0"></path><path d="M186.5 48h0.0"></path><rect height="22" width="45.5" x="141.0" y="37"></rect><text x="163.75" y="52">key</text></g><path d="M186.5 48h10"></path><path d="M196.5 48h10"></path><g class="non-terminal ">
+<path d="M206.5 48h0.0"></path><path d="M269.0 48h0.0"></path><rect height="22" width="62.5" x="206.5" y="37"></rect><text x="237.75" y="52">start</text></g><path d="M269.0 48h10"></path><path d="M279.0 48h10"></path><g class="non-terminal ">
+<path d="M289.0 48h0.0"></path><path d="M334.5 48h0.0"></path><rect height="22" width="45.5" x="289.0" y="37"></rect><text x="311.75" y="52">end</text></g><path d="M334.5 48h10"></path><path d="M344.5 48h10"></path><g>
+<path d="M354.5 48h0.0"></path><path d="M801.5 48h0.0"></path><g>
+<path d="M354.5 48h0.0"></path><path d="M548.0 48h0.0"></path><path d="M354.5 48h20"></path><g>
+<path d="M374.5 48h0.0"></path><path d="M528.0 48h0.0"></path><g class="terminal ">
+<path d="M374.5 48h0.0"></path><path d="M437.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="374.5" y="37"></rect><text x="405.75" y="52">EXACT</text></g><path d="M437.0 48h10"></path><path d="M447.0 48h10"></path><g class="non-terminal ">
+<path d="M457.0 48h0.0"></path><path d="M528.0 48h0.0"></path><rect height="22" width="71.0" x="457.0" y="37"></rect><text x="492.5" y="52">string</text></g></g><path d="M528.0 48h20"></path><path d="M354.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M374.5 78h0.0"></path><path d="M528.0 78h0.0"></path><g class="terminal ">
+<path d="M374.5 78h0.0"></path><path d="M437.0 78h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="374.5" y="67"></rect><text x="405.75" y="82">MATCH</text></g><path d="M437.0 78h10"></path><path d="M447.0 78h10"></path><g class="non-terminal ">
+<path d="M457.0 78h0.0"></path><path d="M528.0 78h0.0"></path><rect height="22" width="71.0" x="457.0" y="67"></rect><text x="492.5" y="82">string</text></g></g><path d="M528.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M354.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g>
+<path d="M374.5 108h0.0"></path><path d="M528.0 108h0.0"></path><g class="terminal ">
+<path d="M374.5 108h0.0"></path><path d="M428.5 108h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="374.5" y="97"></rect><text x="401.5" y="112">GLOB</text></g><path d="M428.5 108h10"></path><path d="M438.5 108h10"></path><g class="non-terminal ">
+<path d="M448.5 108h0.0"></path><path d="M528.0 108h0.0"></path><rect height="22" width="79.5" x="448.5" y="97"></rect><text x="488.25" y="112">pattern</text></g></g><path d="M528.0 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M354.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g>
+<path d="M374.5 138h8.5"></path><path d="M519.5 138h8.5"></path><g class="terminal ">
+<path d="M383.0 138h0.0"></path><path d="M420.0 138h0.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="383.0" y="127"></rect><text x="401.5" y="142">RE</text></g><path d="M420.0 138h10"></path><path d="M430.0 138h10"></path><g class="non-terminal ">
+<path d="M440.0 138h0.0"></path><path d="M519.5 138h0.0"></path><rect height="22" width="79.5" x="440.0" y="127"></rect><text x="479.75" y="142">pattern</text></g></g><path d="M528.0 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M548.0 48h0.0"></path><path d="M801.5 48h0.0"></path><path d="M548.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M568.0 28h213.5"></path></g><path d="M781.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M548.0 48h20"></path><g>
+<path d="M568.0 48h0.0"></path><path d="M781.5 48h0.0"></path><path d="M568.0 48h10"></path><g>
+<path d="M578.0 48h0.0"></path><path d="M771.5 48h0.0"></path><path d="M578.0 48h20"></path><g>
+<path d="M598.0 48h0.0"></path><path d="M751.5 48h0.0"></path><g class="terminal ">
+<path d="M598.0 48h0.0"></path><path d="M660.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="598.0" y="37"></rect><text x="629.25" y="52">EXACT</text></g><path d="M660.5 48h10"></path><path d="M670.5 48h10"></path><g class="non-terminal ">
+<path d="M680.5 48h0.0"></path><path d="M751.5 48h0.0"></path><rect height="22" width="71.0" x="680.5" y="37"></rect><text x="716.0" y="52">string</text></g></g><path d="M751.5 48h20"></path><path d="M578.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M598.0 78h0.0"></path><path d="M751.5 78h0.0"></path><g class="terminal ">
+<path d="M598.0 78h0.0"></path><path d="M660.5 78h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="598.0" y="67"></rect><text x="629.25" y="82">MATCH</text></g><path d="M660.5 78h10"></path><path d="M670.5 78h10"></path><g class="non-terminal ">
+<path d="M680.5 78h0.0"></path><path d="M751.5 78h0.0"></path><rect height="22" width="71.0" x="680.5" y="67"></rect><text x="716.0" y="82">string</text></g></g><path d="M751.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M578.0 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g>
+<path d="M598.0 108h0.0"></path><path d="M751.5 108h0.0"></path><g class="terminal ">
+<path d="M598.0 108h0.0"></path><path d="M652.0 108h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="598.0" y="97"></rect><text x="625.0" y="112">GLOB</text></g><path d="M652.0 108h10"></path><path d="M662.0 108h10"></path><g class="non-terminal ">
+<path d="M672.0 108h0.0"></path><path d="M751.5 108h0.0"></path><rect height="22" width="79.5" x="672.0" y="97"></rect><text x="711.75" y="112">pattern</text></g></g><path d="M751.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M578.0 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g>
+<path d="M598.0 138h8.5"></path><path d="M743.0 138h8.5"></path><g class="terminal ">
+<path d="M606.5 138h0.0"></path><path d="M643.5 138h0.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="606.5" y="127"></rect><text x="625.0" y="142">RE</text></g><path d="M643.5 138h10"></path><path d="M653.5 138h10"></path><g class="non-terminal ">
+<path d="M663.5 138h0.0"></path><path d="M743.0 138h0.0"></path><rect height="22" width="79.5" x="663.5" y="127"></rect><text x="703.25" y="142">pattern</text></g></g><path d="M751.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path></g><path d="M771.5 48h10"></path><path d="M578.0 48a10 10 0 0 0 -10 10v89a10 10 0 0 0 10 10"></path><g>
+<path d="M578.0 157h193.5"></path></g><path d="M771.5 157a10 10 0 0 0 10 -10v-89a10 10 0 0 0 -10 -10"></path></g><path d="M781.5 48h20"></path></g></g><path d="M801.5 48h10"></path><g>
+<path d="M811.5 48h0.0"></path><path d="M1281.5 48h0.0"></path><path d="M811.5 48a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path><g>
+<path d="M831.5 20h430.0"></path></g><path d="M1261.5 20a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path><path d="M811.5 48h20"></path><g>
+<path d="M831.5 48h0.0"></path><path d="M1261.5 48h0.0"></path><g>
+<path d="M831.5 48h0.0"></path><path d="M1016.5 48h0.0"></path><path d="M831.5 48h20"></path><g class="terminal ">
+<path d="M851.5 48h49.75"></path><path d="M946.75 48h49.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="901.25" y="37"></rect><text x="924.0" y="52">AND</text></g><path d="M996.5 48h20"></path><path d="M831.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M851.5 78h54.0"></path><path d="M942.5 78h54.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="905.5" y="67"></rect><text x="924.0" y="82">OR</text></g><path d="M996.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M831.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g>
+<path d="M851.5 108h0.0"></path><path d="M996.5 108h0.0"></path><g class="terminal ">
+<path d="M851.5 108h0.0"></path><path d="M914.0 108h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="851.5" y="97"></rect><text x="882.75" y="112">LIMIT</text></g><path d="M914.0 108h10"></path><path d="M924.0 108h10"></path><g class="non-terminal ">
+<path d="M934.0 108h0.0"></path><path d="M996.5 108h0.0"></path><rect height="22" width="62.5" x="934.0" y="97"></rect><text x="965.25" y="112">limit</text></g></g><path d="M996.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M831.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M851.5 138h20.0"></path><path d="M976.5 138h20.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="871.5" y="127"></rect><text x="924.0" y="142">WITHVALUES</text></g><path d="M996.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M831.5 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M851.5 168h37.0"></path><path d="M959.5 168h37.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="888.5" y="157"></rect><text x="924.0" y="172">NOCASE</text></g><path d="M996.5 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M1016.5 48h0.0"></path><path d="M1261.5 48h0.0"></path><path d="M1016.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1036.5 28h205.0"></path></g><path d="M1241.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1016.5 48h20"></path><g>
+<path d="M1036.5 48h0.0"></path><path d="M1241.5 48h0.0"></path><path d="M1036.5 48h10"></path><g>
+<path d="M1046.5 48h0.0"></path><path d="M1231.5 48h0.0"></path><path d="M1046.5 48h20"></path><g class="terminal ">
+<path d="M1066.5 48h49.75"></path><path d="M1161.75 48h49.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="1116.25" y="37"></rect><text x="1139.0" y="52">AND</text></g><path d="M1211.5 48h20"></path><path d="M1046.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M1066.5 78h54.0"></path><path d="M1157.5 78h54.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="1120.5" y="67"></rect><text x="1139.0" y="82">OR</text></g><path d="M1211.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M1046.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g>
+<path d="M1066.5 108h0.0"></path><path d="M1211.5 108h0.0"></path><g class="terminal ">
+<path d="M1066.5 108h0.0"></path><path d="M1129.0 108h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1066.5" y="97"></rect><text x="1097.75" y="112">LIMIT</text></g><path d="M1129.0 108h10"></path><path d="M1139.0 108h10"></path><g class="non-terminal ">
+<path d="M1149.0 108h0.0"></path><path d="M1211.5 108h0.0"></path><rect height="22" width="62.5" x="1149.0" y="97"></rect><text x="1180.25" y="112">limit</text></g></g><path d="M1211.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M1046.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M1066.5 138h20.0"></path><path d="M1191.5 138h20.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="1086.5" y="127"></rect><text x="1139.0" y="142">WITHVALUES</text></g><path d="M1211.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M1046.5 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M1066.5 168h37.0"></path><path d="M1174.5 168h37.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="1103.5" y="157"></rect><text x="1139.0" y="172">NOCASE</text></g><path d="M1211.5 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path></g><path d="M1231.5 48h10"></path><path d="M1046.5 48a10 10 0 0 0 -10 10v119a10 10 0 0 0 10 10"></path><g>
+<path d="M1046.5 187h185.0"></path></g><path d="M1231.5 187a10 10 0 0 0 10 -10v-119a10 10 0 0 0 -10 -10"></path></g><path d="M1241.5 48h20"></path></g></g><path d="M1261.5 48h20"></path></g></g><path d="M1281.5 48h10"></path><path d="M 1291.5 48 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates plus a new SVG asset; no runtime code paths are changed.
> 
> **Overview**
> Adds full documentation for the new `ARGREP` array command (syntax/predicates/options, examples, return schema) and includes its railroad diagram asset.
> 
> Updates array docs to mention relevant configuration knobs and `ARGREP` complexity, clarifies `ARSEEK` as applying to both `ARINSERT` and `ARRING`, and extends keyspace notification docs to include the new array event class (`a`) and its inclusion in the `A` alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f95eb24533d76e491b2fcb442387a4bcc8e6735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->