### PR TITLE
fix: align Agent Memory docs with current API spec

### DIFF
--- a/content/develop/ai/context-engine/agent-memory/api-examples.md
+++ b/content/develop/ai/context-engine/agent-memory/api-examples.md
@@ -28,7 +28,7 @@ When you call the API, you need to pass the Agent Memory API key in the `Authori
 For example:
 
 ```sh
-curl -s -X GET "https://$HOST/v1/caches/$STORE_ID/session-memory/" \
+curl -s -X GET "https://$HOST/v1/stores/$STORE_ID/session-memory" \
     -H "accept: application/json" \
     -H "Authorization: Bearer $API_KEY" 
 ```
@@ -36,17 +36,17 @@ curl -s -X GET "https://$HOST/v1/caches/$STORE_ID/session-memory/" \
 This example expects several variables to be set in the shell:
 
 - **$HOST** - the Agent Memory API endpoint
-- **$STORE_ID** - the Store ID ID of your cache
+- **$STORE_ID** - the Store ID of your Agent Memory service
 - **$API_KEY** - The Agent Memory API token
 
 ## Examples
 
 ### Add session event
 
-Use [`POST /v1/stores/{storeId}/session-memory`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/session-memory/operation/AddSessionEvent" >}}) to add an event to a session in short-term memory. If a session doesn't exist yet, it will be created.
+Use [`POST /v1/stores/{storeId}/session-memory/events`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/session-memory/operation/AddSessionEvent" >}}) to add an event to a session in short-term memory. If a session doesn't exist yet, it will be created.
 
 ```json
-POST /v1/stores/{storeId}/session-memory
+POST /v1/stores/{storeId}/session-memory/events
 {
     "sessionId": "abcd-efgh",
     "actorId": "user-name",
@@ -56,7 +56,7 @@ POST /v1/stores/{storeId}/session-memory
             "text": "I'm planning a trip to Japan next month."
         }
     ],
-    "createdAt": 1778076906498,
+    "createdAt": "2026-05-02T18:15:06Z",
     "metadata": {
         "browser": "Chrome",
         "source": "web-chat"
@@ -120,8 +120,9 @@ In the `filter` object of the request body, you can filter the search by any of 
 | `sessionId` | string | The session ID the memory comes from. | `eq`, `ne`, `in`, `all` |
 | `ownerId` | string | The owner ID of the memory. | `eq`, `ne`, `in`, `all` |
 | `namespace` | string | The namespace of the memory. | `eq`, `ne`, `in`, `all` |
-| `namespace` | string | The topics of the memory. | `eq`, `ne`, `in`, `all` |
-| `createdAt` | integer | The timestamp when the memory was created. | `eq`, `gt`, `lt`, `gte`, `lte` |
+| `topics` | string | The topics of the memory. | `eq`, `ne`, `in`, `all` |
+| `memoryType` | string | The type of memory (`semantic`, `episodic`, `message`). | `eq`, `ne`, `in`, `all` |
+| `createdAt` | string (ISO 8601) | The timestamp when the memory was created. | `eq`, `gt`, `lt`, `gte`, `lte` |
 
 For all values, you must set only one of these operators:
 

--- a/content/operate/rc/context-engine/agent-memory/create-service.md
+++ b/content/operate/rc/context-engine/agent-memory/create-service.md
@@ -81,7 +81,7 @@ The **Memory configuration** section allows you to define the time-to-live (TTL)
 | Setting name          |Description|
 |:----------------------|:----------|
 | **Short-term TTL** | Defines the time-to-live (TTL) of your agent's **short-term memory** (also known as **session memory**). You can define this TTL in seconds, minutes, hours, or days. Default: 1 hour |
-| **Long-term TTL** | Select the Redis Cloud database to use for this service from the list. You can define this TTL in seconds, minutes, hours, or days. Default: 365 days |
+| **Long-term TTL** | Defines the time-to-live (TTL) of your agent's **long-term memory**. You can define this TTL in seconds, minutes, hours, or days. Default: 365 days |
 
 ### Create service
 


### PR DESCRIPTION
## Summary

Fixes 8 inconsistencies between the hand-written Agent Memory documentation pages and the current [OpenAPI spec](https://github.com/redis/docs/blob/DOC-6447/content/develop/ai/context-engine/agent-memory/api-reference/openapi-agent-memory.json) (verified against the Smithy-generated spec from [langcache main `fd8b6c2b`](https://github.com/redislabsdev/langcache/commit/fd8b6c2b)).

### Fixes in `api-examples.md`

| # | Issue | Severity |
|---|-------|----------|
| 1 | Curl example uses `/v1/caches/` instead of `/v1/stores/` | **High** — broken example |
| 2 | Store ID variable description has typo ("Store ID ID of your cache") | Low |
| 3 | AddSessionEvent endpoint missing `/events` (`/session-memory` -> `/session-memory/events`) | **High** — wrong endpoint |
| 4 | `createdAt` uses Unix ms (`1778076906498`) instead of ISO 8601 (`"2026-05-02T18:15:06Z"`) per [MOD-15623](https://redislabs.atlassian.net/browse/MOD-15623) | **High** — API will reject |
| 5 | Filter table has duplicate `namespace` row; second should be `topics` | Medium |
| 6 | Filter table missing `memoryType` filter | Medium |
| 7 | `createdAt` filter data type listed as `integer` instead of `string (ISO 8601)` | Medium |

### Fixes in `create-service.md`

| # | Issue | Severity |
|---|-------|----------|
| 8 | Long-term TTL description is copy-pasted from the database selector field | Medium |

## Test plan

- [ ] Verify the staging links render correctly after merge into DOC-6447
- [ ] Cross-reference all API examples against the OpenAPI spec

Made with [Cursor](https://cursor.com)

[MOD-15623]: https://redislabs.atlassian.net/browse/MOD-15623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only updates, but they correct previously broken endpoints and payload formats that could mislead users if incorrect.
> 
> **Overview**
> Aligns `api-examples.md` with the current Agent Memory API by fixing the base path (`/v1/stores`), correcting the session event endpoint to `/session-memory/events`, updating `createdAt` examples/filters to ISO-8601 strings, and fixing/expanding the long-term memory search filter table (adds `topics` and `memoryType`, removes duplicate row).
> 
> Clarifies `create-service.md` by correcting the **Long-term TTL** description to describe long-term memory retention rather than unrelated database selection text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32e3ab79b3a80632c88f709e575a5d393d8fe01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->