### PR TITLE
DEV: update data/commands_*.json from GA build

### DIFF
--- a/data/commands.json
+++ b/data/commands.json
@@ -402,6 +402,1122 @@
             "fast"
         ]
     },
+    "ARCOUNT": {
+        "summary": "Returns the number of non-empty elements in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
+        ]
+    },
+    "ARDEL": {
+        "summary": "Deletes elements at the specified indices in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of indices to delete",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@fast"
+        ],
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "delete": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "display_text": "index",
+                "multiple": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
+        ]
+    },
+    "ARDELRANGE": {
+        "summary": "Deletes elements in one or more ranges.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "Proportional to the number of existing elements / slices touched, not to the numeric span of the requested ranges",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@slow"
+        ],
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "delete": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "range",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "start",
+                        "type": "integer",
+                        "display_text": "start"
+                    },
+                    {
+                        "name": "end",
+                        "type": "integer",
+                        "display_text": "end"
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "write"
+        ]
+    },
+    "ARGET": {
+        "summary": "Gets the value at an index in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
+        "arity": 3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "display_text": "index"
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
+        ]
+    },
+    "ARGETRANGE": {
+        "summary": "Gets values in a range of indices.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the range length",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": 4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer",
+                "display_text": "start"
+            },
+            {
+                "name": "end",
+                "type": "integer",
+                "display_text": "end"
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARGREP": {
+        "summary": "Searches array elements in a range using textual predicates.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(P * C) where P is the number of visited positions in touched slices and C is the cost of evaluating the predicates on one existing element.",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -6,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "string",
+                "display_text": "start"
+            },
+            {
+                "name": "end",
+                "type": "string",
+                "display_text": "end"
+            },
+            {
+                "name": "predicate",
+                "type": "oneof",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "exact",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "exact",
+                                "type": "pure-token",
+                                "display_text": "exact",
+                                "token": "EXACT"
+                            },
+                            {
+                                "name": "string",
+                                "type": "string",
+                                "display_text": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "match",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "match",
+                                "type": "pure-token",
+                                "display_text": "match",
+                                "token": "MATCH"
+                            },
+                            {
+                                "name": "string",
+                                "type": "string",
+                                "display_text": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "glob",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "glob",
+                                "type": "pure-token",
+                                "display_text": "glob",
+                                "token": "GLOB"
+                            },
+                            {
+                                "name": "pattern",
+                                "type": "string",
+                                "display_text": "pattern"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "re",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "re",
+                                "type": "pure-token",
+                                "display_text": "re",
+                                "token": "RE"
+                            },
+                            {
+                                "name": "pattern",
+                                "type": "string",
+                                "display_text": "pattern"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "options",
+                "type": "oneof",
+                "optional": true,
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "and",
+                        "type": "pure-token",
+                        "display_text": "and",
+                        "token": "AND"
+                    },
+                    {
+                        "name": "or",
+                        "type": "pure-token",
+                        "display_text": "or",
+                        "token": "OR"
+                    },
+                    {
+                        "name": "limit",
+                        "type": "integer",
+                        "display_text": "limit",
+                        "token": "LIMIT"
+                    },
+                    {
+                        "name": "withvalues",
+                        "type": "pure-token",
+                        "display_text": "withvalues",
+                        "token": "WITHVALUES"
+                    },
+                    {
+                        "name": "nocase",
+                        "type": "pure-token",
+                        "display_text": "nocase",
+                        "token": "NOCASE"
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARINFO": {
+        "summary": "Returns metadata about an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1), or O(N) with FULL option where N is the number of slices.",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "full",
+                "type": "pure-token",
+                "display_text": "full",
+                "token": "FULL",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARINSERT": {
+        "summary": "Inserts one or more values at consecutive indices.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of values",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@fast"
+        ],
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "display_text": "value",
+                "multiple": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
+    "ARLASTITEMS": {
+        "summary": "Returns the most recently inserted elements.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the count",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "display_text": "count"
+            },
+            {
+                "name": "rev",
+                "type": "pure-token",
+                "display_text": "rev",
+                "token": "REV",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARLEN": {
+        "summary": "Returns the length of an array (max index + 1).",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
+        ]
+    },
+    "ARMGET": {
+        "summary": "Gets values at multiple indices in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of indices",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "display_text": "index",
+                "multiple": true
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
+        ]
+    },
+    "ARMSET": {
+        "summary": "Sets multiple index-value pairs in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of pairs",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@fast"
+        ],
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "index",
+                        "type": "integer",
+                        "display_text": "index"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string",
+                        "display_text": "value"
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
+    "ARNEXT": {
+        "summary": "Returns the next index ARINSERT would use.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
+        ]
+    },
+    "AROP": {
+        "summary": "Performs aggregate operations on array elements in a range.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -5,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer",
+                "display_text": "start"
+            },
+            {
+                "name": "end",
+                "type": "integer",
+                "display_text": "end"
+            },
+            {
+                "name": "operation",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "display_text": "sum",
+                        "token": "SUM"
+                    },
+                    {
+                        "name": "min",
+                        "type": "pure-token",
+                        "display_text": "min",
+                        "token": "MIN"
+                    },
+                    {
+                        "name": "max",
+                        "type": "pure-token",
+                        "display_text": "max",
+                        "token": "MAX"
+                    },
+                    {
+                        "name": "and",
+                        "type": "pure-token",
+                        "display_text": "and",
+                        "token": "AND"
+                    },
+                    {
+                        "name": "or",
+                        "type": "pure-token",
+                        "display_text": "or",
+                        "token": "OR"
+                    },
+                    {
+                        "name": "xor",
+                        "type": "pure-token",
+                        "display_text": "xor",
+                        "token": "XOR"
+                    },
+                    {
+                        "name": "match",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "match",
+                                "type": "pure-token",
+                                "display_text": "match",
+                                "token": "MATCH"
+                            },
+                            {
+                                "name": "value",
+                                "type": "string",
+                                "display_text": "value"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "used",
+                        "type": "pure-token",
+                        "display_text": "used",
+                        "token": "USED"
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARRING": {
+        "summary": "Inserts values into a ring buffer of specified size, wrapping and truncating as needed.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(M) normally, O(N+M) on ring resize, where N is the maximum of the old and new ring size and M is the number of inserted values",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@slow"
+        ],
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "size",
+                "type": "integer",
+                "display_text": "size"
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "display_text": "value",
+                "multiple": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom"
+        ]
+    },
+    "ARSCAN": {
+        "summary": "Iterates existing elements in a range, returning index-value pairs.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer",
+                "display_text": "start"
+            },
+            {
+                "name": "end",
+                "type": "integer",
+                "display_text": "end"
+            },
+            {
+                "name": "limit",
+                "type": "integer",
+                "display_text": "limit",
+                "token": "LIMIT",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARSEEK": {
+        "summary": "Sets the ARINSERT / ARRING cursor to a specific index.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@fast"
+        ],
+        "arity": 3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "display_text": "index"
+            }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
+        ]
+    },
+    "ARSET": {
+        "summary": "Sets one or more contiguous values starting at an index in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of values",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@fast"
+        ],
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "display_text": "index"
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "display_text": "value",
+                "multiple": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
     "ASKING": {
         "summary": "Signals that a cluster client is following an -ASK redirect.",
         "since": "3.0.0",
@@ -886,6 +2002,30 @@
                         "type": "pure-token",
                         "display_text": "not",
                         "token": "NOT"
+                    },
+                    {
+                        "name": "diff",
+                        "type": "pure-token",
+                        "display_text": "diff",
+                        "token": "DIFF"
+                    },
+                    {
+                        "name": "diff1",
+                        "type": "pure-token",
+                        "display_text": "diff1",
+                        "token": "DIFF1"
+                    },
+                    {
+                        "name": "andor",
+                        "type": "pure-token",
+                        "display_text": "andor",
+                        "token": "ANDOR"
+                    },
+                    {
+                        "name": "one",
+                        "type": "pure-token",
+                        "display_text": "one",
+                        "token": "ONE"
                     }
                 ]
             },
@@ -1760,7 +2900,7 @@
                 "`LADDR` option."
             ],
             [
-                "8.0.0",
+                "7.4.0",
                 "`MAXAGE` option."
             ]
         ],
@@ -1883,7 +3023,7 @@
                                 "type": "integer",
                                 "display_text": "maxage",
                                 "token": "MAXAGE",
-                                "since": "8.0.0",
+                                "since": "7.4.0",
                                 "optional": true
                             }
                         ]
@@ -1927,6 +3067,18 @@
             [
                 "7.0.3",
                 "Added `ssub` field."
+            ],
+            [
+                "7.2.0",
+                "Added `lib-name` and `lib-ver` fields."
+            ],
+            [
+                "7.4.0",
+                "Added `watch` field."
+            ],
+            [
+                "8.0.0",
+                "Added `io-thread` field."
             ]
         ],
         "acl_categories": [
@@ -2497,6 +3649,7 @@
         ],
         "command_flags": [
             "admin",
+            "loading",
             "stale"
         ],
         "hints": [
@@ -2715,6 +3868,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -2738,6 +3892,7 @@
             }
         ],
         "command_flags": [
+            "loading",
             "stale"
         ]
     },
@@ -2751,6 +3906,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -2799,6 +3955,89 @@
             "no_async_loading"
         ]
     },
