### PR TITLE
RS: Added CVE fixes to the release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-116.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-116.md
@@ -147,6 +147,28 @@ Redis Software 7.22.2-116 supports open source Redis 7.4, 7.2, and 6.2. Below is
 
 Redis 7.4.x:
 
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - Integer overflow in `hllPatLen`.
 
 - RedisBloom: Restore invalid filter.
@@ -174,6 +196,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - Integer overflow in `hllPatLen`.
 
@@ -244,6 +288,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - Integer overflow in `hllPatLen`.
 

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-79.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-79.md
@@ -149,6 +149,28 @@ Redis Software 7.22.2-79 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 
 Redis 7.4.x:
 
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - Integer overflow in `hllPatLen`.
 
 - RedisBloom: Restore invalid filter.
@@ -176,6 +198,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - Integer overflow in `hllPatLen`.
 
@@ -246,6 +290,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - Integer overflow in `hllPatLen`.
 

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-93.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-93.md
@@ -145,6 +145,28 @@ Redis Software 7.22.2-93 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 
 Redis 7.4.x:
 
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - Integer overflow in `hllPatLen`.
 
 - RedisBloom: Restore invalid filter.
@@ -172,6 +194,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - Integer overflow in `hllPatLen`.
 
@@ -242,6 +286,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - Integer overflow in `hllPatLen`.
 

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-279.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-279.md
@@ -216,6 +216,28 @@ Redis Software 7.4.6-279 supports open source Redis 7.2, 6.2, and 6.0. Below is 
 
 Redis 7.2.x:
 
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - Integer overflow in `hllPatLen`.
@@ -285,6 +307,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-253.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-253.md
@@ -141,6 +141,28 @@ Redis Software 7.8.6-253 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 
 Redis 7.4.x:
 
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - Integer overflow in `hllPatLen`.
@@ -168,6 +190,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -238,6 +282,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-256.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-256.md
@@ -133,6 +133,28 @@ Redis Software 7.8.6-256 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 
 Redis 7.4.x:
 
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - Integer overflow in `hllPatLen`.
@@ -160,6 +182,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -230,6 +274,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-260.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-260.md
@@ -133,6 +133,28 @@ Redis Software 7.8.6-260 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 
 Redis 7.4.x:
 
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - Integer overflow in `hllPatLen`.
@@ -160,6 +182,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -230,6 +274,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-64.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-64.md
@@ -247,7 +247,57 @@ Some CVEs announced for Redis Open Source do not affect Redis Software due to di
 
 Redis Software 8.0.10-64 supports Redis Open Source 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
+Redis 8.4.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 Redis 8.2.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -277,6 +327,30 @@ Redis 8.2.x:
 
 Redis 8.0.x:
 
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - The `HGETEX` command can lead to a buffer overflow.
@@ -302,6 +376,28 @@ Redis 8.0.x:
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
 Redis 7.4.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -330,6 +426,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -400,6 +518,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-76.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-76.md
@@ -150,7 +150,57 @@ Some CVEs announced for Redis Open Source do not affect Redis Software due to di
 
 Redis Software 8.0.10-76 supports Redis Open Source 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
+Redis 8.4.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 Redis 8.2.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -180,6 +230,30 @@ Redis 8.2.x:
 
 Redis 8.0.x:
 
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - The `HGETEX` command can lead to a buffer overflow.
@@ -205,6 +279,28 @@ Redis 8.0.x:
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
 Redis 7.4.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -233,6 +329,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -303,6 +421,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-81.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-81.md
@@ -150,7 +150,57 @@ Some CVEs announced for Redis Open Source do not affect Redis Software due to di
 
 Redis Software 8.0.10-81 supports Redis Open Source 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
+Redis 8.4.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 Redis 8.2.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -180,6 +230,30 @@ Redis 8.2.x:
 
 Redis 8.0.x:
 
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - The `HGETEX` command can lead to a buffer overflow.
@@ -205,6 +279,28 @@ Redis 8.0.x:
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
 Redis 7.4.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -233,6 +329,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -303,6 +421,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
@@ -252,7 +252,57 @@ Some CVEs announced for Redis Open Source do not affect Redis Software due to di
 
 Redis Software 8.0.16-29 supports Redis Open Source 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
+Redis 8.4.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 Redis 8.2.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -282,6 +332,30 @@ Redis 8.2.x:
 
 Redis 8.0.x:
 
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - The `HGETEX` command can lead to a buffer overflow.
@@ -307,6 +381,28 @@ Redis 8.0.x:
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
 Redis 7.4.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -335,6 +431,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -405,6 +523,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
@@ -163,7 +163,57 @@ Some CVEs announced for Redis Open Source do not affect Redis Software due to di
 
 Redis Software 8.0.16-33 supports Redis Open Source 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
+Redis 8.4.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 Redis 8.2.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -193,6 +243,30 @@ Redis 8.2.x:
 
 Redis 8.0.x:
 
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - The `HGETEX` command can lead to a buffer overflow.
@@ -218,6 +292,28 @@ Redis 8.0.x:
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
 Redis 7.4.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -246,6 +342,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -316,6 +434,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
@@ -91,7 +91,7 @@ The previous method of upgrading Active-Active databases by manually upgrading e
 
 ### Redis database versions
 
-Redis Software version 8.0.16 includes the following Redis database versions: 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, and 6.2.13.
+Redis Software version 8.0.18 includes the following Redis database versions: 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, and 6.2.13.
 
 The [default Redis database version]({{<relref "/operate/rs/databases/configure/db-defaults#database-version">}}) is 8.6.
 
@@ -273,9 +273,85 @@ As part of Redis's commitment to security, Redis Software implements the latest 
 
 Some CVEs announced for Redis Open Source do not affect Redis Software due to different or additional functionality available in Redis Software that is not available in Redis Open Source.
 
-Redis Software 8.0.18-23 supports Redis Open Source 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
+Redis Software 8.0.18-23 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
+
+Redis 8.6.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+Redis 8.4.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 Redis 8.2.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -305,6 +381,30 @@ Redis 8.2.x:
 
 Redis 8.0.x:
 
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
 - RedisBloom: Restore invalid filter.
 
 - The `HGETEX` command can lead to a buffer overflow.
@@ -330,6 +430,28 @@ Redis 8.0.x:
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
 Redis 7.4.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -358,6 +480,28 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 
@@ -428,6 +572,28 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 - RedisBloom: Restore invalid filter.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change, but incorrect CVE/version text could mislead customers about security coverage.
> 
> **Overview**
> **Release note security sections were expanded/updated** to list additional Redis OSS CVEs and vulnerabilities (notably several 2026 `RESTORE`/replication/Lua/RedisBloom issues and DoS/resource-exhaustion notes) across multiple Redis Software versions (`7.22.2-*`, `7.8.6-*`, `7.4.6-279`, and `8.0.10-*`/`8.0.16-*`).
> 
> For Redis Software `8.0.x` notes, this also adds coverage entries for newer upstream versions (*new `Redis 8.4.x` sections in `8.0.10-*` and `Redis 8.6.x` in `8.0.18-23`*), including a `VSET` OOM/buffer overflow item, and fixes a small version text typo (`8.0.16` → `8.0.18`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8e74b77c25c82b516b9c19bd096dda95e18580c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->