### PR TITLE
DOC-6627 noted minimum versions of clients that support SCH

### DIFF
--- a/content/develop/clients/go/connect.md
+++ b/content/develop/clients/go/connect.md
@@ -136,6 +136,11 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
+{{< note >}}Using SCH with go-redis requires v9.16.0 or later for
+basic connections, and v9.18.0 or later for
+[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
+{{< /note >}}
+
 By default, `go-redis` always attempts to connect via SCH but falls back to
 a non-SCH connection if the server doesn't support it. However, you can configure SCH
 explicitly by passing a `MaintNotificationsConfig` object during the connection,

--- a/content/develop/clients/lettuce/connect.md
+++ b/content/develop/clients/lettuce/connect.md
@@ -264,6 +264,9 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
+{{< note >}}Support for SCH in Lettuce requires v7.0.0 or later.
+{{< /note >}}
+
 By default, `Lettuce` always attempts to connect via SCH but falls back to
 a non-SCH connection if the server doesn't support it. However, you can configure SCH
 explicitly by creating a `MaintNotificationsConfig` object and/or a `TimeoutOptions`

--- a/content/develop/clients/nodejs/connect.md
+++ b/content/develop/clients/nodejs/connect.md
@@ -338,6 +338,11 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
+{{< note >}}Using SCH with node-redis requires v5.9.0 or later for
+basic connections, and v5.11.0 or later for
+[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
+{{< /note >}}
+
 Use the configuration options shown in the example below to enable SCH
 during the connection:
 

--- a/content/develop/clients/redis-py/connect.md
+++ b/content/develop/clients/redis-py/connect.md
@@ -262,6 +262,11 @@ lets a client take action to avoid disruptions in service.
 See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
 for more information about SCH.
 
+{{< note >}}Using SCH with redis-py requires v7.0.0 or later for
+basic connections, and v7.2.0 or later for
+[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
+{{< /note >}}
+
 By default, `redis-py` always attempts to connect via SCH but falls back to
 a non-SCH connection if the server doesn't support it. However, you can configure SCH
 explicitly by passing a `MaintNotificationsConfig` object during the connection,

--- a/content/develop/clients/sch.md
+++ b/content/develop/clients/sch.md
@@ -59,12 +59,17 @@ if you select the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-vers
 protocol, which is a requirement for SCH. However, you can
 configure some parameters, such as the timeouts to use
 during maintenance.
-See the pages linked below to learn how to configure SCH for:
 
-- [redis-py]({{< relref "/develop/clients/redis-py/connect#connect-using-smart-client-handoffs-sch" >}})
-- [node-redis]({{< relref "/develop/clients/nodejs/connect#connect-using-smart-client-handoffs-sch" >}})
-- [Lettuce]({{< relref "/develop/clients/lettuce/connect#connect-using-smart-client-handoffs-sch" >}})
-- [go-redis]({{< relref "/develop/clients/go/connect#connect-using-smart-client-handoffs-sch" >}})
+The table below lists the Redis client libraries that support SCH,
+and the versions that added support for basic connections and
+[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
+
+| Client | Basic connection | OSS Cluster API |
+| :-- | :-- | :-- |
+| [redis-py]({{< relref "/develop/clients/redis-py/connect#connect-using-smart-client-handoffs-sch" >}}) | v7.0.0 | v7.2.0 |
+| [node-redis]({{< relref "/develop/clients/nodejs/connect#connect-using-smart-client-handoffs-sch" >}}) | v5.9.0 | v5.11.0 |
+| [Lettuce]({{< relref "/develop/clients/lettuce/connect#connect-using-smart-client-handoffs-sch" >}}) | v7.0.0 | - |
+| [go-redis]({{< relref "/develop/clients/go/connect#connect-using-smart-client-handoffs-sch" >}}) | v9.16.0 | v9.18.0 |
 
 ## SCH support in Redis server products
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds version requirements; primary risk is incorrect version numbers or links causing user confusion.
> 
> **Overview**
> Adds explicit *minimum Redis client library versions* required to use Smart Client Handoffs (SCH) in the `go-redis`, `node-redis`, `redis-py`, and `Lettuce` connect guides, including separate requirements for basic vs *OSS Cluster API* connections where applicable.
> 
> Updates the main `sch` overview page to include a small compatibility table summarizing SCH support and the first supporting versions across these clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe5e785d522cfd4bf567ed505bc348dfa30c742. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->