### PR TITLE
DEV: (cmds) update INCREX command page for recent API change

### DIFF
--- a/content/commands/increx.md
+++ b/content/commands/increx.md
@@ -140,22 +140,21 @@ If neither `BYFLOAT` nor `BYINT` is specified, the key is incremented by `1` in 
 
 <details open><summary><code>LBOUND lowerbound</code></summary>
 
-Sets a lower bound for the resulting value. If the computed result would fall below `lowerbound`, the behavior is determined by the `SATURATE` option. Defaults to `LLONG_MIN` in integer mode or `-LDBL_MAX` in `BYFLOAT` mode. `LBOUND` must be less than or equal to `UBOUND` when both are specified.
+Sets a lower bound for the resulting value. If the computed result would fall below `lowerbound`, the behavior is determined by the `SATURATE` flag. Defaults to `LLONG_MIN` in integer mode or `-LDBL_MAX` in `BYFLOAT` mode. `LBOUND` must be less than or equal to `UBOUND` when both are specified.
 
 </details>
 
 <details open><summary><code>UBOUND upperbound</code></summary>
 
-Sets an upper bound for the resulting value. If the computed result would exceed `upperbound`, the behavior is determined by the `SATURATE` option. Defaults to `LLONG_MAX` in integer mode or `LDBL_MAX` in `BYFLOAT` mode. `UBOUND` must be greater than or equal to `LBOUND` when both are specified.
+Sets an upper bound for the resulting value. If the computed result would exceed `upperbound`, the behavior is determined by the `SATURATE` flag. Defaults to `LLONG_MAX` in integer mode or `LDBL_MAX` in `BYFLOAT` mode. `UBOUND` must be greater than or equal to `LBOUND` when both are specified.
 
 </details>
 
 <details open><summary><code>SATURATE</code></summary>
 
-Controls how out-of-bounds results are handled. A bound violation includes both exceeding an explicit `LBOUND`/`UBOUND` and overflowing the type limits when no explicit bound is given.
+When specified, an out-of-bounds result is capped at `UBOUND` or floored at `LBOUND` (or saturated to the type limits when no explicit bound is given). The second element of the reply reflects the saturated delta. An error is returned if the delta cannot be represented as a 64-bit signed integer in integer mode, or would produce Infinity in `BYFLOAT` mode. Any expiration option is still applied as specified.
 
-* Default (without `SATURATE`): the operation is skipped. The key value and its TTL are left unchanged, no keyspace notification is fired, and nothing is replicated. The reply is `[current_value, 0]`, allowing the caller to detect the non-application by checking the applied-increment field without handling an error. Any expiration option is ignored on the rejected branch.
-* With `SATURATE`: the result is capped at `UBOUND` or floored at `LBOUND` (or saturated to the type limits when no explicit bound is given). The second element of the reply reflects the saturated delta. An error is returned if the delta cannot be represented as a 64-bit signed integer in integer mode, or would produce Infinity in `BYFLOAT` mode. Any expiration option is still applied as specified.
+A bound violation includes both exceeding an explicit `LBOUND`/`UBOUND` and overflowing the type limits when no explicit bound is given.
 
 </details>
 

--- a/content/commands/increx.md
+++ b/content/commands/increx.md
@@ -115,7 +115,7 @@ Increments or decrements the numeric value stored at `key` by the specified amou
 If the key does not exist, it is set to `0` before performing the operation.
 An error is returned if the key contains a value of the wrong type or a string that cannot be interpreted as a number.
 
-Unlike [`INCR`]({{< relref "/commands/incr" >}}) and [`INCRBY`]({{< relref "/commands/incrby" >}}), `INCREX` returns an array of two elements: the new value of the key after the increment, and the increment that was actually applied. When the computed result would fall outside an explicit `LBOUND`/`UBOUND` or the type limits, the default is to skip the operation and reply with `[current_value, 0]`, leaving the key and its TTL untouched. The `SATURATE` option changes this behavior so the result is capped at the bound instead.
+Unlike [`INCR`]({{< relref "/commands/incr" >}}) and [`INCRBY`]({{< relref "/commands/incrby" >}}), `INCREX` returns an array of two elements: the new value of the key after the increment, and the increment that was actually applied. When the computed result would fall outside an explicit `LBOUND`/`UBOUND` or the type limits, the default is to skip the operation and reply with `[current_value, 0]`, leaving the key and its TTL untouched. The `SATURATE` flag changes this behavior so the result is capped at the bound instead.
 
 ## Required arguments
 
