### PR TITLE
K8s: added registry.connect.redhat to downloads list

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
@@ -25,7 +25,10 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 ### OpenShift downloads
 
 - **OLM operator bundle**: `v7.22.0-17.0`
-- **Call Home Client**: `redislabs/call-home-client:7.22.0-17`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:7.22.0-250`
+- **Operator**: `registry.connect.redhat.com/redislabs/operator:7.22.0-17`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:7.22.0-17`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.0-17`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
@@ -25,7 +25,10 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 ### OpenShift downloads
 
 - **OLM operator bundle**: `v7.22.2-39.0`
-- **Call Home Client**: `redislabs/call-home-client:7.22.2-39`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:7.22.2-116`
+- **Operator**: `registry.connect.redhat.com/redislabs/operator:7.22.2-39`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:7.22.2-39`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-39`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
@@ -25,7 +25,10 @@ This is a maintenance release to support Redis Enterprise Software version 8.0.1
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.10-23.0`
-- **Call Home Client**: `redislabs/call-home-client:8.0.10-23`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.10-81`
+- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.10-23`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.10-23`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.10-23`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-25-march2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-25-march2026.md
@@ -26,4 +26,7 @@ For version changes, supported distributions, and known limitations, see the [re
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.16-25.0`
-- **Call Home Client**: `redislabs/call-home-client:8.0.16-25`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.16-33`
+- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.16-25`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.16-25`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.16-25`

--- a/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-6-december2025.md
+++ b/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-6-december2025.md
@@ -103,7 +103,10 @@ Any distribution not listed in the table is not supported for production workloa
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.2-6.1`
-- **Call Home Client**: `redislabs/call-home-client:8.0.2-6`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.2-41`
+- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.2-6`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.2-6`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.2-6`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/8-0-6-releases/8-0-6-8-december2025.md
+++ b/content/operate/kubernetes/release-notes/8-0-6-releases/8-0-6-8-december2025.md
@@ -98,7 +98,10 @@ Any distribution not listed in the table is not supported for production workloa
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.6-8.0`
-- **Call Home Client**: `redislabs/call-home-client:8.0.6-8`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.6-54`
+- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.6-8`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.6-8`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.6-8`
 
 ## Known limitations
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds additional OpenShift image pull references; no product code or behavior is modified.
> 
> **Overview**
> Updates multiple Kubernetes operator release notes to expand the **OpenShift downloads** section with `registry.connect.redhat.com/redislabs/...` image references for Redis Enterprise, Operator, Services Rigger, and Call Home Client (alongside the existing bundle tag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4502cc2eeddb7991a9227ebd91c03505bb847529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->