### PR TITLE
DOC-6537 New RDI page about redis.lookup denormalisation

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example.md
@@ -1,5 +1,5 @@
 ---
-Title: Denormalisation with redis.lookup
+Title: Denormalization with redis.lookup
 alwaysopen: false
 categories:
 - docs
@@ -8,7 +8,7 @@ categories:
 - rdi
 description: null
 group: di
-linkTitle: Denormalisation with redis.lookup
+linkTitle: Denormalization with redis.lookup
 summary: Redis Data Integration keeps Redis in sync with a primary database in near
   real time.
 type: integration
@@ -22,9 +22,10 @@ job. This is useful when you want to denormalize incoming change data by enrichi
 a record with values that RDI has already written to Redis from another table
 (see [Data denormalization]({{< relref "/integrate/redis-data-integration/data-pipelines/data-denormalization" >}}) for more information about this technique).
 
-For example, a pipeline might write customer records to Redis, then use `redis.lookup` in
-an invoice job to add selected customer details
-to each invoice before writing the invoice to the target database. This lets you
+For example, a pipeline for the Chinook database might write `artist` records to
+Redis, then use `redis.lookup` in
+an `album` table job to add selected artist details
+to each album record before writing it to the target database. This lets you
 design the structure of your Redis data to fit the read patterns of your
 application while still keeping the source database normalized.
 