@@ -140,13 +140,13 @@ If neither `BYFLOAT` nor `BYINT` is specified, the key is incremented by `1` in 
 
 <details open><summary><code>LBOUND lowerbound</code></summary>
 
-Sets a lower bound for the resulting value. If the computed result would fall below `lowerbound`, the behavior is determined by the `SATURATE` flag. Defaults to `LLONG_MIN` in integer mode or `-LDBL_MAX` in `BYFLOAT` mode. `LBOUND` must be less than or equal to `UBOUND` when both are specified.
+Sets a lower bound for the resulting value. If the computed result would fall below `lowerbound`, the operation is skipped and the reply is `[current_value, 0]` (or use the `SATURATE` flag to floor the result at `lowerbound` instead). When omitted, the bound is `LLONG_MIN` in integer mode or `-LDBL_MAX` in `BYFLOAT` mode. `LBOUND` must be less than or equal to `UBOUND` when both are specified.
 
 </details>
 
 <details open><summary><code>UBOUND upperbound</code></summary>
 
-Sets an upper bound for the resulting value. If the computed result would exceed `upperbound`, the behavior is determined by the `SATURATE` flag. Defaults to `LLONG_MAX` in integer mode or `LDBL_MAX` in `BYFLOAT` mode. `UBOUND` must be greater than or equal to `LBOUND` when both are specified.
+Sets an upper bound for the resulting value. If the computed result would exceed `upperbound`, the operation is skipped and the reply is `[current_value, 0]` (or use the `SATURATE` flag to cap the result at `upperbound` instead). When omitted, the bound is `LLONG_MAX` in integer mode or `LDBL_MAX` in `BYFLOAT` mode. `UBOUND` must be greater than or equal to `LBOUND` when both are specified.
 
 </details>
 

--- a/content/commands/increx.md
+++ b/content/commands/increx.md
@@ -17,22 +17,13 @@ arguments:
   name: increment
   optional: true
   type: oneof
-- arguments:
-  - name: fail
-    token: FAIL
-    type: pure-token
-  - name: sat
-    token: SAT
-    type: pure-token
-  - name: reject
-    token: REJECT
-    type: pure-token
-  name: overflow-block
+- name: saturate
   optional: true
-  summary: Out-of-bounds policy; defaults to FAIL. Missing LBOUND/UBOUND default to
-    the type limits (LLONG_MIN/LLONG_MAX for BYINT, -LDBL_MAX/LDBL_MAX for BYFLOAT).
-  token: OVERFLOW
-  type: oneof
+  summary: Saturate the result to LBOUND/UBOUND (or the type limits when no explicit
+    bound is given) when out of bounds. Without this option, out-of-bounds operations
+    are rejected and reply [current_value, 0].
+  token: SATURATE
+  type: pure-token
 - name: lowerbound
   optional: true
   summary: Integer when used with BYINT, floating-point when used with BYFLOAT.
@@ -115,17 +106,16 @@ reply_schema:
 since: 8.8.0
 summary: Increments the numeric value of a key by a number and sets its expiration
   time. Uses 0 as initial value if the key doesn't exist.
-syntax_fmt: "INCREX key [BYFLOAT\_float | BYINT\_integer]\n\
-  \ [LBOUND\_lowerbound] [UBOUND\_upperbound] [OVERFLOW\_<FAIL | SAT | REJECT>]\n\
-  \ [EX\_seconds | PX\_milliseconds| EXAT\_unix-time-seconds | PXAT\_unix-time-milliseconds | PERSIST]\n\
-  \ [ENX]"
+syntax_fmt: "INCREX key [BYFLOAT\_increment | BYINT\_increment]\n\
+  \ [LBOUND\_lowerbound] [UBOUND\_upperbound] [SATURATE]\n\
+  \ [EX\_seconds | PX\_milliseconds | EXAT\_unix-time-seconds| PXAT\_unix-time-milliseconds | PERSIST] [ENX]"
 title: INCREX
 ---
 Increments or decrements the numeric value stored at `key` by the specified amount, with optional upper/lower bounds and expiration control, in a single atomic operation.
 If the key does not exist, it is set to `0` before performing the operation.
 An error is returned if the key contains a value of the wrong type or a string that cannot be interpreted as a number.
 
