### PR TITLE
K8s: add resolved issue for pod failures

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-0-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/_index.md
@@ -57,6 +57,8 @@ For detailed steps, see the relevant upgrade page:
 
 ## Known limitations
 
+- **Expired license causes pod readiness failures, blocking recovery and upgrades** <!--RED-185977--> If a pod is stuck during upgrade, manually update the licenses via the REST API.
+
 - **Only upgrades from 7.4.2-2 and later are supported.** If you are using an earlier version, install 7.4.2-2 before upgrading to 7.8.2-6 or later.
 
 - **When changing the REDB field `spec.modulesList`, version might be upgraded to latest, even if a different version is specified.** To prevent the upgrade to latest, set  `spec.upgradeSpec.setModuleToLatest` to `false` before upgrading.

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/_index.md
@@ -21,6 +21,8 @@ Redis Enterprise for Kubernetes 8.0.10 includes bug fixes, enhancements, and sup
 
 ### New limitations
 
+- **Expired license causes pod readiness failures, blocking recovery and upgrades** <!--RED-185977--> If a pod is stuck during upgrade, manually update the licenses via the REST API.
+
 - **SSO configuration doesn't work with IPv6 or dual stack (IPv4/IPv6) clusters.** <!--RED-180550-->
 
 ### Existing limitations

--- a/content/operate/kubernetes/release-notes/8-0-16-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-16-releases/_index.md
@@ -21,6 +21,8 @@ Redis Enterprise for Kubernetes 8.0.16-24 is a maintenance release of Redis Ente
 
 ### New limitations
 
+- **Expired license causes pod readiness failures, blocking recovery and upgrades** <!--RED-185977--> If a pod is stuck during upgrade, manually update the licenses via the REST API.
+
 - **SSO configuration doesn't work with IPv6 or dual stack (IPv4/IPv6) clusters.** <!--RED-180550-->
 
 ### Existing limitations

--- a/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026.md
@@ -40,6 +40,7 @@ Redis Enterprise for Kubernetes 8.0.18-11 is a feature release that supports [Re
 - Security fixes
 - Fixed operator reconciliation loop causing excessive RBAC updates <!--RED-189582-->
 - Added LDAP CBA field support to the REC API <!--RED-192794-->
+- Fixed issue causing pod readiness failures due to expired license <!--RED-185977-->
 
 ## API changes
 

--- a/content/operate/kubernetes/release-notes/8-0-18-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/_index.md
@@ -32,8 +32,6 @@ The following table shows supported Kubernetes versions at the time of this rele
 
 ## Known limitations
 
-- **An expired license causes pod readiness failures, which block recovery and upgrades.** If a pod is stuck during an upgrade, manually update the licenses through the REST API. <!--RED-185977-->
-
 - **SSO configuration does not work with IPv6 or dual-stack (IPv4/IPv6) clusters.** <!--RED-180550-->
 
 - **Upgrades from versions earlier than 7.4.2-2 are not supported.** If you use an earlier version, upgrade to 7.4.2-2 before upgrading to this version.

--- a/content/operate/kubernetes/release-notes/8-0-18-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/_index.md
@@ -32,6 +32,8 @@ The following table shows supported Kubernetes versions at the time of this rele
 
 ## Known limitations
 
+- **An expired license causes pod readiness failures, which block recovery and upgrades.** If a pod is stuck during an upgrade, manually update the licenses through the REST API. <!--RED-185977-->
+
 - **SSO configuration does not work with IPv6 or dual-stack (IPv4/IPv6) clusters.** <!--RED-180550-->
 
 - **Upgrades from versions earlier than 7.4.2-2 are not supported.** If you use an earlier version, upgrade to 7.4.2-2 before upgrading to this version.

--- a/content/operate/kubernetes/release-notes/8-0-2-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-2-releases/_index.md
@@ -33,6 +33,8 @@ For detailed steps, see the relevant upgrade page:
 
 ## Known limitations
 
+- **Expired license causes pod readiness failures, blocking recovery and upgrades** <!--RED-185977--> If a pod is stuck during upgrade, manually update the licenses via the REST API.
+
 - **Only upgrades from 7.4.2-2 and later are supported.** If you are using an earlier version, install 7.4.2-2 before upgrading to 8.0.2-2.
 
 - **Custom certificate upload is not supported for internode encryption (RED-173229).** Internode communication between cluster nodes continues to use default self-signed certificates and cannot be configured with customer-provided certificates.

--- a/content/operate/kubernetes/release-notes/8-0-6-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-6-releases/_index.md
@@ -19,6 +19,8 @@ Redis Enterprise for Kubernetes 8.0.6 includes bug fixes, enhancements, and supp
 
 ## Known limitations
 
+- **Expired license causes pod readiness failures, blocking recovery and upgrades** <!--RED-185977--> If a pod is stuck during upgrade, manually update the licenses via the REST API.
+
 - **SSO configuration doesn't work with IPv6 or dual stack (IPv4/IPv6) clusters.** <!--RED-180550-->
 
 - **Only upgrades from 7.4.2-2 and later are supported.** If you are using an earlier version, install 7.4.2-2 before upgrading to 8.0.6-8.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes limited to release notes; no product code or behavior is modified.
> 
> **Overview**
> Adds a new **Known limitation** entry across multiple Redis Enterprise for Kubernetes release-note indexes (`7.22.0`, `8.0.2`, `8.0.6`, `8.0.10`, `8.0.16`) warning that an *expired license can cause pod readiness failures* and advising manual license update via the REST API.
> 
> Updates the `8.0.18-11` release notes to include a **Resolved issue** noting the fix for the expired-license readiness failure (RED-185977).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2595284dd8ee6adedecc1a5b05594d12aa18a6f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->