### PR TITLE
K8s: add info about AA cert updates

### DIFF
--- a/content/operate/kubernetes/active-active/_index.md
+++ b/content/operate/kubernetes/active-active/_index.md
@@ -68,6 +68,12 @@ For a full list of fields and options, see the [RERC API reference]({{<relref "/
 
 For examples, see the [YAML examples]({{< relref "/operate/kubernetes/reference/yaml/active-active" >}}) section.
 
+### Manage certificates
+
+The operator automates Active-Active certificate updates. When you update the proxy or syncer certificate secret on a participating cluster's REC, the operator detects the change and propagates the new certificate to the other participating clusters.
+
+For details, see [Manage REC certificates]({{< relref "/operate/kubernetes/security/manage-rec-certificates" >}}) and [cert-manager integration]({{< relref "/operate/kubernetes/security/cert-manager" >}}).
+
 ### Limitations
 
 * Existing Redis databases cannot be migrated to a REAADB. (DOC-3594)

--- a/content/operate/kubernetes/security/manage-rec-certificates.md
+++ b/content/operate/kubernetes/security/manage-rec-certificates.md
@@ -67,6 +67,12 @@ Check the operator logs and use the API to verify the certificate has been updat
   GET /v1/cluster/certificates
   ```
 
+## Active-Active database certificate updates
+
+The operator automates certificate updates for [Active-Active]({{< relref "/operate/kubernetes/active-active" >}}) databases. When you update the proxy or syncer certificate secret referenced by the REC, the operator detects the change and propagates the new certificate to all participating clusters.
+
+This automation applies whether you manage the secret directly or with [cert-manager]({{< relref "/operate/kubernetes/security/cert-manager#active-active-databases-with-automatic-certificate-sync" >}}).
+
 ## More info
 
 - [Update certificates]({{< relref "/operate/rs/security/certificates/updating-certificates" >}})


### PR DESCRIPTION
DOC-6109

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds guidance and cross-links; no code or behavior changes.
> 
> **Overview**
> Documents that the Kubernetes operator **automatically propagates Active-Active proxy/syncer certificate secret updates** across participating clusters.
> 
> Adds a new *Manage certificates* section to the Active-Active docs and expands `Manage REC certificates` with an *Active-Active database certificate updates* section, including links to the relevant cert-manager integration guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06afd893ae1aef1cd1126e7265901ab3e13feb2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->