### PR TITLE
[codex] RDSC-4454 Document RDI maintenance deletion limit

### DIFF
--- a/content/operate/rc/databases/rdi/view-edit.md
+++ b/content/operate/rc/databases/rdi/view-edit.md
@@ -151,6 +151,11 @@ Stopping the data pipeline will suspend data processing. To restart the pipeline
 
 To delete the data pipeline:
 
+{{< note >}}
+You can't delete a data pipeline while the target database's Redis Cloud cluster is in maintenance mode.
+Wait until maintenance is complete, and then delete the data pipeline.
+{{< /note >}}
+
 1. From the **Data pipeline** tab, select **More actions**, and then **Delete pipeline**.
 
 1. Select **Delete data pipeline** to confirm.


### PR DESCRIPTION
## Summary
- Add a note to the RDI Delete pipeline docs that data pipelines cannot be deleted while the target Redis Cloud cluster is in maintenance mode.
- Tell users to retry deletion after maintenance is complete.

## Why
RDSC-4454 exposed the maintenance-mode restriction during RDI pipeline deletion. The docs now call out the limitation in the relevant delete workflow.

## Validation
- `git diff --check`