### PR TITLE
K8s: cancun maint 2

### DIFF
--- a/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-14-may2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-14-may2026.md
@@ -24,7 +24,7 @@ This is a maintenance release to support Redis Enterprise Software version 8.0.1
 
 ### OpenShift downloads
 
-- **OLM operator bundle**: `8.0.18-14.0`
+- **OLM operator bundle**: `8.0.18-14.2`
 - **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.18-36.14` (`registry.connect.redhat.com/redislabs/redis:8.0.18-36.14.minimal` for minimal base image)
 - **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.18-14`
 - **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.18-14`

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-21-may2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-21-may2026.md
@@ -1,0 +1,35 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: This is a maintenance release to support Redis Enterprise Software version 8.0.20-19.
+hideListLinks: true
+linkTitle: 8.0.20-21 (May 2026)
+title: Redis Enterprise for Kubernetes 8.0.20-21 (May 2026) release notes
+weight: 30
+---
+
+## Highlights
+
+This is a maintenance release to support Redis Enterprise Software version 8.0.20-19. For version changes, supported distributions, and known limitations, see the [release notes for 8.0.18-11 (April 2026)]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026">}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:8.0.20-19.21` (`redislabs/redis:8.0.20-19.21.minimal` for minimal base image)
+- **Operator**: `redislabs/operator:8.0.20-21`
+- **Services Rigger**: `redislabs/k8s-controller:8.0.20-21`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.20-21`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `8.0.20-21.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.20-19.21` (`registry.connect.redhat.com/redislabs/redis:8.0.20-19.21.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.20-21`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.20-21`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.20-21`
+
+## Known limitations
+
+See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
@@ -1,0 +1,22 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: Releases with support for Redis Enterprise Software 8.0.20
+hideListLinks: true
+linkTitle: 8.0.20 releases
+title: Redis Enterprise for Kubernetes 8.0.20 release notes
+weight: 84
+---
+
+Redis Enterprise for Kubernetes 8.0.20-21 is a maintenance release of [Redis Enterprise for Kubernetes 8.0.18]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/">}}). The latest release is 8.0.20-21 with support for Redis Enterprise Software version 8.0.20-19.
+
+## Detailed release notes
+
+{{<table-children columnNames="Version&nbsp;(Release&nbsp;date)&nbsp;,Major changes" columnSources="LinkTitle,Description" enableLinks="LinkTitle">}}
+
+## Known limitations
+
+See the [8.0.18-11 (April 2026) release notes]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026">}}) for supported distributions and known limitations.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates release note pages and image/version strings with no code or behavior changes.
> 
> **Overview**
> Adds new Redis Enterprise for Kubernetes *8.0.20* release-note pages (`8-0-20-releases/_index.md` and `8-0-20-21-may2026.md`) documenting the 8.0.20-21 maintenance release and its download image tags.
> 
> Fixes the OpenShift **OLM operator bundle** version listed in the existing `8.0.18-14 (May 2026)` release notes (from `8.0.18-14.0` to `8.0.18-14.2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7271af792d3b22ea2ddfe7a2e96efa2c548d729f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->