@@ -41,7 +42,8 @@ here is that the `args` elements are all interpreted as [JMESPath](https://jmesp
 expressions, but YAML syntax allows for each element to be a quoted string. This means that
 you must *double quote* any string arguments that you want to be treated as
 literal strings (as with `name` below), otherwise JMESPath will try to interpret
-them as field names, which will generally give the wrong result. 
+them as field names, which will generally give the wrong result. Specifically, use
+a different quote character for the outer quotes and the inner quotes.
 
 ```yaml
 source:
@@ -69,7 +71,7 @@ output:
 Without denormalization, the album hash object contains only the `artistid` field to
 reference the artist:
 
-```
+```bash
 > hgetall album:albumid:1
 1) "albumid"
 2) "1"
@@ -140,7 +142,7 @@ output:
 After running this job, the album JSON object includes the artist object
 in a new `artist` field:
 
-```bash
+```json
 {
   "albumid": 239,
   "title": "War",

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example.md
@@ -1,0 +1,152 @@
+---
+Title: Denormalisation with redis.lookup
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+- rdi
+description: null
+group: di
+linkTitle: Denormalisation with redis.lookup
+summary: Redis Data Integration keeps Redis in sync with a primary database in near
+  real time.
+type: integration
+weight: 40
+---
+
+You can use the
+[`redis.lookup`]({{< relref "/integrate/redis-data-integration/reference/data-transformation/lookup" >}})
+transformation to read existing data from Redis during the `transform` stage of a
+job. This is useful when you want to denormalize incoming change data by enriching
+a record with values that RDI has already written to Redis from another table
+(see [Data denormalization]({{< relref "/integrate/redis-data-integration/data-pipelines/data-denormalization" >}}) for more information about this technique).
+
+For example, a pipeline might write customer records to Redis, then use `redis.lookup` in
+an invoice job to add selected customer details
+to each invoice before writing the invoice to the target database. This lets you
+design the structure of your Redis data to fit the read patterns of your
+application while still keeping the source database normalized.
+
+## Denormalizing a hash
+
+The `redis.lookup` transformation works by executing a Redis command and adding the
+result to the record. You specify the command and its arguments in the
+`transform` configuration with the `cmd` and `args` properties. For example, the
+following transformation job uses the
+[`HGET`]({{< relref "/commands/hget" >}}) command to read the `name` field from an
+artist [hash]({{< relref "/develop/data-types/hashes" >}}) and adds it to the
+album record under the `artist` field. A particularly important thing to note
+here is that the `args` elements are all interpreted as [JMESPath](https://jmespath.org/)
+expressions, but YAML syntax allows for each element to be a quoted string. This means that
+you must *double quote* any string arguments that you want to be treated as
+literal strings (as with `name` below), otherwise JMESPath will try to interpret
+them as field names, which will generally give the wrong result. 
+
+```yaml
+source:
+  table: album
+transform:
+  - uses: redis.lookup
+    with:
+      connection: target
+      cmd: HGET
+      args:
+        - concat(['artist:artistid:', artistid])
+        - '`name`'
+      language: jmespath
+      field: artist
+output:
+  - uses: redis.write
+    with:
+      connection: target
+      data_type: hash
+      key:
+        expression: concat(['album:albumid:', albumid])
+        language: jmespath
+```
+
+Without denormalization, the album hash object contains only the `artistid` field to
+reference the artist:
+
+```
+> hgetall album:albumid:1
+1) "albumid"
+2) "1"
+3) "title"
+4) "For Those About To Rock We Salute You"
+5) "artistid"
+6) "1"
+```
+
+After running the job specified above, querying one of the album hash objects shows the
+extra `artist` field obtained by looking up the artist with the `artistid`:
+
+```bash
+> hgetall album:albumid:1
+1) "albumid"
+2) "1"
+3) "title"
+4) "For Those About To Rock We Salute You"
+5) "artistid"
+6) "1"
+7) "artist"
+8) "AC/DC"
+```
+
+## Denormalizing a JSON document
+
+If you are using [JSON]({{< relref "/develop/data-types/json" >}}) objects,
+you can denormalize to include the whole of one object
+as a field of another. The following example shows how to do this using a temporary field
+to hold the result of the `redis.lookup` command. It then uses
+[`add_field`]({{< relref "/integrate/redis-data-integration/reference/data-transformation/add_field" >}})
+to insert the new field and
+[`remove_field`]({{< relref "/integrate/redis-data-integration/reference/data-transformation/remove_field" >}})
+to remove the temporary field and the now-redundant `artistid` field before writing the album object.
+
+```yaml
+source:
+  table: album
+transform:
+  - uses: redis.lookup
+    with:
+      connection: target
+      cmd: JSON.GET
+      args:
+        - concat(['artist:artistid:', artistid])
+      language: jmespath
+      field: artiststring
+  - uses: add_field
+    with:
+      field: artist
+      language: jmespath
+      expression: json_parse(artiststring)
+  - uses: remove_field
+    with:
+      fields:
+        - field: artistid
+        - field: artiststring
+output:
+  - uses: redis.write
+    with:
+      connection: target
+      data_type: json
+      key:
+        expression: concat(['album:albumid:', albumid])
+        language: jmespath
+```
+
+After running this job, the album JSON object includes the artist object
+in a new `artist` field:
+
+```bash
+{
+  "albumid": 239,
+  "title": "War",
+  "artist": {
+    "artistid": 150,
+    "name": "U2"
+  }
+}
+```

--- a/content/integrate/redis-data-integration/reference/data-transformation/lookup.md
+++ b/content/integrate/redis-data-integration/reference/data-transformation/lookup.md
@@ -28,10 +28,37 @@ weight: 10
 
 **Additional Properties:** not allowed
 
-## args\[\]: Redis command arguments {#args}
-
-The list of expressions that produce arguments.
-
 **Items**
 
 **Item Type:** `string`
+
+**Example**
+
+Denormalize a hash:
+
+```yaml
+source:
+  table: album
+transform:
+  - uses: redis.lookup
+    with:
+      connection: target
+      cmd: HGET
+      args:
+        - concat(['artist:artistid:', artistid])
+        - '`name`'
+      language: jmespath
+      field: artist
+output:
+  - uses: redis.write
+    with:
+      connection: target
+      data_type: hash
+      key:
+        expression: concat(['album:albumid:', albumid])
+        language: jmespath
+```
+
+## args\[\]: Redis command arguments {#args}
+
+The list of expressions that produce arguments.


### PR DESCRIPTION
This PR adds a transformation example about denormalisation using `redis.lookup`, based on a Slack request summarised in [RDSC-5122](https://redislabs.atlassian.net/browse/RDSC-5122).

Note: I've tested the transform examples included in the new page but Codex has configured RDI to use lowercase for the target DB key names rather than the mixed case used in the Chinook source DB and some of our other examples. It's perfectly legitimate to do this but let me know if you think it's important to preserve the mixed case here.

[RDSC-5122]: https://redislabs.atlassian.net/browse/RDSC-5122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new example page and expands the `redis.lookup` reference with a concrete `args` usage example.
> 
> **Overview**
> Adds a new RDI transform example page demonstrating denormalization with `redis.lookup`, including worked YAML pipelines for enriching album records from existing artist data in Redis (hash `HGET`) and embedding full artist objects into album JSON (`JSON.GET` + `add_field`/`remove_field`).
> 
> Updates the `redis.lookup` reference docs to include an `args` example (hash denormalization) and restores the `args` section header/description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b2f27051e6271c43bc7f8a44db5a5cc9cfdcf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->