+    "CLUSTER MIGRATION": {
+        "summary": "Start, monitor and cancel slot migration.",
+        "since": "8.4.0",
+        "group": "cluster",
+        "complexity": "O(N) where N is the total number of the slots between the start slot and end slot arguments.",
+        "acl_categories": [
+            "@admin",
+            "@slow",
+            "@dangerous"
+        ],
+        "arity": -4,
+        "arguments": [
+            {
+                "name": "subcommand",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "import",
+                        "type": "block",
+                        "token": "IMPORT",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "start-slot",
+                                "type": "integer",
+                                "display_text": "start-slot"
+                            },
+                            {
+                                "name": "end-slot",
+                                "type": "integer",
+                                "display_text": "end-slot"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "cancel",
+                        "type": "oneof",
+                        "token": "CANCEL",
+                        "arguments": [
+                            {
+                                "name": "task-id",
+                                "type": "string",
+                                "display_text": "task-id",
+                                "token": "ID"
+                            },
+                            {
+                                "name": "all",
+                                "type": "pure-token",
+                                "display_text": "all",
+                                "token": "ALL"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "status",
+                        "type": "oneof",
+                        "token": "STATUS",
+                        "arguments": [
+                            {
+                                "name": "task-id",
+                                "type": "string",
+                                "display_text": "task-id",
+                                "token": "ID",
+                                "optional": true
+                            },
+                            {
+                                "name": "all",
+                                "type": "pure-token",
+                                "display_text": "all",
+                                "token": "ALL",
+                                "optional": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "admin",
+            "stale",
+            "no_async_loading"
+        ]
+    },
     "CLUSTER MYID": {
         "summary": "Returns the ID of a node.",
         "since": "3.0.0",
@@ -2809,6 +4048,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ]
     },
@@ -2822,6 +4062,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -2838,6 +4079,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -2864,6 +4106,7 @@
         ],
         "command_flags": [
             "admin",
+            "loading",
             "stale"
         ],
         "hints": [
@@ -3066,6 +4309,7 @@
         ],
         "command_flags": [
             "admin",
+            "loading",
             "stale"
         ],
         "doc_flags": [
@@ -3073,6 +4317,87 @@
         ],
         "hints": [
             "nondeterministic_output"
+        ]
+    },
+    "CLUSTER SLOT-STATS": {
+        "summary": "Return an array of slot usage statistics for slots assigned to the current node.",
+        "since": "8.2.0",
+        "group": "cluster",
+        "complexity": "O(N) where N is the total number of slots based on arguments. O(N*log(N)) with ORDERBY subcommand.",
+        "acl_categories": [
+            "@slow"
+        ],
+        "arity": -4,
+        "arguments": [
+            {
+                "name": "filter",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "slotsrange",
+                        "type": "block",
+                        "token": "SLOTSRANGE",
+                        "arguments": [
+                            {
+                                "name": "start-slot",
+                                "type": "integer",
+                                "display_text": "start-slot"
+                            },
+                            {
+                                "name": "end-slot",
+                                "type": "integer",
+                                "display_text": "end-slot"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "orderby",
+                        "type": "block",
+                        "token": "ORDERBY",
+                        "arguments": [
+                            {
+                                "name": "metric",
+                                "type": "string",
+                                "display_text": "metric"
+                            },
+                            {
+                                "name": "limit",
+                                "type": "integer",
+                                "display_text": "limit",
+                                "token": "LIMIT",
+                                "optional": true
+                            },
+                            {
+                                "name": "order",
+                                "type": "oneof",
+                                "optional": true,
+                                "arguments": [
+                                    {
+                                        "name": "asc",
+                                        "type": "pure-token",
+                                        "display_text": "asc",
+                                        "token": "ASC"
+                                    },
+                                    {
+                                        "name": "desc",
+                                        "type": "pure-token",
+                                        "display_text": "desc",
+                                        "token": "DESC"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "loading",
+            "stale"
+        ],
+        "hints": [
+            "nondeterministic_output",
+            "request_policy:all_shards"
         ]
     },
     "CLUSTER SLOTS": {
@@ -3102,6 +4427,123 @@
         ],
         "doc_flags": [
             "deprecated"
+        ],
+        "hints": [
+            "nondeterministic_output"
+        ]
+    },
+    "CLUSTER SYNCSLOTS": {
+        "summary": "Internal command for atomic slot migration protocol between cluster nodes.",
+        "since": "8.4.0",
+        "group": "cluster",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@admin",
+            "@slow",
+            "@dangerous"
+        ],
+        "arity": -3,
+        "arguments": [
+            {
+                "name": "subcommand",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "sync",
+                        "type": "block",
+                        "token": "SYNC",
+                        "arguments": [
+                            {
+                                "name": "task-id",
+                                "type": "string",
+                                "display_text": "task-id"
+                            },
+                            {
+                                "name": "slot-range",
+                                "type": "block",
+                                "multiple": true,
+                                "arguments": [
+                                    {
+                                        "name": "start-slot",
+                                        "type": "integer",
+                                        "display_text": "start-slot"
+                                    },
+                                    {
+                                        "name": "end-slot",
+                                        "type": "integer",
+                                        "display_text": "end-slot"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "name": "task-id",
+                        "type": "string",
+                        "display_text": "task-id",
+                        "token": "RDBCHANNEL"
+                    },
+                    {
+                        "name": "snapshot-eof",
+                        "type": "pure-token",
+                        "display_text": "snapshot-eof",
+                        "token": "SNAPSHOT-EOF"
+                    },
+                    {
+                        "name": "stream-eof",
+                        "type": "pure-token",
+                        "display_text": "stream-eof",
+                        "token": "STREAM-EOF"
+                    },
+                    {
+                        "name": "ack",
+                        "type": "block",
+                        "token": "ACK",
+                        "arguments": [
+                            {
+                                "name": "state",
+                                "type": "string",
+                                "display_text": "state"
+                            },
+                            {
+                                "name": "offset",
+                                "type": "integer",
+                                "display_text": "offset"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "error",
+                        "type": "string",
+                        "display_text": "error",
+                        "token": "FAIL"
+                    },
+                    {
+                        "name": "conf",
+                        "type": "block",
+                        "token": "CONF",
+                        "arguments": [
+                            {
+                                "name": "option",
+                                "type": "string",
+                                "display_text": "option",
+                                "multiple": true
+                            },
+                            {
+                                "name": "value",
+                                "type": "string",
+                                "display_text": "value",
+                                "multiple": true
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "admin",
+            "stale",
+            "no_async_loading"
         ],
         "hints": [
             "nondeterministic_output"
@@ -3732,6 +5174,126 @@
         "hints": [
             "request_policy:multi_shard",
             "response_policy:agg_sum"
+        ]
+    },
+    "DELEX": {
+        "summary": "Conditionally removes the specified key based on value or digest comparison.",
+        "since": "8.4.0",
+        "group": "string",
+        "complexity": "O(1) for IFEQ/IFNE, O(N) for IFDEQ/IFDNE where N is the length of the string value.",
+        "acl_categories": [
+            "@write",
+            "@string",
+            "@fast"
+        ],
+        "arity": -2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "delete": true,
+                "variable_flags": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "ifeq-value",
+                        "type": "string",
+                        "display_text": "ifeq-value",
+                        "token": "IFEQ"
+                    },
+                    {
+                        "name": "ifne-value",
+                        "type": "string",
+                        "display_text": "ifne-value",
+                        "token": "IFNE"
+                    },
+                    {
+                        "name": "ifdeq-digest",
+                        "type": "integer",
+                        "display_text": "ifdeq-digest",
+                        "token": "IFDEQ"
+                    },
+                    {
+                        "name": "ifdne-digest",
+                        "type": "integer",
+                        "display_text": "ifdne-digest",
+                        "token": "IFDNE"
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
+        ]
+    },
+    "DIGEST": {
+        "summary": "Returns the XXH3 hash of a string value.",
+        "since": "8.4.0",
+        "group": "string",
+        "complexity": "O(N) where N is the length of the string value.",
+        "acl_categories": [
+            "@read",
+            "@string",
+            "@fast"
+        ],
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
         ]
     },
     "DISCARD": {
@@ -6968,15 +8530,15 @@
     },
     "HEXPIRE": {
         "summary": "Set expiry for hash field using relative time to expire (seconds)",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@write",
             "@hash",
             "@fast"
         ],
-        "arity": -5,
+        "arity": -6,
         "key_specs": [
             {
                 "begin_search": {
@@ -7041,34 +8603,40 @@
                 ]
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
             "write",
-            "denyoom",
             "fast"
         ]
     },
     "HEXPIREAT": {
         "summary": "Set expiry for hash field using an absolute Unix timestamp (seconds)",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@write",
             "@hash",
             "@fast"
         ],
-        "arity": -5,
+        "arity": -6,
         "key_specs": [
             {
                 "begin_search": {
@@ -7133,34 +8701,40 @@
                 ]
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
             "write",
-            "denyoom",
             "fast"
         ]
     },
     "HEXPIRETIME": {
         "summary": "Returns the expiration time of a hash field as a Unix timestamp, in seconds.",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@read",
             "@hash",
             "@fast"
         ],
-        "arity": -4,
+        "arity": -5,
         "key_specs": [
             {
                 "begin_search": {
@@ -7189,15 +8763,22 @@
                 "key_spec_index": 0
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
@@ -7300,11 +8881,11 @@
             "nondeterministic_output_order"
         ]
     },
-    "HGETF": {
-        "summary": "For each specified field, returns its value and optionally set the field's remaining expiration time in seconds / milliseconds",
+    "HGETDEL": {
+        "summary": "Returns the value of a field and deletes it from the hash.",
         "since": "8.0.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@write",
             "@hash",
@@ -7328,7 +8909,8 @@
                     }
                 },
                 "RW": true,
-                "update": true
+                "access": true,
+                "delete": true
             }
         ],
         "arguments": [
@@ -7339,35 +8921,68 @@
                 "key_spec_index": 0
             },
             {
-                "name": "condition",
-                "type": "oneof",
-                "optional": true,
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
                 "arguments": [
                     {
-                        "name": "nx",
-                        "type": "pure-token",
-                        "display_text": "nx",
-                        "token": "NX"
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
                     },
                     {
-                        "name": "xx",
-                        "type": "pure-token",
-                        "display_text": "xx",
-                        "token": "XX"
-                    },
-                    {
-                        "name": "gt",
-                        "type": "pure-token",
-                        "display_text": "gt",
-                        "token": "GT"
-                    },
-                    {
-                        "name": "lt",
-                        "type": "pure-token",
-                        "display_text": "lt",
-                        "token": "LT"
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
                     }
                 ]
+            }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
+        ]
+    },
+    "HGETEX": {
+        "summary": "Get the value of one or more fields of a given hash key, and optionally set their expiration.",
+        "since": "8.0.0",
+        "group": "hash",
+        "complexity": "O(N) where N is the number of specified fields",
+        "acl_categories": [
+            "@write",
+            "@hash",
+            "@fast"
+        ],
+        "arity": -5,
+        "key_specs": [
+            {
+                "notes": "RW and UPDATE because it changes the TTL",
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
             },
             {
                 "name": "expiration",
@@ -7408,24 +9023,25 @@
             },
             {
                 "name": "fields",
-                "type": "string",
-                "display_text": "fields"
-            },
-            {
-                "name": "count",
-                "type": "integer",
-                "display_text": "count"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
             "write",
-            "denyoom",
             "fast"
         ]
     },
@@ -7747,17 +9363,187 @@
             "deprecated"
         ]
     },
+    "HOTKEYS": {
+        "summary": "A container for hotkeys tracking commands.",
+        "since": "8.6.0",
+        "group": "server",
+        "complexity": "Depends on subcommand.",
+        "acl_categories": [
+            "@slow"
+        ],
+        "arity": -2
+    },
+    "HOTKEYS GET": {
+        "summary": "Returns lists of top K hotkeys depending on metrics chosen in HOTKEYS START command.",
+        "since": "8.6.0",
+        "group": "server",
+        "complexity": "O(K) where K is the number of hotkeys returned.",
+        "acl_categories": [
+            "@admin",
+            "@slow",
+            "@dangerous"
+        ],
+        "arity": 2,
+        "command_flags": [
+            "admin",
+            "noscript"
+        ],
+        "hints": [
+            "nondeterministic_output",
+            "request_policy:special",
+            "response_policy:special"
+        ]
+    },
+    "HOTKEYS HELP": {
+        "summary": "Return helpful text about HOTKEYS command parameters.",
+        "since": "8.6.1",
+        "group": "server",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@slow"
+        ],
+        "arity": 2,
+        "command_flags": [
+            "loading",
+            "stale"
+        ]
+    },
+    "HOTKEYS RESET": {
+        "summary": "Release the resources used for hotkey tracking.",
+        "since": "8.6.0",
+        "group": "server",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@admin",
+            "@slow",
+            "@dangerous"
+        ],
+        "arity": 2,
+        "command_flags": [
+            "admin",
+            "noscript"
+        ],
+        "hints": [
+            "request_policy:special"
+        ]
+    },
+    "HOTKEYS START": {
+        "summary": "Starts hotkeys tracking.",
+        "since": "8.6.0",
+        "group": "server",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@admin",
+            "@slow",
+            "@dangerous"
+        ],
+        "arity": -2,
+        "arguments": [
+            {
+                "name": "metrics",
+                "type": "block",
+                "token": "METRICS",
+                "arguments": [
+                    {
+                        "name": "count",
+                        "type": "integer",
+                        "display_text": "count"
+                    },
+                    {
+                        "name": "cpu",
+                        "type": "pure-token",
+                        "display_text": "cpu",
+                        "token": "CPU",
+                        "optional": true
+                    },
+                    {
+                        "name": "net",
+                        "type": "pure-token",
+                        "display_text": "net",
+                        "token": "NET",
+                        "optional": true
+                    }
+                ]
+            },
+            {
+                "name": "k",
+                "type": "integer",
+                "display_text": "k",
+                "token": "COUNT",
+                "optional": true
+            },
+            {
+                "name": "seconds",
+                "type": "integer",
+                "display_text": "seconds",
+                "token": "DURATION",
+                "optional": true
+            },
+            {
+                "name": "ratio",
+                "type": "integer",
+                "display_text": "ratio",
+                "token": "SAMPLE",
+                "optional": true
+            },
+            {
+                "name": "slots",
+                "type": "block",
+                "token": "SLOTS",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "count",
+                        "type": "integer",
+                        "display_text": "count"
+                    },
+                    {
+                        "name": "slot",
+                        "type": "integer",
+                        "display_text": "slot",
+                        "multiple": true
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "admin",
+            "noscript"
+        ],
+        "hints": [
+            "request_policy:special"
+        ]
+    },
+    "HOTKEYS STOP": {
+        "summary": "Stops hotkeys tracking.",
+        "since": "8.6.0",
+        "group": "server",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@admin",
+            "@slow",
+            "@dangerous"
+        ],
+        "arity": 2,
+        "command_flags": [
+            "admin",
+            "noscript"
+        ],
+        "hints": [
+            "request_policy:special"
+        ]
+    },
     "HPERSIST": {
         "summary": "Removes the expiration time for each specified field",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
-            "@read",
+            "@write",
             "@hash",
             "@fast"
         ],
-        "arity": -4,
+        "arity": -5,
         "key_specs": [
             {
                 "begin_search": {
@@ -7774,8 +9560,8 @@
                         "limit": 0
                     }
                 },
-                "RO": true,
-                "access": true
+                "RW": true,
+                "update": true
             }
         ],
         "arguments": [
@@ -7786,33 +9572,40 @@
                 "key_spec_index": 0
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
-            "readonly",
+            "write",
             "fast"
         ]
     },
     "HPEXPIRE": {
         "summary": "Set expiry for hash field using relative time to expire (milliseconds)",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@write",
             "@hash",
             "@fast"
         ],
-        "arity": -5,
+        "arity": -6,
         "key_specs": [
             {
                 "begin_search": {
@@ -7877,34 +9670,40 @@
                 ]
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
             "write",
-            "denyoom",
             "fast"
         ]
     },
     "HPEXPIREAT": {
         "summary": "Set expiry for hash field using an absolute Unix timestamp (milliseconds)",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@write",
             "@hash",
             "@fast"
         ],
-        "arity": -5,
+        "arity": -6,
         "key_specs": [
             {
                 "begin_search": {
@@ -7969,34 +9768,40 @@
                 ]
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
             "write",
-            "denyoom",
             "fast"
         ]
     },
     "HPEXPIRETIME": {
         "summary": "Returns the expiration time of a hash field as a Unix timestamp, in msec.",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@read",
             "@hash",
             "@fast"
         ],
-        "arity": -4,
+        "arity": -5,
         "key_specs": [
             {
                 "begin_search": {
@@ -8025,15 +9830,22 @@
                 "key_spec_index": 0
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
@@ -8043,15 +9855,15 @@
     },
     "HPTTL": {
         "summary": "Returns the TTL in milliseconds of a hash field.",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@read",
             "@hash",
             "@fast"
         ],
-        "arity": -4,
+        "arity": -5,
         "key_specs": [
             {
                 "begin_search": {
@@ -8080,20 +9892,30 @@
                 "key_spec_index": 0
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
             "readonly",
             "fast"
+        ],
+        "hints": [
+            "nondeterministic_output"
         ]
     },
     "HRANDFIELD": {
@@ -8301,11 +10123,11 @@
             "fast"
         ]
     },
-    "HSETF": {
-        "summary": "For each specified field, returns its value and optionally set the field's remaining expiration time in seconds / milliseconds",
+    "HSETEX": {
+        "summary": "Set the value of one or more fields of a given hash key, and optionally set their expiration.",
         "since": "8.0.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of fields being set.",
         "acl_categories": [
             "@write",
             "@hash",
@@ -8340,78 +10162,21 @@
                 "key_spec_index": 0
             },
             {
-                "name": "create key option",
-                "type": "pure-token",
-                "display_text": "create key option",
-                "token": "DC",
-                "optional": true
-            },
-            {
-                "name": "create option",
-                "type": "oneof",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "dcf",
-                        "type": "pure-token",
-                        "display_text": "dcf",
-                        "token": "DCF"
-                    },
-                    {
-                        "name": "dof",
-                        "type": "pure-token",
-                        "display_text": "dof",
-                        "token": "DOF"
-                    }
-                ]
-            },
-            {
-                "name": "return option",
-                "type": "oneof",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "getnew",
-                        "type": "pure-token",
-                        "display_text": "getnew",
-                        "token": "GETNEW"
-                    },
-                    {
-                        "name": "getold",
-                        "type": "pure-token",
-                        "display_text": "getold",
-                        "token": "GETOLD"
-                    }
-                ]
-            },
-            {
                 "name": "condition",
                 "type": "oneof",
                 "optional": true,
                 "arguments": [
                     {
-                        "name": "nx",
+                        "name": "fnx",
                         "type": "pure-token",
-                        "display_text": "nx",
-                        "token": "NX"
+                        "display_text": "fnx",
+                        "token": "FNX"
                     },
                     {
-                        "name": "xx",
+                        "name": "fxx",
                         "type": "pure-token",
-                        "display_text": "xx",
-                        "token": "XX"
-                    },
-                    {
-                        "name": "gt",
-                        "type": "pure-token",
-                        "display_text": "gt",
-                        "token": "GT"
-                    },
-                    {
-                        "name": "lt",
-                        "type": "pure-token",
-                        "display_text": "lt",
-                        "token": "LT"
+                        "display_text": "fxx",
+                        "token": "FXX"
                     }
                 ]
             },
@@ -8453,29 +10218,31 @@
                 ]
             },
             {
-                "name": "fvs",
-                "type": "string",
-                "display_text": "fvs"
-            },
-            {
-                "name": "count",
-                "type": "integer",
-                "display_text": "count"
-            },
-            {
-                "name": "data",
+                "name": "fields",
                 "type": "block",
-                "multiple": true,
+                "token": "FIELDS",
                 "arguments": [
                     {
-                        "name": "field",
-                        "type": "string",
-                        "display_text": "field"
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
                     },
                     {
-                        "name": "value",
-                        "type": "string",
-                        "display_text": "value"
+                        "name": "data",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "field",
+                                "type": "string",
+                                "display_text": "field"
+                            },
+                            {
+                                "name": "value",
+                                "type": "string",
+                                "display_text": "value"
+                            }
+                        ]
                     }
                 ]
             }
@@ -8591,15 +10358,15 @@
     },
     "HTTL": {
         "summary": "Returns the TTL in seconds of a hash field.",
-        "since": "8.0.0",
+        "since": "7.4.0",
         "group": "hash",
-        "complexity": "O(N) where N is the number of arguments to the command",
+        "complexity": "O(N) where N is the number of specified fields",
         "acl_categories": [
             "@read",
             "@hash",
             "@fast"
         ],
-        "arity": -4,
+        "arity": -5,
         "key_specs": [
             {
                 "begin_search": {
@@ -8628,20 +10395,30 @@
                 "key_spec_index": 0
             },
             {
-                "name": "numfields",
-                "type": "integer",
-                "display_text": "numfields"
-            },
-            {
-                "name": "field",
-                "type": "string",
-                "display_text": "field",
-                "multiple": true
+                "name": "fields",
+                "type": "block",
+                "token": "FIELDS",
+                "arguments": [
+                    {
+                        "name": "numfields",
+                        "type": "integer",
+                        "display_text": "numfields"
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "display_text": "field",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
             "readonly",
             "fast"
+        ],
+        "hints": [
+            "nondeterministic_output"
         ]
     },
     "HVALS": {
@@ -8830,6 +10607,159 @@
                 "name": "increment",
                 "type": "double",
                 "display_text": "increment"
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
+    "INCREX": {
+        "summary": "Increments the numeric value of a key by a number and sets its expiration time. Uses 0 as initial value if the key doesn't exist.",
+        "since": "8.8.0",
+        "group": "string",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@write",
+            "@string",
+            "@fast"
+        ],
+        "arity": -2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "increment",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "float",
+                        "type": "double",
+                        "display_text": "float",
+                        "token": "BYFLOAT"
+                    },
+                    {
+                        "name": "integer",
+                        "type": "integer",
+                        "display_text": "integer",
+                        "token": "BYINT"
+                    }
+                ]
+            },
+            {
+                "name": "overflow-block",
+                "type": "oneof",
+                "token": "OVERFLOW",
+                "summary": "Out-of-bounds policy; defaults to FAIL. Missing LBOUND/UBOUND default to the type limits (LLONG_MIN/LLONG_MAX for BYINT, -LDBL_MAX/LDBL_MAX for BYFLOAT).",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "fail",
+                        "type": "pure-token",
+                        "display_text": "fail",
+                        "token": "FAIL"
+                    },
+                    {
+                        "name": "sat",
+                        "type": "pure-token",
+                        "display_text": "sat",
+                        "token": "SAT"
+                    },
+                    {
+                        "name": "reject",
+                        "type": "pure-token",
+                        "display_text": "reject",
+                        "token": "REJECT"
+                    }
+                ]
+            },
+            {
+                "name": "lowerbound",
+                "type": "string",
+                "display_text": "lowerbound",
+                "token": "LBOUND",
+                "summary": "Integer when used with BYINT, floating-point when used with BYFLOAT.",
+                "optional": true
+            },
+            {
+                "name": "upperbound",
+                "type": "string",
+                "display_text": "upperbound",
+                "token": "UBOUND",
+                "summary": "Integer when used with BYINT, floating-point when used with BYFLOAT.",
+                "optional": true
+            },
+            {
+                "name": "expiration",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "seconds",
+                        "type": "integer",
+                        "display_text": "seconds",
+                        "token": "EX"
+                    },
+                    {
+                        "name": "milliseconds",
+                        "type": "integer",
+                        "display_text": "milliseconds",
+                        "token": "PX"
+                    },
+                    {
+                        "name": "unix-time-seconds",
+                        "type": "unix-time",
+                        "display_text": "unix-time-seconds",
+                        "token": "EXAT"
+                    },
+                    {
+                        "name": "unix-time-milliseconds",
+                        "type": "unix-time",
+                        "display_text": "unix-time-milliseconds",
+                        "token": "PXAT"
+                    },
+                    {
+                        "name": "persist",
+                        "type": "pure-token",
+                        "display_text": "persist",
+                        "token": "PERSIST"
+                    }
+                ]
+            },
+            {
+                "name": "enx",
+                "type": "pure-token",
+                "display_text": "enx",
+                "token": "ENX",
+                "summary": "Only set the expiration if the key currently has no TTL. Requires one of EX/PX/EXAT/PXAT; cannot be combined with PERSIST.",
+                "optional": true
             }
         ],
         "command_flags": [
@@ -10645,6 +12575,128 @@
             "response_policy:all_succeeded"
         ]
     },
