### PR TITLE
google-adk: bring docs to parity with adk-redis 0.0.5

### DIFF
--- a/content/integrate/google-adk/_index.md
+++ b/content/integrate/google-adk/_index.md
@@ -42,11 +42,16 @@ docker run -d --name redis -p 6379:6379 redis:8.4-alpine
 docker run -d --name agent-memory-server -p 8088:8088 \
   -e REDIS_URL=redis://host.docker.internal:6379 \
   -e GEMINI_API_KEY=your-key \
-  -e GENERATION_MODEL=gemini/gemini-2.0-flash \
+  -e GENERATION_MODEL=gemini/gemini-2.5-flash \
   -e EMBEDDING_MODEL=gemini/text-embedding-004 \
   redislabs/agent-memory-server:latest \
   agent-memory api --host 0.0.0.0 --port 8088 --task-backend=asyncio
 ```
+
+On Linux, `host.docker.internal` does not resolve by default. Use
+`--network=host` plus `REDIS_URL=redis://127.0.0.1:6379`, or point
+`REDIS_URL` at the Docker bridge gateway (typically
+`redis://172.17.0.1:6379`).
 
 ## Installation
 
@@ -57,11 +62,17 @@ pip install adk-redis[memory]
 # Search tools via RedisVL
 pip install adk-redis[search]
 
+# SQL-style search tool (sql-redis)
+pip install adk-redis[sql]
+
 # Managed semantic caching via LangCache
 pip install adk-redis[langcache]
 
 # Everything
 pip install adk-redis[all]