-Unlike [`INCR`]({{< relref "/commands/incr" >}}) and [`INCRBY`]({{< relref "/commands/incrby" >}}), `INCREX` returns an array of two elements: the new value of the key after the increment, and the increment that was actually applied. The `OVERFLOW` option controls what happens when the computed result would fall outside an explicit `LBOUND`/`UBOUND` or the type limits: the command can fail with an error (the default), saturate the result to the bound, or skip the operation.
+Unlike [`INCR`]({{< relref "/commands/incr" >}}) and [`INCRBY`]({{< relref "/commands/incrby" >}}), `INCREX` returns an array of two elements: the new value of the key after the increment, and the increment that was actually applied. When the computed result would fall outside an explicit `LBOUND`/`UBOUND` or the type limits, the default is to skip the operation and reply with `[current_value, 0]`, leaving the key and its TTL untouched. The `SATURATE` option changes this behavior so the result is capped at the bound instead.
 
 ## Required arguments
 
@@ -137,7 +127,7 @@ The name of the key to increment.
 
 ## Optional arguments
 
-<details open><summary><code>BYFLOAT float | BYINT integer</code></summary>
+<details open><summary><code>BYFLOAT increment | BYINT increment</code></summary>
 
 Specifies the increment amount and type:
 
@@ -150,23 +140,22 @@ If neither `BYFLOAT` nor `BYINT` is specified, the key is incremented by `1` in 
 
 <details open><summary><code>LBOUND lowerbound</code></summary>
 
-Sets a lower bound for the resulting value. If the computed result would fall below `lowerbound`, the behavior is determined by the `OVERFLOW` option. Defaults to `LLONG_MIN` in integer mode or `-LDBL_MAX` in `BYFLOAT` mode. `LBOUND` must be less than or equal to `UBOUND` when both are specified.
+Sets a lower bound for the resulting value. If the computed result would fall below `lowerbound`, the behavior is determined by the `SATURATE` option. Defaults to `LLONG_MIN` in integer mode or `-LDBL_MAX` in `BYFLOAT` mode. `LBOUND` must be less than or equal to `UBOUND` when both are specified.
 
 </details>
 
 <details open><summary><code>UBOUND upperbound</code></summary>
 
-Sets an upper bound for the resulting value. If the computed result would exceed `upperbound`, the behavior is determined by the `OVERFLOW` option. Defaults to `LLONG_MAX` in integer mode or `LDBL_MAX` in `BYFLOAT` mode. `UBOUND` must be greater than or equal to `LBOUND` when both are specified.
+Sets an upper bound for the resulting value. If the computed result would exceed `upperbound`, the behavior is determined by the `SATURATE` option. Defaults to `LLONG_MAX` in integer mode or `LDBL_MAX` in `BYFLOAT` mode. `UBOUND` must be greater than or equal to `LBOUND` when both are specified.
 
 </details>
 
-<details open><summary><code>OVERFLOW FAIL | SAT | REJECT</code></summary>
+<details open><summary><code>SATURATE</code></summary>
 
-Sets the policy for handling out-of-bounds results. A bound violation includes both exceeding an explicit `LBOUND`/`UBOUND` and overflowing the type limits when no explicit bound is given.
+Controls how out-of-bounds results are handled. A bound violation includes both exceeding an explicit `LBOUND`/`UBOUND` and overflowing the type limits when no explicit bound is given.
 