+    "MSETEX": {
+        "summary": "Atomically sets multiple string keys with a shared expiration in a single operation. Supports flexible argument parsing where condition and expiration flags can appear in any order.",
+        "since": "8.4.0",
+        "group": "string",
+        "complexity": "O(N) where N is the number of keys to set.",
+        "acl_categories": [
+            "@write",
+            "@string",
+            "@slow"
+        ],
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "keynum",
+                    "spec": {
+                        "keynumidx": 0,
+                        "firstkey": 1,
+                        "keystep": 2
+                    }
+                },
+                "OW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "numkeys",
+                "type": "integer",
+                "display_text": "numkeys"
+            },
+            {
+                "name": "data",
+                "type": "block",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "key",
+                        "type": "key",
+                        "display_text": "key",
+                        "key_spec_index": 0
+                    },
+                    {
+                        "name": "value",
+                        "type": "string",
+                        "display_text": "value"
+                    }
+                ]
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "nx",
+                        "type": "pure-token",
+                        "display_text": "nx",
+                        "token": "NX"
+                    },
+                    {
+                        "name": "xx",
+                        "type": "pure-token",
+                        "display_text": "xx",
+                        "token": "XX"
+                    }
+                ]
+            },
+            {
+                "name": "expiration",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "seconds",
+                        "type": "integer",
+                        "display_text": "seconds",
+                        "token": "EX"
+                    },
+                    {
+                        "name": "milliseconds",
+                        "type": "integer",
+                        "display_text": "milliseconds",
+                        "token": "PX"
+                    },
+                    {
+                        "name": "unix-time-seconds",
+                        "type": "unix-time",
+                        "display_text": "unix-time-seconds",
+                        "token": "EXAT"
+                    },
+                    {
+                        "name": "unix-time-milliseconds",
+                        "type": "unix-time",
+                        "display_text": "unix-time-milliseconds",
+                        "token": "PXAT"
+                    },
+                    {
+                        "name": "keepttl",
+                        "type": "pure-token",
+                        "display_text": "keepttl",
+                        "token": "KEEPTTL"
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "movablekeys"
+        ],
+        "hints": [
+            "request_policy:multi_shard",
+            "response_policy:all_succeeded"
+        ]
+    },
     "MSETNX": {
         "summary": "Atomically modifies the string values of one or more keys only when all keys don't exist.",
         "since": "1.0.1",
@@ -11532,6 +13584,7 @@
             }
         ],
         "command_flags": [
+            "denyoom",
             "pubsub",
             "noscript",
             "loading",
@@ -13118,6 +15171,10 @@
             [
                 "7.0.0",
                 "Allowed the `NX` and `GET` options to be used together."
+            ],
+            [
+                "8.4.0",
+                "Added 'IFEQ', 'IFNE', 'IFDEQ', 'IFDNE' options."
             ]
         ],
         "acl_categories": [
@@ -13178,6 +15235,34 @@
                         "type": "pure-token",
                         "display_text": "xx",
                         "token": "XX"
+                    },
+                    {
+                        "name": "ifeq-value",
+                        "type": "string",
+                        "display_text": "ifeq-value",
+                        "token": "IFEQ",
+                        "since": "8.4.0"
+                    },
+                    {
+                        "name": "ifne-value",
+                        "type": "string",
+                        "display_text": "ifne-value",
+                        "token": "IFNE",
+                        "since": "8.4.0"
+                    },
+                    {
+                        "name": "ifdeq-digest",
+                        "type": "integer",
+                        "display_text": "ifdeq-digest",
+                        "token": "IFDEQ",
+                        "since": "8.4.0"
+                    },
+                    {
+                        "name": "ifdne-digest",
+                        "type": "integer",
+                        "display_text": "ifdne-digest",
+                        "token": "IFDNE",
+                        "since": "8.4.0"
                     }
                 ]
             },
@@ -14682,6 +16767,7 @@
             }
         ],
         "command_flags": [
+            "denyoom",
             "pubsub",
             "noscript",
             "loading",
@@ -14750,6 +16836,7 @@
             }
         ],
         "command_flags": [
+            "denyoom",
             "pubsub",
             "noscript",
             "loading",
@@ -15087,6 +17174,53 @@
             "response_policy:agg_sum"
         ]
     },