+
+# For the RedisVL MCP server (used with ADK's native McpToolset)
+pip install 'redisvl[mcp]>=0.18.2'
 ```
 
 ## Quick start
@@ -118,9 +129,9 @@ runner = Runner(
 |------------|-------------|------|
 | **Redis Agent Memory** | Working and long-term memory via framework services, REST tools, or MCP | [Redis Agent Memory]({{< relref "/integrate/google-adk/redis-agent-memory" >}}) |
 | **Integration patterns** | Framework-managed, LLM-controlled REST, and MCP tools | [Integration patterns]({{< relref "/integrate/google-adk/integration-patterns" >}}) |
-| **Search tools** | Vector, hybrid, text, and range search via RedisVL | [Search tools]({{< relref "/integrate/google-adk/search-tools" >}}) |
+| **Search tools** | Vector, hybrid, text, range, and SQL search via RedisVL, plus the `rvl mcp` server over `McpToolset` | [Search tools]({{< relref "/integrate/google-adk/search-tools" >}}) |
 | **Semantic caching** | LLM response and tool result caching | [Semantic caching]({{< relref "/integrate/google-adk/semantic-caching" >}}) |
-| **Examples** | Seven complete examples covering all capabilities | [Examples]({{< relref "/integrate/google-adk/examples" >}}) |
+| **Examples** | Nine complete examples covering all capabilities | [Examples]({{< relref "/integrate/google-adk/examples" >}}) |
 
 ## More info
 

--- a/content/integrate/google-adk/examples.md
+++ b/content/integrate/google-adk/examples.md
@@ -11,13 +11,13 @@ categories:
 description: Complete examples for every adk-redis capability.
 group: ai
 stack: true
-summary: Seven runnable examples covering Redis Agent Memory, search tools, semantic
+summary: Nine runnable examples covering Redis Agent Memory, search tools, semantic
   caching, and MCP integration.
 type: integration
 weight: 5
 ---
 
-The [adk-redis repository](https://github.com/redis-developer/adk-redis/tree/main/examples) includes seven complete examples. Each focuses on a specific capability.
+The [adk-redis repository](https://github.com/redis-developer/adk-redis/tree/main/examples) includes nine complete examples. Each focuses on a specific capability.
 
 ## Prerequisites
 
@@ -64,9 +64,25 @@ Demonstrates MCP-based memory integration. The agent connects to the Agent Memor
 
 **Capability:** Vector, hybrid, text, and range search
 
-All four RedisVL [search tools]({{< relref "/integrate/google-adk/search-tools" >}}) plugged into a single agent with a product catalog dataset.
+Four in-process RedisVL [search tools]({{< relref "/integrate/google-adk/search-tools" >}}) plugged into a single agent with a product catalog dataset.
 
 [View on GitHub](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_search_tools)
+
+## `redis_sql_search`
+
+**Capability:** SQL `SELECT` search
+
+A 10-product catalog with the `RedisSQLSearchTool`. The agent emits parameterized SQL (`WHERE category = 'electronics' AND price < :max_price`) to answer structured catalog questions. Requires `pip install 'adk-redis[sql]'`.
+
+[View on GitHub](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_sql_search)
+
+## `redisvl_mcp_search`
+
+**Capability:** RedisVL MCP server via ADK's `McpToolset`
+
+The MCP counterpart of `redis_search_tools`. A `rvl mcp` server hosts a knowledge-base index in hybrid (vector + BM25) mode and the agent connects via ADK's native `McpToolset`. No adk-redis wrapper involved; the standard `McpToolset` + `StdioConnectionParams` pattern is used.
+
+[View on GitHub](https://github.com/redis-developer/adk-redis/tree/main/examples/redisvl_mcp_search)
 
 ## `semantic_cache`
 

--- a/content/integrate/google-adk/redis-agent-memory.md
+++ b/content/integrate/google-adk/redis-agent-memory.md
@@ -45,7 +45,7 @@ session_service = RedisWorkingMemorySessionService(
     config=RedisWorkingMemorySessionServiceConfig(
         api_base_url="http://localhost:8088",
         default_namespace="my_app",
-        model_name="gemini-2.0-flash",
+        model_name="gemini-2.5-flash",
         context_window_max=8000,
     )
 )

--- a/content/integrate/google-adk/search-tools.md
+++ b/content/integrate/google-adk/search-tools.md
@@ -8,7 +8,7 @@ categories:
 - oss
 - rs
 - rc
-description: Vector, hybrid, text, and range search tools for Google ADK agents.
+description: Vector, hybrid, text, range, and SQL search tools for Google ADK agents, plus the RedisVL MCP server.
 group: ai
 stack: true
 summary: Add retrieval-augmented generation (RAG) to ADK agents using RedisVL-powered
@@ -17,7 +17,7 @@ type: integration
 weight: 3
 ---
 
-adk-redis provides four search tools that wrap [RedisVL]({{< relref "/develop/ai/redisvl" >}}) query types into ADK-compatible tools. The LLM sees each tool as a callable function with a `query` parameter and gets back structured results.
+adk-redis provides five in-process search tools that wrap [RedisVL]({{< relref "/develop/ai/redisvl" >}}) query types into ADK-compatible tools. The LLM sees each tool as a callable function and gets back structured results. For multi-agent or polyglot deployments, the same RedisVL index can also be served over MCP via the `rvl mcp` server and consumed with ADK's native `McpToolset` (see the [RedisVL MCP server](#redisvl-mcp-server) section below).
 
 ## Overview
 
@@ -27,6 +27,7 @@ adk-redis provides four search tools that wrap [RedisVL]({{< relref "/develop/ai
 | `RedisHybridSearchTool` | Vector + BM25 | Queries with specific terms + concepts |
 | `RedisTextSearchTool` | BM25 keyword | Exact terms, error messages, IDs |
 | `RedisRangeSearchTool` | Distance threshold | Exhaustive retrieval within a radius |
+| `RedisSQLSearchTool` | SQL `SELECT` | Structured filters (`WHERE`, `BETWEEN`, parameterized) |
 
 ## Vector search
 
@@ -106,6 +107,80 @@ range_tool = RedisRangeSearchTool(
 )
 ```
 
