### PR TITLE
DEV: add ROS8.8 what's new page

### DIFF
--- a/content/develop/whats-new/8-8.md
+++ b/content/develop/whats-new/8-8.md
@@ -1,0 +1,156 @@
+---
+title: Redis 8.8
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+- rc
+description: What's new in Redis 8.8
+linkTitle: What's new in Redis 8.8
+weight: 1
+---
+
+Redis 8.8 introduces new features and performance improvements, building on the foundation of Redis 8.6.
+
+This release delivers improvements across multiple areas:
+- A new Array data structure
+- `INCREX`: window counter rate limiter combining `INCR`, `INCRBY`, `INCRBYFLOAT`, bounds, and expiration
+- New in-group sorting reducer - `COLLECT` for `FT.AGGREGATE`
+- Substantial Search and Query performance improvements (Rust iterators, devirtualized vector hot paths, AArch64 atomics)
+- HyperLogLog, `MGET`/`MSET`, and `HGETALL` performance improvements
+- Numerous security fixes and bug fixes across core, Search, JSON, and Time Series
+
+Below is a detailed breakdown of these updates.
+
+## Supported operating systems
+
+Redis 8.8 is tested on:
+
+- Ubuntu 22.04 (Jammy Jellyfish), 24.04 (Noble Numbat), 26.04 (Resolute Raccoon)
+- Rocky Linux 8.10, 9.7, 10.1
+- AlmaLinux 8.10, 9.7, 10.1
+- Debian 12.13 (Bookworm), Debian 13.4 (Trixie)
+- Alpine 3.23
+- macOS 14.8.4 (Sonoma), 15.7.4 (Sequoia), 26.3 (Tahoe) - for both Intel and ARM
+
+## Security fixes
+
+Redis 8.8 includes important security fixes (compared to 8.8-M03):
+
+- (CVE-2026-23479) Use-After-Free in unblock client flow may lead to remote code execution.
+- (CVE-2026-25243) Invalid memory access in `RESTORE` may lead to remote code execution.
+- (CVE-2026-23631) Lua Use-After-Free may lead to remote code execution.
+- (CVE-2026-25588) Invalid memory access in `RESTORE` may lead to remote code execution (Time Series).
+- (CVE-2026-25589) Invalid memory access in `RESTORE` may lead to remote code execution (Probabilistic).
+
+## New features
+
+### Array data structure
+
+Redis 8.8 introduces a new Array data structure (#15162), providing a dedicated data type for ordered, indexable collections.
+
+### INCREX rate limiter
+
+The new [`INCREX`]({{< relref "/commands/increx/" >}}) command (#15045) is a window counter rate limiter that combines `INCR`, `INCRBY`, `INCRBYFLOAT`, bounds, and expiration into a single atomic operation. It simplifies common rate-limiting patterns by eliminating the need for multi-command transactions.
+
+### In-group sorting reducer
+
+A new reducer for [`FT.AGGREGATE`]({{< relref "/commands/ft.aggregate/" >}}) allows you to unwind grouped documents after `GROUPBY` and sort them within each group, enabling more sophisticated aggregation pipelines.
+
+## Bug fixes
+
+Redis 8.8 includes a broad set of bug fixes (compared to 8.8-M03).
+
+### Core fixes
+
+- `SUBSCRIBE`, `PSUBSCRIBE`, `SSUBSCRIBE`: crash on OOM (RED-167788).
+- `CONFIG SET`: some settings allow invalid characters (RED-167787).
+- `SCRIPT DEBUG`: potential crash on scripts (RED-175507).
+- `VADD`: crash or buffer overflow on large `REDUCE` value (RED-170921).
+- `VSET`: crash on huge allocations (MOD-12678).
+- `cluster-announce-ip` rejecting hostnames (regression) (#15188).
+- Double free when loading streams with duplicate consumer PEL entries (#15095).
+- Issues processing corrupt Streams RDB data (#15124).
+- `fast_float_strtod` rounding mismatch (#15111).
+- `vecClear` reset the logical size without releasing element ownership (#15190).
+- `MULTI` queue incorrect memory accounting (#15163).
+- Cluster crash when `CLIENT KILL` unsubscribes `SSUBSCRIBE` client inside `EXEC` (#15094).
+- Listpack backlength encoding thresholds off-by-one (#15151).
+- Under-copy in the Lua debugger (#15115).
+- Sentinel config injection via `SENTINEL SET` (#14970).
+- Client output buffer memory tracking not accounting for copy-avoided bulk string references (#14934).
+
+### Search and Query fixes
+
+- `FT.PROFILE HYBRID` returns an empty reply (MOD-14778).
+- `FT.SPELLCHECK` treats `PARAMS` placeholders as literal terms instead of resolving them (MOD-10596).
+- `FT.PROFILE` output is inconsistent when a profiled value is missing (MOD-10560).
+- `FT.CREATE` now rejects schema definitions with invalid option combinations at creation time (MOD-14655).
+- `PERSIST` and `HPERSIST` notifications are not reflected in index expiration tracking (MOD-14800).
+- Race condition in `FT.HYBRID` causes intermittent failures under concurrent hybrid query load (MOD-14732).
+- Crash on `FT.SEARCH` when topology validation fails (for example, some nodes unreachable) (MOD-14475).
+- Coordinator deadlock under mixed `FT.SEARCH` and `FT.AGGREGATE` load (MOD-14268).
+- Memory leak when `FT.DROPINDEX` runs concurrently with in-flight hybrid queries (MOD-14135).
+- `FT.CURSOR READ` timeout and `ON_TIMEOUT FAIL` not enforced on coordinator and shard (MOD-14284, MOD-14998).
+- Cursors not cleaned up after `MAXIDLE`, causing resource exhaustion (MOD-6430).
+- Coordinator `RETURN_STRICT` returns wrong data on partial results, including `SORTBY` pipeline (MOD-13617).
+- `MAXPREFIXEXPANSION` warnings not propagated to clients in cluster mode (MOD-13804).
+- Search commands fail when no worker thread is available instead of falling back to main thread (MOD-14921).
+- RDB load missing validation of `FT.CREATE` arguments, allowing corrupt index state on load (MOD-13118).
+- Use-after-move in `Indexer_Process` causes crash during indexing (MOD-14980).
+- Deadlock between background query and main-thread writer (MOD-15364).
+- `FT.PROFILE` prints output using wrong iterator type (MOD-14678).
+- Confusing error returned when `DEBUG_PARAMS_COUNT` is zero (MOD-15118).
+- Stack-smashing error in coordinator code path (MOD-14649).
+
+### JSON fixes
+
+- Trailing chars are ignored (MOD-7266).
+- Wrong mutation ordering for array commands with recursive paths (MOD-6722).
+- JSONPath evaluation issues (MOD-14664, MOD-7264, MOD-7272, MOD-7270, MOD-7268).
+
+### Time series fixes
+
+- Potential crash on disconnections and TLS failures (MOD-14850).
+- `count`, `countNaN`, `countAll` reducers return NaN when all values are NaN (MOD-14420).
+
+## Performance and resource utilization improvements
+
+Redis 8.8 delivers a broad set of performance improvements (compared to 8.6).
+
+### Core improvements
+
+- HyperLogLog: 4 independent accumulators that are merged at the end (#15049).
+- Batched prefetch for `MGET` and `MSET` (#15133).
+- Batched prefetch for `HGETALL` on hashtable-encoded hashes (#14988).
+- Pass size hint to jemalloc for faster deallocation (#15071).
+- Reduces allocator and accounting overhead by adding compile-time jemalloc tuning (#15096).
+
+### Search and Query improvements
+
+- Vector index hot path (HNSW and brute-force) devirtualized, reducing per-query latency (MOD-14916).
+- Inline LSE atomics enabled on AArch64, improving atomic operation throughput on ARM64 (MOD-14916, MOD-15419).
+- Expiration handling overhead reduced when many keys expire simultaneously (MOD-14916).
+- LTO (link-time optimization) enabled for x86_64 release builds (MOD-14700).
+- Shard-level timeout adjusted to coordinator dispatch time for more accurate accounting (MOD-13189).
+- Iterators ported to Rust, reducing FFI overhead.
+- `numRecords` no longer updated for vector fields, removing unnecessary write overhead on ingest (MOD-15487).
+- VecSim SVS thread pool integrated with the worker pool for better thread utilization (MOD-9881).
+
+## Configuration parameters
+
+Redis 8.8 introduces new configuration parameters (compared to 8.8-M03):
+
+- Slowlog entry truncation limits (#15182):
+  - `slowlog-entry-max-argc`: maximum number of command arguments kept in a slowlog entry.
+  - `slowlog-entry-max-string-len`: maximum length of a command argument in a slowlog entry.
+- Default maximum worker threads value updated; `MAX_WORKER_THREADS` is now a string config (MOD-14486, MOD-14763).
+
+## Metrics
+
+- `FT.PROFILE`: added queue time tracking (MOD-13602).
+
+## CLI tools
+
+- Fixed memory leak on malformed legacy help entry in `redis-cli` (#15150).

--- a/content/develop/whats-new/_index.md
+++ b/content/develop/whats-new/_index.md
@@ -12,6 +12,12 @@ hideListLinks: true
 weight: 10
 ---
 
+## Q2 2026 (April - June) Updates
+
+### Redis Version Updates
+
+- [Redis 8.8]({{< relref "/develop/whats-new/8-8" >}}) - New Array data structure, `INCREX` rate limiter, in-group sorting reducer for `FT.AGGREGATE`, Rust iterators and devirtualized vector hot paths in Search, HyperLogLog and `MGET`/`MSET`/`HGETALL` performance improvements.
+
 ## Q1 2026 (January - March) Updates
 
 ### Tools

--- a/content/develop/whats-new/redis-feature-sets.md
+++ b/content/develop/whats-new/redis-feature-sets.md
@@ -17,6 +17,7 @@ To use a new feature introduced in a later feature set, you must upgrade the cor
 
 | Redis feature set | What's new |
 |-------------------|------------|
+| **Feature set version:** 8.8| See [here]({{< relref "/develop/whats-new/8-8" >}})|
 | **Feature set version:** 8.6| See [here]({{< relref "/develop/whats-new/8-6" >}})|
 | **Feature set version:** 8.4| See [here]({{< relref "/develop/whats-new/8-4" >}})|
 | **Feature set version:** 8.2| See [here]({{< relref "/develop/whats-new/8-2" >}})|


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add a new release notes page and update navigation links; minimal risk beyond potential typos or broken relrefs.
> 
> **Overview**
> Adds a new `content/develop/whats-new/8-8.md` page summarizing Redis 8.8 highlights, including *new features*, *security fixes*, *bug fixes*, and *performance/config updates*.
> 
> Updates `content/develop/whats-new/_index.md` to list Redis 8.8 under Q2 2026, and updates `redis-feature-sets.md` to add a Feature Set 8.8 entry linking to the new page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db51a22a9da9d6b39237f1344f5e39152036eb12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->