+    "TRIMSLOTS": {
+        "summary": "Trim the keys that belong to specified slots.",
+        "since": "8.4.0",
+        "group": "server",
+        "complexity": "O(N) where N is the total number of keys in all databases",
+        "acl_categories": [
+            "@keyspace",
+            "@write",
+            "@slow",
+            "@dangerous"
+        ],
+        "arity": -5,
+        "arguments": [
+            {
+                "name": "ranges",
+                "type": "block",
+                "token": "RANGES",
+                "arguments": [
+                    {
+                        "name": "numranges",
+                        "type": "integer",
+                        "display_text": "numranges"
+                    },
+                    {
+                        "name": "slots",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                            {
+                                "name": "startslot",
+                                "type": "integer",
+                                "display_text": "startslot"
+                            },
+                            {
+                                "name": "endslot",
+                                "type": "integer",
+                                "display_text": "endslot"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "write"
+        ]
+    },
     "TTL": {
         "summary": "Returns the expiration time in seconds of a key.",
         "since": "1.0.0",
@@ -15276,6 +17410,791 @@
             "allow_busy"
         ]
     },
+    "VADD": {
+        "summary": "Add one or more elements to a vector set, or update its vector if it already exists",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": -5,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "reduce",
+                "type": "block",
+                "token": "REDUCE",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "dim",
+                        "type": "integer",
+                        "display_text": "dim"
+                    }
+                ]
+            },
+            {
+                "name": "format",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "fp32",
+                        "type": "pure-token",
+                        "display_text": "fp32",
+                        "token": "FP32"
+                    },
+                    {
+                        "name": "values",
+                        "type": "pure-token",
+                        "display_text": "values",
+                        "token": "VALUES"
+                    }
+                ]
+            },
+            {
+                "name": "vector",
+                "type": "string",
+                "display_text": "vector"
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "display_text": "element"
+            },
+            {
+                "name": "cas",
+                "type": "pure-token",
+                "display_text": "cas",
+                "token": "CAS",
+                "optional": true
+            },
+            {
+                "name": "quant_type",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "noquant",
+                        "type": "pure-token",
+                        "display_text": "noquant",
+                        "token": "NOQUANT"
+                    },
+                    {
+                        "name": "bin",
+                        "type": "pure-token",
+                        "display_text": "bin",
+                        "token": "BIN"
+                    },
+                    {
+                        "name": "q8",
+                        "type": "pure-token",
+                        "display_text": "q8",
+                        "token": "Q8"
+                    }
+                ]
+            },
+            {
+                "name": "build-exploration-factor",
+                "type": "integer",
+                "display_text": "build-exploration-factor",
+                "token": "EF",
+                "optional": true
+            },
+            {
+                "name": "attributes",
+                "type": "string",
+                "display_text": "attributes",
+                "token": "SETATTR",
+                "optional": true
+            },
+            {
+                "name": "numlinks",
+                "type": "integer",
+                "display_text": "numlinks",
+                "token": "M",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "module"
+        ],
+        "module": "vectorset"
+    },
+    "VCARD": {
+        "summary": "Return the number of elements in a vector set",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module",
+            "fast"
+        ],
+        "module": "vectorset"
+    },
+    "VDIM": {
+        "summary": "Return the dimension of vectors in the vector set",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module",
+            "fast"
+        ],
+        "module": "vectorset"
+    },
+    "VEMB": {
+        "summary": "Return the vector associated with an element",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "display_text": "element"
+            },
+            {
+                "name": "raw",
+                "type": "pure-token",
+                "display_text": "raw",
+                "token": "RAW",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module",
+            "fast"
+        ],
+        "module": "vectorset"
+    },
+    "VGETATTR": {
+        "summary": "Retrieve the JSON attributes of elements",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": 3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "display_text": "element"
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module",
+            "fast"
+        ],
+        "module": "vectorset"
+    },
+    "VINFO": {
+        "summary": "Return information about a vector set",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module",
+            "fast"
+        ],
+        "module": "vectorset"
+    },
+    "VISMEMBER": {
+        "summary": "Check if an element exists in a vector set",
+        "since": "8.2.0",
+        "group": "module",
+        "arity": 3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "display_text": "element"
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module"
+        ],
+        "module": "vectorset"
+    },
+    "VLINKS": {
+        "summary": "Return the neighbors of an element at each layer in the HNSW graph",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "display_text": "element"
+            },
+            {
+                "name": "withscores",
+                "type": "pure-token",
+                "display_text": "withscores",
+                "token": "WITHSCORES",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module",
+            "fast"
+        ],
+        "module": "vectorset"
+    },
+    "VRANDMEMBER": {
+        "summary": "Return one or multiple random members from a vector set",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": -2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "display_text": "count",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module"
+        ],
+        "module": "vectorset"
+    },
+    "VRANGE": {
+        "summary": "Return vector set elements in a lex range",
+        "since": "8.4.0",
+        "group": "module",
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "string",
+                "display_text": "start"
+            },
+            {
+                "name": "end",
+                "type": "string",
+                "display_text": "end"
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "display_text": "count",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module"
+        ],
+        "module": "vectorset"
+    },
+    "VREM": {
+        "summary": "Remove an element from a vector set",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": 3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "display_text": "element"
+            }
+        ],
+        "command_flags": [
+            "write",
+            "module"
+        ],
+        "module": "vectorset"
+    },
+    "VSETATTR": {
+        "summary": "Associate or remove the JSON attributes of elements",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": 4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "element",
+                "type": "string",
+                "display_text": "element"
+            },
+            {
+                "name": "json",
+                "type": "string",
+                "display_text": "json"
+            }
+        ],
+        "command_flags": [
+            "write",
+            "module",
+            "fast"
+        ],
+        "module": "vectorset"
+    },
+    "VSIM": {
+        "summary": "Return elements by vector similarity",
+        "since": "8.0.0",
+        "group": "module",
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "format",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "ele",
+                        "type": "pure-token",
+                        "display_text": "ele",
+                        "token": "ELE"
+                    },
+                    {
+                        "name": "fp32",
+                        "type": "pure-token",
+                        "display_text": "fp32",
+                        "token": "FP32"
+                    },
+                    {
+                        "name": "values",
+                        "type": "pure-token",
+                        "display_text": "values",
+                        "token": "VALUES"
+                    }
+                ]
+            },
+            {
+                "name": "vector_or_element",
+                "type": "string",
+                "display_text": "vector_or_element"
+            },
+            {
+                "name": "withscores",
+                "type": "pure-token",
+                "display_text": "withscores",
+                "token": "WITHSCORES",
+                "optional": true
+            },
+            {
+                "name": "withattribs",
+                "type": "pure-token",
+                "display_text": "withattribs",
+                "token": "WITHATTRIBS",
+                "optional": true
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "display_text": "count",
+                "token": "COUNT",
+                "optional": true
+            },
+            {
+                "name": "max_distance",
+                "type": "double",
+                "display_text": "max_distance",
+                "token": "EPSILON",
+                "optional": true
+            },
+            {
+                "name": "search-exploration-factor",
+                "type": "integer",
+                "display_text": "search-exploration-factor",
+                "token": "EF",
+                "optional": true
+            },
+            {
+                "name": "expression",
+                "type": "string",
+                "display_text": "expression",
+                "token": "FILTER",
+                "optional": true
+            },
+            {
+                "name": "max-filtering-effort",
+                "type": "integer",
+                "display_text": "max-filtering-effort",
+                "token": "FILTER-EF",
+                "optional": true
+            },
+            {
+                "name": "truth",
+                "type": "pure-token",
+                "display_text": "truth",
+                "token": "TRUTH",
+                "optional": true
+            },
+            {
+                "name": "nothread",
+                "type": "pure-token",
+                "display_text": "nothread",
+                "token": "NOTHREAD",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "module"
+        ],
+        "module": "vectorset"
+    },
     "WAIT": {
         "summary": "Blocks until the asynchronous replication of all preceding write commands sent by the connection is completed.",
         "since": "3.0.0",
@@ -15444,6 +18363,99 @@
             "fast"
         ]
     },
+    "XACKDEL": {
+        "summary": "Acknowledges and deletes one or multiple messages for a stream consumer group.",
+        "since": "8.2.0",
+        "group": "stream",
+        "complexity": "O(1) for each message ID processed.",
+        "acl_categories": [
+            "@write",
+            "@stream",
+            "@fast"
+        ],
+        "arity": -6,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true,
+                "delete": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string",
+                "display_text": "group"
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "keepref",
+                        "type": "pure-token",
+                        "display_text": "keepref",
+                        "token": "KEEPREF"
+                    },
+                    {
+                        "name": "delref",
+                        "type": "pure-token",
+                        "display_text": "delref",
+                        "token": "DELREF"
+                    },
+                    {
+                        "name": "acked",
+                        "type": "pure-token",
+                        "display_text": "acked",
+                        "token": "ACKED"
+                    }
+                ]
+            },
+            {
+                "name": "ids",
+                "type": "block",
+                "token": "IDS",
+                "arguments": [
+                    {
+                        "name": "numids",
+                        "type": "integer",
+                        "display_text": "numids"
+                    },
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "display_text": "id",
+                        "multiple": true
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
+        ]
+    },
     "XADD": {
         "summary": "Appends a new message to a stream. Creates the key if it doesn't exist.",
         "since": "5.0.0",
@@ -15457,6 +18469,10 @@
             [
                 "7.0.0",
                 "Added support for the `<ms>-*` explicit ID form."
+            ],
+            [
+                "8.2.0",
+                "Added the `KEEPREF`, `DELREF` and `ACKED` options."
             ]
         ],
         "acl_categories": [
@@ -15500,6 +18516,62 @@
                 "token": "NOMKSTREAM",
                 "since": "6.2.0",
                 "optional": true
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "keepref",
+                        "type": "pure-token",
+                        "display_text": "keepref",
+                        "token": "KEEPREF"
+                    },
+                    {
+                        "name": "delref",
+                        "type": "pure-token",
+                        "display_text": "delref",
+                        "token": "DELREF"
+                    },
+                    {
+                        "name": "acked",
+                        "type": "pure-token",
+                        "display_text": "acked",
+                        "token": "ACKED"
+                    }
+                ]
+            },
+            {
+                "name": "idmp",
+                "type": "oneof",
+                "since": "8.6.0",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "pid",
+                        "type": "string",
+                        "display_text": "pid",
+                        "token": "IDMPAUTO"
+                    },
+                    {
+                        "name": "idmp",
+                        "type": "block",
+                        "token": "IDMP",
+                        "arguments": [
+                            {
+                                "name": "pid",
+                                "type": "string",
+                                "display_text": "pid"
+                            },
+                            {
+                                "name": "iid",
+                                "type": "string",
+                                "display_text": "iid"
+                            }
+                        ]
+                    }
+                ]
             },
             {
                 "name": "trim",
@@ -15690,6 +18762,64 @@
             "nondeterministic_output"
         ]
     },
+    "XCFGSET": {
+        "summary": "Sets the IDMP configuration parameters for a stream.",
+        "since": "8.6.0",
+        "group": "stream",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@write",
+            "@stream",
+            "@fast"
+        ],
+        "arity": -2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "idmp-duration",
+                "type": "integer",
+                "display_text": "idmp-duration",
+                "token": "IDMP-DURATION",
+                "optional": true
+            },
+            {
+                "name": "idmp-maxsize",
+                "type": "integer",
+                "display_text": "idmp-maxsize",
+                "token": "IDMP-MAXSIZE",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
+        ]
+    },
     "XCLAIM": {
         "summary": "Changes, or acquires, ownership of a message in a consumer group, as if the message was delivered a consumer group member.",
         "since": "5.0.0",
@@ -15843,6 +18973,93 @@
                 "type": "string",
                 "display_text": "id",
                 "multiple": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
+        ]
+    },
+    "XDELEX": {
+        "summary": "Deletes one or multiple entries from the stream.",
+        "since": "8.2.0",
+        "group": "stream",
+        "complexity": "O(1) for each single item to delete in the stream, regardless of the stream size.",
+        "acl_categories": [
+            "@write",
+            "@stream",
+            "@fast"
+        ],
+        "arity": -5,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "delete": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "condition",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "keepref",
+                        "type": "pure-token",
+                        "display_text": "keepref",
+                        "token": "KEEPREF"
+                    },
+                    {
+                        "name": "delref",
+                        "type": "pure-token",
+                        "display_text": "delref",
+                        "token": "DELREF"
+                    },
+                    {
+                        "name": "acked",
+                        "type": "pure-token",
+                        "display_text": "acked",
+                        "token": "ACKED"
+                    }
+                ]
+            },
+            {
+                "name": "ids",
+                "type": "block",
+                "token": "IDS",
+                "arguments": [
+                    {
+                        "name": "numids",
+                        "type": "integer",
+                        "display_text": "numids"
+                    },
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "display_text": "id",
+                        "multiple": true
+                    }
+                ]
             }
         ],
         "command_flags": [
@@ -16194,6 +19411,66 @@
             "write"
         ]
     },
+    "XIDMPRECORD": {
+        "summary": "An internal command for setting IDMP metadata on an existing stream message.",
+        "since": "8.6.2",
+        "group": "stream",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@write",
+            "@stream",
+            "@fast"
+        ],
+        "arity": 5,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "pid",
+                "type": "string",
+                "display_text": "pid"
+            },
+            {
+                "name": "iid",
+                "type": "string",
+                "display_text": "iid"
+            },
+            {
+                "name": "stream-id",
+                "type": "string",
+                "display_text": "stream-id"
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
     "XINFO": {
         "summary": "A container for stream introspection commands.",
         "since": "5.0.0",
@@ -16342,6 +19619,14 @@
             [
                 "7.2.0",
                 "Added the `active-time` field, and changed the meaning of `seen-time`."
+            ],
+            [
+                "8.6.0",
+                "Added the `idmp-duration`, `idmp-maxsize`, `pids-tracked`, `iids-tracked`, `iids-added` and `iids-duplicates` fields for IDMP tracking."
+            ],
+            [
+                "8.8.0",
+                "Added the `nacked-count` field to consumer groups in `FULL` output."
             ]
         ],
         "acl_categories": [
@@ -16442,6 +19727,111 @@
         ],
         "command_flags": [
             "readonly",
+            "fast"
+        ]
+    },
+    "XNACK": {
+        "summary": "Releases claimed messages back to the group's PEL without acknowledging them, making them available for re-delivery.",
+        "since": "8.8.0",
+        "group": "stream",
+        "complexity": "O(1) for each message ID processed.",
+        "acl_categories": [
+            "@write",
+            "@stream",
+            "@fast"
+        ],
+        "arity": -7,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string",
+                "display_text": "group"
+            },
+            {
+                "name": "mode",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "silent",
+                        "type": "pure-token",
+                        "display_text": "silent",
+                        "token": "SILENT"
+                    },
+                    {
+                        "name": "fail",
+                        "type": "pure-token",
+                        "display_text": "fail",
+                        "token": "FAIL"
+                    },
+                    {
+                        "name": "fatal",
+                        "type": "pure-token",
+                        "display_text": "fatal",
+                        "token": "FATAL"
+                    }
+                ]
+            },
+            {
+                "name": "ids",
+                "type": "block",
+                "token": "IDS",
+                "arguments": [
+                    {
+                        "name": "numids",
+                        "type": "integer",
+                        "display_text": "numids"
+                    },
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "display_text": "id",
+                        "multiple": true
+                    }
+                ]
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "display_text": "count",
+                "token": "RETRYCOUNT",
+                "optional": true
+            },
+            {
+                "name": "force",
+                "type": "pure-token",
+                "display_text": "force",
+                "token": "FORCE",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "write",
             "fast"
         ]
     },
@@ -16744,6 +20134,13 @@
                 "optional": true
             },
             {
+                "name": "min-idle-time",
+                "type": "integer",
+                "display_text": "min-idle-time",
+                "token": "CLAIM",
+                "optional": true
+            },
+            {
                 "name": "noack",
                 "type": "pure-token",
                 "display_text": "noack",
@@ -16924,6 +20321,10 @@
             [
                 "6.2.0",
                 "Added the `MINID` trimming strategy and the `LIMIT` option."
+            ],
+            [
+                "8.2.0",
+                "Added the `KEEPREF`, `DELREF` and `ACKED` options."
             ]
         ],
         "acl_categories": [
@@ -17013,6 +20414,31 @@
                         "token": "LIMIT",
                         "since": "6.2.0",
                         "optional": true
+                    },
+                    {
+                        "name": "condition",
+                        "type": "oneof",
+                        "optional": true,
+                        "arguments": [
+                            {
+                                "name": "keepref",
+                                "type": "pure-token",
+                                "display_text": "keepref",
+                                "token": "KEEPREF"
+                            },
+                            {
+                                "name": "delref",
+                                "type": "pure-token",
+                                "display_text": "delref",
+                                "token": "DELREF"
+                            },
+                            {
+                                "name": "acked",
+                                "type": "pure-token",
+                                "display_text": "acked",
+                                "token": "ACKED"
+                            }
+                        ]
                     }
                 ]
             }
