### PR TITLE
RDI 1.18.1 release notes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -56,7 +56,7 @@ rdi_redis_gears_version = "1.2.6"
 rdi_debezium_server_version = "2.3.0.Final"
 rdi_db_types = "cassandra|mysql|oracle|postgresql|sqlserver"
 rdi_cli_latest = "latest"
-rdi_current_version = "1.18.0"
+rdi_current_version = "1.18.1"
 
 
 [params.clientsConfig]

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-1.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-1.md
@@ -1,0 +1,19 @@
+---
+Title: Redis Data Integration release notes 1.18.1 (May 2026)
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: |
+  Debezium 3.5.0 upgrade with default collector image updates, Oracle connector compatibility updates, and Microsoft Entra ID authentication support.
+linkTitle: 1.18.1 (May 2026)
+toc: 'true'
+weight: 970
+---
+
+## What's New in 1.18.1
+
+### Improvements
+
+- **Debezium upgrade**: RDI now uses Debezium 3.5.0 by default and updates the default collector image to `docker.io/redislabs/debezium-server:3.5.0.Final-rdi.1`. This update includes Oracle connector compatibility updates and Microsoft Entra ID authentication support.


### PR DESCRIPTION
## Summary
- add public release notes for Redis Data Integration 1.18.1
- document the Debezium 3.5.0 upgrade from the RDI changelog

## Validation
- verified release notes do not include Jira ticket IDs, PR IDs, commit IDs, or branch IDs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; it updates a site config version string and adds a new release-notes page without affecting runtime logic.
> 
> **Overview**
> Updates site config to set `rdi_current_version` from `1.18.0` to `1.18.1`.
> 
> Adds a new `rdi-1-18-1.md` release-notes page documenting the 1.18.1 improvements, primarily the default upgrade to Debezium 3.5.0 (including updated collector image, Oracle connector compatibility updates, and Microsoft Entra ID auth support).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf00eeea6531bc8e0e9d33f16d6acced47b94760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->