### PR TITLE
Explaining the use of Active-Active for RDI DB

### DIFF
--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -47,6 +47,14 @@ No. RDI is designed and tested to work only with Redis Enterprise. The staging d
 only use version 6.4 or above. The target Redis database can be of any version and can be a
 replica of an Active-Active replication setup or an Auto tiering database.
 
+## Can I use Active-Active for the RDI database?
+
+Yes. Starting with RDI 1.16.0, you can use Active-Active for the RDI database. This is useful if you
+want to create DR setup for RDI using  GCS to provide a reliable lease mechanism for leader election).
+The configuration for the GCS is available only for Helm based installations.
+
+**Important:** You should only use this configuration when both sites use the same source configuration.
+
 ## Can RDI automatically track changes to the source database schema?
 
 If you don't configure RDI to capture a specific set of tables in the schema then it will

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -49,9 +49,9 @@ replica of an Active-Active replication setup or an Auto tiering database.
 
 ## Can I use Active-Active for the RDI database?
 
-Yes. Starting with RDI 1.16.0, you can use Active-Active for the RDI database. This is useful if you
-want to create DR setup for RDI using  GCS to provide a reliable lease mechanism for leader election).
-The configuration for the GCS is available only for Helm based installations.
+Yes, starting with RDI 1.16.0, you can use Active-Active for the RDI database. This is useful if you
+want to create a disaster recovery setup for RDI using Google Cloud Storage (GCS) to provide a reliable lease mechanism for leader election.
+The configuration for the GCS is available only for [Helm based installations]({{< relref "/integrate/redis-data-integration/installation/install-k8s" >}}).
 
 **Important:** You should only use this configuration when both sites use the same source configuration.
 


### PR DESCRIPTION
We often get questions about whether our customers can use Active-Active for RDI DB.

This is possible with a few caveats:
1. Just running two separate RDI installations with Active-Active DB for DR is risky, as Active-Active does not provide a reliable locking mechanism, and may cause a split-brain situation (both instances believing they are the leader).
2. This should only be done if both instances use the same source DB due to problems with offset management when using replication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no product or configuration logic is modified.
> 
> **Overview**
> Adds a new FAQ entry explaining that **Active-Active can be used for the RDI database starting in RDI `1.16.0`**, primarily for DR when using Google Cloud Storage as a lease mechanism for leader election.
> 
> Notes that the GCS-based configuration is **Helm-installation only** and includes an *Important* caveat to use this setup only when both sites share the same source configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b70568f5e80a09006f32c9eb20d5a13d5aeed7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->