### PR TITLE
Update k8s api sync workflow to support new CRDs

### DIFF
--- a/.github/workflows/k8s_apis_sync.yaml
+++ b/.github/workflows/k8s_apis_sync.yaml
@@ -88,6 +88,48 @@ jobs:
           sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_remote_cluster_api.md
           awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_remote_cluster_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_remote_cluster_api.md
 
+          crdoc --resources crds/reacl_crd.yaml --output artifacts/redis_enterprise_acl_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseACL\./### /g' artifacts/redis_enterprise_acl_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterpriseacl/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_acl_api.md
+          sed -E -i 's/<td><a href="#redisenterpriseacl/<td><a href="#/' artifacts/redis_enterprise_acl_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_acl_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_acl_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_acl_api.md
+
+          crdoc --resources crds/recrole_crd.yaml --output artifacts/redis_enterprise_cluster_role_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseClusterRole\./### /g' artifacts/redis_enterprise_cluster_role_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterpriseclusterrole/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_cluster_role_api.md
+          sed -E -i 's/<td><a href="#redisenterpriseclusterrole/<td><a href="#/' artifacts/redis_enterprise_cluster_role_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_cluster_role_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_cluster_role_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_cluster_role_api.md
+
+          crdoc --resources crds/recrolebinding_crd.yaml --output artifacts/redis_enterprise_cluster_role_binding_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseClusterRoleBinding\./### /g' artifacts/redis_enterprise_cluster_role_binding_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterpriseclusterrolebinding/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_cluster_role_binding_api.md
+          sed -E -i 's/<td><a href="#redisenterpriseclusterrolebinding/<td><a href="#/' artifacts/redis_enterprise_cluster_role_binding_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_cluster_role_binding_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_cluster_role_binding_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_cluster_role_binding_api.md
+
+          crdoc --resources crds/redbrole_crd.yaml --output artifacts/redis_enterprise_database_role_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseDatabaseRole\./### /g' artifacts/redis_enterprise_database_role_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterprisedatabaserole/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_database_role_api.md
+          sed -E -i 's/<td><a href="#redisenterprisedatabaserole/<td><a href="#/' artifacts/redis_enterprise_database_role_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_database_role_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_database_role_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_database_role_api.md
+
+          crdoc --resources crds/redbrolebinding_crd.yaml --output artifacts/redis_enterprise_database_role_binding_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseDatabaseRoleBinding\./### /g' artifacts/redis_enterprise_database_role_binding_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterprisedatabaserolebinding/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_database_role_binding_api.md
+          sed -E -i 's/<td><a href="#redisenterprisedatabaserolebinding/<td><a href="#/' artifacts/redis_enterprise_database_role_binding_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_database_role_binding_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_database_role_binding_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_database_role_binding_api.md
+
+          crdoc --resources crds/reuser_crd.yaml --output artifacts/redis_enterprise_user_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseUser\./### /g' artifacts/redis_enterprise_user_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterpriseuser/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_user_api.md
+          sed -E -i 's/<td><a href="#redisenterpriseuser/<td><a href="#/' artifacts/redis_enterprise_user_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_user_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_user_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_user_api.md
+
       - name: 'Remove fields without description'
         run: |-
           file="artifacts/redis_enterprise_cluster_api.md"
@@ -161,6 +203,12 @@ jobs:
           sed -E -i 's/linkTitle: RedisEnterpriseCluster API Reference/linkTitle: REC API/g' artifacts/redis_enterprise_cluster_api.md
           sed -E -i 's/linkTitle: RedisEnterpriseDatabase API Reference/linkTitle: REDB API/g' artifacts/redis_enterprise_database_api.md
           sed -E -i 's/linkTitle: RedisEnterpriseRemoteCluster API Reference/linkTitle: RERC API/g' artifacts/redis_enterprise_remote_cluster_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseACL API Reference/linkTitle: REACL API/g' artifacts/redis_enterprise_acl_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseClusterRole API Reference/linkTitle: RECROLE API/g' artifacts/redis_enterprise_cluster_role_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseClusterRoleBinding API Reference/linkTitle: RECROLEBINDING API/g' artifacts/redis_enterprise_cluster_role_binding_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseDatabaseRole API Reference/linkTitle: REDBROLE API/g' artifacts/redis_enterprise_database_role_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseDatabaseRoleBinding API Reference/linkTitle: REDBROLEBINDING API/g' artifacts/redis_enterprise_database_role_binding_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseUser API Reference/linkTitle: REUSER API/g' artifacts/redis_enterprise_user_api.md
 
       - name: 'Generate YAML snippets'
         run: |-
@@ -214,6 +262,12 @@ jobs:
           cp artifacts/redis_enterprise_cluster_api.md content/operate/kubernetes/reference/api/
           cp artifacts/redis_enterprise_database_api.md content/operate/kubernetes/reference/api/
           cp artifacts/redis_enterprise_remote_cluster_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_acl_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_cluster_role_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_cluster_role_binding_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_database_role_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_database_role_binding_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_user_api.md content/operate/kubernetes/reference/api/
 
           git add content/operate/kubernetes/reference/api/
           git add content/embeds/k8s/


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes only a GitHub Actions docs-sync workflow by adding additional generated artifacts and copy steps; main failure mode is broken doc generation/publishing if CRD names/paths change.
> 
> **Overview**
> Expands the `k8s_apis_sync` GitHub Actions workflow to generate and publish API reference docs for additional Redis Enterprise Operator CRDs.
> 
> The workflow now runs `crdoc` (plus the existing header/link/index cleanup) for `RedisEnterpriseACL`, `RedisEnterpriseClusterRole`, `RedisEnterpriseClusterRoleBinding`, `RedisEnterpriseDatabaseRole`, `RedisEnterpriseDatabaseRoleBinding`, and `RedisEnterpriseUser`, updates their `linkTitle` rewrites, and copies the new markdown artifacts into `content/operate/kubernetes/reference/api/` before creating the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d45816c5f4dfd687a9427fccb9f3196c5182206. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->