### PR TITLE
Document CLIENT TRACKING NOLOOP behavior

### DIFF
--- a/content/commands/client-tracking.md
+++ b/content/commands/client-tracking.md
@@ -101,7 +101,7 @@ command when enabling tracking:
 * `PREFIX <prefix>`: for broadcasting, register a given key prefix, so that notifications will be provided only for keys starting with this string. This option can be given multiple times to register multiple prefixes. If broadcasting is enabled without this option, Redis will send notifications for every key. You can't delete a single prefix, but you can delete all prefixes by disabling and re-enabling tracking. Using this option adds the additional time complexity of O(N^2), where N is the total number of prefixes tracked. 
 * `OPTIN`: when broadcasting is NOT active, normally don't track keys in read only commands, unless they are called immediately after a `CLIENT CACHING yes` command.
 * `OPTOUT`: when broadcasting is NOT active, normally track keys in read only commands, unless they are called immediately after a `CLIENT CACHING no` command.
-* `NOLOOP`: don't send notifications about keys modified by this connection itself.
+* `NOLOOP`: don't send notifications about keys modified by this connection itself. In the default tracking mode, modifying a tracked key removes it from the invalidation table even when `NOLOOP` suppresses the notification to the modifying connection. The connection must read the key again to track it for future invalidations.
 
 ## Redis Software and Redis Cloud compatibility
 

--- a/content/develop/reference/client-side-caching.md
+++ b/content/develop/reference/client-side-caching.md
@@ -304,6 +304,13 @@ in normal and broadcasting mode. Using this option, clients are able to
 tell the server they don't want to receive invalidation messages for keys
 that they modified.
 
+With tracking in the default mode, the server removes the key from the
+invalidation table when the key is modified. If the connection that modified
+the key is using `NOLOOP`, Redis suppresses the invalidation message to that
+connection, but the key is still no longer tracked for that connection after
+the write. To receive future invalidations for the same key, the connection
+must read the key again so that Redis can track it again.
+
 ## Avoiding race conditions
 
 When implementing client-side caching redirecting the invalidation messages
@@ -364,4 +371,3 @@ keys that were not served recently.
 ## Limiting the amount of memory used by Redis
 
 Be sure to configure a suitable value for the maximum number of keys remembered by Redis or alternatively use the BCAST mode that consumes no memory at all on the Redis side. Note that the memory consumed by Redis when BCAST is not used, is proportional both to the number of keys tracked and the number of clients requesting such keys.
-


### PR DESCRIPTION
Updates the CLIENT TRACKING command reference and client-side caching guide to clarify NOLOOP behavior in default tracking mode. Explains that Redis removes a modified key from the invalidation table even when NOLOOP suppresses the notification to the modifying connection, so the key must be read again to receive future invalidations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change clarifying `NOLOOP` semantics; no code or behavior changes.
> 
> **Overview**
> Documents that in default tracking mode a write *removes the key from the invalidation table* even when `NOLOOP` suppresses the invalidation message to the writer, so the client must `GET`/read the key again to resume tracking.
> 
> This clarification is added both to the `CLIENT TRACKING` command reference and the client-side caching guide to prevent clients from assuming they’ll keep receiving future invalidations after local writes with `NOLOOP`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462cd62f6b24420ced448a3067e2154d91787150. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->