@@ -17446,6 +20872,12 @@
         "since": "6.2.0",
         "group": "sorted-set",
         "complexity": "O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@sortedset",
@@ -17516,6 +20948,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             },
@@ -17594,6 +21033,12 @@
         "since": "2.0.0",
         "group": "sorted-set",
         "complexity": "O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@write",
             "@sortedset",
@@ -17688,6 +21133,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             }
@@ -19134,6 +22586,12 @@
         "since": "6.2.0",
         "group": "sorted-set",
         "complexity": "O(N)+O(M*log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@sortedset",
@@ -19204,6 +22662,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             },
@@ -19225,6 +22690,12 @@
         "since": "2.0.0",
         "group": "sorted-set",
         "complexity": "O(N)+O(M log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@write",
             "@sortedset",
@@ -19319,6 +22790,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             }

--- a/data/commands_core.json
+++ b/data/commands_core.json
@@ -402,144 +402,136 @@
             "fast"
         ]
     },
-        "ARCOUNT": {
+    "ARCOUNT": {
         "summary": "Returns the number of non-empty elements in an array.",
-        "complexity": "O(1)",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": 2,
-        "function": "arcountCommand",
-        "command_flags": [
-            "READONLY",
-            "FAST"
-        ],
+        "complexity": "O(1)",
         "acl_categories": [
-            "ARRAY"
+            "@read",
+            "@array",
+            "@fast"
         ],
+        "arity": 2,
         "key_specs": [
             {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RO": true,
+                "access": true
             }
         ],
-        "reply_schema": {
-            "description": "The number of non-empty elements, or 0 if key does not exist.",
-            "type": "integer"
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
         ]
     },
     "ARDEL": {
         "summary": "Deletes elements at the specified indices in an array.",
-        "complexity": "O(N) where N is the number of indices to delete",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": -3,
-        "function": "ardelCommand",
-        "command_flags": [
-            "WRITE",
-            "FAST"
-        ],
+        "complexity": "O(N) where N is the number of indices to delete",
         "acl_categories": [
-            "ARRAY"
+            "@write",
+            "@array",
+            "@fast"
         ],
+        "arity": -3,
         "key_specs": [
             {
-                "flags": [
-                    "RW",
-                    "DELETE"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RW": true,
+                "delete": true
             }
         ],
-        "reply_schema": {
-            "description": "Number of elements deleted.",
-            "type": "integer"
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
                 "name": "index",
                 "type": "integer",
+                "display_text": "index",
                 "multiple": true
             }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
         ]
     },
     "ARDELRANGE": {
         "summary": "Deletes elements in one or more ranges.",
-        "complexity": "Proportional to the number of existing elements / slices touched, not to the numeric span of the requested ranges",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": -4,
-        "function": "ardelrangeCommand",
-        "command_flags": [
-            "WRITE"
-        ],
+        "complexity": "Proportional to the number of existing elements / slices touched, not to the numeric span of the requested ranges",
         "acl_categories": [
-            "ARRAY"
+            "@write",
+            "@array",
+            "@slow"
         ],
+        "arity": -4,
         "key_specs": [
             {
-                "flags": [
-                    "RW",
-                    "DELETE"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RW": true,
+                "delete": true
             }
         ],
-        "reply_schema": {
-            "description": "Number of elements deleted.",
-            "type": "integer"
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
@@ -549,502 +541,575 @@
                 "arguments": [
                     {
                         "name": "start",
-                        "type": "integer"
+                        "type": "integer",
+                        "display_text": "start"
                     },
                     {
                         "name": "end",
-                        "type": "integer"
+                        "type": "integer",
+                        "display_text": "end"
                     }
                 ]
             }
+        ],
+        "command_flags": [
+            "write"
         ]
     },
     "ARGET": {
         "summary": "Gets the value at an index in an array.",
-        "complexity": "O(1)",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
         "arity": 3,
-        "function": "argetCommand",
-        "command_flags": [
-            "READONLY",
-            "FAST"
-        ],
-        "acl_categories": [
-            "ARRAY"
-        ],
         "key_specs": [
             {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RO": true,
+                "access": true
             }
         ],
-        "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "The value at the given index.",
-                    "type": "string"
-                },
-                {
-                    "description": "Null reply if key or index does not exist.",
-                    "type": "null"
-                }
-            ]
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
-                "key_spec_index": 0
-            },
-            {
-                "name": "index",
-                "type": "integer"
-            }
-        ]
-    },
-    "ARGETRANGE": {
-        "summary": "Gets values in a range of indices.",
-        "complexity": "O(N) where N is the range length",
-        "group": "array",
-        "since": "8.0.0",
-        "arity": 4,
-        "function": "argetrangeCommand",
-        "command_flags": [
-            "READONLY"
-        ],
-        "acl_categories": [
-            "ARRAY"
-        ],
-        "key_specs": [
-            {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
-                "begin_search": {
-                    "index": {
-                        "pos": 1
-                    }
-                },
-                "find_keys": {
-                    "range": {
-                        "lastkey": 0,
-                        "step": 1,
-                        "limit": 0
-                    }
-                }
-            }
-        ],
-        "reply_schema": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string"
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
-            }
-        },
-        "arguments": [
-            {
-                "name": "key",
-                "type": "key",
-                "key_spec_index": 0
-            },
-            {
-                "name": "start",
-                "type": "integer"
-            },
-            {
-                "name": "end",
-                "type": "integer"
-            }
-        ]
-    },
-    "ARINFO": {
-        "summary": "Returns metadata about an array.",
-        "complexity": "O(1), or O(N) with FULL option where N is the number of slices.",
-        "group": "array",
-        "since": "8.0.0",
-        "arity": -2,
-        "function": "arinfoCommand",
-        "command_flags": [
-            "READONLY"
-        ],
-        "acl_categories": [
-            "ARRAY"
-        ],
-        "key_specs": [
-            {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
-                "begin_search": {
-                    "index": {
-                        "pos": 1
-                    }
-                },
-                "find_keys": {
-                    "range": {
-                        "lastkey": 0,
-                        "step": 1,
-                        "limit": 0
-                    }
-                }
-            }
-        ],
-        "reply_schema": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "count": {
-                    "type": "integer",
-                    "description": "Total number of non-empty elements."
-                },
-                "len": {
-                    "type": "integer",
-                    "description": "Logical length (highest index + 1)."
-                },
-                "next-insert-index": {
-                    "type": "integer",
-                    "description": "Index the next ARINSERT would use, or 0 if unset/exhausted."
-                },
-                "slices": {
-                    "type": "integer",
-                    "description": "Number of allocated slices."
-                },
-                "directory-size": {
-                    "type": "integer",
-                    "description": "Directory allocation capacity (flat dir_alloc or superdir sdir_cap)."
-                },
-                "super-dir-entries": {
-                    "type": "integer",
-                    "description": "Number of super-directory entries (0 if not in superdir mode)."
-                },
-                "slice-size": {
-                    "type": "integer",
-                    "description": "Configured slice size."
-                },
-                "dense-slices": {
-                    "type": "integer",
-                    "description": "Number of dense slices (FULL only)."
-                },
-                "sparse-slices": {
-                    "type": "integer",
-                    "description": "Number of sparse slices (FULL only)."
-                },
-                "avg-dense-size": {
-                    "type": "number",
-                    "description": "Average allocation size of dense slices (FULL only)."
-                },
-                "avg-dense-fill": {
-                    "type": "number",
-                    "description": "Average fill rate of dense slices (FULL only)."
-                },
-                "avg-sparse-size": {
-                    "type": "number",
-                    "description": "Average capacity of sparse slices (FULL only)."
-                }
-            }
-        },
-        "arguments": [
-            {
-                "name": "key",
-                "type": "key",
-                "key_spec_index": 0
-            },
-            {
-                "name": "full",
-                "type": "pure-token",
-                "token": "FULL",
-                "optional": true
-            }
-        ]
-    },
-    "ARINSERT": {
-        "summary": "Inserts one or more values at consecutive indices.",
-        "complexity": "O(N) where N is the number of values",
-        "group": "array",
-        "since": "8.0.0",
-        "arity": -3,
-        "function": "arinsertCommand",
-        "command_flags": [
-            "WRITE",
-            "DENYOOM",
-            "FAST"
-        ],
-        "acl_categories": [
-            "ARRAY"
-        ],
-        "key_specs": [
-            {
-                "flags": [
-                    "RW",
-                    "UPDATE"
-                ],
-                "begin_search": {
-                    "index": {
-                        "pos": 1
-                    }
-                },
-                "find_keys": {
-                    "range": {
-                        "lastkey": 0,
-                        "step": 1,
-                        "limit": 0
-                    }
-                }
-            }
-        ],
-        "reply_schema": {
-            "description": "The last index where a value was inserted.",
-            "type": "integer"
-        },
-        "arguments": [
-            {
-                "name": "key",
-                "type": "key",
-                "key_spec_index": 0
-            },
-            {
-                "name": "value",
-                "type": "string",
-                "multiple": true
-            }
-        ]
-    },
-    "ARLASTITEMS": {
-        "summary": "Returns the most recently inserted elements.",
-        "complexity": "O(N) where N is the count",
-        "group": "array",
-        "since": "8.0.0",
-        "arity": -3,
-        "function": "arlastitemsCommand",
-        "command_flags": [
-            "READONLY"
-        ],
-        "acl_categories": [
-            "ARRAY"
-        ],
-        "key_specs": [
-            {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
-                "begin_search": {
-                    "index": {
-                        "pos": 1
-                    }
-                },
-                "find_keys": {
-                    "range": {
-                        "lastkey": 0,
-                        "step": 1,
-                        "limit": 0
-                    }
-                }
-            }
-        ],
-        "reply_schema": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string"
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
-            }
-        },
-        "arguments": [
-            {
-                "name": "key",
-                "type": "key",
-                "key_spec_index": 0
-            },
-            {
-                "name": "count",
-                "type": "integer"
-            },
-            {
-                "name": "rev",
-                "type": "pure-token",
-                "token": "REV",
-                "optional": true
-            }
-        ]
-    },
-    "ARLEN": {
-        "summary": "Returns the length of an array (max index + 1).",
-        "complexity": "O(1)",
-        "group": "array",
-        "since": "8.0.0",
-        "arity": 2,
-        "function": "arlenCommand",
-        "command_flags": [
-            "READONLY",
-            "FAST"
-        ],
-        "acl_categories": [
-            "ARRAY"
-        ],
-        "key_specs": [
-            {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
-                "begin_search": {
-                    "index": {
-                        "pos": 1
-                    }
-                },
-                "find_keys": {
-                    "range": {
-                        "lastkey": 0,
-                        "step": 1,
-                        "limit": 0
-                    }
-                }
-            }
-        ],
-        "reply_schema": {
-            "description": "The length of the array (max index + 1), or 0 if key does not exist.",
-            "type": "integer"
-        },
-        "arguments": [
-            {
-                "name": "key",
-                "type": "key",
-                "key_spec_index": 0
-            }
-        ]
-    },
-    "ARMGET": {
-        "summary": "Gets values at multiple indices in an array.",
-        "complexity": "O(N) where N is the number of indices",
-        "group": "array",
-        "since": "8.0.0",
-        "arity": -3,
-        "function": "armgetCommand",
-        "command_flags": [
-            "READONLY",
-            "FAST"
-        ],
-        "acl_categories": [
-            "ARRAY"
-        ],
-        "key_specs": [
-            {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
-                "begin_search": {
-                    "index": {
-                        "pos": 1
-                    }
-                },
-                "find_keys": {
-                    "range": {
-                        "lastkey": 0,
-                        "step": 1,
-                        "limit": 0
-                    }
-                }
-            }
-        ],
-        "reply_schema": {
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "string"
-                    },
-                    {
-                        "type": "null"
-                    }
-                ]
-            }
-        },
-        "arguments": [
-            {
-                "name": "key",
-                "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
                 "name": "index",
                 "type": "integer",
-                "multiple": true
+                "display_text": "index"
             }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
         ]
     },