-* `FAIL` (default): if the computed result would violate a bound, the command returns an error and the key is left unchanged. This matches the existing semantics of [`INCRBY`]({{< relref "/commands/incrby" >}}) and [`INCRBYFLOAT`]({{< relref "/commands/incrbyfloat" >}}) on overflow.
-* `SAT`: the result is capped at `UBOUND` or floored at `LBOUND` (or saturated to the type limits when no explicit bound is given). The second element of the reply reflects the saturated delta. An error is returned if the delta cannot be represented as a 64-bit signed integer in integer mode, or would produce Infinity in `BYFLOAT` mode. If the result is saturated, any expiration option is still applied as specified.
-* `REJECT`: the operation is skipped. The key value and its TTL are left unchanged, no keyspace notification is fired, and nothing is replicated. The reply is `[current_value, 0]`, allowing the caller to detect the rejection without handling an error. Any expiration option is ignored on the rejected branch.
+* Default (without `SATURATE`): the operation is skipped. The key value and its TTL are left unchanged, no keyspace notification is fired, and nothing is replicated. The reply is `[current_value, 0]`, allowing the caller to detect the non-application by checking the applied-increment field without handling an error. Any expiration option is ignored on the rejected branch.
+* With `SATURATE`: the result is capped at `UBOUND` or floored at `LBOUND` (or saturated to the type limits when no explicit bound is given). The second element of the reply reflects the saturated delta. An error is returned if the delta cannot be represented as a 64-bit signed integer in integer mode, or would produce Infinity in `BYFLOAT` mode. Any expiration option is still applied as specified.
 
 </details>
 
@@ -243,27 +232,25 @@ INCREX mykey BYINT 1 PERSIST
 TTL mykey
 {{% /redis-cli %}}
 
-Compare the three `OVERFLOW` policies when the result would exceed `UBOUND`. The default `FAIL` returns an error, `SAT` caps the result at the bound, and `REJECT` leaves the key untouched and reports a zero delta:
+Compare the default out-of-bounds behavior with `SATURATE` when the result would exceed `UBOUND`. By default the key is left untouched and the reply reports a zero delta; with `SATURATE` the result is capped at the bound and the reply reflects the saturated delta:
 
 {{% redis-cli %}}
 SET mykey 99
 INCREX mykey BYINT 5 UBOUND 100
 SET mykey 99
-INCREX mykey BYINT 5 UBOUND 100 OVERFLOW SAT
-SET mykey 99
-INCREX mykey BYINT 5 UBOUND 100 OVERFLOW REJECT
+INCREX mykey BYINT 5 UBOUND 100 SATURATE
 {{% /redis-cli %}}
 
 ## Pattern: window counter rate limiter
 
 A common rate-limiting pattern requires atomically incrementing a counter and setting its expiration. With plain [`INCR`]({{< relref "/commands/incr" >}}) and [`EXPIRE`]({{< relref "/commands/expire" >}}), this typically requires a Lua script to be atomic.
 
