### PR TITLE
Document JSON.DEL empty root deletion

### DIFF
--- a/content/commands/json.del.md
+++ b/content/commands/json.del.md
@@ -54,6 +54,8 @@ is JSONPath to specify. Default is root `$`. Nonexisting paths are ignored.
 {{% alert title="Note" color="warning" %}}
  
 Deleting an object's root is equivalent to deleting the key from Redis.
+If `JSON.DEL` deletes a value and leaves the root object or array empty,
+the key is also deleted from Redis.
 
 {{% /alert %}}
 </details>
@@ -82,6 +84,17 @@ Get the updated document.
 {{< highlight bash >}}
 redis> JSON.GET doc $
 "[{\"nested\":{\"b\":3}}]"
+{{< / highlight >}}
+
+Delete the last value from the root object.
+
+{{< highlight bash >}}
+redis> JSON.SET doc $ '{"a": 1}'
+OK
+redis> JSON.DEL doc $.a
+(integer) 1
+redis> EXISTS doc
+(integer) 0
 {{< / highlight >}}
 </details>
 
@@ -113,4 +126,3 @@ redis> JSON.GET doc $
 
 * [RedisJSON]({{< relref "/develop/data-types/json/" >}})
 * [Index and search JSON documents]({{< relref "/develop/ai/search-and-query/indexing/" >}})
-


### PR DESCRIPTION
## Summary
- Clarify that JSON.DEL removes the key when deleting the final value from a root object or array.
- Add a command example showing JSON.DEL followed by EXISTS returning 0.

## Testing
- Not run; documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies behavior when deleting the last root value; no runtime or API behavior changes.
> 
> **Overview**
> Clarifies in `JSON.DEL` docs that when a delete leaves the root object/array empty, Redis also removes the key.
> 
> Adds an example showing deleting the final root field and verifying the key is gone via `EXISTS` returning `0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4a91f8b45b79ccd1a754854f12b742711cad5a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->