-    "ARMSET": {
-        "summary": "Sets multiple index-value pairs in an array.",
-        "complexity": "O(N) where N is the number of pairs",
+    "ARGETRANGE": {
+        "summary": "Gets values in a range of indices.",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": -4,
-        "function": "armsetCommand",
-        "command_flags": [
-            "WRITE",
-            "DENYOOM",
-            "FAST"
-        ],
+        "complexity": "O(N) where N is the range length",
         "acl_categories": [
-            "ARRAY"
+            "@read",
+            "@array",
+            "@slow"
         ],
+        "arity": 4,
         "key_specs": [
             {
-                "flags": [
-                    "RW",
-                    "UPDATE"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RO": true,
+                "access": true
             }
         ],
-        "reply_schema": {
-            "description": "Number of new slots that were set (previously empty).",
-            "type": "integer"
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "integer",
+                "display_text": "start"
+            },
+            {
+                "name": "end",
+                "type": "integer",
+                "display_text": "end"
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARGREP": {
+        "summary": "Searches array elements in a range using textual predicates.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(P * C) where P is the number of visited positions in touched slices and C is the cost of evaluating the predicates on one existing element.",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -6,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "start",
+                "type": "string",
+                "display_text": "start"
+            },
+            {
+                "name": "end",
+                "type": "string",
+                "display_text": "end"
+            },
+            {
+                "name": "predicate",
+                "type": "oneof",
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "exact",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "exact",
+                                "type": "pure-token",
+                                "display_text": "exact",
+                                "token": "EXACT"
+                            },
+                            {
+                                "name": "string",
+                                "type": "string",
+                                "display_text": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "match",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "match",
+                                "type": "pure-token",
+                                "display_text": "match",
+                                "token": "MATCH"
+                            },
+                            {
+                                "name": "string",
+                                "type": "string",
+                                "display_text": "string"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "glob",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "glob",
+                                "type": "pure-token",
+                                "display_text": "glob",
+                                "token": "GLOB"
+                            },
+                            {
+                                "name": "pattern",
+                                "type": "string",
+                                "display_text": "pattern"
+                            }
+                        ]
+                    },
+                    {
+                        "name": "re",
+                        "type": "block",
+                        "arguments": [
+                            {
+                                "name": "re",
+                                "type": "pure-token",
+                                "display_text": "re",
+                                "token": "RE"
+                            },
+                            {
+                                "name": "pattern",
+                                "type": "string",
+                                "display_text": "pattern"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "name": "options",
+                "type": "oneof",
+                "optional": true,
+                "multiple": true,
+                "arguments": [
+                    {
+                        "name": "and",
+                        "type": "pure-token",
+                        "display_text": "and",
+                        "token": "AND"
+                    },
+                    {
+                        "name": "or",
+                        "type": "pure-token",
+                        "display_text": "or",
+                        "token": "OR"
+                    },
+                    {
+                        "name": "limit",
+                        "type": "integer",
+                        "display_text": "limit",
+                        "token": "LIMIT"
+                    },
+                    {
+                        "name": "withvalues",
+                        "type": "pure-token",
+                        "display_text": "withvalues",
+                        "token": "WITHVALUES"
+                    },
+                    {
+                        "name": "nocase",
+                        "type": "pure-token",
+                        "display_text": "nocase",
+                        "token": "NOCASE"
+                    }
+                ]
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARINFO": {
+        "summary": "Returns metadata about an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1), or O(N) with FULL option where N is the number of slices.",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "full",
+                "type": "pure-token",
+                "display_text": "full",
+                "token": "FULL",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARINSERT": {
+        "summary": "Inserts one or more values at consecutive indices.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of values",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@fast"
+        ],
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "value",
+                "type": "string",
+                "display_text": "value",
+                "multiple": true
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
+    "ARLASTITEMS": {
+        "summary": "Returns the most recently inserted elements.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the count",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@slow"
+        ],
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "display_text": "count"
+            },
+            {
+                "name": "rev",
+                "type": "pure-token",
+                "display_text": "rev",
+                "token": "REV",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "readonly"
+        ]
+    },
+    "ARLEN": {
+        "summary": "Returns the length of an array (max index + 1).",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
+        "arity": 2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
+        ]
+    },
+    "ARMGET": {
+        "summary": "Gets values at multiple indices in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of indices",
+        "acl_categories": [
+            "@read",
+            "@array",
+            "@fast"
+        ],
+        "arity": -3,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RO": true,
+                "access": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "index",
+                "type": "integer",
+                "display_text": "index",
+                "multiple": true
+            }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
+        ]
+    },
+    "ARMSET": {
+        "summary": "Sets multiple index-value pairs in an array.",
+        "since": "8.8.0",
+        "group": "array",
+        "complexity": "O(N) where N is the number of pairs",
+        "acl_categories": [
+            "@write",
+            "@array",
+            "@fast"
+        ],
+        "arity": -4,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
@@ -1054,132 +1119,114 @@
                 "arguments": [
                     {
                         "name": "index",
-                        "type": "integer"
+                        "type": "integer",
+                        "display_text": "index"
                     },
                     {
                         "name": "value",
-                        "type": "string"
+                        "type": "string",
+                        "display_text": "value"
                     }
                 ]
             }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
         ]
     },
     "ARNEXT": {
         "summary": "Returns the next index ARINSERT would use.",
-        "complexity": "O(1)",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": 2,
-        "function": "arnextCommand",
-        "command_flags": [
-            "READONLY",
-            "FAST"
-        ],
+        "complexity": "O(1)",
         "acl_categories": [
-            "ARRAY"
+            "@read",
+            "@array",
+            "@fast"
         ],
+        "arity": 2,
         "key_specs": [
             {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RO": true,
+                "access": true
             }
         ],
-        "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "The next index ARINSERT would use. Returns 0 for missing keys or when no insert happened yet.",
-                    "type": "integer"
-                },
-                {
-                    "description": "Null when the insertion cursor is exhausted (next insert would overflow).",
-                    "type": "null"
-                }
-            ]
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             }
+        ],
+        "command_flags": [
+            "readonly",
+            "fast"
         ]
     },
     "AROP": {
         "summary": "Performs aggregate operations on array elements in a range.",
-        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": -5,
-        "function": "aropCommand",
-        "command_flags": [
-            "READONLY"
-        ],
+        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
         "acl_categories": [
-            "ARRAY"
+            "@read",
+            "@array",
+            "@slow"
         ],
+        "arity": -5,
         "key_specs": [
             {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RO": true,
+                "access": true
             }
         ],
-        "reply_schema": {
-            "oneOf": [
-                {
-                    "description": "Result of the operation.",
-                    "type": "string"
-                },
-                {
-                    "description": "Integer result for MATCH, USED, AND, OR, XOR.",
-                    "type": "integer"
-                },
-                {
-                    "description": "Null if no elements match the operation.",
-                    "type": "null"
-                }
-            ]
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
                 "name": "start",
-                "type": "integer"
+                "type": "integer",
+                "display_text": "start"
             },
             {
                 "name": "end",
-                "type": "integer"
+                "type": "integer",
+                "display_text": "end"
             },
             {
                 "name": "operation",
@@ -1188,31 +1235,37 @@
                     {
                         "name": "sum",
                         "type": "pure-token",
+                        "display_text": "sum",
                         "token": "SUM"
                     },
                     {
                         "name": "min",
                         "type": "pure-token",
+                        "display_text": "min",
                         "token": "MIN"
                     },
                     {
                         "name": "max",
                         "type": "pure-token",
+                        "display_text": "max",
                         "token": "MAX"
                     },
                     {
                         "name": "and",
                         "type": "pure-token",
+                        "display_text": "and",
                         "token": "AND"
                     },
                     {
                         "name": "or",
                         "type": "pure-token",
+                        "display_text": "or",
                         "token": "OR"
                     },
                     {
                         "name": "xor",
                         "type": "pure-token",
+                        "display_text": "xor",
                         "token": "XOR"
                     },
                     {
@@ -1222,253 +1275,247 @@
                             {
                                 "name": "match",
                                 "type": "pure-token",
+                                "display_text": "match",
                                 "token": "MATCH"
                             },
                             {
                                 "name": "value",
-                                "type": "string"
+                                "type": "string",
+                                "display_text": "value"
                             }
                         ]
                     },
                     {
                         "name": "used",
                         "type": "pure-token",
+                        "display_text": "used",
                         "token": "USED"
                     }
                 ]
             }
+        ],
+        "command_flags": [
+            "readonly"
         ]
     },
     "ARRING": {
         "summary": "Inserts values into a ring buffer of specified size, wrapping and truncating as needed.",
-        "complexity": "O(M) normally, O(N+M) on ring resize, where N is the maximum of the old and new ring size and M is the number of inserted values",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": -4,
-        "function": "arringCommand",
-        "command_flags": [
-            "WRITE",
-            "DENYOOM"
-        ],
+        "complexity": "O(M) normally, O(N+M) on ring resize, where N is the maximum of the old and new ring size and M is the number of inserted values",
         "acl_categories": [
-            "ARRAY"
+            "@write",
+            "@array",
+            "@slow"
         ],
+        "arity": -4,
         "key_specs": [
             {
-                "flags": [
-                    "RW",
-                    "UPDATE"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RW": true,
+                "update": true
             }
         ],
-        "reply_schema": {
-            "description": "The last index where a value was inserted.",
-            "type": "integer"
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
                 "name": "size",
-                "type": "integer"
+                "type": "integer",
+                "display_text": "size"
             },
             {
                 "name": "value",
                 "type": "string",
+                "display_text": "value",
                 "multiple": true
             }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom"
         ]
     },
     "ARSCAN": {
         "summary": "Iterates existing elements in a range, returning index-value pairs.",
-        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": -4,
-        "function": "arscanCommand",
-        "command_flags": [
-            "READONLY"
-        ],
+        "complexity": "O(P) where P is visited positions in touched slices (dense scanned slots + sparse entries), with worst-case O(|end-start|+1) and typical case close to O(N), where N is the number of existing elements in range.",
         "acl_categories": [
-            "ARRAY"
+            "@read",
+            "@array",
+            "@slow"
         ],
+        "arity": -4,
         "key_specs": [
             {
-                "flags": [
-                    "RO",
-                    "ACCESS"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RO": true,
+                "access": true
             }
         ],
-        "reply_schema": {
-            "description": "Flat array of index-value pairs: [idx1, val1, idx2, val2, ...]",
-            "type": "array",
-            "items": {
-                "oneOf": [
-                    {
-                        "type": "integer",
-                        "description": "Index of existing element"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Value at that index"
-                    }
-                ]
-            }
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
                 "name": "start",
-                "type": "integer"
+                "type": "integer",
+                "display_text": "start"
             },
             {
                 "name": "end",
-                "type": "integer"
+                "type": "integer",
+                "display_text": "end"
             },
             {
                 "name": "limit",
-                "token": "LIMIT",
                 "type": "integer",
+                "display_text": "limit",
+                "token": "LIMIT",
                 "optional": true
             }
+        ],
+        "command_flags": [
+            "readonly"
         ]
     },
     "ARSEEK": {
-        "summary": "Sets the ARINSERT cursor to a specific index.",
-        "complexity": "O(1)",
+        "summary": "Sets the ARINSERT / ARRING cursor to a specific index.",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": 3,
-        "function": "arseekCommand",
-        "command_flags": [
-            "WRITE",
-            "FAST"
-        ],
+        "complexity": "O(1)",
         "acl_categories": [
-            "ARRAY"
+            "@write",
+            "@array",
+            "@fast"
         ],
+        "arity": 3,
         "key_specs": [
             {
-                "flags": [
-                    "RW",
-                    "UPDATE"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RW": true,
+                "update": true
             }
         ],
-        "reply_schema": {
-            "description": "1 if the cursor was set, 0 if the key does not exist.",
-            "type": "integer"
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
                 "name": "index",
-                "type": "integer"
+                "type": "integer",
+                "display_text": "index"
             }
+        ],
+        "command_flags": [
+            "write",
+            "fast"
         ]
     },
     "ARSET": {
         "summary": "Sets one or more contiguous values starting at an index in an array.",
-        "complexity": "O(N) where N is the number of values",
+        "since": "8.8.0",
         "group": "array",
-        "since": "8.0.0",
-        "arity": -4,
-        "function": "arsetCommand",
-        "command_flags": [
-            "WRITE",
-            "DENYOOM",
-            "FAST"
-        ],
+        "complexity": "O(N) where N is the number of values",
         "acl_categories": [
-            "ARRAY"
+            "@write",
+            "@array",
+            "@fast"
         ],
+        "arity": -4,
         "key_specs": [
             {
-                "flags": [
-                    "RW",
-                    "UPDATE"
-                ],
                 "begin_search": {
-                    "index": {
-                        "pos": 1
+                    "type": "index",
+                    "spec": {
+                        "index": 1
                     }
                 },
                 "find_keys": {
-                    "range": {
+                    "type": "range",
+                    "spec": {
                         "lastkey": 0,
-                        "step": 1,
+                        "keystep": 1,
                         "limit": 0
                     }
-                }
+                },
+                "RW": true,
+                "update": true
             }
         ],
-        "reply_schema": {
-            "description": "Number of new slots that were set (previously empty).",
-            "type": "integer"
-        },
         "arguments": [
             {
                 "name": "key",
                 "type": "key",
+                "display_text": "key",
                 "key_spec_index": 0
             },
             {
                 "name": "index",
-                "type": "integer"
+                "type": "integer",
+                "display_text": "index"
             },
             {
                 "name": "value",
                 "type": "string",
+                "display_text": "value",
                 "multiple": true
             }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
         ]
     },
     "ASKING": {
@@ -3602,6 +3649,7 @@
         ],
         "command_flags": [
             "admin",
+            "loading",
             "stale"
         ],
         "hints": [
@@ -3820,6 +3868,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -3843,6 +3892,7 @@
             }
         ],
         "command_flags": [
+            "loading",
             "stale"
         ]
     },
@@ -3856,6 +3906,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -3997,6 +4048,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ]
     },
@@ -4010,6 +4062,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -4026,6 +4079,7 @@
         ],
         "arity": 2,
         "command_flags": [
+            "loading",
             "stale"
         ],
         "hints": [
@@ -4052,6 +4106,7 @@
         ],
         "command_flags": [
             "admin",
+            "loading",
             "stale"
         ],
         "hints": [
@@ -4254,6 +4309,7 @@
         ],
         "command_flags": [
             "admin",
+            "loading",
             "stale"
         ],
         "doc_flags": [
@@ -9338,6 +9394,20 @@
             "response_policy:special"
         ]
     },
