### PR TITLE
K8s: RN image name fix

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-11-june2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-11-june2025.md
@@ -25,4 +25,7 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.0-11.2`
-- **Call Home Client**: `redislabs/call-home-client:7.22.0-11`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.0-95`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.0-11`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.0-11`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.0-11`

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-15-july2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-15-july2025.md
@@ -94,7 +94,10 @@ Any distribution not listed below is not supported for production workloads.
 ### Openshift downloads
 
 - **OLM operator bundle**: `7.22.0-15.0`
-- **Call Home Client**: `redislabs/call-home-client:7.22.0-15`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.0-216`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.0-15`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.0-15`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.0-15`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-16-august2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-16-august2025.md
@@ -25,7 +25,10 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.0-16.0`
-- **Call Home Client**: `redislabs/call-home-client:7.22.0-16`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.0-241`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.0-16`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.0-16`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.0-16`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-17-september2025.md
@@ -25,9 +25,9 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 ### OpenShift downloads
 
 - **OLM operator bundle**: `v7.22.0-17.0`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:7.22.0-250`
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:7.22.0-17`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:7.22.0-17`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.0-250`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.0-17`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.0-17`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.0-17`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-7-april2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-0-releases/7-22-0-7-april2025.md
@@ -82,8 +82,11 @@ Any distribution not listed below is not supported for production workloads.
 
 ### Openshift downloads
 
-- **OLM operator bundle** : `7.22.0-7.0`
-- **Call Home Client**: `redislabs/call-home-client:7.22.0-7`
+- **OLM operator bundle**: `7.22.0-7.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.0-28`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.0-7`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.0-7`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.0-7`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-21-october2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-21-october2025.md
@@ -25,7 +25,10 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.2-21.1`
-- **Call Home Client**: `redislabs/call-home-client:7.22.2-21`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-14`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-21`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-21`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-21`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-22-october2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-22-october2025.md
@@ -25,7 +25,10 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.2-22.0`
-- **Call Home Client**: `redislabs/call-home-client:7.22.2-22`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-20`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-22`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-22`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-22`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-31-december2025.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-31-december2025.md
@@ -46,7 +46,10 @@ This is a maintenance release to support [Redis Enterprise Software version 7.22
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.2-31.1`
-- **Call Home Client**: `redislabs/call-home-client:7.22.2-31`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-41`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-31`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-31`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-31`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-32-january2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-32-january2026.md
@@ -25,7 +25,10 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.2-32.1`
-- **Call Home Client**: `redislabs/call-home-client:7.22.2-32`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-55`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-32`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-32`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-32`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-37-feb2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-37-feb2026.md
@@ -25,7 +25,10 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.2-37.1`
-- **Call Home Client**: `redislabs/call-home-client:7.22.2-37`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-79`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-37`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-37`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-37`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-38-march2026.md
@@ -29,7 +29,10 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 ### Openshift downloads
 
 - **OLM operator bundle**: `v7.22.2-38.0`
-- **Call Home Client**: `redislabs/call-home-client:7.22.2-38`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-93`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-38`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-38`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-38`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-39-april2026.md
@@ -25,9 +25,9 @@ This is a maintenance release to support Redis Enterprise Software version 7.22.
 ### OpenShift downloads
 
 - **OLM operator bundle**: `v7.22.2-39.0`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:7.22.2-116`
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:7.22.2-39`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:7.22.2-39`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-116`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-39`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-39`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-39`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-21-feb2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-21-feb2026.md
@@ -85,8 +85,11 @@ Any distribution not listed in the table is not supported for production workloa
 
 ### Openshift downloads
 
-- **Redis Enterprise OLM operator bundle**: `8.0.10-21.0`
-- **Call Home Client**: `redislabs/call-home-client:8.0.10-21`
+- **OLM operator bundle**: `8.0.10-21.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.10-64`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.10-21`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.10-21`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.10-21`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-22-feb2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-22-feb2026.md
@@ -25,7 +25,10 @@ This is a maintenance release to support Redis Enterprise Software version 8.0.1
 ### Openshift downloads
 
 - **OLM operator bundle**: `8.0.10-22.0`
-- **Call Home Client**: `redislabs/call-home-client:8.0.10-22`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.10-76`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.10-22`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.10-22`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.10-22`
 
 ## Known limitations
 

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-23-feb2026.md
@@ -25,9 +25,9 @@ This is a maintenance release to support Redis Enterprise Software version 8.0.1
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.10-23.0`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.10-81`
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.10-23`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.10-23`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.10-81`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.10-23`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.10-23`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.10-23`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-24-march2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-24-march2026.md
@@ -4,7 +4,7 @@ categories:
 - docs
 - operate
 - kubernetes
-description: Feature release with OSS Cluster API support for external clients, ARM architecture support, and Redis Software 8.0.16-64.
+description: Feature release with OSS Cluster API support for external clients, ARM architecture support, and Redis Software 8.0.16-29.
 hideListLinks: true
 linkTitle: 8.0.16-24 (March 2026)
 title: Redis Enterprise for Kubernetes 8.0.16-24 (March 2026) release notes
@@ -23,7 +23,7 @@ For version changes, supported distributions, and known limitations, see the [re
 
 ## Downloads
 
-- **Redis Enterprise**: `redislabs/redis:8.0.16-64`
+- **Redis Enterprise**: `redislabs/redis:8.0.16-29`
 - **Operator**: `redislabs/operator:8.0.16-24`
 - **Services Rigger**: `redislabs/k8s-controller:8.0.16-24`
 - **Callhome client**: `redislabs/re-call-home-client:8.0.16-24`
@@ -31,4 +31,7 @@ For version changes, supported distributions, and known limitations, see the [re
 ### Openshift downloads
 
 - **OLM operator bundle**: `8.0.16-24.4`
-- **Call Home Client**: `redislabs/call-home-client:8.0.16-24`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.16-29`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.16-24`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.16-24`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.16-24`

--- a/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-25-march2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-16-releases/8-0-16-25-march2026.md
@@ -26,7 +26,7 @@ For version changes, supported distributions, and known limitations, see the [re
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.16-25.0`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.16-33`
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.16-25`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.16-25`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.16-33`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.16-25`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.16-25`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.16-25`

--- a/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026.md
@@ -82,8 +82,11 @@ The following table shows supported Kubernetes versions at the time of this rele
 
 ### Openshift downloads
 
-- **Redis Enterprise OLM operator bundle**: `8.0.18-11.0`
-- **Call Home Client**: `redislabs/call-home-client:8.0.18-11`
+- **OLM operator bundle**: `8.0.18-11.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.18-23.11` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.0.18-23.11.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.18-11`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.18-11`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.18-11`
 
 {{<note>}}When you pull images from container registries such as Docker Hub, ARM support is transparent. The registry automatically serves the correct image based on the node architecture (AMD64 or ARM64).{{</note>}}
 

--- a/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-14-may2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-14-may2026.md
@@ -25,9 +25,9 @@ This is a maintenance release to support Redis Enterprise Software version 8.0.1
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.18-14.2`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.18-36.14` (`registry.connect.redhat.com/redislabs/redis:8.0.18-36.14.minimal` for minimal base image)
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.18-14`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.18-14`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.18-36.14` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.0.18-36.14.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.18-14`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.18-14`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.18-14`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-2-october2025.md
+++ b/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-2-october2025.md
@@ -136,8 +136,11 @@ Any distribution not listed in the table is not supported for production workloa
 
 ### Openshift downloads
 
-- **OLM operator bundle** : `8.0.2-2.9`
-- **Call Home Client**: `redislabs/call-home-client:8.0.2-2`
+- **OLM operator bundle**: `8.0.2-2.9`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.2-17`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.2-2`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.2-2`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.2-2`
 
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-6-december2025.md
+++ b/content/operate/kubernetes/release-notes/8-0-2-releases/8-0-2-6-december2025.md
@@ -103,9 +103,9 @@ Any distribution not listed in the table is not supported for production workloa
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.2-6.1`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.2-41`
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.2-6`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.2-6`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.2-41`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.2-6`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.2-6`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.2-6`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-21-may2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-21-may2026.md
@@ -25,9 +25,9 @@ This is a maintenance release to support Redis Enterprise Software version 8.0.2
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.20-21.0`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.20-19.21` (`registry.connect.redhat.com/redislabs/redis:8.0.20-19.21.minimal` for minimal base image)
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.20-21`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.20-21`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-19.21` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-19.21.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.20-21`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.20-21`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.20-21`
 
 ## Known limitations

--- a/content/operate/kubernetes/release-notes/8-0-6-releases/8-0-6-8-december2025.md
+++ b/content/operate/kubernetes/release-notes/8-0-6-releases/8-0-6-8-december2025.md
@@ -98,9 +98,9 @@ Any distribution not listed in the table is not supported for production workloa
 ### OpenShift downloads
 
 - **OLM operator bundle**: `8.0.6-8.0`
-- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis:8.0.6-54`
-- **Operator**: `registry.connect.redhat.com/redislabs/operator:8.0.6-8`
-- **Services Rigger**: `registry.connect.redhat.com/redislabs/k8s-controller:8.0.6-8`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.6-54`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.6-8`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.6-8`
 - **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.6-8`
 
 ## Known limitations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk docs-only change updating release-note download references; main risk is publishing incorrect image tags/names if any were mistyped.
> 
> **Overview**
> Updates multiple Kubernetes operator release notes to **correct and standardize OpenShift/Red Hat registry image references**, adding the `registry.connect.redhat.com/redislabs/redis-enterprise`, `redis-enterprise-operator`, `services-manager`, and `call-home-client` image names under *OpenShift downloads*.
> 
> Also fixes an incorrect Redis Enterprise image version reference in the `8.0.16-24` release notes (description and downloads) to `8.0.16-29`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdeba9035f6153ccfad81f567da016149bddcab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->