### PR TITLE
K8s: change gp2 to gp3

### DIFF
--- a/content/operate/kubernetes/7.22/recommendations/persistent-volumes.md
+++ b/content/operate/kubernetes/7.22/recommendations/persistent-volumes.md
@@ -71,18 +71,18 @@ deployment, use the following command:
 
     kubectl get StorageClass
 
-Typically, AWS provides "gp2" as the Storage Class name while GKE uses "standard."
+Typically, AWS provides "gp3" as the Storage Class name while GKE uses "standard."
 Azure provides two Storage Classes: "default" using HDDs, and "managed-premium" using SSDs.
 
 Below is an example of a response to the command.
 
 |                         |                                                         |
 | ----------------------- | ------------------------------------------------------- |
-| *Name:*                 | *gp2*                                                   |
+| *Name:*                 | *gp3*                                                   |
 | *IsDefaultClass:*       | *Yes*                                                   |
 | *Annotations:*          | *storageclass.beta.kubernetes.io/is-default-class=true* |
 | *Provisioner:*          | *kubernetes.io/aws-ebs*                                 |
-| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp2*                    |
+| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp3*                    |
 | *AllowVolumeExpansion:* | *\<unset\>*                                             |
 | *MountOptions:*         | *\<none\>*                                              |
 | *ReclaimPolicy:*        | *Delete*                                                |

--- a/content/operate/kubernetes/7.4.6/recommendations/persistent-volumes.md
+++ b/content/operate/kubernetes/7.4.6/recommendations/persistent-volumes.md
@@ -71,18 +71,18 @@ deployment, use the following command:
 
     kubectl get StorageClass
 
-Typically, AWS provides "gp2" as the Storage Class name while GKE uses "standard."
+Typically, AWS provides "gp3" as the Storage Class name while GKE uses "standard."
 Azure provides two Storage Classes: "default" using HDDs, and "managed-premium" using SSDs.
 
 Below is an example of a response to the command.
 
 |                         |                                                         |
 | ----------------------- | ------------------------------------------------------- |
-| *Name:*                 | *gp2*                                                   |
+| *Name:*                 | *gp3*                                                   |
 | *IsDefaultClass:*       | *Yes*                                                   |
 | *Annotations:*          | *storageclass.beta.kubernetes.io/is-default-class=true* |
 | *Provisioner:*          | *kubernetes.io/aws-ebs*                                 |
-| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp2*                    |
+| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp3*                    |
 | *AllowVolumeExpansion:* | *\<unset\>*                                             |
 | *MountOptions:*         | *\<none\>*                                              |
 | *ReclaimPolicy:*        | *Delete*                                                |

--- a/content/operate/kubernetes/7.8.4/recommendations/persistent-volumes.md
+++ b/content/operate/kubernetes/7.8.4/recommendations/persistent-volumes.md
@@ -71,18 +71,18 @@ deployment, use the following command:
 
     kubectl get StorageClass
 
-Typically, AWS provides "gp2" as the Storage Class name while GKE uses "standard."
+Typically, AWS provides "gp3" as the Storage Class name while GKE uses "standard."
 Azure provides two Storage Classes: "default" using HDDs, and "managed-premium" using SSDs.
 
 Below is an example of a response to the command.
 
 |                         |                                                         |
 | ----------------------- | ------------------------------------------------------- |
-| *Name:*                 | *gp2*                                                   |
+| *Name:*                 | *gp3*                                                   |
 | *IsDefaultClass:*       | *Yes*                                                   |
 | *Annotations:*          | *storageclass.beta.kubernetes.io/is-default-class=true* |
 | *Provisioner:*          | *kubernetes.io/aws-ebs*                                 |
-| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp2*                    |
+| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp3*                    |
 | *AllowVolumeExpansion:* | *\<unset\>*                                             |
 | *MountOptions:*         | *\<none\>*                                              |
 | *ReclaimPolicy:*        | *Delete*                                                |

--- a/content/operate/kubernetes/7.8.6/recommendations/persistent-volumes.md
+++ b/content/operate/kubernetes/7.8.6/recommendations/persistent-volumes.md
@@ -71,18 +71,18 @@ deployment, use the following command:
 
     kubectl get StorageClass
 
-Typically, AWS provides "gp2" as the Storage Class name while GKE uses "standard."
+Typically, AWS provides "gp3" as the Storage Class name while GKE uses "standard."
 Azure provides two Storage Classes: "default" using HDDs, and "managed-premium" using SSDs.
 
 Below is an example of a response to the command.
 
 |                         |                                                         |
 | ----------------------- | ------------------------------------------------------- |
-| *Name:*                 | *gp2*                                                   |
+| *Name:*                 | *gp3*                                                   |
 | *IsDefaultClass:*       | *Yes*                                                   |
 | *Annotations:*          | *storageclass.beta.kubernetes.io/is-default-class=true* |
 | *Provisioner:*          | *kubernetes.io/aws-ebs*                                 |
-| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp2*                    |
+| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp3*                    |
 | *AllowVolumeExpansion:* | *\<unset\>*                                             |
 | *MountOptions:*         | *\<none\>*                                              |
 | *ReclaimPolicy:*        | *Delete*                                                |

--- a/content/operate/kubernetes/recommendations/persistent-volumes.md
+++ b/content/operate/kubernetes/recommendations/persistent-volumes.md
@@ -70,18 +70,18 @@ deployment, use the following command:
 
     kubectl get StorageClass
 
-Typically, AWS provides "gp2" as the Storage Class name while GKE uses "standard."
+Typically, AWS provides "gp3" as the Storage Class name while GKE uses "standard."
 Azure provides two Storage Classes: "default" using HDDs, and "managed-premium" using SSDs.
 
 Below is an example of a response to the command.
 
 |                         |                                                         |
 | ----------------------- | ------------------------------------------------------- |
-| *Name:*                 | *gp2*                                                   |
+| *Name:*                 | *gp3*                                                   |
 | *IsDefaultClass:*       | *Yes*                                                   |
 | *Annotations:*          | *storageclass.beta.kubernetes.io/is-default-class=true* |
 | *Provisioner:*          | *kubernetes.io/aws-ebs*                                 |
-| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp2*                    |
+| *Parameters:*           | *encrypted=false,kmsKeyId=,type=gp3*                    |
 | *AllowVolumeExpansion:* | *\<unset\>*                                             |
 | *MountOptions:*         | *\<none\>*                                              |
 | *ReclaimPolicy:*        | *Delete*                                                |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change updating the referenced AWS StorageClass name and example parameters; no runtime or configuration code is modified.
> 
> **Overview**
> Updates Kubernetes persistent volume documentation to reference AWS EBS `gp3` (instead of `gp2`) as the typical/default StorageClass name, including the sample `kubectl get StorageClass` output and parameters.
> 
> Applies the same `gp2`→`gp3` text change across the versioned docs (`7.4.6`, `7.8.4`, `7.8.6`, `7.22`) and the unversioned `persistent-volumes.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9db1cab2bf7673b98f3228a2c54ab85f2c77c0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->