+    "HOTKEYS HELP": {
+        "summary": "Return helpful text about HOTKEYS command parameters.",
+        "since": "8.6.1",
+        "group": "server",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@slow"
+        ],
+        "arity": 2,
+        "command_flags": [
+            "loading",
+            "stale"
+        ]
+    },
     "HOTKEYS RESET": {
         "summary": "Release the resources used for hotkey tracking.",
         "since": "8.6.0",
@@ -10537,6 +10607,159 @@
                 "name": "increment",
                 "type": "double",
                 "display_text": "increment"
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
+    "INCREX": {
+        "summary": "Increments the numeric value of a key by a number and sets its expiration time. Uses 0 as initial value if the key doesn't exist.",
+        "since": "8.8.0",
+        "group": "string",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@write",
+            "@string",
+            "@fast"
+        ],
+        "arity": -2,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "access": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "increment",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "float",
+                        "type": "double",
+                        "display_text": "float",
+                        "token": "BYFLOAT"
+                    },
+                    {
+                        "name": "integer",
+                        "type": "integer",
+                        "display_text": "integer",
+                        "token": "BYINT"
+                    }
+                ]
+            },
+            {
+                "name": "overflow-block",
+                "type": "oneof",
+                "token": "OVERFLOW",
+                "summary": "Out-of-bounds policy; defaults to FAIL. Missing LBOUND/UBOUND default to the type limits (LLONG_MIN/LLONG_MAX for BYINT, -LDBL_MAX/LDBL_MAX for BYFLOAT).",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "fail",
+                        "type": "pure-token",
+                        "display_text": "fail",
+                        "token": "FAIL"
+                    },
+                    {
+                        "name": "sat",
+                        "type": "pure-token",
+                        "display_text": "sat",
+                        "token": "SAT"
+                    },
+                    {
+                        "name": "reject",
+                        "type": "pure-token",
+                        "display_text": "reject",
+                        "token": "REJECT"
+                    }
+                ]
+            },
+            {
+                "name": "lowerbound",
+                "type": "string",
+                "display_text": "lowerbound",
+                "token": "LBOUND",
+                "summary": "Integer when used with BYINT, floating-point when used with BYFLOAT.",
+                "optional": true
+            },
+            {
+                "name": "upperbound",
+                "type": "string",
+                "display_text": "upperbound",
+                "token": "UBOUND",
+                "summary": "Integer when used with BYINT, floating-point when used with BYFLOAT.",
+                "optional": true
+            },
+            {
+                "name": "expiration",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                    {
+                        "name": "seconds",
+                        "type": "integer",
+                        "display_text": "seconds",
+                        "token": "EX"
+                    },
+                    {
+                        "name": "milliseconds",
+                        "type": "integer",
+                        "display_text": "milliseconds",
+                        "token": "PX"
+                    },
+                    {
+                        "name": "unix-time-seconds",
+                        "type": "unix-time",
+                        "display_text": "unix-time-seconds",
+                        "token": "EXAT"
+                    },
+                    {
+                        "name": "unix-time-milliseconds",
+                        "type": "unix-time",
+                        "display_text": "unix-time-milliseconds",
+                        "token": "PXAT"
+                    },
+                    {
+                        "name": "persist",
+                        "type": "pure-token",
+                        "display_text": "persist",
+                        "token": "PERSIST"
+                    }
+                ]
+            },
+            {
+                "name": "enx",
+                "type": "pure-token",
+                "display_text": "enx",
+                "token": "ENX",
+                "summary": "Only set the expiration if the key currently has no TTL. Requires one of EX/PX/EXAT/PXAT; cannot be combined with PERSIST.",
+                "optional": true
             }
         ],
         "command_flags": [
@@ -13361,6 +13584,7 @@
             }
         ],
         "command_flags": [
+            "denyoom",
             "pubsub",
             "noscript",
             "loading",
@@ -16543,6 +16767,7 @@
             }
         ],
         "command_flags": [
+            "denyoom",
             "pubsub",
             "noscript",
             "loading",
@@ -16611,6 +16836,7 @@
             }
         ],
         "command_flags": [
+            "denyoom",
             "pubsub",
             "noscript",
             "loading",
@@ -18319,35 +18545,20 @@
             {
                 "name": "idmp",
                 "type": "oneof",
+                "since": "8.6.0",
                 "optional": true,
                 "arguments": [
                     {
-                        "name": "idmpauto-with-pid",
-                        "type": "block",
-                        "arguments": [
-                            {
-                                "name": "idmpauto-token",
-                                "type": "pure-token",
-                                "display_text": "idmpauto-token",
-                                "token": "IDMPAUTO"
-                            },
-                            {
-                                "name": "pid",
-                                "type": "string",
-                                "display_text": "pid"
-                            }
-                        ]
+                        "name": "pid",
+                        "type": "string",
+                        "display_text": "pid",
+                        "token": "IDMPAUTO"
                     },
                     {
-                        "name": "idmp-with-pid-iid",
+                        "name": "idmp",
                         "type": "block",
+                        "token": "IDMP",
                         "arguments": [
-                            {
-                                "name": "idmp-token",
-                                "type": "pure-token",
-                                "display_text": "idmp-token",
-                                "token": "IDMP"
-                            },
                             {
                                 "name": "pid",
                                 "type": "string",
@@ -18590,40 +18801,18 @@
                 "key_spec_index": 0
             },
             {
-                "name": "idmp-duration-block",
-                "type": "block",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "idmp-duration-token",
-                        "type": "pure-token",
-                        "display_text": "idmp-duration-token",
-                        "token": "IDMP-DURATION"
-                    },
-                    {
-                        "name": "duration",
-                        "type": "integer",
-                        "display_text": "duration"
-                    }
-                ]
+                "name": "idmp-duration",
+                "type": "integer",
+                "display_text": "idmp-duration",
+                "token": "IDMP-DURATION",
+                "optional": true
             },
             {
-                "name": "idmp-maxsize-block",
-                "type": "block",
-                "optional": true,
-                "arguments": [
-                    {
-                        "name": "idmp-maxsize-token",
-                        "type": "pure-token",
-                        "display_text": "idmp-maxsize-token",
-                        "token": "IDMP-MAXSIZE"
-                    },
-                    {
-                        "name": "maxsize",
-                        "type": "integer",
-                        "display_text": "maxsize"
-                    }
-                ]
+                "name": "idmp-maxsize",
+                "type": "integer",
+                "display_text": "idmp-maxsize",
+                "token": "IDMP-MAXSIZE",
+                "optional": true
             }
         ],
         "command_flags": [
@@ -19222,6 +19411,66 @@
             "write"
         ]
     },
+    "XIDMPRECORD": {
+        "summary": "An internal command for setting IDMP metadata on an existing stream message.",
+        "since": "8.6.2",
+        "group": "stream",
+        "complexity": "O(1)",
+        "acl_categories": [
+            "@write",
+            "@stream",
+            "@fast"
+        ],
+        "arity": 5,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "pid",
+                "type": "string",
+                "display_text": "pid"
+            },
+            {
+                "name": "iid",
+                "type": "string",
+                "display_text": "iid"
+            },
+            {
+                "name": "stream-id",
+                "type": "string",
+                "display_text": "stream-id"
+            }
+        ],
+        "command_flags": [
+            "write",
+            "denyoom",
+            "fast"
+        ]
+    },
     "XINFO": {
         "summary": "A container for stream introspection commands.",
         "since": "5.0.0",
@@ -19374,6 +19623,10 @@
             [
                 "8.6.0",
                 "Added the `idmp-duration`, `idmp-maxsize`, `pids-tracked`, `iids-tracked`, `iids-added` and `iids-duplicates` fields for IDMP tracking."
+            ],
+            [
+                "8.8.0",
+                "Added the `nacked-count` field to consumer groups in `FULL` output."
             ]
         ],
         "acl_categories": [
@@ -19474,6 +19727,111 @@
         ],
         "command_flags": [
             "readonly",
+            "fast"
+        ]
+    },
+    "XNACK": {
+        "summary": "Releases claimed messages back to the group's PEL without acknowledging them, making them available for re-delivery.",
+        "since": "8.8.0",
+        "group": "stream",
+        "complexity": "O(1) for each message ID processed.",
+        "acl_categories": [
+            "@write",
+            "@stream",
+            "@fast"
+        ],
+        "arity": -7,
+        "key_specs": [
+            {
+                "begin_search": {
+                    "type": "index",
+                    "spec": {
+                        "index": 1
+                    }
+                },
+                "find_keys": {
+                    "type": "range",
+                    "spec": {
+                        "lastkey": 0,
+                        "keystep": 1,
+                        "limit": 0
+                    }
+                },
+                "RW": true,
+                "update": true
+            }
+        ],
+        "arguments": [
+            {
+                "name": "key",
+                "type": "key",
+                "display_text": "key",
+                "key_spec_index": 0
+            },
+            {
+                "name": "group",
+                "type": "string",
+                "display_text": "group"
+            },
+            {
+                "name": "mode",
+                "type": "oneof",
+                "arguments": [
+                    {
+                        "name": "silent",
+                        "type": "pure-token",
+                        "display_text": "silent",
+                        "token": "SILENT"
+                    },
+                    {
+                        "name": "fail",
+                        "type": "pure-token",
+                        "display_text": "fail",
+                        "token": "FAIL"
+                    },
+                    {
+                        "name": "fatal",
+                        "type": "pure-token",
+                        "display_text": "fatal",
+                        "token": "FATAL"
+                    }
+                ]
+            },
+            {
+                "name": "ids",
+                "type": "block",
+                "token": "IDS",
+                "arguments": [
+                    {
+                        "name": "numids",
+                        "type": "integer",
+                        "display_text": "numids"
+                    },
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "display_text": "id",
+                        "multiple": true
+                    }
+                ]
+            },
+            {
+                "name": "count",
+                "type": "integer",
+                "display_text": "count",
+                "token": "RETRYCOUNT",
+                "optional": true
+            },
+            {
+                "name": "force",
+                "type": "pure-token",
+                "display_text": "force",
+                "token": "FORCE",
+                "optional": true
+            }
+        ],
+        "command_flags": [
+            "write",
             "fast"
         ]
     },
@@ -20514,6 +20872,12 @@
         "since": "6.2.0",
         "group": "sorted-set",
         "complexity": "O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@sortedset",
@@ -20584,6 +20948,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             },
@@ -20662,6 +21033,12 @@
         "since": "2.0.0",
         "group": "sorted-set",
         "complexity": "O(N*K)+O(M*log(M)) worst case with N being the smallest input sorted set, K being the number of input sorted sets and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@write",
             "@sortedset",
@@ -20756,6 +21133,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             }
@@ -22202,6 +22586,12 @@
         "since": "6.2.0",
         "group": "sorted-set",
         "complexity": "O(N)+O(M*log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@read",
             "@sortedset",
@@ -22272,6 +22662,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             },
@@ -22293,6 +22690,12 @@
         "since": "2.0.0",
         "group": "sorted-set",
         "complexity": "O(N)+O(M log(M)) with N being the sum of the sizes of the input sorted sets, and M being the number of elements in the resulting sorted set.",
+        "history": [
+            [
+                "8.8.0",
+                "Added `COUNT` aggregate option."
+            ]
+        ],
         "acl_categories": [
             "@write",
             "@sortedset",
@@ -22387,6 +22790,13 @@
                         "type": "pure-token",
                         "display_text": "max",
                         "token": "MAX"
+                    },
+                    {
+                        "name": "count",
+                        "type": "pure-token",
+                        "display_text": "count",
+                        "token": "COUNT",
+                        "since": "8.8.0"
                     }
                 ]
             }

