### PR TITLE
OP: add RediSearch release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
@@ -22,7 +22,7 @@ RediSearch v2.10.30 requires:
 
 This is a maintenance release for Redis Search 2.10. 
 
-Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade!
 
 Bug fixes:
 - [#Q8948](https://github.com/redisearch/redisearch/pull/8948) `FT.CURSOR READ` enters an infinite loop when the caller lacks the required ACL permissions. (MOD-14479)

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
@@ -13,10 +13,40 @@ weight: 90
 ---
 ## Requirements
 
-RediSearch v2.10.25 requires:
+RediSearch v2.10.30 requires:
 
 - Minimum Redis compatibility version (database): 7.4
 - Minimum Redis Enterprise Software version (cluster): 7.8
+
+## v2.10.30 (May 2026)
+
+This is a maintenance release for Redis Search 2.10. 
+
+Update urgency: `HIGH`: There is a critical bug that may affect a subset of users. Upgrade
+
+Bug fixes:
+- [#Q8948](https://github.com/redisearch/redisearch/pull/8948) `FT.CURSOR READ` enters an infinite loop when the caller lacks the required ACL permissions. (MOD-14479)
+- [#Q8794](https://github.com/redisearch/redisearch/pull/8794) `FT.EXPLAIN` crashes or produces corrupt output when a concurrent schema change occurs. (MOD-14461)
+- [#Q9176](https://github.com/redisearch/redisearch/pull/9176), [#Q9314](https://github.com/redisearch/redisearch/pull/9314) Coordinator deadlock under mixed `FT.SEARCH` and `FT.AGGREGATE` load. (MOD-14268)
+- [#Q9273](https://github.com/redisearch/redisearch/pull/9273), [#Q9302](https://github.com/redisearch/redisearch/pull/9302) Async shard connect hangs indefinitely when a peer endpoint is unreachable; the connect is now bounded by search-connect-timeout. (MOD-12739)
+- [#Q9167](https://github.com/redisearch/redisearch/pull/9167) Crash on `FT.SEARCH` when topology validation fails (for example, some nodes unreachable). (MOD-14475)
+- [#Q9082](https://github.com/redisearch/redisearch/pull/9082) `FT.SPELLCHECK` ignores $param placeholders even when `PARAMS` is supplied. (MOD-10596)
+- [#Q9050](https://github.com/redisearch/redisearch/pull/9050) `FT.PROFILE` produces malformed output for documents with missing field values. (MOD-10560)
+- [#Q9075](https://github.com/redisearch/redisearch/pull/9075) Invalid schema option combinations are silently accepted at `FT.CREATE` time. (MOD-14655)
+- [#Q9436](https://github.com/redisearch/redisearch/pull/9436) Malformed index definitions in an RDB file crash the shard or load an invalid index. (MOD-13118)
+- [#Q7686](https://github.com/redisearch/redisearch/pull/7686) Cursors are not released on certain error paths, leaking cursor slots over time. (MOD-12807)
+- [#Q8465](https://github.com/redisearch/redisearch/pull/8465) Garbage collector mishandles out-of-memory responses on replicas, leaving the index inconsistent. (MOD-14066)
+- [#Q7771](https://github.com/redisearch/redisearch/pull/7771) String comparisons truncate at embedded `NULL` bytes, returning wrong results for TAG and binary fields. (MOD-13010)
+- [#Q7851](https://github.com/redisearch/redisearch/pull/7851) `FT.SUG*` commands are not registered on Redis Enterprise builds. (MOD-13152)
+- [#Q8154](https://github.com/redisearch/redisearch/pull/8154) Per-shard total time in cluster `FT.PROFILE` output is reported incorrectly. (MOD-13735, MOD-13181)
+- [#Q8084](https://github.com/redisearch/redisearch/pull/8084) `FULLTEXT` field count in `FT.INFO` statistics is inaccurate. (MOD-13432)
+
+Metrics:
+- [#Q7558](https://github.com/redisearch/redisearch/pull/7558), [#Q7688](https://github.com/redisearch/redisearch/pull/7688), [#Q7723](https://github.com/redisearch/redisearch/pull/7723), [#Q7791](https://github.com/redisearch/redisearch/pull/7791), [#Q7749](https://github.com/redisearch/redisearch/pull/7749), [#Q7738](https://github.com/redisearch/redisearch/pull/7738), [#Q7744](https://github.com/redisearch/redisearch/pull/7744) New `FT.INFO` metrics expose live thread-pool utilization and pending-job depth for worker, coordinator, IO, and topology-update pools (`search_active_io_threads`, `search_active_worker_threads`, `search_active_coord_threads`, `search_active_topology_update_threads`, `search_workers_low_priority_pending_jobs`, `search_workers_high_priority_pending_jobs`, `search_workers_admin_priority_pending_jobs`, `search_coord_high_priority_pending_jobs`). (MOD-12069, MOD-12695, MOD-12694, MOD-12790, MOD-12791)
+- [#Q7793](https://github.com/redisearch/redisearch/pull/7793), [#Q7816](https://github.com/redisearch/redisearch/pull/7816) New `FT.INFO` counters track per-shard and coordinator query timeouts and `MAXPREFIXEXPANSIONS` truncations (`search_shard_total_query_errors_timeout`, `search_shard_total_query_warnings_timeout`, `search_shard_total_query_warnings_max_prefix_expansions`, and equivalent `search_coord_total_* counters`). (MOD-12419, MOD-12417)
+- [#Q7766](https://github.com/redisearch/redisearch/pull/7766) New `FT.INFO` per-field-type indexing-operation counters added for `TEXT`, `TAG`, `NUMERIC`, `GEO`, `GEOSHAPE`, and `VECTOR fields`. (MOD-12070)
+- [#Q7746](https://github.com/redisearch/redisearch/pull/7746) New Internal cursor reads counter in cluster `FT.PROFILE` output surfaces internal cursor-hop round-trips per query. (MOD-12414)
+- [#Q7593](https://github.com/redisearch/redisearch/pull/7593) FT.PROFILE now reports GIL time, giving an accurate breakdown of where query time is spent. (MOD-11987, MOD-12816)
 
 ## v2.10.25 (December 2025)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md
@@ -15,10 +15,24 @@ weight: 92
 ---
 ## Requirements
 
-RediSearch v2.6.32 requires:
+RediSearch v2.6.36 requires:
 
 - Minimum Redis compatibility version (database): 6.0.16
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v2.6.36 (May 2026)
+
+This is a maintenance release for Redis Search 2.6.
+
+Update urgency: `HIGH` : There is a critical bug that may affect a subset of users. Upgrade!
+
+Bug fixes:
+
+- [#Q8950](https://github.com/redisearch/redisearch/pull/8950) `FT.CURSOR` enters an infinite loop when the invoking user's ACL restricts access to the cursor's index, causing CPU exhaustion and shard restarts. (MOD-14479)
+- [#Q8468](https://github.com/redisearch/redisearch/pull/8468) Garbage collector mishandles out-of-memory conditions on replicas, causing instability under memory pressure during indexing. (MOD-14066)
+- [#Q6792](https://github.com/redisearch/redisearch/pull/6792) Counter result-processor cleanup uses an incorrect type cast, risking memory corruption when freeing query pipeline resources. (MOD-11216)
+- [#Q6998](https://github.com/redisearch/redisearch/pull/6998) `FT.INFO` is fanned out to replicas in clustered deployments, producing inconsistent responses and unnecessary inter-node traffic.
+- [#Q6871](https://github.com/redisearch/redisearch/pull/6871) Coupled grow/shrink logic in Flat and HNSW vector index containers causes excess memory churn for large or fluctuating vector datasets. (MOD-10559)
 
 ## v2.6.32 (August 2025)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md
@@ -13,10 +13,42 @@ weight: 91
 ---
 ## Requirements
 
-RediSearch v2.8.32 requires:
+RediSearch v2.8.37 requires:
 
 - Minimum Redis compatibility version (database): 7.2
 - Minimum Redis Enterprise Software version (cluster): 7.2.4
+
+## v2.8.37 (May 2026)
+
+This is a maintenance release for Redis Search 2.8.
+
+Update urgency: `HIGH` : There is a critical bug that may affect a subset of users. Upgrade!
+
+Bug fixes:
+
+- [#Q7860](https://github.com/redisearch/redisearch/pull/7860): `FT.SUGADD` and `FT.SUGDEL`return inconsistent results in sharded pre-Redis-8 deployments due to random shard routing (MOD-13152)
+- [#Q8949](https://github.com/redisearch/redisearch/pull/8949): `FT.CURSOR` enters an infinite loop when the caller's ACL restricts key access (MOD-14479)
+- [#Q8795](https://github.com/redisearch/redisearch/pull/8795):  `FT.EXPLAIN` crashes or reads stale state under concurrent schema changes (MOD-14461)
+- [#Q7697](https://github.com/redisearch/redisearch/pull/7697): Stack-use-after-scope in `_FT.CURSOR PROFILE` produces undefined behavior (MOD-12955)
+- [#Q7687](https://github.com/redisearch/redisearch/pull/7687): Cursor resources leak when the associated index is dropped while the cursor is open (MOD-12807)
+- [#Q8466](https://github.com/redisearch/redisearch/pull/8466): Garbage collector mishandles Out-of-Memory conditions on replicas (MOD-14066)
+- [#Q8163](https://github.com/redisearch/redisearch/pull/8163): `FT.PROFILE` reports incorrect shard total profile time in cluster mode (MOD-13735, MOD-13181)
+- [#Q8085](https://github.com/redisearch/redisearch/pull/8085): `FT.PROFILE` reports incorrect `FULLTEXT` field metric count (MOD-13432)
+- [#Q7721](https://github.com/redisearch/redisearch/pull/7721): `FT.PROFILE` always reports GILTime 0 due to missing initialization and accumulation (MOD-11987, MOD-12816)
+- [#Q9074](https://github.com/redisearch/redisearch/pull/9074): `FT.CREATE` accepts invalid schema option combinations that fail silently at query time (MOD-14655)
+- [#Q9083](https://github.com/redisearch/redisearch/pull/9083): `FT.SPELLCHECK` ignores $param placeholders from the `PARAMS` clause (MOD-10596)
+- [#Q9435](https://github.com/redisearch/redisearch/pull/9435): RDB loader accepts out-of-range or malformed values, causing instability on restore (MOD-13118)
+- [#Q7703](https://github.com/redisearch/redisearch/pull/7703), #Q7727: Pending coordinator and worker jobs are not correctly tracked in the queue
+- [#Q7629](https://github.com/redisearch/redisearch/pull/7629), #Q7653, #Q7662: `FT.PROFILE` gains a debug mode to simulate timeouts, crashes, and mid-execution pauses (MOD-8127, MOD-11155, MOD-12627)
+- [#Q7966](https://github.com/redisearch/redisearch/pull/7966): Module load no longer fails when find_module is undefined (MOD-13330)
+
+Metrics:
+
+- [#Q7597](https://github.com/redisearch/redisearch/pull/7597), [#Q7645](https://github.com/redisearch/redisearch/pull/7645), [#Q7665](https://github.com/redisearch/redisearch/pull/7665): New `active_io_threads`, `active_worker_threads`, and `active_coord_threads` metrics expose live thread activity (MOD-12069, MOD-12694, MOD-12695)
+- [#Q7778](https://github.com/redisearch/redisearch/pull/7778): New counters track total documents indexed and fields indexed per field type across all indexes (MOD-12070)
+- [#Q7788](https://github.com/redisearch/redisearch/pull/7788), [#Q7819](https://github.com/redisearch/redisearch/pull/7819), [#Q7820](https://github.com/redisearch/redisearch/pull/7820): New `FT.INFO` counters track query syntax errors, timeout errors/warnings, and MAXPREFIXEXPANSIONS warnings (MOD-12416, MOD-12417, MOD-12419)
+- [#Q7751](https://github.com/redisearch/redisearch/pull/7751): Cluster-mode `FT.PROFILE` now reports Internal cursor reads per shard (MOD-12414)
+- [#Q8066](https://github.com/redisearch/redisearch/pull/8066): Index commands now emit informational log entries for operational visibility (MOD-13431)
 
 ## v2.8.32 (November 2025)
 


### PR DESCRIPTION
RediSearch release notes:

v2.6.36
v2.8.37
v2.10.30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates RediSearch release notes with new maintenance versions and associated bug-fix/metrics lists.
> 
> **Overview**
> Updates the RediSearch release notes for `v2.6`, `v2.8`, and `v2.10` to reflect new maintenance releases (`2.6.36`, `2.8.37`, `2.10.30`) and bumps the stated “requires” version numbers accordingly.
> 
> Adds the May 2026 entries with **HIGH update urgency** and detailed lists of bug fixes (notably cursor/ACL infinite-loop issues, crash/deadlock fixes, and RDB/schema robustness) plus new/expanded `FT.INFO` and `FT.PROFILE` metrics coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbbcd04672d9127c5c049392e52fd1dd5084a60d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->