### PR TITLE
DOC-6630 RDI: note about one install per k8s cluster

### DIFF
--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -55,6 +55,14 @@ The configuration for the GCS is available only for [Helm based installations]({
 
 **Important:** You should only use this configuration when both sites use the same source configuration.
 
+## Can I run multiple RDI installations in the same Kubernetes cluster?
+
+No. Only one RDI installation is supported per Kubernetes cluster, even if
+you install into different namespaces. If you need more than one RDI
+deployment, use separate Kubernetes clusters. See
+[Install on Kubernetes]({{< relref "/integrate/redis-data-integration/installation/install-k8s" >}})
+for installation details.
+
 ## Can RDI automatically track changes to the source database schema?
 
 If you don't configure RDI to capture a specific set of tables in the schema then it will

--- a/content/integrate/redis-data-integration/installation/install-k8s.md
+++ b/content/integrate/redis-data-integration/installation/install-k8s.md
@@ -173,7 +173,13 @@ To pull images from a private image registry, you must provide the image pull se
     {{< note >}}The above command will install RDI in a namespace called
     `rdi`. If you want to use a different namespace, pass the option
     `-n <custom-namespace>` to the `helm install` command instead.
-    {{< /note >}} 
+    {{< /note >}}
+
+    {{< warning >}}Only one RDI installation is supported per Kubernetes
+    cluster. Installing RDI into multiple namespaces in the same cluster is
+    not supported and will fail. If you need more than one RDI deployment,
+    use separate Kubernetes clusters.
+    {{< /warning >}} 
 
 ### The `values.yaml` file
 

--- a/content/integrate/redis-data-integration/installation/install-k8s.md
+++ b/content/integrate/redis-data-integration/installation/install-k8s.md
@@ -174,7 +174,7 @@ To pull images from a private image registry, you must provide the image pull se
     `rdi`. If you want to use a different namespace, pass the option
     `-n <custom-namespace>` to the `helm install` command instead.
     {{< /note >}}
-
+    &nbsp;
     {{< warning >}}Only one RDI installation is supported per Kubernetes
     cluster. Installing RDI into multiple namespaces in the same cluster is
     not supported and will fail. If you need more than one RDI deployment,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk docs-only change; main impact is clarifying an installation constraint that may affect user expectations but not runtime behavior.
> 
> **Overview**
> Adds explicit guidance that **only one RDI installation is supported per Kubernetes cluster**, even across namespaces.
> 
> This is documented both as a new FAQ entry in `faq.md` and as a prominent `warning` callout in the Kubernetes Helm install instructions (`install-k8s.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d4070379f42def5be309646092a5801a852e522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->