### PR TITLE
DOC-6564 updated RS SCH support info

### DIFF
--- a/content/develop/clients/sch.md
+++ b/content/develop/clients/sch.md
@@ -97,14 +97,13 @@ curl -k -X PUT -H "accept: application/json" \
 ```
 
 Redis Software uses relaxed timeouts to avoid command failures during
-database version upgrades. The support for pre-handoffs depends on
+database version upgrades. SCH is supported for Redis Software from v8.0.2 on,
+and OSS Cloud and OSS Cluster API from v8.0.16 on.
+
+The degree of support for pre-handoffs depends on
 the specific upgrade method you use, as detailed in the table below.
 
-| Upgrade method | SCH support | Expected behavior |
-| --- | --- | --- |
-| [Rolling upgrade]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-cluster#rolling-upgrade" >}}) | Full | New nodes and old ones removed sequentially. SCH pre-handoffs and relaxed timeouts greatly reduce disruptions during the upgrade. |
-| [In-place upgrade]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-cluster#in-place-upgrade" >}}) | Partial | Relaxed timeouts reduce errors but there are no pre-handoffs. Disconnections occur when processes are replaced during the upgrade, so clients should rely on auto-reconnect, which will cause brief lapses in service. |
-| [Maintenance mode]({{< relref "/operate/rs/clusters/maintenance-mode" >}}) | Full | SCH is fully supported during hardware or OS patching operations. Pre-handoffs and relaxed timeouts minimize application impact. |
+{{< embed-md "rs-sch-support.md" >}}
 
 ### Redis Enterprise for Kubernetes
 

--- a/content/embeds/rs-sch-support.md
+++ b/content/embeds/rs-sch-support.md
@@ -1,0 +1,5 @@
+| Upgrade method | SCH support | Expected behavior |
+| --- | --- | --- |
+| [Rolling upgrade]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-cluster#rolling-upgrade" >}}) | Full | New nodes and old ones removed sequentially. SCH pre-handoffs and relaxed timeouts greatly reduce disruptions during the upgrade. |
+| [In-place upgrade]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-cluster#in-place-upgrade" >}}) | Partial | Relaxed timeouts reduce errors but there are no pre-handoffs. Disconnections occur when processes are replaced during the upgrade, so clients should rely on auto-reconnect, which will cause brief lapses in service. |
+| [Maintenance mode]({{< relref "/operate/rs/clusters/maintenance-mode" >}}) | Full | SCH is fully supported during hardware or OS patching operations. Pre-handoffs and relaxed timeouts minimize application impact. |

--- a/content/operate/rs/clusters/configure/sch.md
+++ b/content/operate/rs/clusters/configure/sch.md
@@ -13,7 +13,7 @@ weight: 90
 Smart client handoffs (SCH) is a feature of Redis Cloud and Redis Software servers that lets them actively notify clients about planned server maintenance shortly before it happens. This lets a client reconnect or otherwise respond gracefully without significant interruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}}) for more information about SCH.
 
-SCH is supported for Redis Software from v8.0.2 on, and OSS Cloud mode and OSS Cluster API from v8.0.16 on.
+SCH is supported for Redis Software from v8.0.2 on, and OSS Cluster API from v8.0.16 on.
 The degree of support for SCH depends on the specific upgrade method you use, as detailed in the table below.
 
 {{< embed-md "rs-sch-support.md" >}}

--- a/content/operate/rs/clusters/configure/sch.md
+++ b/content/operate/rs/clusters/configure/sch.md
@@ -13,8 +13,10 @@ weight: 90
 Smart client handoffs (SCH) is a feature of Redis Cloud and Redis Software servers that lets them actively notify clients about planned server maintenance shortly before it happens. This lets a client reconnect or otherwise respond gracefully without significant interruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}}) for more information about SCH.
 
-{{< note >}}SCH is supported only for [rolling upgrades]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-cluster#rolling-upgrade" >}}).
-{{< /note >}}
+SCH is supported for Redis Software from v8.0.2 on, and OSS Cloud mode and OSS Cluster API from v8.0.16 on.
+The degree of support for SCH depends on the specific upgrade method you use, as detailed in the table below.
+
+{{< embed-md "rs-sch-support.md" >}}
 
 To enable SCH on a Redis Software server, you must use the
 [/v1/cluster]({{< relref "/operate/rs/references/rest-api/requests/cluster#put-cluster" >}})


### PR DESCRIPTION
Updated the info about RS support for Smart client handoffs for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies stated SCH support versions and upgrade-method behavior; no product code changes.
> 
> **Overview**
> Clarifies Redis Software Smart client handoffs (SCH) support by stating minimum supported versions (RS `v8.0.2+`, OSS Cloud/Cluster API `v8.0.16+`) and noting that SCH behavior varies by upgrade method.
> 
> Replaces duplicated inline content with a shared embedded table (`content/embeds/rs-sch-support.md`) and updates the RS configuration page to align with the same upgrade-method support guidance (removing the previous “rolling upgrades only” note).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0211432a909bbb63fddba7ff039e012dd07307ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->