### PR TITLE
OP: add RedisTimeSeries release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.10-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.10-release-notes.md
@@ -14,10 +14,22 @@ weight: 95
 ---
 ## Requirements
 
-RedisTimeSeries v1.10.20 requires:
+RedisTimeSeries v1.10.24 requires:
 
 - Minimum Redis compatibility version (database): 7.2
 - Minimum Redis Enterprise Software version (cluster): 7.2.4
+
+## v1.10.24 (May 2026)
+
+This is a maintenance release for RedisTimeSeries 1.10.
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+Details:
+
+- **Security:**
+
+  - (CVE-2026-25588) Invalid memory access in `RESTORE` may lead to Remote Code Execution.
 
 ## v1.10.20 (October 2025)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.12-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.12-release-notes.md
@@ -14,10 +14,29 @@ weight: 94
 ---
 ## Requirements
 
-RedisTimeSeries v1.12.9 requires:
+RedisTimeSeries v1.12.14 requires:
 
 - Minimum Redis compatibility version (database): 7.4
 - Minimum Redis Enterprise Software version (cluster): 7.8
+
+## v1.12.14 (May 2026)
+
+{{< note >}}
+Starting with Redis 8, the time series data structure is integral to Redis. You don't need to install this module separately.
+This is not the latest release.
+We no longer release new standalone versions of RedisTimeSeries; we only patch old versions.
+See https://github.com/redis/redis
+{{< /note >}}
+
+This is a maintenance release for RedisTimeSeries 1.12.
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+Details:
+
+- **Security:**
+
+  - (CVE-2026-25588) Invalid memory access in `RESTORE` may lead to Remote Code Execution.
 
 ## v1.12.9 (October 2025)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.8-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.8-release-notes.md
@@ -16,10 +16,22 @@ weight: 96
 ---
 ## Requirements
 
-RedisTimeSeries v1.8.19 requires:
+RedisTimeSeries v1.8.23 requires:
 
 - Minimum Redis compatibility version (database): 6.0.16
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v1.8.23 (May 2026)
+
+This is a maintenance release for RedisTimeSeries 1.8.
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+Details:
+
+- **Security:**
+
+  - (CVE-2026-25588) Invalid memory access in `RESTORE` may lead to Remote Code Execution.
 
 ## v1.8.19 (October 2025)
 
@@ -45,7 +57,7 @@ Update urgency: `MODERATE`: Plan an upgrade of the server, but it's not urgent.
 
 Details:
 
-*Bug fixes:
+Bug fixes:
 - [#1725](https://github.com/redistimeseries/redistimeseries/pull/1725) `TS.DEL` crashes on keys with compactions if the deletion removes the last compaction bucket (MOD-8936)
 - [LibMR#58](https://github.com/RedisGears/LibMR/pull/58) Crash when a cluster contains both 1.8 and newer nodes (MOD-8976, MOD-9192)
 


### PR DESCRIPTION
RedisTimeSeries release notes for older versions: v1.8.23, v1.10.24, and v1.12.14.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only change updating release notes content; main risk is misinformation if version/CVE details are wrong.
> 
> **Overview**
> Adds new RedisTimeSeries maintenance release entries for **v1.8.23**, **v1.10.24**, and **v1.12.14**, marking them as `SECURITY` updates and documenting **CVE-2026-25588** (invalid memory access in `RESTORE` that may lead to RCE).
> 
> Updates the “Requirements” sections to reference the new patch versions, and adds a note in the v1.12.14 notes that starting with Redis 8 the time series data structure is built-in (standalone module only receives patches). Also fixes minor formatting in the v1.8 notes (bug-fix heading).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b1a5f3b43b2f6effc90146e2905974f65fc2636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->