-`INCREX` requires a single native command. `UBOUND` enforces the rate cap, `OVERFLOW REJECT` skips the operation once the cap is reached, and `ENX` ensures that a new window with the correct duration is created if the previous one has expired; if a window already exists, it won't be extended. When the counter has already reached the cap, `actual_increment` is `0`, giving the caller immediate feedback without extra reads or error handling:
+`INCREX` requires a single native command. `UBOUND` enforces the rate cap — by default, once the cap is reached the operation is skipped — and `ENX` ensures that a new window with the correct duration is created if the previous one has expired; if a window already exists, it won't be extended. When the counter has already reached the cap, `actual_increment` is `0`, giving the caller immediate feedback without extra reads or error handling:
 
 ```python
 new_val, actual_incr = redis.execute_command(
     "INCREX", f"ratelimit:{user_id}",
-    "BYINT", 1, "UBOUND", 100, "OVERFLOW", "REJECT",
+    "BYINT", 1, "UBOUND", 100,
     "EX", 60, "ENX",
 )
 if actual_incr == 0:
@@ -284,8 +271,8 @@ if actual_incr == 0:
 
 [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a two-element array:
 
-1. **New value** — the value of the key after the increment, or the unchanged current value under `OVERFLOW REJECT`.
-2. **Actual increment** — the increment that was actually applied. May differ from the requested increment when `OVERFLOW SAT` saturates the result to a bound, and is always `0` when `OVERFLOW REJECT` skipped the operation.
+1. **New value** — the value of the key after the increment, or the unchanged current value when an out-of-bounds result caused the operation to be skipped.
+2. **Actual increment** — the increment that was actually applied. May differ from the requested increment when `SATURATE` caps the result at a bound, and is always `0` when an out-of-bounds result caused the operation to be skipped.
 
 Both elements are [Integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) in integer mode (default or `BYINT`), or [Bulk string replies]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) representing the float values in `BYFLOAT` mode.
 
@@ -293,8 +280,8 @@ Both elements are [Integer replies]({{< relref "/develop/reference/protocol-spec
 
 [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a two-element array:
 
-1. **New value** — the value of the key after the increment, or the unchanged current value under `OVERFLOW REJECT`.
-2. **Actual increment** — the increment that was actually applied. May differ from the requested increment when `OVERFLOW SAT` saturates the result to a bound, and is always `0` when `OVERFLOW REJECT` skipped the operation.
+1. **New value** — the value of the key after the increment, or the unchanged current value when an out-of-bounds result caused the operation to be skipped.
+2. **Actual increment** — the increment that was actually applied. May differ from the requested increment when `SATURATE` caps the result at a bound, and is always `0` when an out-of-bounds result caused the operation to be skipped.
 
 Both elements are [Integer replies]({{< relref "/develop/reference/protocol-spec#integers" >}}) in integer mode (default or `BYINT`), or [Double replies]({{< relref "/develop/reference/protocol-spec#doubles" >}}) in `BYFLOAT` mode.
 

--- a/static/images/railroad/increx.svg
+++ b/static/images/railroad/increx.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="191" viewBox="0 0 1656.0 191" width="1656.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="191" viewBox="0 0 1535.0 191" width="1535.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,7 +44,7 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
-<path d="M50 40h0.0"></path><path d="M1606.0 40h0.0"></path><g class="terminal ">
+<path d="M50 40h0.0"></path><path d="M1485.0 40h0.0"></path><g class="terminal ">
 <path d="M50.0 40h0.0"></path><path d="M121.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="29"></rect><text x="85.5" y="44">INCREX</text></g><path d="M121.0 40h10"></path><path d="M131.0 40h10"></path><g class="non-terminal ">
 <path d="M141.0 40h0.0"></path><path d="M186.5 40h0.0"></path><rect height="22" width="45.5" x="141.0" y="29"></rect><text x="163.75" y="44">key</text></g><path d="M186.5 40h10"></path><g>
 <path d="M196.5 40h0.0"></path><path d="M438.5 40h0.0"></path><path d="M196.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
@@ -56,40 +56,35 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 <path d="M236.5 70h0.0"></path><path d="M398.5 70h0.0"></path><g class="terminal ">
 <path d="M236.5 70h0.0"></path><path d="M299.0 70h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="236.5" y="59"></rect><text x="267.75" y="74">BYINT</text></g><path d="M299.0 70h10"></path><path d="M309.0 70h10"></path><g class="non-terminal ">
 <path d="M319.0 70h0.0"></path><path d="M398.5 70h0.0"></path><rect height="22" width="79.5" x="319.0" y="59"></rect><text x="358.75" y="74">integer</text></g></g><path d="M398.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><path d="M418.5 40h20"></path></g><g>
-<path d="M438.5 40h0.0"></path><path d="M687.5 40h0.0"></path><path d="M438.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M458.5 20h209.0"></path></g><path d="M667.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M438.5 40h20"></path><g>
-<path d="M458.5 40h0.0"></path><path d="M667.5 40h0.0"></path><g class="terminal ">
-<path d="M458.5 40h0.0"></path><path d="M546.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="458.5" y="29"></rect><text x="502.5" y="44">OVERFLOW</text></g><path d="M546.5 40h10"></path><g>
-<path d="M556.5 40h0.0"></path><path d="M667.5 40h0.0"></path><path d="M556.5 40h20"></path><g class="terminal ">
-<path d="M576.5 40h8.5"></path><path d="M639.0 40h8.5"></path><rect height="22" rx="10" ry="10" width="54.0" x="585.0" y="29"></rect><text x="612.0" y="44">FAIL</text></g><path d="M647.5 40h20"></path><path d="M556.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M576.5 70h12.75"></path><path d="M634.75 70h12.75"></path><rect height="22" rx="10" ry="10" width="45.5" x="589.25" y="59"></rect><text x="612.0" y="74">SAT</text></g><path d="M647.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M556.5 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M576.5 100h0.0"></path><path d="M647.5 100h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="576.5" y="89"></rect><text x="612.0" y="104">REJECT</text></g><path d="M647.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path></g></g><path d="M667.5 40h20"></path></g><g>
-<path d="M687.5 40h0.0"></path><path d="M923.5 40h0.0"></path><path d="M687.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M707.5 20h196.0"></path></g><path d="M903.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M687.5 40h20"></path><g>
-<path d="M707.5 40h0.0"></path><path d="M903.5 40h0.0"></path><g class="terminal ">
-<path d="M707.5 40h0.0"></path><path d="M778.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="707.5" y="29"></rect><text x="743.0" y="44">LBOUND</text></g><path d="M778.5 40h10"></path><path d="M788.5 40h10"></path><g class="non-terminal ">
-<path d="M798.5 40h0.0"></path><path d="M903.5 40h0.0"></path><rect height="22" width="105.0" x="798.5" y="29"></rect><text x="851.0" y="44">lowerbound</text></g></g><path d="M903.5 40h20"></path></g><g>
-<path d="M923.5 40h0.0"></path><path d="M1159.5 40h0.0"></path><path d="M923.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M943.5 20h196.0"></path></g><path d="M1139.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M923.5 40h20"></path><g>
-<path d="M943.5 40h0.0"></path><path d="M1139.5 40h0.0"></path><g class="terminal ">
-<path d="M943.5 40h0.0"></path><path d="M1014.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="943.5" y="29"></rect><text x="979.0" y="44">UBOUND</text></g><path d="M1014.5 40h10"></path><path d="M1024.5 40h10"></path><g class="non-terminal ">
-<path d="M1034.5 40h0.0"></path><path d="M1139.5 40h0.0"></path><rect height="22" width="105.0" x="1034.5" y="29"></rect><text x="1087.0" y="44">upperbound</text></g></g><path d="M1139.5 40h20"></path></g><g>
-<path d="M1159.5 40h0.0"></path><path d="M1520.5 40h0.0"></path><path d="M1159.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1179.5 20h321.0"></path></g><path d="M1500.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1159.5 40h20"></path><g>
-<path d="M1179.5 40h0.0"></path><path d="M1500.5 40h0.0"></path><path d="M1179.5 40h20"></path><g>
-<path d="M1199.5 40h72.25"></path><path d="M1408.25 40h72.25"></path><g class="terminal ">
-<path d="M1271.75 40h0.0"></path><path d="M1308.75 40h0.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="1271.75" y="29"></rect><text x="1290.25" y="44">EX</text></g><path d="M1308.75 40h10"></path><path d="M1318.75 40h10"></path><g class="non-terminal ">
-<path d="M1328.75 40h0.0"></path><path d="M1408.25 40h0.0"></path><rect height="22" width="79.5" x="1328.75" y="29"></rect><text x="1368.5" y="44">seconds</text></g></g><path d="M1480.5 40h20"></path><path d="M1179.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
-<path d="M1199.5 70h51.0"></path><path d="M1429.5 70h51.0"></path><g class="terminal ">
-<path d="M1250.5 70h0.0"></path><path d="M1287.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="1250.5" y="59"></rect><text x="1269.0" y="74">PX</text></g><path d="M1287.5 70h10"></path><path d="M1297.5 70h10"></path><g class="non-terminal ">
-<path d="M1307.5 70h0.0"></path><path d="M1429.5 70h0.0"></path><rect height="22" width="122.0" x="1307.5" y="59"></rect><text x="1368.5" y="74">milliseconds</text></g></g><path d="M1480.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M1179.5 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g>
-<path d="M1199.5 100h21.25"></path><path d="M1459.25 100h21.25"></path><g class="terminal ">
-<path d="M1220.75 100h0.0"></path><path d="M1274.75 100h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="1220.75" y="89"></rect><text x="1247.75" y="104">EXAT</text></g><path d="M1274.75 100h10"></path><path d="M1284.75 100h10"></path><g class="non-terminal ">
-<path d="M1294.75 100h0.0"></path><path d="M1459.25 100h0.0"></path><rect height="22" width="164.5" x="1294.75" y="89"></rect><text x="1377.0" y="104">unix-time-seconds</text></g></g><path d="M1480.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M1179.5 40a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g>
-<path d="M1199.5 130h0.0"></path><path d="M1480.5 130h0.0"></path><g class="terminal ">
-<path d="M1199.5 130h0.0"></path><path d="M1253.5 130h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="1199.5" y="119"></rect><text x="1226.5" y="134">PXAT</text></g><path d="M1253.5 130h10"></path><path d="M1263.5 130h10"></path><g class="non-terminal ">
-<path d="M1273.5 130h0.0"></path><path d="M1480.5 130h0.0"></path><rect height="22" width="207.0" x="1273.5" y="119"></rect><text x="1377.0" y="134">unix-time-milliseconds</text></g></g><path d="M1480.5 130a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M1179.5 40a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
-<path d="M1199.5 160h100.75"></path><path d="M1379.75 160h100.75"></path><rect height="22" rx="10" ry="10" width="79.5" x="1300.25" y="149"></rect><text x="1340.0" y="164">PERSIST</text></g><path d="M1480.5 160a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path></g><path d="M1500.5 40h20"></path></g><g>
-<path d="M1520.5 40h0.0"></path><path d="M1606.0 40h0.0"></path><path d="M1520.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1540.5 20h45.5"></path></g><path d="M1586.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1520.5 40h20"></path><g class="terminal ">
-<path d="M1540.5 40h0.0"></path><path d="M1586.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="1540.5" y="29"></rect><text x="1563.25" y="44">ENX</text></g><path d="M1586.0 40h20"></path></g></g><path d="M1606.0 40h10"></path><path d="M 1616.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M438.5 40h0.0"></path><path d="M566.5 40h0.0"></path><path d="M438.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M458.5 20h88.0"></path></g><path d="M546.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M438.5 40h20"></path><g class="terminal ">
+<path d="M458.5 40h0.0"></path><path d="M546.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="458.5" y="29"></rect><text x="502.5" y="44">SATURATE</text></g><path d="M546.5 40h20"></path></g><g>
+<path d="M566.5 40h0.0"></path><path d="M802.5 40h0.0"></path><path d="M566.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M586.5 20h196.0"></path></g><path d="M782.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M566.5 40h20"></path><g>
+<path d="M586.5 40h0.0"></path><path d="M782.5 40h0.0"></path><g class="terminal ">
+<path d="M586.5 40h0.0"></path><path d="M657.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="586.5" y="29"></rect><text x="622.0" y="44">LBOUND</text></g><path d="M657.5 40h10"></path><path d="M667.5 40h10"></path><g class="non-terminal ">
+<path d="M677.5 40h0.0"></path><path d="M782.5 40h0.0"></path><rect height="22" width="105.0" x="677.5" y="29"></rect><text x="730.0" y="44">lowerbound</text></g></g><path d="M782.5 40h20"></path></g><g>
+<path d="M802.5 40h0.0"></path><path d="M1038.5 40h0.0"></path><path d="M802.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M822.5 20h196.0"></path></g><path d="M1018.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M802.5 40h20"></path><g>
+<path d="M822.5 40h0.0"></path><path d="M1018.5 40h0.0"></path><g class="terminal ">
+<path d="M822.5 40h0.0"></path><path d="M893.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="822.5" y="29"></rect><text x="858.0" y="44">UBOUND</text></g><path d="M893.5 40h10"></path><path d="M903.5 40h10"></path><g class="non-terminal ">
+<path d="M913.5 40h0.0"></path><path d="M1018.5 40h0.0"></path><rect height="22" width="105.0" x="913.5" y="29"></rect><text x="966.0" y="44">upperbound</text></g></g><path d="M1018.5 40h20"></path></g><g>
+<path d="M1038.5 40h0.0"></path><path d="M1399.5 40h0.0"></path><path d="M1038.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1058.5 20h321.0"></path></g><path d="M1379.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1038.5 40h20"></path><g>
+<path d="M1058.5 40h0.0"></path><path d="M1379.5 40h0.0"></path><path d="M1058.5 40h20"></path><g>
+<path d="M1078.5 40h72.25"></path><path d="M1287.25 40h72.25"></path><g class="terminal ">
+<path d="M1150.75 40h0.0"></path><path d="M1187.75 40h0.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="1150.75" y="29"></rect><text x="1169.25" y="44">EX</text></g><path d="M1187.75 40h10"></path><path d="M1197.75 40h10"></path><g class="non-terminal ">
+<path d="M1207.75 40h0.0"></path><path d="M1287.25 40h0.0"></path><rect height="22" width="79.5" x="1207.75" y="29"></rect><text x="1247.5" y="44">seconds</text></g></g><path d="M1359.5 40h20"></path><path d="M1058.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M1078.5 70h51.0"></path><path d="M1308.5 70h51.0"></path><g class="terminal ">
+<path d="M1129.5 70h0.0"></path><path d="M1166.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="37.0" x="1129.5" y="59"></rect><text x="1148.0" y="74">PX</text></g><path d="M1166.5 70h10"></path><path d="M1176.5 70h10"></path><g class="non-terminal ">
+<path d="M1186.5 70h0.0"></path><path d="M1308.5 70h0.0"></path><rect height="22" width="122.0" x="1186.5" y="59"></rect><text x="1247.5" y="74">milliseconds</text></g></g><path d="M1359.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M1058.5 40a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g>
+<path d="M1078.5 100h21.25"></path><path d="M1338.25 100h21.25"></path><g class="terminal ">
+<path d="M1099.75 100h0.0"></path><path d="M1153.75 100h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="1099.75" y="89"></rect><text x="1126.75" y="104">EXAT</text></g><path d="M1153.75 100h10"></path><path d="M1163.75 100h10"></path><g class="non-terminal ">
+<path d="M1173.75 100h0.0"></path><path d="M1338.25 100h0.0"></path><rect height="22" width="164.5" x="1173.75" y="89"></rect><text x="1256.0" y="104">unix-time-seconds</text></g></g><path d="M1359.5 100a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M1058.5 40a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g>
+<path d="M1078.5 130h0.0"></path><path d="M1359.5 130h0.0"></path><g class="terminal ">
+<path d="M1078.5 130h0.0"></path><path d="M1132.5 130h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="1078.5" y="119"></rect><text x="1105.5" y="134">PXAT</text></g><path d="M1132.5 130h10"></path><path d="M1142.5 130h10"></path><g class="non-terminal ">
+<path d="M1152.5 130h0.0"></path><path d="M1359.5 130h0.0"></path><rect height="22" width="207.0" x="1152.5" y="119"></rect><text x="1256.0" y="134">unix-time-milliseconds</text></g></g><path d="M1359.5 130a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M1058.5 40a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M1078.5 160h100.75"></path><path d="M1258.75 160h100.75"></path><rect height="22" rx="10" ry="10" width="79.5" x="1179.25" y="149"></rect><text x="1219.0" y="164">PERSIST</text></g><path d="M1359.5 160a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path></g><path d="M1379.5 40h20"></path></g><g>
+<path d="M1399.5 40h0.0"></path><path d="M1485.0 40h0.0"></path><path d="M1399.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1419.5 20h45.5"></path></g><path d="M1465.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1399.5 40h20"></path><g class="terminal ">
+<path d="M1419.5 40h0.0"></path><path d="M1465.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="45.5" x="1419.5" y="29"></rect><text x="1442.25" y="44">ENX</text></g><path d="M1465.0 40h20"></path></g></g><path d="M1485.0 40h10"></path><path d="M 1495.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
Redis 8.8 feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation and diagram updates only, but they reflect a behavioral/API change (default out-of-bounds handling and option names) that could confuse users if inaccurate.
> 
> **Overview**
> Updates the `INCREX` command docs to match the new out-of-bounds API: removes `OVERFLOW <FAIL|SAT|REJECT>` in favor of a `SATURATE` flag, and documents that the *default* on bound/type-limit violations is now to skip the operation and return `[current_value, 0]`.
> 
> Refreshes syntax strings, option descriptions, examples (including the rate-limiter snippet), return-value notes, and the railroad diagram (`static/images/railroad/increx.svg`) accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496fcf7f4756c3926fe491dde69bba1f1eeceeaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->