### PR TITLE
RS: Added 8.0.20 to upgrade tables

### DIFF
--- a/content/embeds/rs-upgrade-paths.md
+++ b/content/embeds/rs-upgrade-paths.md
@@ -2,7 +2,7 @@
 
 <span title="X icon">:x:</span> Not supported – You cannot upgrade directly from the current Redis Software cluster version. You must first upgrade to a supported intermediate version.
 
-| Current Redis Software cluster version | Upgrade to Redis Software 7.2.x | Upgrade to Redis Software 7.4.x |  Upgrade to Redis Software 7.8.x | Upgrade to Redis Software 7.22.x | Upgrade to Redis Software 8.0.2-8.0.10 | Upgrade to Redis Software 8.0.16-8.0.18 |
+| Current Redis Software cluster version | Upgrade to Redis Software 7.2.x | Upgrade to Redis Software 7.4.x |  Upgrade to Redis Software 7.8.x | Upgrade to Redis Software 7.22.x | Upgrade to Redis Software 8.0.2-8.0.10 | Upgrade to Redis Software 8.0.16-8.0.20 |
 |:-----------------------:|:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|:----------------:|
 | 6.0.x | <span title="Supported">&#x2705;</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> |
 | 6.2.4<br />6.2.8 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> | <span title="Not supported">:x:</span> |

--- a/content/embeds/rs-upgrade-paths.md
+++ b/content/embeds/rs-upgrade-paths.md
@@ -13,4 +13,4 @@
 | 7.8.x | – | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | 7.22.x | – | – | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
 | 8.0.2<br />8.0.6<br />8.0.10 | – | – | – | – | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
-| 8.0.16<br />8.0.18 | – | – | – | – | - | <span title="Supported">&#x2705;</span> |
+| 8.0.16<br />8.0.18<br />8.0.20 | – | – | – | – | - | <span title="Supported">&#x2705;</span> |

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
@@ -25,6 +25,7 @@ The default Redis database version differs between Redis Software releases as fo
 <a name="db-versions-table"></a>
 | Redis<br />Software | Bundled Redis<br />DB versions | Default DB version<br />(upgraded/new databases) |
 |-------|----------|-----|
+| 8.0.20 | 6.2, 7.2, 7.4, 8.0, 8.2, 8.4, 8.6 | 8.6 |
 | 8.0.18 | 6.2, 7.2, 7.4, 8.0, 8.2, 8.4, 8.6 | 8.6 |
 | 8.0.16 | 6.2, 7.2, 7.4, 8.0, 8.2, 8.4 | 8.4 |
 | 8.0.10 | 6.2, 7.2, 7.4, 8.0, 8.2, 8.4 | 8.4 |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates version compatibility tables; risk is limited to potential user confusion if the new version ranges are incorrect.
> 
> **Overview**
> Updates Redis Software upgrade documentation to include **Redis Software `8.0.20`**.
> 
> The upgrade path embed expands the `8.0.16-8.0.18` target range to `8.0.16-8.0.20` and adds `8.0.20` as a supported source version in the table.
> 
> The database upgrade guide adds a new `8.0.20` row describing bundled Redis DB versions and the default DB version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd0efe7ebe06e1a718279ca7f58fee58a5bfbad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->