### PR TITLE
K8s: document expected secrets and PEM files in pods

### DIFF
--- a/content/operate/kubernetes/7.22/security/configuration-secrets.md
+++ b/content/operate/kubernetes/7.22/security/configuration-secrets.md
@@ -100,6 +100,29 @@ kubectl create secret generic dp-internode-cert \
 
 Reference these secrets in your REC specification under `spec.certificates`. See [Internode encryption]({{< relref "/operate/kubernetes/7.22/security/internode-encryption" >}}) for complete configuration details.
 
+## Secrets and PEM files in Redis Enterprise pods
+
+Redis Enterprise pods use Kubernetes Secrets and PEM-encoded certificates and keys for cluster formation, node identity, encrypted communication, and automated recovery. Their presence is expected — not a sign of compromise.
+
+You create the Secrets. The operator references them and manages their lifecycle (for example, when you rename the credential Secret). TLS, license, and client authentication Secrets are always user-supplied.
+
+### What's mounted in the pod
+
+- Kubernetes Secret volumes at operator-managed mount paths such as:
+  - `/opt/redislabs/credentials` — cluster admin credential Secret.
+  - `/opt/redislabs/proxy` — call-home proxy credentials, when configured.
+- PEM-encoded certificates and keys for TLS, internode encryption, and proxy or database endpoints. Exact paths vary by version and component.
+
+### What the Secrets contain
+
+Field names vary by deployment.
+
+- **Cluster admin credentials** — `username` and `password` in the Secret named by `clusterCredentialSecretName`.
+- **License** — `license` field in the Secret named by `licenseSecretName`.
+- **Cluster Certificate Authority (CA)** — `ca.crt` or `ca.pem`. Validates peer certificates for mutual TLS. Optional.
+- **Service TLS certificates and keys** for API, Cluster Manager (CM), metrics exporter, proxy, syncer, and LDAP. Fields: `certificate`, `cert`, or `tls.crt`, plus `key` or `tls.key`. See [Service certificates](#service-certificates).
+- **Client authentication certificates** for databases. Set in the Redis Enterprise database (REDB) `clientAuthenticationCertificates` field.
+
 ## Best practices
 
 - Store sensitive configuration in Secrets rather than directly in YAML files.

--- a/content/operate/kubernetes/7.22/security/configuration-secrets.md
+++ b/content/operate/kubernetes/7.22/security/configuration-secrets.md
@@ -106,12 +106,12 @@ Redis Enterprise pods use Kubernetes Secrets and PEM-encoded certificates and ke
 
 You create the Secrets. The operator references them and manages their lifecycle (for example, when you rename the credential Secret). TLS, license, and client authentication Secrets are always user-supplied.
 
-### What's mounted in the pod
+### What you'll see in the pod
 
-- Kubernetes Secret volumes at operator-managed mount paths such as:
+- **Mounted Secret volumes** at operator-managed paths such as:
   - `/opt/redislabs/credentials` — cluster admin credential Secret.
   - `/opt/redislabs/proxy` — call-home proxy credentials, when configured.
-- PEM-encoded certificates and keys for TLS, internode encryption, and proxy or database endpoints. Exact paths vary by version and component.
+- **PEM-encoded certificates and keys** for TLS, internode encryption, and proxy or database endpoints. The operator applies these certificates through the cluster's REST API rather than as Secret volume mounts, and Redis Enterprise writes them to the pod filesystem. Exact paths vary by version and component.
 
 ### What the Secrets contain
 

--- a/content/operate/kubernetes/security/configuration-secrets.md
+++ b/content/operate/kubernetes/security/configuration-secrets.md
@@ -117,6 +117,29 @@ kubectl create secret generic dp-internode-cert \
 
 Reference these secrets in your REC specification under `spec.certificates`. See [Internode encryption]({{< relref "/operate/kubernetes/security/internode-encryption" >}}) for complete configuration details.
 
+## Secrets and PEM files in Redis Enterprise pods
+
+Redis Enterprise pods use Kubernetes Secrets and PEM-encoded certificates and keys for cluster formation, node identity, encrypted communication, and automated recovery. Their presence is expected — not a sign of compromise.
+
+You create the Secrets. The operator references them and manages their lifecycle (for example, when you rename the credential Secret). TLS, license, and client authentication Secrets are always user-supplied.
+
+### What's mounted in the pod
+
+- Kubernetes Secret volumes at operator-managed mount paths such as:
+  - `/opt/redislabs/credentials` — cluster admin credential Secret.
+  - `/opt/redislabs/proxy` — call-home proxy credentials, when configured.
+- PEM-encoded certificates and keys for TLS, internode encryption, and proxy or database endpoints. Exact paths vary by version and component.
+
+### What the Secrets contain
+
+Field names vary by deployment.
+
+- **Cluster admin credentials** — `username` and `password` in the Secret named by `clusterCredentialSecretName`.
+- **License** — `license` field in the Secret named by `licenseSecretName`.
+- **Cluster Certificate Authority (CA)** — `ca.crt` or `ca.pem`. Validates peer certificates for mutual TLS. Optional.
+- **Service TLS certificates and keys** for API, Cluster Manager (CM), metrics exporter, proxy, syncer, and LDAP. Fields: `certificate`, `cert`, or `tls.crt`, plus `key` or `tls.key`. See [Service certificates](#service-certificates).
+- **Client authentication certificates** for databases. Set in the Redis Enterprise database (REDB) `clientAuthenticationCertificates` field.
+
 ## Best practices
 
 - Store sensitive configuration in Secrets rather than directly in YAML files.

--- a/content/operate/kubernetes/security/configuration-secrets.md
+++ b/content/operate/kubernetes/security/configuration-secrets.md
@@ -123,12 +123,12 @@ Redis Enterprise pods use Kubernetes Secrets and PEM-encoded certificates and ke
 
 You create the Secrets. The operator references them and manages their lifecycle (for example, when you rename the credential Secret). TLS, license, and client authentication Secrets are always user-supplied.
 
-### What's mounted in the pod
+### What you'll see in the pod
 
-- Kubernetes Secret volumes at operator-managed mount paths such as:
+- **Mounted Secret volumes** at operator-managed paths such as:
   - `/opt/redislabs/credentials` — cluster admin credential Secret.
   - `/opt/redislabs/proxy` — call-home proxy credentials, when configured.
-- PEM-encoded certificates and keys for TLS, internode encryption, and proxy or database endpoints. Exact paths vary by version and component.
+- **PEM-encoded certificates and keys** for TLS, internode encryption, and proxy or database endpoints. The operator applies these certificates through the cluster's REST API rather than as Secret volume mounts, and Redis Enterprise writes them to the pod filesystem. Exact paths vary by version and component.
 
 ### What the Secrets contain
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Docs-only change that adds clarification text; no product code or configuration behavior is modified.
> 
> **Overview**
> Adds a new **"Secrets and PEM files in Redis Enterprise pods"** section to both the versioned (`/7.22/`) and unversioned Kubernetes `configuration-secrets` docs.
> 
> The new text explains that mounted Secret volumes and on-disk PEM certificates/keys are *expected* in Redis Enterprise pods, outlines common mount locations, and summarizes typical Secret fields (credentials, license, CA, service TLS, and client auth certs) and how the operator applies them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3797633856d7d1dddab83edde9905d197225a55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->