+## SQL search
+
+`RedisSQLSearchTool` wraps `redisvl.query.SQLQuery`. The LLM emits a SQL `SELECT` statement (with optional `:name` parameter placeholders) and the tool translates it into the right `FT.SEARCH` or `FT.AGGREGATE` call. Best for structured filters: tag equality, numeric ranges, multi-predicate `WHERE` clauses. Requires `pip install 'adk-redis[sql]'`.
+
+```python
+from adk_redis import RedisSQLSearchTool
+
+sql_tool = RedisSQLSearchTool(
+    index=index,
+    name="catalog_sql_search",
+    description=(
+        "Run a SQL SELECT against the product catalog. "
+        "Use :name placeholders for values."
+    ),
+)
+```
+
+The LLM might emit a call like:
+
+```sql
+SELECT title, brand, price
+FROM products
+WHERE category = 'electronics' AND price < :max_price
+```
+
+with `params={"max_price": 100}`. See the [redis_sql_search example](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_sql_search) for a runnable demo.
+
+## RedisVL MCP server
+
+The five tools above run in-process against a Python `SearchIndex`. To serve one Redis index to multiple agents (Python, JS, Claude Desktop), or to put server-side guardrails like `--read-only` and bearer auth between the agent and the index, run RedisVL's MCP server (`rvl mcp`) and connect ADK's native `McpToolset` to it.
+
+```python
+from google.adk import Agent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+agent = Agent(
+    model="gemini-2.5-flash",
+    name="redis_mcp_agent",
+    instruction="Use the search-records tool to answer questions.",
+    tools=[
+        McpToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="rvl",
+                    args=[
+                        "mcp",
+                        "--config",
+                        "/path/to/mcp_config.yaml",
+                        "--read-only",
+                    ],
+                ),
+                timeout=30,
+            ),
+            tool_filter=["search-records"],
+        ),
+    ],
+)
+```
+
+The server is configured per index via a YAML file and exposes two tools: `search-records` (vector / fulltext / hybrid, chosen at server start, with schema-aware filter and return-field hints) and `upsert-records` (suppress with `--read-only`). Supports `stdio`, `sse`, and `streamable-http` transports; bearer auth on HTTP.
+
+Install the CLI with `pip install 'redisvl[mcp]>=0.18.2'`. For a runnable demo, see the [redisvl_mcp_search example](https://github.com/redis-developer/adk-redis/tree/main/examples/redisvl_mcp_search).
+
+### When to choose in-process vs MCP
+
+| Path | Use when |
+|------|----------|
+| In-process tools (above) | Single Python agent, fast onboarding, complex Python-side `FilterExpression` composition. |
+| MCP server | Multi-agent or polyglot deployments, server-side ops gates, schema-aware tool descriptions. |
+
+Range and SQL search have no MCP equivalent today; use the in-process tools for either.
+
 ## Multi-tool agent
 
 Wire multiple search tools into a single agent and let the LLM choose the right one:
@@ -129,5 +204,7 @@ The `name` and `description` on each tool matter: the LLM reads them to decide w
 
 ## More info
 
-- [redis_search_tools example](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_search_tools): All four search tools with a product catalog
+- [redis_search_tools example](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_search_tools): vector, text, and range tools with a product catalog
+- [redis_sql_search example](https://github.com/redis-developer/adk-redis/tree/main/examples/redis_sql_search): SQL `SELECT` against a bound index
+- [redisvl_mcp_search example](https://github.com/redis-developer/adk-redis/tree/main/examples/redisvl_mcp_search): same corpus served via `rvl mcp` + ADK `McpToolset`
 - [RedisVL documentation]({{< relref "/develop/ai/redisvl" >}})

--- a/content/integrate/google-adk/semantic-caching.md
+++ b/content/integrate/google-adk/semantic-caching.md
@@ -45,7 +45,7 @@ provider = RedisVLCacheProvider(
         ttl=3600,
         distance_threshold=0.1,
     ),
-    vectorizer=HFTextVectorizer(model="redis/langcache-embed-v1"),
+    vectorizer=HFTextVectorizer(model="redis/langcache-embed-v2"),
 )
 ```
 
@@ -89,7 +89,7 @@ before_cb, after_cb = create_llm_cache_callbacks(llm_cache)
 
 agent = Agent(
     name="cached_agent",
-    model="gemini-2.0-flash",
+    model="gemini-2.5-flash",
     instruction="You are a helpful assistant.",
     before_model_callback=before_cb,
     after_model_callback=after_cb,


### PR DESCRIPTION
## Summary

adk-redis [0.0.5 shipped to PyPI](https://pypi.org/project/adk-redis/0.0.5/) earlier today ([release notes](https://github.com/redis-developer/adk-redis/releases/tag/0.0.5)). It includes a few user-facing changes the redis.io ADK docs were behind on:

- New `RedisSQLSearchTool` and `adk-redis[sql]` extra.
- New `redis_sql_search` and `redisvl_mcp_search` examples (the latter mirrors `redis_search_tools` but uses the `rvl mcp` server over MCP).
- Repo-canonical model and embedder bumped: `gemini-2.0-flash` → `gemini-2.5-flash` and `redis/langcache-embed-v1` → `redis/langcache-embed-v2`.
- Linux quirk on `host.docker.internal` documented.
- `epsilon` removed from `RedisVectorQueryConfig` (breaking, range only).
- `redisvl.extensions.llmcache` import migrated to `redisvl.extensions.cache.llm`.

This PR brings every page under `content/integrate/google-adk/` up to date.

## Changes per page

### `_index.md`
- AMS Docker command: `gemini-2.0-flash` → `gemini-2.5-flash`.
- New paragraph on the `host.docker.internal` Linux quirk (use `--network=host` and `127.0.0.1`, or the `172.17.0.1` bridge gateway).
- Installation section adds `pip install adk-redis[sql]` and `pip install 'redisvl[mcp]>=0.18.2'`.
- Capabilities table now mentions the SQL tool and the `rvl mcp` server; example count goes from seven to nine.

### `search-tools.md`
- Page now describes **five** in-process search tools (was four). New `RedisSQLSearchTool` section with the parameterized-SQL pattern.
- New "RedisVL MCP server" section showing ADK's **native `McpToolset`** wired to `rvl mcp` over stdio, following the maintainer guidance on [google/adk-docs#1777](https://github.com/google/adk-docs/pull/1777). Includes "When to choose in-process vs MCP" matrix and a coverage note that range/SQL have no MCP equivalent today.
- Bottom links now point at the two new examples.

### `redis-agent-memory.md`
- Working-memory `model_name` bumped to `gemini-2.5-flash`.

### `examples.md`
- Count bumped to nine; added `redis_sql_search` and `redisvl_mcp_search` entries.

### `semantic-caching.md`
- Vectorizer model: `redis/langcache-embed-v1` → `redis/langcache-embed-v2` (matches the runnable example).
- Agent model: `gemini-2.0-flash` → `gemini-2.5-flash`.

## What is intentionally NOT in this PR

- **No mention of `create_redisvl_mcp_toolset(...)` or the `[mcp-search]` extra.** That helper lived briefly on the adk-redis main branch but was removed before 0.0.5 shipped, per the [adk-docs PR review](https://github.com/google/adk-docs/pull/1777) which steered the integration toward ADK's native `McpToolset` pattern (matching cartesia / chroma / mongodb / pinecone catalog pages). The published package does not ship the helper; the docs should not reference it.

## Test plan

- [x] Grep verifies no stale references remain: `create_redisvl_mcp_toolset`, `mcp-search`, `gemini-2.0-flash`, `langcache-embed-v1`, "four search tools", "seven (complete\|runnable) examples".
- [x] All five edited pages are markdown-only, no front-matter or shortcode changes that would affect Hugo render.
- [ ] Hugo build preview (please verify on the redis.io staging deploy).

## References

- [adk-redis PR #11 (the 0.0.5 release)](https://github.com/redis-developer/adk-redis/pull/11)
- [adk-redis 0.0.5 release notes](https://github.com/redis-developer/adk-redis/releases/tag/0.0.5)
- [google/adk-docs PR #1777 (catalog page)](https://github.com/google/adk-docs/pull/1777)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates: adds new SQL search/MCP guidance and refreshes example snippets and model names, with no runtime code changes. Risk is limited to potential confusion if instructions or version pins are incorrect.
> 
> **Overview**
> Brings the Google ADK integration docs up to date with `adk-redis` v0.0.5 by documenting the new `RedisSQLSearchTool` (and `adk-redis[sql]` install extra), adding a new RedisVL MCP server section showing ADK-native `McpToolset` usage, and expanding the examples list from seven to nine.
> 
> Updates snippets and setup guidance to match current defaults (Gemini `gemini-2.5-flash`, `redis/langcache-embed-v2`), adds Linux notes for `host.docker.internal`, and links/install instructions for `redisvl[mcp]>=0.18.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61be38b429ea296276fd7977987df00c3f8e6d0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->