--- a/data/commands_redisearch.json
+++ b/data/commands_redisearch.json
@@ -38,6 +38,28 @@
         "summary": "Specifies the type of data to index, such as HASH or JSON."
       },
       {
+        "name": "indexall",
+        "token": "INDEXALL",
+        "type": "oneof",
+        "optional": true,
+        "since": "8.0.0",
+        "arguments": [
+          {
+            "name": "enable",
+            "type": "pure-token",
+            "token": "ENABLE",
+            "summary": "Maintains an inverted index of all document IDs for wildcard queries."
+          },
+          {
+            "name": "disable",
+            "type": "pure-token",
+            "token": "DISABLE",
+            "summary": "Does not maintain an inverted index of all document IDs (default behavior)."
+          }
+        ],
+        "summary": "When enabled, maintains an inverted index of all document IDs to optimize wildcard queries in heavy update scenarios."
+      },
+      {
         "name": "prefix",
         "type": "block",
         "optional": true,
@@ -210,6 +232,11 @@
                 "name": "geo",
                 "type": "pure-token",
                 "token": "GEO"
+              },
+              {
+                "name": "geoshape",
+                "type": "pure-token",
+                "token": "GEOSHAPE"
               },
               {
                 "name": "vector",
@@ -1296,98 +1323,232 @@
           },
           {
             "name": "reduce",
-            "type": "block",
+            "type": "oneof",
             "optional": true,
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
-                "token": "REDUCE",
-                "type": "pure-token"
-              },
-              {
-                "name": "function",
-                "type": "oneof",
+                "name": "generic_reduce",
+                "type": "block",
+                "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results.",
                 "arguments": [
                   {
-                    "name": "count",
-                    "type": "pure-token",
-                    "token": "COUNT"
+                    "name": "reduce",
+                    "token": "REDUCE",
+                    "type": "pure-token"
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
+                    "name": "function",
+                    "type": "oneof",
+                    "arguments": [
+                      {
+                        "name": "count",
+                        "type": "pure-token",
+                        "token": "COUNT"
+                      },
+                      {
+                        "name": "count_distinct",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCT"
+                      },
+                      {
+                        "name": "count_distinctish",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCTISH"
+                      },
+                      {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                      },
+                      {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                      },
+                      {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                      },
+                      {
+                        "name": "avg",
+                        "type": "pure-token",
+                        "token": "AVG"
+                      },
+                      {
+                        "name": "stddev",
+                        "type": "pure-token",
+                        "token": "STDDEV"
+                      },
+                      {
+                        "name": "quantile",
+                        "type": "pure-token",
+                        "token": "QUANTILE"
+                      },
+                      {
+                        "name": "tolist",
+                        "type": "pure-token",
+                        "token": "TOLIST"
+                      },
+                      {
+                        "name": "first_value",
+                        "type": "pure-token",
+                        "token": "FIRST_VALUE"
+                      },
+                      {
+                        "name": "random_sample",
+                        "type": "pure-token",
+                        "token": "RANDOM_SAMPLE"
+                      }
+                    ]
                   },
                   {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
+                    "name": "nargs",
+                    "type": "integer"
                   },
                   {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
+                    "name": "arg",
+                    "type": "string",
+                    "multiple": true
                   },
                   {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
                   }
                 ]
               },
               {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
-              },
-              {
-                "name": "name",
-                "type": "string",
-                "token": "AS",
-                "optional": true
+                "name": "collect_reduce",
+                "type": "block",
+                "since": "8.8.0",
+                "arguments": [
+                  {
+                    "name": "reduce",
+                    "token": "REDUCE",
+                    "type": "pure-token"
+                  },
+                  {
+                    "name": "collect_token",
+                    "type": "pure-token",
+                    "token": "COLLECT"
+                  },
+                  {
+                    "name": "nargs",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "fields",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "fields_token",
+                        "type": "pure-token",
+                        "token": "FIELDS"
+                      },
+                      {
+                        "name": "fields_spec",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "all",
+                            "type": "pure-token",
+                            "token": "*"
+                          },
+                          {
+                            "name": "explicit",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "sortby",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "sortby_token",
+                        "type": "pure-token",
+                        "token": "SORTBY"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "key",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                          {
+                            "name": "field",
+                            "type": "string"
+                          },
+                          {
+                            "name": "order",
+                            "type": "oneof",
+                            "optional": true,
+                            "arguments": [
+                              {
+                                "name": "asc",
+                                "type": "pure-token",
+                                "token": "ASC"
+                              },
+                              {
+                                "name": "desc",
+                                "type": "pure-token",
+                                "token": "DESC"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "limit",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "limit_token",
+                        "type": "pure-token",
+                        "token": "LIMIT"
+                      },
+                      {
+                        "name": "offset",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "count",
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
+                  }
+                ]
               }
-            ],
-            "summary": "Applies a reducer function, like `SUM` or `COUNT`, on grouped results."
+            ]
           }
         ],
         "summary": "Groups results by specified fields, often used for aggregations."
@@ -1895,7 +2056,7 @@
     "group": "search"
   },
   "FT.PROFILE": {
-    "summary": "Performs a `FT.SEARCH` or `FT.AGGREGATE` command and collects performance information",
+    "summary": "Performs a `FT.SEARCH`, `FT.AGGREGATE`, or `FT.HYBRID` command and collects performance information",
     "complexity": "O(N)",
     "arguments": [
       {
@@ -1916,6 +2077,11 @@
             "name": "aggregate",
             "type": "pure-token",
             "token": "AGGREGATE"
+          },
+          {
+            "name": "hybrid",
+            "type": "pure-token",
+            "token": "HYBRID"
           }
         ]
       },
@@ -2066,6 +2232,13 @@
                     "type": "integer",
                     "token": "EF_RUNTIME",
                     "optional": true
+                  },
+                  {
+                    "name": "shard_k_ratio",
+                    "type": "double",
+                    "token": "SHARD_K_RATIO",
+                    "optional": true,
+                    "since": "8.6.1"
                   },
                   {
                     "name": "yield_score_as",
@@ -2360,95 +2533,229 @@
           },
           {
             "name": "reduce",
-            "type": "block",
+            "type": "oneof",
             "optional": true,
             "multiple": true,
             "arguments": [
               {
-                "name": "reduce",
-                "type": "pure-token",
-                "token": "REDUCE"
-              },
-              {
-                "name": "function",
-                "type": "oneof",
+                "name": "generic_reduce",
+                "type": "block",
                 "arguments": [
                   {
-                    "name": "count",
+                    "name": "reduce",
                     "type": "pure-token",
-                    "token": "COUNT"
+                    "token": "REDUCE"
                   },
                   {
-                    "name": "count_distinct",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCT"
+                    "name": "function",
+                    "type": "oneof",
+                    "arguments": [
+                      {
+                        "name": "count",
+                        "type": "pure-token",
+                        "token": "COUNT"
+                      },
+                      {
+                        "name": "count_distinct",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCT"
+                      },
+                      {
+                        "name": "count_distinctish",
+                        "type": "pure-token",
+                        "token": "COUNT_DISTINCTISH"
+                      },
+                      {
+                        "name": "sum",
+                        "type": "pure-token",
+                        "token": "SUM"
+                      },
+                      {
+                        "name": "min",
+                        "type": "pure-token",
+                        "token": "MIN"
+                      },
+                      {
+                        "name": "max",
+                        "type": "pure-token",
+                        "token": "MAX"
+                      },
+                      {
+                        "name": "avg",
+                        "type": "pure-token",
+                        "token": "AVG"
+                      },
+                      {
+                        "name": "stddev",
+                        "type": "pure-token",
+                        "token": "STDDEV"
+                      },
+                      {
+                        "name": "quantile",
+                        "type": "pure-token",
+                        "token": "QUANTILE"
+                      },
+                      {
+                        "name": "tolist",
+                        "type": "pure-token",
+                        "token": "TOLIST"
+                      },
+                      {
+                        "name": "first_value",
+                        "type": "pure-token",
+                        "token": "FIRST_VALUE"
+                      },
+                      {
+                        "name": "random_sample",
+                        "type": "pure-token",
+                        "token": "RANDOM_SAMPLE"
+                      }
+                    ]
                   },
                   {
-                    "name": "count_distinctish",
-                    "type": "pure-token",
-                    "token": "COUNT_DISTINCTISH"
+                    "name": "nargs",
+                    "type": "integer"
                   },
                   {
-                    "name": "sum",
-                    "type": "pure-token",
-                    "token": "SUM"
+                    "name": "arg",
+                    "type": "string",
+                    "multiple": true
                   },
                   {
-                    "name": "min",
-                    "type": "pure-token",
-                    "token": "MIN"
-                  },
-                  {
-                    "name": "max",
-                    "type": "pure-token",
-                    "token": "MAX"
-                  },
-                  {
-                    "name": "avg",
-                    "type": "pure-token",
-                    "token": "AVG"
-                  },
-                  {
-                    "name": "stddev",
-                    "type": "pure-token",
-                    "token": "STDDEV"
-                  },
-                  {
-                    "name": "quantile",
-                    "type": "pure-token",
-                    "token": "QUANTILE"
-                  },
-                  {
-                    "name": "tolist",
-                    "type": "pure-token",
-                    "token": "TOLIST"
-                  },
-                  {
-                    "name": "first_value",
-                    "type": "pure-token",
-                    "token": "FIRST_VALUE"
-                  },
-                  {
-                    "name": "random_sample",
-                    "type": "pure-token",
-                    "token": "RANDOM_SAMPLE"
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
                   }
                 ]
               },
               {
-                "name": "nargs",
-                "type": "integer"
-              },
-              {
-                "name": "arg",
-                "type": "string",
-                "multiple": true
-              },
-              {
-                "name": "name",
-                "type": "string",
-                "token": "AS",
-                "optional": true
+                "name": "collect_reduce",
+                "type": "block",
+                "since": "8.8.0",
+                "arguments": [
+                  {
+                    "name": "reduce",
+                    "type": "pure-token",
+                    "token": "REDUCE"
+                  },
+                  {
+                    "name": "collect_token",
+                    "type": "pure-token",
+                    "token": "COLLECT"
+                  },
+                  {
+                    "name": "nargs",
+                    "type": "integer"
+                  },
+                  {
+                    "name": "fields",
+                    "type": "block",
+                    "arguments": [
+                      {
+                        "name": "fields_token",
+                        "type": "pure-token",
+                        "token": "FIELDS"
+                      },
+                      {
+                        "name": "fields_spec",
+                        "type": "oneof",
+                        "arguments": [
+                          {
+                            "name": "all",
+                            "type": "pure-token",
+                            "token": "*"
+                          },
+                          {
+                            "name": "explicit",
+                            "type": "block",
+                            "arguments": [
+                              {
+                                "name": "num_fields",
+                                "type": "integer"
+                              },
+                              {
+                                "name": "field",
+                                "type": "string",
+                                "multiple": true
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "sortby",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "sortby_token",
+                        "type": "pure-token",
+                        "token": "SORTBY"
+                      },
+                      {
+                        "name": "nargs",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "key",
+                        "type": "block",
+                        "multiple": true,
+                        "arguments": [
+                          {
+                            "name": "field",
+                            "type": "string"
+                          },
+                          {
+                            "name": "order",
+                            "type": "oneof",
+                            "optional": true,
+                            "arguments": [
+                              {
+                                "name": "asc",
+                                "type": "pure-token",
+                                "token": "ASC"
+                              },
+                              {
+                                "name": "desc",
+                                "type": "pure-token",
+                                "token": "DESC"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "name": "limit",
+                    "type": "block",
+                    "optional": true,
+                    "arguments": [
+                      {
+                        "name": "limit_token",
+                        "type": "pure-token",
+                        "token": "LIMIT"
+                      },
+                      {
+                        "name": "offset",
+                        "type": "integer"
+                      },
+                      {
+                        "name": "count",
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  {
+                    "name": "name",
+                    "type": "string",
+                    "token": "AS",
+                    "optional": true
+                  }
+                ]
               }
             ]
           }

--- a/data/commands_redisjson.json
+++ b/data/commands_redisjson.json
@@ -134,6 +134,39 @@
           }
         ],
         "optional": true
+      },
+      {
+        "name": "fpha",
+        "type": "block",
+        "arguments": [
+          {
+            "name": "fpha-type",
+            "type": "oneof",
+            "arguments": [
+              {
+                "name": "FP16",
+                "type": "pure-token",
+                "token": "FP16"
+              },
+              {
+                "name": "BF16",
+                "type": "pure-token",
+                "token": "BF16"
+              },
+              {
+                "name": "FP32",
+                "type": "pure-token",
+                "token": "FP32"
+              },
+              {
+                "name": "FP64",
+                "type": "pure-token",
+                "token": "FP64"
+              }
+            ]
+          }
+        ],
+        "optional": true
       }
     ],
     "since": "1.0.0",

--- a/data/commands_redistimeseries.json
+++ b/data/commands_redistimeseries.json
@@ -635,89 +635,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",
@@ -810,89 +730,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",
@@ -1041,89 +881,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",
@@ -1298,89 +1058,9 @@
                         "optional": true
                     },
                     {
-                        "type": "oneof",
+                        "type": "string",
                         "token": "AGGREGATION",
-                        "name": "aggregator",
-                        "arguments": [
-                            {
-                                "name": "avg",
-                                "type": "pure-token",
-                                "token": "AVG"
-                            },
-                            {
-                                "name": "first",
-                                "type": "pure-token",
-                                "token": "FIRST"
-                            },
-                            {
-                                "name": "last",
-                                "type": "pure-token",
-                                "token": "LAST"
-                            },
-                            {
-                                "name": "min",
-                                "type": "pure-token",
-                                "token": "MIN"
-                            },
-                            {
-                                "name": "max",
-                                "type": "pure-token",
-                                "token": "MAX"
-                            },
-                            {
-                                "name": "sum",
-                                "type": "pure-token",
-                                "token": "SUM"
-                            },
-                            {
-                                "name": "range",
-                                "type": "pure-token",
-                                "token": "RANGE"
-                            },
-                            {
-                                "name": "count",
-                                "type": "pure-token",
-                                "token": "COUNT"
-                            },
-                            {
-                                "name": "std.p",
-                                "type": "pure-token",
-                                "token": "STD.P"
-                            },
-                            {
-                                "name": "std.s",
-                                "type": "pure-token",
-                                "token": "STD.S"
-                            },
-                            {
-                                "name": "var.p",
-                                "type": "pure-token",
-                                "token": "VAR.P"
-                            },
-                            {
-                                "name": "var.s",
-                                "type": "pure-token",
-                                "token": "VAR.S"
-                            },
-                            {
-                                "name": "twa",
-                                "type": "pure-token",
-                                "token": "TWA",
-                                "since": "1.8.0"
-                            },
-                            {
-                                "name": "countnan",
-                                "type": "pure-token",
-                                "token": "COUNTNAN",
-                                "since": "8.6.0"
-                            },
-                            {
-                                "name": "countall",
-                                "type": "pure-token",
-                                "token": "COUNTALL",
-                                "since": "8.6.0"
-                            }
-                        ]
+                        "name": "aggregators"
                     },
                     {
                         "name": "bucketDuration",


### PR DESCRIPTION
Redis 8.8 content

Reviewers: this content was taken directly from the Redis core and module repos.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large, generated updates to command metadata JSON files; risk is mainly that downstream tooling relying on these specs may need to accommodate added/changed fields and new commands.
> 
> **Overview**
> Refreshes the generated Redis module command specification files (notably `data/commands_redisearch.json`, `data/commands_redisjson.json`, and `data/commands_redistimeseries.json`) to match the Redis 8.8 GA build.
> 
> This updates command metadata (summaries, complexity notes, argument schemas, and version history) and adds newly introduced options/commands where applicable, keeping the local command catalog in sync with upstream Redis core/module repos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68ec03ab9a2c1ad9d8c3f6842b264be71564e407. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->