### PR TITLE
Add interactive example for ruby

### DIFF
--- a/content/develop/clients/ruby/_index.md
+++ b/content/develop/clients/ruby/_index.md
@@ -36,23 +36,19 @@ gem install redis
 
 Connect to localhost on port 6379:
 
-{{< clients-example set="landing" step="connect" lang_filter="Ruby" description="Foundational: Connect to a Redis server and establish a client connection" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="connect" lang_filter="Ruby" description="Foundational: Connect to a Redis server and establish a client connection" difficulty="beginner" />}}
 
 Store and retrieve a simple string.
 
-{{< clients-example set="landing" step="set_get_string" lang_filter="Ruby" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="set_get_string" lang_filter="Ruby" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" />}}
 
 Store and retrieve a dict.
 
-{{< clients-example set="landing" step="hash_operations" lang_filter="Ruby" description="Foundational: Store and retrieve hash data structures using HSET and HGETALL" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="hash_operations" lang_filter="Ruby" description="Foundational: Store and retrieve hash data structures using HSET and HGETALL" difficulty="beginner" />}}
 
 Close the connection when you're done.
 
-{{< clients-example set="landing" step="close" lang_filter="Ruby" description="Foundational: Properly close a Redis client connection to release resources" difficulty="beginner" >}}
-{{< /clients-example >}}
+{{< jupyter-example set="landing" step="close" lang_filter="Ruby" description="Foundational: Properly close a Redis client connection to release resources" difficulty="beginner" />}}
 
 ## More information
 

--- a/content/develop/clients/ruby/_index.md
+++ b/content/develop/clients/ruby/_index.md
@@ -48,7 +48,7 @@ Store and retrieve a dict.
 
 Close the connection when you're done.
 
-{{< jupyter-example set="landing" step="close" depends="connect" lang_filter="Ruby" description="Foundational: Properly close a Redis client connection to release resources" difficulty="beginner" />}}
+{{< jupyter-example set="landing" step="close" depends="connect" lang_filter="Ruby" description="Foundational: Properly close a Redis client connection to release resources" difficulty="beginner" no_output="true" />}}
 
 ## More information
 

--- a/content/develop/clients/ruby/_index.md
+++ b/content/develop/clients/ruby/_index.md
@@ -40,15 +40,15 @@ Connect to localhost on port 6379:
 
 Store and retrieve a simple string.
 
-{{< jupyter-example set="landing" step="set_get_string" lang_filter="Ruby" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" />}}
+{{< jupyter-example set="landing" step="set_get_string" depends="connect" lang_filter="Ruby" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" />}}
 
 Store and retrieve a dict.
 
-{{< jupyter-example set="landing" step="hash_operations" lang_filter="Ruby" description="Foundational: Store and retrieve hash data structures using HSET and HGETALL" difficulty="beginner" />}}
+{{< jupyter-example set="landing" step="hash_operations" depends="connect" lang_filter="Ruby" description="Foundational: Store and retrieve hash data structures using HSET and HGETALL" difficulty="beginner" />}}
 
 Close the connection when you're done.
 
-{{< jupyter-example set="landing" step="close" lang_filter="Ruby" description="Foundational: Properly close a Redis client connection to release resources" difficulty="beginner" />}}
+{{< jupyter-example set="landing" step="close" depends="connect" lang_filter="Ruby" description="Foundational: Properly close a Redis client connection to release resources" difficulty="beginner" />}}
 
 ## More information
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1551,6 +1551,82 @@
           }, 120000);
         }
 
+        // Same workaround as JS above, applied to Ruby cells.
+        const CM_RUBY_MODE_URL = 'https://unpkg.com/codemirror@5.65.16/mode/ruby/ruby.js';
+
+        function loadCodeMirrorRubyMode(CM) {
+          if (!CM || typeof CM.defineMode !== 'function') return Promise.resolve(false);
+          if (CM.modes && CM.modes.ruby) return Promise.resolve(true);
+          if (window.__cmRubyModePromise) return window.__cmRubyModePromise;
+
+          window.__cmRubyModePromise = new Promise(function(resolve) {
+            const hadPrev = Object.prototype.hasOwnProperty.call(window, 'CodeMirror');
+            const prev = window.CodeMirror;
+            window.CodeMirror = CM;
+            const script = document.createElement('script');
+            script.src = CM_RUBY_MODE_URL;
+            const restore = function() {
+              if (hadPrev) { window.CodeMirror = prev; } else { try { delete window.CodeMirror; } catch (e) { window.CodeMirror = undefined; } }
+            };
+            script.onload = function() {
+              restore();
+              resolve(!!(CM.modes && CM.modes.ruby));
+            };
+            script.onerror = function() {
+              restore();
+              console.warn('[Thebe] Failed to load CodeMirror Ruby mode from', CM_RUBY_MODE_URL);
+              window.__cmRubyModePromise = null;
+              resolve(false);
+            };
+            document.head.appendChild(script);
+          });
+          return window.__cmRubyModePromise;
+        }
+
+        function findRubyCmInstances() {
+          const out = [];
+          document.querySelectorAll('.thebe-cell .CodeMirror').forEach(function(cmEl) {
+            const cm = cmEl.CodeMirror;
+            if (!cm) return;
+            const mode = cm.getOption('mode');
+            const modeName = (typeof mode === 'string') ? mode : (mode && mode.name);
+            if (modeName === 'ruby') out.push(cm);
+          });
+          return out;
+        }
+
+        function applyRubyModeToCells() {
+          findRubyCmInstances().forEach(function(cm) {
+            cm.setOption('mode', null);
+            cm.setOption('mode', 'ruby');
+          });
+        }
+
+        let __rubyHighlightDone = false;
+        let __rubyHighlightObserver = null;
+        function __tryRegisterRubyMode() {
+          if (__rubyHighlightDone) return;
+          const rubyCms = findRubyCmInstances();
+          if (rubyCms.length === 0) return;
+          __rubyHighlightDone = true;
+          if (__rubyHighlightObserver) { __rubyHighlightObserver.disconnect(); __rubyHighlightObserver = null; }
+          const CM = rubyCms[0].constructor;
+          loadCodeMirrorRubyMode(CM).then(function(ok) {
+            if (ok) applyRubyModeToCells();
+          });
+        }
+        function ensureRubyHighlightingForActivatedCells() {
+          __tryRegisterRubyMode();
+          if (__rubyHighlightDone || __rubyHighlightObserver) return;
+          if (typeof MutationObserver !== 'function') return;
+          __rubyHighlightObserver = new MutationObserver(function() { __tryRegisterRubyMode(); });
+          __rubyHighlightObserver.observe(document.body, { childList: true, subtree: true });
+          // Safety net: stop observing after 2 minutes even if no Ruby cells ever appear.
+          setTimeout(function() {
+            if (__rubyHighlightObserver) { __rubyHighlightObserver.disconnect(); __rubyHighlightObserver = null; }
+          }, 120000);
+        }
+
         // Function to handle kernel expiration/disconnection
         function handleKernelExpired() {
           // Clear localStorage session so fresh start on reload
@@ -1599,6 +1675,7 @@
           // Start watching for JS cells so we can install CM's javascript mode as soon
           // as Thebe creates the editors (covers both fresh click and auto-reconnect).
           ensureJsHighlightingForActivatedCells();
+          ensureRubyHighlightingForActivatedCells();
 
           // NOTE: Loading state is now managed by individual click handlers (lines 1189-1190)
           // This prevents all blocks from showing "Starting kernel..." when only one is clicked

--- a/local_examples/client-specific/ruby/landing.rb
+++ b/local_examples/client-specific/ruby/landing.rb
@@ -1,11 +1,8 @@
 # EXAMPLE: landing
 # BINDER_ID ruby-landing
 # KERNEL_NAME ruby3
-# STEP_START import
-require 'redis'
-# STEP_END
-
 # STEP_START connect
+require 'redis'
 r = Redis.new
 # STEP_END
 

--- a/local_examples/client-specific/ruby/landing.rb
+++ b/local_examples/client-specific/ruby/landing.rb
@@ -1,6 +1,6 @@
 # EXAMPLE: landing
-# BINDER_ID: ruby-landing
-# KERNEL_NAME: ruby3
+# BINDER_ID ruby-landing
+# KERNEL_NAME ruby3
 # STEP_START import
 require 'redis'
 # STEP_END

--- a/local_examples/client-specific/ruby/landing.rb
+++ b/local_examples/client-specific/ruby/landing.rb
@@ -1,4 +1,6 @@
 # EXAMPLE: landing
+# BINDER_ID: ruby-landing
+# KERNEL_NAME: ruby3
 # STEP_START import
 require 'redis'
 # STEP_END
@@ -10,7 +12,7 @@ r = Redis.new
 # STEP_START set_get_string
 r.set 'foo', 'bar'
 value = r.get('foo')
-puts value # >>> bar
+puts value
 # STEP_END
 
 # STEP_START hash_operations
@@ -21,7 +23,6 @@ r.hset 'user-session:123', 'age', 29
 
 hash_value = r.hgetall('user-session:123')
 puts hash_value
-# >>> {"name"=>"John", "surname"=>"Smith", "company"=>"Redis", "age"=>"29"}
 # STEP_END
 
 # STEP_START close


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new global Thebe/CodeMirror behavior (lazy-loading Ruby mode and DOM observation) which could affect interactive code rendering on any page using Thebe. Doc/example updates are low risk, but the base template JS change could introduce regressions in highlighting or performance.
> 
> **Overview**
> Switches the Ruby client guide to use `jupyter-example` interactive snippets (with dependency wiring and `no_output` on the close step) instead of the prior `clients-example` blocks.
> 
> Adds a Ruby-specific CodeMirror mode loader in `baseof.html` (mirroring the existing JavaScript workaround) so Ruby Thebe cells keep syntax highlighting after activation, and wires it into Thebe bootstrap.
> 
> Updates the Ruby landing example source to include `BINDER_ID`/`KERNEL_NAME`, move `require 'redis'` into the `connect` step, and remove embedded expected-output comments so notebook output reflects actual execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91d0fb02f1b4738212d9607ca3728a2a62a3dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->