### PR TITLE
DOC-6615: Link home page and AI index to Context Engine

### DIFF
--- a/content/develop/ai/_index.md
+++ b/content/develop/ai/_index.md
@@ -16,7 +16,7 @@ Redis stores and indexes vector embeddings that semantically represent unstructu
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
   {{< image-card image="images/ai-lib.svg" alt="AI Redis icon" title="Redis vector Python client library documentation" url="/develop/ai/redisvl/" >}}
   {{< image-card image="images/ai-cube.svg" alt="AI Redis icon" title="Use Redis Search to search data" url="/develop/ai/search-and-query/" >}}
-  {{< image-card image="images/ai-brain.svg" alt="AI Redis icon" title="Use LangCache to store LLM responses" url="/develop/ai/langcache/" >}}
+  {{< image-card image="images/ai-brain.svg" alt="AI Redis icon" title="Give AI agents the context engine they need with Redis Iris." url="/develop/ai/context-engine/" >}}
 </div>
 
 ## Redis Feature Form

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -274,7 +274,7 @@
               </div>
 
               <!-- Middle Layer: Redis (Highlighted) -->
-              <div class="relative bg-redis-red-10 border border-redis-red-500 rounded-lg p-4 shadow-xl text-center">
+              <a href="{{ relURL "develop/ai/context-engine/" }}" class="relative bg-redis-red-10 border border-redis-red-500 rounded-lg p-4 shadow-xl text-center block hover:border-redis-red-400 hover:bg-redis-red-10/80 transition-colors">
                 <!-- Redis Logo Badge -->
                 <div class="absolute -left-6 top-1/2 -translate-y-1/2">
                   <svg width="37" height="37" viewBox="0 0 37 37" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -296,7 +296,7 @@
                 <div class="text-xs text-redis-red-500 opacity-60 mt-2">
                   Memory, retrieval, state, streaming
                 </div>
-              </div>
+              </a>
 
               <!-- Connection Arrow -->
               <div class="flex justify-center -my-1">


### PR DESCRIPTION
Updates the Redis AI index page image-card and home page diagram layer to point to the new /develop/ai/context-engine/ page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates navigation links; main risk is an incorrect URL or unintended styling/UX change from making the diagram node clickable.
> 
> **Overview**
> Updates Redis AI entry points to promote the new Context Engine docs.
> 
> On `content/develop/ai/_index.md`, replaces the LangCache image-card with a new card linking to `/develop/ai/context-engine/` and updated copy. On `layouts/home.html`, turns the highlighted Redis layer in the AI stack diagram into a clickable link to the same page (adds hover styling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fbcf308e41d7d4d119a324d014d3850a82cb48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->