### PR TITLE
K8s: fix ingress doc bugs

### DIFF
--- a/content/embeds/k8s/rerc-ohare.md
+++ b/content/embeds/k8s/rerc-ohare.md
@@ -7,6 +7,6 @@ spec:
   recName: rec-chicago
   recNamespace: ns-illinois
   apiFqdnUrl: api-rec-chicago-ns-illinois.example.com
-  dbFqdnSuffix: -db-rec-chicago-ns-illinois.example.com
+  dbFqdnSuffix: .db-rec-chicago-ns-illinois.example.com
   secretName: redis-enterprise-rerc-ohare
 ```

--- a/content/embeds/k8s/rerc-raegan.md
+++ b/content/embeds/k8s/rerc-raegan.md
@@ -7,6 +7,6 @@ spec:
   recName: rec-arlington
   recNamespace: ns-virginia
   apiFqdnUrl: api-rec-arlington-ns-virginia.example.com
-  dbFqdnSuffix: -db-rec-arlington-ns-virginia.example.com
+  dbFqdnSuffix: .db-rec-arlington-ns-virginia.example.com
   secretName: redis-enterprise-rerc-raegan
 ```

--- a/content/embeds/k8s/rerc.md
+++ b/content/embeds/k8s/rerc.md
@@ -17,7 +17,7 @@ spec:
 
   # The database URL suffix, will be used for the active-active
   # database replication endpoint and replication endpoint SNI.
-  dbFqdnSuffix: -example-new-york-1-ns1.redislabs.com
+  dbFqdnSuffix: .example-new-york-1-ns1.redislabs.com
 
   # The name of the secret containing cluster credentials.
   # Needs to be formatted as: "redis-enterprise-<RERC name>"

--- a/content/operate/kubernetes/7.22/networking/_index.md
+++ b/content/operate/kubernetes/7.22/networking/_index.md
@@ -24,7 +24,7 @@ Connect applications to your Redis Enterprise databases:
 
 Choose the appropriate method for your environment to enable external access:
 
-- [Ingress routing]({{< relref "/operate/kubernetes/7.22/networking/ingress" >}}) - Use NGINX or HAProxy ingress controllers with `ingress` API resources
+- [Ingress routing]({{< relref "/operate/kubernetes/7.22/networking/ingress" >}}) - Use HAProxy ingress controller with `ingress` API resources (the community NGINX ingress controller is retired)
 - [Istio ingress routing]({{< relref "/operate/kubernetes/7.22/networking/istio-ingress" >}}) - Use Istio service mesh with `Gateway` and `VirtualService` API resources
 - [OpenShift routes]({{< relref "/operate/kubernetes/7.22/networking/routes" >}}) - Use OpenShift-specific route resources for external traffic
 

--- a/content/operate/kubernetes/7.22/networking/database-connectivity.md
+++ b/content/operate/kubernetes/7.22/networking/database-connectivity.md
@@ -109,9 +109,9 @@ To access databases from outside the Kubernetes cluster, you need to configure e
 
 Redis Enterprise for Kubernetes only supports the following ingress controllers for external database access:
 
-- NGINX Ingress - Supports SSL passthrough for Redis connections
-- HAProxy Ingress - Built-in SSL passthrough support  
-- Istio Gateway - Service mesh integration with advanced traffic management
+- HAProxy Ingress - Built-in SSL passthrough support.
+- Istio Gateway - Service mesh integration with advanced traffic management.
+- Ingress-NGINX - SSL passthrough is off by default; start the controller with `--enable-ssl-passthrough`. The community `kubernetes/ingress-nginx` project is retired (maintenance ended March 2026); existing deployments only.
 
 See [Ingress routing]({{< relref "/operate/kubernetes/7.22/networking/ingress" >}}) for detailed configuration steps.
 

--- a/content/operate/kubernetes/7.22/networking/ingress.md
+++ b/content/operate/kubernetes/7.22/networking/ingress.md
@@ -12,18 +12,21 @@ weight: 5
 url: '/operate/kubernetes/7.22/networking/ingress/'
 ---
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio as shown below, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Prerequisites
 
 Before creating an Ingress, you'll need:
 
  - A RedisEnterpriseDatabase (REDB) with TLS enabled for client connections
- - A supported Ingress controller with `ssl-passthrough` enabled
-    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/)
-        - Be sure to use the `kubernetes/ingress-nginx` controller and NOT the `nginxinc/kubernetes-ingress` controller.
+ - An Ingress controller with `ssl-passthrough` enabled. Options include:
     - [HAProxy Ingress](https://haproxy-ingress.github.io/docs/getting-started/)
+    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (retired; existing deployments only)
     - To use Istio for your Ingress resources, see [Configure Istio for external routing]({{< relref "/operate/kubernetes/7.22/networking/istio-ingress" >}})
 
-{{<note>}}Make sure your Ingress controller has `ssl-passthrough`enabled. This is enabled by default for HAProxy, but disabled by default for NGINX. See the [NGINX User Guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details. {{</note>}}
+{{<note>}}Make sure your Ingress controller has `ssl-passthrough` enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag. See the [Ingress-NGINX TLS guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details.{{</note>}}
 
 ## Create an Ingress resource
 
@@ -45,7 +48,7 @@ Before creating an Ingress, you'll need:
 
 1. Create a DNS entry that resolves your chosen database hostname to the IP address for the Ingress controller's LoadBalancer.  
 
-1. Create the Ingress resource YAML file.  
+1. Create the Ingress resource YAML file.
 
     ``` YAML
     apiVersion: networking.k8s.io/v1
@@ -55,6 +58,7 @@ Before creating an Ingress, you'll need:
       annotations:
         <controller-specific-annotations-below>
     spec:
+      ingressClassName: <haproxy | nginx>
       rules:
       - host: <my-db-hostname>
         http:
@@ -66,23 +70,23 @@ Before creating an Ingress, you'll need:
                 name: <db-name>
                 port:
                   name: redis
-    ```  
-
-    For HAProxy, insert the following into the `annotations` section:  
-
-    ``` YAML
-    kubernetes.io/ingress.class: haproxy
-     ingress.kubernetes.io/ssl-passthrough: "true"
     ```
 
-    For NGINX, insert the following into the `annotations` section:  
+    Set `ingressClassName` to match the `IngressClass` your controller installed. The deprecated `kubernetes.io/ingress.class` annotation is no longer accepted by recent controller versions, so use `ingressClassName` instead.
+
+    For HAProxy, add the following annotation:
 
     ``` YAML
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    ```  
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
 
-    The `ssl-passthrough` annotation is required to allow access to the database. The specific format changes depending on your Ingress controller and any additional customizations. See [NGINX Configuration annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress Options](https://www.haproxy.com/documentation/kubernetes/latest/configuration/ingress/) for updated annotation formats.  
+    For Ingress-NGINX, add the following annotation:
+
+    ``` YAML
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
+
+    The `ssl-passthrough` annotation is required to allow access to the database. The exact format depends on your Ingress controller and any additional customizations. See [Ingress-NGINX annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress configuration keys](https://haproxy-ingress.github.io/docs/configuration/keys/) for current annotation formats.
 
 ## Test your external access  
 

--- a/content/operate/kubernetes/7.22/networking/ingressorroutespec.md
+++ b/content/operate/kubernetes/7.22/networking/ingressorroutespec.md
@@ -12,25 +12,29 @@ url: '/operate/kubernetes/7.22/networking/ingressorroutespec/'
 ---
 An Ingress is an API resource that provides a standardized and flexible way to manage external access to services running within a Kubernetes cluster.
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Install Ingress controller
 
 Redis Enterprise for Kubernetes supports the Ingress controllers below:
 * [HAProxy](https://haproxy-ingress.github.io/)
-* [NGINX](https://kubernetes.github.io/ingress-nginx/)
 * [Istio](https://istio.io/latest/docs/setup/getting-started/)
+* [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only)
 
 OpenShift users can use [routes]({{< relref "/operate/kubernetes/7.22/networking/routes" >}}) instead of an Ingress.
 
-Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. `ssl-passthrough` is turned off by default for NGINX but enabled by default for HAProxy.
+Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag.
 
 ## Configure DNS
 
-1. Choose the hostname (FQDN) you will use to access your database according to the recommended naming conventions below, replacing `<placeholders>` with your own values.
+1. Choose the API hostname and database hostname suffix you will use, replacing `<placeholders>` with your own values. The recommended formats are:
 
-     REC API hostname: `api-<rec-name>-<rec-namespace>.<subdomain>`
-     REAADB hostname: `-db-<rec-name>-<rec-namespace>.<subdomain>`
-     
-     We recommend using a wildcard (`*`) in place of the database name, followed by the hostname suffix.
+     * REC API hostname (`apiFqdnUrl`): `api-<rec-name>-<rec-namespace>.<subdomain>`
+     * Database hostname suffix (`dbFqdnSuffix`): `-db-<rec-name>-<rec-namespace>.<subdomain>`
+
+     The operator appends each database name to `dbFqdnSuffix` to build the per-database hostname. For example, a database named `mydb` with the suffix above resolves to `mydb-db-<rec-name>-<rec-namespace>.<subdomain>`. For the wildcard DNS record, use `*` in place of the database name followed by the suffix.
 
 1. Retrieve the `EXTERNAL-IP` of your Ingress controller's `LoadBalancer` service.
 
@@ -60,16 +64,17 @@ Edit the RedisEnterpriseCluster (REC) spec to add the `ingressOrRouteSpec` field
 * Add any additional annotations required for your ingress controller. See [NGINX docs](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) or [HAproxy docs](https://haproxy-ingress.github.io/docs/configuration/keys/) for more information.
 
 ```sh
-kubectl patch rec  <rec-name> --type merge --patch "{\"spec\": \
+kubectl patch rec <rec-name> --type merge --patch "{\"spec\": \
     {\"ingressOrRouteSpec\": \
       {\"apiFqdnUrl\": \"api-<rec-name>-<rec-namespace>.example.com\", \
       \"dbFqdnSuffix\": \"-db-<rec-name>-<rec-namespace>.example.com\", \
       \"ingressAnnotations\": \
-       {\"<kubernetes | github>.io/ingress.class\": \
-       \"<ingress-controller>\", \
-       \"<ingress-controller-annotation>/ssl-passthrough\": \ \"true\"}, \
+       {\"kubernetes.io/ingress.class\": \"<ingress-controller>\", \
+       \"<ingress-controller-annotation>/ssl-passthrough\": \"true\"}, \
       \"method\": \"ingress\"}}}"
 ```
+
+Set `<ingress-controller>` to `haproxy` or `nginx`. The operator validates that `ingressAnnotations` includes `kubernetes.io/ingress.class` and is the only annotation key it requires; add any other controller-specific annotations alongside it.
 
 ### OpenShift routes
 

--- a/content/operate/kubernetes/7.22/networking/istio-ingress.md
+++ b/content/operate/kubernetes/7.22/networking/istio-ingress.md
@@ -57,7 +57,7 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
 1. On a different namespace from `istio-system`, create a `Gateway` custom resource file (`redis-gateway.yaml` in this example).
 
     - Replace `.istio.k8s.my.example.com` with the domain that matches your DNS record.
-    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod (most common is `istio: ingress`).
+    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod. A default `istioctl install` deploys the gateway with label `istio: ingressgateway`.
     - TLS passthrough mode is required to allow secure access to the database.
 
     ```yaml
@@ -72,9 +72,9 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
       - hosts:
         - '*.istio.k8s.my.example.com'
         port:
-          name: https
+          name: tls
           number: 443
-          protocol: HTTPS
+          protocol: TLS
         tls:
           mode: PASSTHROUGH
     ```

--- a/content/operate/kubernetes/7.4.6/networking/_index.md
+++ b/content/operate/kubernetes/7.4.6/networking/_index.md
@@ -14,7 +14,7 @@ url: '/operate/kubernetes/7.4.6/networking/'
 
 Redis Enterprise for Kubernetes supports several ways to route external traffic to your RedisEnterpriseCluster:
 
-- Ingress controllers [HAProxy](https://haproxy-ingress.github.io/) and [NGINX](https://kubernetes.github.io/ingress-nginx/) require an `ingress` API resource.
+- Ingress controllers [HAProxy](https://haproxy-ingress.github.io/) and [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only) require an `ingress` API resource.
 - [Istio](https://istio.io/latest/docs/setup/getting-started/) requires `Gateway` and `VirtualService` API resources.
 - OpenShift uses [routes]({{< relref "/operate/kubernetes/7.4.6/networking/routes.md" >}}) to route external traffic.
 - The RedisEnterpriseActiveActiveDatabase (REAADB) requires any of the above routing methods to be configured in the RedisEnterpriseCluster (REC) with the `ingressOrRouteSpec` field.
@@ -27,7 +27,7 @@ Redis Enterprise supports three [types of services](https://kubernetes.io/docs/c
 
 By default, the operator creates a `ClusterIP` type service, which exposes a cluster-internal IP and that can only be accessed from within the K8s cluster. For requests to be routed from outside the K8s cluster, you need an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) (or [route](https://docs.openshift.com/container-platform/4.12/networking/routes/route-configuration.html) if you are using OpenShift). See [kubernetes.io](https://kubernetes.io/docs/) for more details on [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) and [Ingress controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 
-* To use NGINX or HAProxy Ingress controllers, see [Ingress routing]({{< relref "/operate/kubernetes/7.4.6/networking/ingress.md" >}}).
+* To use HAProxy as an Ingress controller, see [Ingress routing]({{< relref "/operate/kubernetes/7.4.6/networking/ingress.md" >}}). The community NGINX ingress controller is retired.
 * To use OpenShift routes, see [OpenShift routes]({{< relref "/operate/kubernetes/7.4.6/networking/routes.md" >}}).
 * To use Istio as an Ingress controller, see [Istio Ingress routing]({{< relref "/operate/kubernetes/7.4.6/networking/istio-ingress.md" >}})
 

--- a/content/operate/kubernetes/7.4.6/networking/ingress.md
+++ b/content/operate/kubernetes/7.4.6/networking/ingress.md
@@ -12,18 +12,21 @@ weight: 5
 url: '/operate/kubernetes/7.4.6/networking/ingress/'
 ---
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio as shown below, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Prerequisites
 
 Before creating an Ingress, you'll need:
 
  - A RedisEnterpriseDatabase (REDB) with TLS enabled for client connections
- - A supported Ingress controller with `ssl-passthrough` enabled
-    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/)
-        - Be sure to use the `kubernetes/ingress-nginx` controller and NOT the `nginxinc/kubernetes-ingress` controller.
+ - An Ingress controller with `ssl-passthrough` enabled. Options include:
     - [HAProxy Ingress](https://haproxy-ingress.github.io/docs/getting-started/)
+    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (retired; existing deployments only)
     - To use Istio for your Ingress resources, see [Configure Istio for external routing]({{< relref "/operate/kubernetes/7.4.6/networking/istio-ingress.md" >}})
 
-{{<note>}}Make sure your Ingress controller has `ssl-passthrough`enabled. This is enabled by default for HAProxy, but disabled by default for NGINX. See the [NGINX User Guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details. {{</note>}}
+{{<note>}}Make sure your Ingress controller has `ssl-passthrough` enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag. See the [Ingress-NGINX TLS guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details.{{</note>}}
 
 ## Create an Ingress resource
 
@@ -45,7 +48,7 @@ Before creating an Ingress, you'll need:
 
 1. Create a DNS entry that resolves your chosen database hostname to the IP address for the Ingress controller's LoadBalancer.  
 
-1. Create the Ingress resource YAML file.  
+1. Create the Ingress resource YAML file.
 
     ``` YAML
     apiVersion: networking.k8s.io/v1
@@ -55,6 +58,7 @@ Before creating an Ingress, you'll need:
       annotations:
         <controller-specific-annotations-below>
     spec:
+      ingressClassName: <haproxy | nginx>
       rules:
       - host: <my-db-hostname>
         http:
@@ -66,23 +70,23 @@ Before creating an Ingress, you'll need:
                 name: <db-name>
                 port:
                   name: redis
-    ```  
-
-    For HAProxy, insert the following into the `annotations` section:  
-
-    ``` YAML
-    kubernetes.io/ingress.class: haproxy
-     ingress.kubernetes.io/ssl-passthrough: "true"
     ```
 
-    For NGINX, insert the following into the `annotations` section:  
+    Set `ingressClassName` to match the `IngressClass` your controller installed. The deprecated `kubernetes.io/ingress.class` annotation is no longer accepted by recent controller versions, so use `ingressClassName` instead.
+
+    For HAProxy, add the following annotation:
 
     ``` YAML
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    ```  
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
 
-    The `ssl-passthrough` annotation is required to allow access to the database. The specific format changes depending on your Ingress controller and any additional customizations. See [NGINX Configuration annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress Options](https://www.haproxy.com/documentation/kubernetes/latest/configuration/ingress/) for updated annotation formats.  
+    For Ingress-NGINX, add the following annotation:
+
+    ``` YAML
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
+
+    The `ssl-passthrough` annotation is required to allow access to the database. The exact format depends on your Ingress controller and any additional customizations. See [Ingress-NGINX annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress configuration keys](https://haproxy-ingress.github.io/docs/configuration/keys/) for current annotation formats.
 
 ## Test your external access  
 

--- a/content/operate/kubernetes/7.4.6/networking/ingressorroutespec.md
+++ b/content/operate/kubernetes/7.4.6/networking/ingressorroutespec.md
@@ -12,25 +12,29 @@ url: '/operate/kubernetes/7.4.6/networking/ingressorroutespec/'
 ---
 An Ingress is an API resource that provides a standardized and flexible way to manage external access to services running within a Kubernetes cluster.
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Install Ingress controller
 
 Redis Enterprise for Kubernetes supports the Ingress controllers below:
 * [HAProxy](https://haproxy-ingress.github.io/)
-* [NGINX](https://kubernetes.github.io/ingress-nginx/)
 * [Istio](https://istio.io/latest/docs/setup/getting-started/)
+* [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only)
 
 OpenShift users can use [routes]({{< relref "/operate/kubernetes/7.4.6/networking/routes.md" >}}) instead of an Ingress.
 
-Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. `ssl-passthrough` is turned off by default for NGINX but enabled by default for HAProxy.
+Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag.
 
 ## Configure DNS
 
-1. Choose the hostname (FQDN) you will use to access your database according to the recommended naming conventions below, replacing `<placeholders>` with your own values.
+1. Choose the API hostname and database hostname suffix you will use, replacing `<placeholders>` with your own values. The recommended formats are:
 
-     REC API hostname: `api-<rec-name>-<rec-namespace>.<subdomain>`
-     REAADB hostname: `-db-<rec-name>-<rec-namespace>.<subdomain>`
-     
-     We recommend using a wildcard (`*`) in place of the database name, followed by the hostname suffix.
+     * REC API hostname (`apiFqdnUrl`): `api-<rec-name>-<rec-namespace>.<subdomain>`
+     * Database hostname suffix (`dbFqdnSuffix`): `-db-<rec-name>-<rec-namespace>.<subdomain>`
+
+     The operator appends each database name to `dbFqdnSuffix` to build the per-database hostname. For example, a database named `mydb` with the suffix above resolves to `mydb-db-<rec-name>-<rec-namespace>.<subdomain>`. For the wildcard DNS record, use `*` in place of the database name followed by the suffix.
 
 1. Retrieve the `EXTERNAL-IP` of your Ingress controller's `LoadBalancer` service.
 
@@ -60,16 +64,17 @@ Edit the RedisEnterpriseCluster (REC) spec to add the `ingressOrRouteSpec` field
 * Add any additional annotations required for your ingress controller. See [NGINX docs](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) or [HAproxy docs](https://haproxy-ingress.github.io/docs/configuration/keys/) for more information.
 
 ```sh
-kubectl patch rec  <rec-name> --type merge --patch "{\"spec\": \
+kubectl patch rec <rec-name> --type merge --patch "{\"spec\": \
     {\"ingressOrRouteSpec\": \
       {\"apiFqdnUrl\": \"api-<rec-name>-<rec-namespace>.example.com\", \
       \"dbFqdnSuffix\": \"-db-<rec-name>-<rec-namespace>.example.com\", \
       \"ingressAnnotations\": \
-       {\"<kubernetes | github>.io/ingress.class\": \
-       \"<ingress-controller>\", \
-       \"<ingress-controller-annotation>/ssl-passthrough\": \ \"true\"}, \
+       {\"kubernetes.io/ingress.class\": \"<ingress-controller>\", \
+       \"<ingress-controller-annotation>/ssl-passthrough\": \"true\"}, \
       \"method\": \"ingress\"}}}"
 ```
+
+Set `<ingress-controller>` to `haproxy` or `nginx`. The operator validates that `ingressAnnotations` includes `kubernetes.io/ingress.class` and is the only annotation key it requires; add any other controller-specific annotations alongside it.
 
 ### OpenShift routes
 

--- a/content/operate/kubernetes/7.4.6/networking/istio-ingress.md
+++ b/content/operate/kubernetes/7.4.6/networking/istio-ingress.md
@@ -57,7 +57,7 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
 1. On a different namespace from `istio-system`, create a `Gateway` custom resource file (`redis-gateway.yaml` in this example).
 
     - Replace `.istio.k8s.my.example.com` with the domain that matches your DNS record.
-    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod (most common is `istio: ingress`).
+    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod. A default `istioctl install` deploys the gateway with label `istio: ingressgateway`.
     - TLS passthrough mode is required to allow secure access to the database.
 
     ```yaml
@@ -72,9 +72,9 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
       - hosts:
         - '*.istio.k8s.my.example.com'
         port:
-          name: https
+          name: tls
           number: 443
-          protocol: HTTPS
+          protocol: TLS
         tls:
           mode: PASSTHROUGH
     ```

--- a/content/operate/kubernetes/7.8.4/networking/_index.md
+++ b/content/operate/kubernetes/7.8.4/networking/_index.md
@@ -14,7 +14,7 @@ url: '/operate/kubernetes/7.8.4/networking/'
 
 Redis Enterprise for Kubernetes supports several ways to route external traffic to your RedisEnterpriseCluster:
 
-- Ingress controllers [HAProxy](https://haproxy-ingress.github.io/) and [NGINX](https://kubernetes.github.io/ingress-nginx/) require an `ingress` API resource.
+- Ingress controllers [HAProxy](https://haproxy-ingress.github.io/) and [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only) require an `ingress` API resource.
 - [Istio](https://istio.io/latest/docs/setup/getting-started/) requires `Gateway` and `VirtualService` API resources.
 - OpenShift uses [routes]({{< relref "/operate/kubernetes/7.8.4/networking/routes.md" >}}) to route external traffic.
 - The RedisEnterpriseActiveActiveDatabase (REAADB) requires any of the above routing methods to be configured in the RedisEnterpriseCluster (REC) with the `ingressOrRouteSpec` field.
@@ -27,7 +27,7 @@ Redis Enterprise supports three [types of services](https://kubernetes.io/docs/c
 
 By default, the operator creates a `ClusterIP` type service, which exposes a cluster-internal IP and that can only be accessed from within the K8s cluster. For requests to be routed from outside the K8s cluster, you need an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) (or [route](https://docs.openshift.com/container-platform/4.12/networking/routes/route-configuration.html) if you are using OpenShift). See [kubernetes.io](https://kubernetes.io/docs/) for more details on [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) and [Ingress controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 
-* To use NGINX or HAProxy Ingress controllers, see [Ingress routing]({{< relref "/operate/kubernetes/7.8.4/networking/ingress.md" >}}).
+* To use HAProxy as an Ingress controller, see [Ingress routing]({{< relref "/operate/kubernetes/7.8.4/networking/ingress.md" >}}). The community NGINX ingress controller is retired.
 * To use OpenShift routes, see [OpenShift routes]({{< relref "/operate/kubernetes/7.8.4/networking/routes.md" >}}).
 * To use Istio as an Ingress controller, see [Istio Ingress routing]({{< relref "/operate/kubernetes/7.8.4/networking/istio-ingress.md" >}})
 

--- a/content/operate/kubernetes/7.8.4/networking/ingress.md
+++ b/content/operate/kubernetes/7.8.4/networking/ingress.md
@@ -12,18 +12,21 @@ weight: 5
 url: '/operate/kubernetes/7.8.4/networking/ingress/'
 ---
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio as shown below, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Prerequisites
 
 Before creating an Ingress, you'll need:
 
  - A RedisEnterpriseDatabase (REDB) with TLS enabled for client connections
- - A supported Ingress controller with `ssl-passthrough` enabled
-    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/)
-        - Be sure to use the `kubernetes/ingress-nginx` controller and NOT the `nginxinc/kubernetes-ingress` controller.
+ - An Ingress controller with `ssl-passthrough` enabled. Options include:
     - [HAProxy Ingress](https://haproxy-ingress.github.io/docs/getting-started/)
+    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (retired; existing deployments only)
     - To use Istio for your Ingress resources, see [Configure Istio for external routing]({{< relref "/operate/kubernetes/7.8.4/networking/istio-ingress.md" >}})
 
-{{<note>}}Make sure your Ingress controller has `ssl-passthrough`enabled. This is enabled by default for HAProxy, but disabled by default for NGINX. See the [NGINX User Guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details. {{</note>}}
+{{<note>}}Make sure your Ingress controller has `ssl-passthrough` enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag. See the [Ingress-NGINX TLS guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details.{{</note>}}
 
 ## Create an Ingress resource
 
@@ -45,7 +48,7 @@ Before creating an Ingress, you'll need:
 
 1. Create a DNS entry that resolves your chosen database hostname to the IP address for the Ingress controller's LoadBalancer.  
 
-1. Create the Ingress resource YAML file.  
+1. Create the Ingress resource YAML file.
 
     ``` YAML
     apiVersion: networking.k8s.io/v1
@@ -55,6 +58,7 @@ Before creating an Ingress, you'll need:
       annotations:
         <controller-specific-annotations-below>
     spec:
+      ingressClassName: <haproxy | nginx>
       rules:
       - host: <my-db-hostname>
         http:
@@ -66,23 +70,23 @@ Before creating an Ingress, you'll need:
                 name: <db-name>
                 port:
                   name: redis
-    ```  
-
-    For HAProxy, insert the following into the `annotations` section:  
-
-    ``` YAML
-    kubernetes.io/ingress.class: haproxy
-     ingress.kubernetes.io/ssl-passthrough: "true"
     ```
 
-    For NGINX, insert the following into the `annotations` section:  
+    Set `ingressClassName` to match the `IngressClass` your controller installed. The deprecated `kubernetes.io/ingress.class` annotation is no longer accepted by recent controller versions, so use `ingressClassName` instead.
+
+    For HAProxy, add the following annotation:
 
     ``` YAML
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    ```  
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
 
-    The `ssl-passthrough` annotation is required to allow access to the database. The specific format changes depending on your Ingress controller and any additional customizations. See [NGINX Configuration annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress Options](https://www.haproxy.com/documentation/kubernetes/latest/configuration/ingress/) for updated annotation formats.  
+    For Ingress-NGINX, add the following annotation:
+
+    ``` YAML
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
+
+    The `ssl-passthrough` annotation is required to allow access to the database. The exact format depends on your Ingress controller and any additional customizations. See [Ingress-NGINX annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress configuration keys](https://haproxy-ingress.github.io/docs/configuration/keys/) for current annotation formats.
 
 ## Test your external access  
 

--- a/content/operate/kubernetes/7.8.4/networking/ingressorroutespec.md
+++ b/content/operate/kubernetes/7.8.4/networking/ingressorroutespec.md
@@ -12,25 +12,29 @@ url: '/operate/kubernetes/7.8.4/networking/ingressorroutespec/'
 ---
 An Ingress is an API resource that provides a standardized and flexible way to manage external access to services running within a Kubernetes cluster.
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Install Ingress controller
 
 Redis Enterprise for Kubernetes supports the Ingress controllers below:
 * [HAProxy](https://haproxy-ingress.github.io/)
-* [NGINX](https://kubernetes.github.io/ingress-nginx/)
 * [Istio](https://istio.io/latest/docs/setup/getting-started/)
+* [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only)
 
 OpenShift users can use [routes]({{< relref "/operate/kubernetes/7.8.4/networking/routes.md" >}}) instead of an Ingress.
 
-Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. `ssl-passthrough` is turned off by default for NGINX but enabled by default for HAProxy.
+Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag.
 
 ## Configure DNS
 
-1. Choose the hostname (FQDN) you will use to access your database according to the recommended naming conventions below, replacing `<placeholders>` with your own values.
+1. Choose the API hostname and database hostname suffix you will use, replacing `<placeholders>` with your own values. The recommended formats are:
 
-     REC API hostname: `api-<rec-name>-<rec-namespace>.<subdomain>`
-     REAADB hostname: `-db-<rec-name>-<rec-namespace>.<subdomain>`
-     
-     We recommend using a wildcard (`*`) in place of the database name, followed by the hostname suffix.
+     * REC API hostname (`apiFqdnUrl`): `api-<rec-name>-<rec-namespace>.<subdomain>`
+     * Database hostname suffix (`dbFqdnSuffix`): `-db-<rec-name>-<rec-namespace>.<subdomain>`
+
+     The operator appends each database name to `dbFqdnSuffix` to build the per-database hostname. For example, a database named `mydb` with the suffix above resolves to `mydb-db-<rec-name>-<rec-namespace>.<subdomain>`. For the wildcard DNS record, use `*` in place of the database name followed by the suffix.
 
 1. Retrieve the `EXTERNAL-IP` of your Ingress controller's `LoadBalancer` service.
 
@@ -60,16 +64,17 @@ Edit the RedisEnterpriseCluster (REC) spec to add the `ingressOrRouteSpec` field
 * Add any additional annotations required for your ingress controller. See [NGINX docs](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) or [HAproxy docs](https://haproxy-ingress.github.io/docs/configuration/keys/) for more information.
 
 ```sh
-kubectl patch rec  <rec-name> --type merge --patch "{\"spec\": \
+kubectl patch rec <rec-name> --type merge --patch "{\"spec\": \
     {\"ingressOrRouteSpec\": \
       {\"apiFqdnUrl\": \"api-<rec-name>-<rec-namespace>.example.com\", \
       \"dbFqdnSuffix\": \"-db-<rec-name>-<rec-namespace>.example.com\", \
       \"ingressAnnotations\": \
-       {\"<kubernetes | github>.io/ingress.class\": \
-       \"<ingress-controller>\", \
-       \"<ingress-controller-annotation>/ssl-passthrough\": \ \"true\"}, \
+       {\"kubernetes.io/ingress.class\": \"<ingress-controller>\", \
+       \"<ingress-controller-annotation>/ssl-passthrough\": \"true\"}, \
       \"method\": \"ingress\"}}}"
 ```
+
+Set `<ingress-controller>` to `haproxy` or `nginx`. The operator validates that `ingressAnnotations` includes `kubernetes.io/ingress.class` and is the only annotation key it requires; add any other controller-specific annotations alongside it.
 
 ### OpenShift routes
 

--- a/content/operate/kubernetes/7.8.4/networking/istio-ingress.md
+++ b/content/operate/kubernetes/7.8.4/networking/istio-ingress.md
@@ -57,7 +57,7 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
 1. On a different namespace from `istio-system`, create a `Gateway` custom resource file (`redis-gateway.yaml` in this example).
 
     - Replace `.istio.k8s.my.example.com` with the domain that matches your DNS record.
-    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod (most common is `istio: ingress`).
+    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod. A default `istioctl install` deploys the gateway with label `istio: ingressgateway`.
     - TLS passthrough mode is required to allow secure access to the database.
 
     ```yaml
@@ -72,9 +72,9 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
       - hosts:
         - '*.istio.k8s.my.example.com'
         port:
-          name: https
+          name: tls
           number: 443
-          protocol: HTTPS
+          protocol: TLS
         tls:
           mode: PASSTHROUGH
     ```

--- a/content/operate/kubernetes/7.8.6/networking/_index.md
+++ b/content/operate/kubernetes/7.8.6/networking/_index.md
@@ -14,7 +14,7 @@ url: '/operate/kubernetes/7.8.6/networking/'
 
 Redis Enterprise for Kubernetes supports several ways to route external traffic to your RedisEnterpriseCluster:
 
-- Ingress controllers [HAProxy](https://haproxy-ingress.github.io/) and [NGINX](https://kubernetes.github.io/ingress-nginx/) require an `ingress` API resource.
+- Ingress controllers [HAProxy](https://haproxy-ingress.github.io/) and [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only) require an `ingress` API resource.
 - [Istio](https://istio.io/latest/docs/setup/getting-started/) requires `Gateway` and `VirtualService` API resources.
 - OpenShift uses [routes]({{< relref "/operate/kubernetes/7.8.6/networking/routes.md" >}}) to route external traffic.
 - The RedisEnterpriseActiveActiveDatabase (REAADB) requires any of the above routing methods to be configured in the RedisEnterpriseCluster (REC) with the `ingressOrRouteSpec` field.
@@ -27,7 +27,7 @@ Redis Enterprise supports three [types of services](https://kubernetes.io/docs/c
 
 By default, the operator creates a `ClusterIP` type service, which exposes a cluster-internal IP and that can only be accessed from within the K8s cluster. For requests to be routed from outside the K8s cluster, you need an [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) (or [route](https://docs.openshift.com/container-platform/4.12/networking/routes/route-configuration.html) if you are using OpenShift). See [kubernetes.io](https://kubernetes.io/docs/) for more details on [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) and [Ingress controllers](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/).
 
-* To use NGINX or HAProxy Ingress controllers, see [Ingress routing]({{< relref "/operate/kubernetes/7.8.6/networking/ingress.md" >}}).
+* To use HAProxy as an Ingress controller, see [Ingress routing]({{< relref "/operate/kubernetes/7.8.6/networking/ingress.md" >}}). The community NGINX ingress controller is retired.
 * To use OpenShift routes, see [OpenShift routes]({{< relref "/operate/kubernetes/7.8.6/networking/routes.md" >}}).
 * To use Istio as an Ingress controller, see [Istio Ingress routing]({{< relref "/operate/kubernetes/7.8.6/networking/istio-ingress.md" >}})
 

--- a/content/operate/kubernetes/7.8.6/networking/ingress.md
+++ b/content/operate/kubernetes/7.8.6/networking/ingress.md
@@ -12,18 +12,21 @@ weight: 5
 url: '/operate/kubernetes/7.8.6/networking/ingress/'
 ---
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio as shown below, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Prerequisites
 
 Before creating an Ingress, you'll need:
 
  - A RedisEnterpriseDatabase (REDB) with TLS enabled for client connections
- - A supported Ingress controller with `ssl-passthrough` enabled
-    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/)
-        - Be sure to use the `kubernetes/ingress-nginx` controller and NOT the `nginxinc/kubernetes-ingress` controller.
+ - An Ingress controller with `ssl-passthrough` enabled. Options include:
     - [HAProxy Ingress](https://haproxy-ingress.github.io/docs/getting-started/)
+    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (retired; existing deployments only)
     - To use Istio for your Ingress resources, see [Configure Istio for external routing]({{< relref "/operate/kubernetes/7.8.6/networking/istio-ingress.md" >}})
 
-{{<note>}}Make sure your Ingress controller has `ssl-passthrough`enabled. This is enabled by default for HAProxy, but disabled by default for NGINX. See the [NGINX User Guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details. {{</note>}}
+{{<note>}}Make sure your Ingress controller has `ssl-passthrough` enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag. See the [Ingress-NGINX TLS guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details.{{</note>}}
 
 ## Create an Ingress resource
 
@@ -45,7 +48,7 @@ Before creating an Ingress, you'll need:
 
 1. Create a DNS entry that resolves your chosen database hostname to the IP address for the Ingress controller's LoadBalancer.  
 
-1. Create the Ingress resource YAML file.  
+1. Create the Ingress resource YAML file.
 
     ``` YAML
     apiVersion: networking.k8s.io/v1
@@ -55,6 +58,7 @@ Before creating an Ingress, you'll need:
       annotations:
         <controller-specific-annotations-below>
     spec:
+      ingressClassName: <haproxy | nginx>
       rules:
       - host: <my-db-hostname>
         http:
@@ -66,23 +70,23 @@ Before creating an Ingress, you'll need:
                 name: <db-name>
                 port:
                   name: redis
-    ```  
-
-    For HAProxy, insert the following into the `annotations` section:  
-
-    ``` YAML
-    kubernetes.io/ingress.class: haproxy
-     ingress.kubernetes.io/ssl-passthrough: "true"
     ```
 
-    For NGINX, insert the following into the `annotations` section:  
+    Set `ingressClassName` to match the `IngressClass` your controller installed. The deprecated `kubernetes.io/ingress.class` annotation is no longer accepted by recent controller versions, so use `ingressClassName` instead.
+
+    For HAProxy, add the following annotation:
 
     ``` YAML
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    ```  
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
 
-    The `ssl-passthrough` annotation is required to allow access to the database. The specific format changes depending on your Ingress controller and any additional customizations. See [NGINX Configuration annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress Options](https://www.haproxy.com/documentation/kubernetes/latest/configuration/ingress/) for updated annotation formats.  
+    For Ingress-NGINX, add the following annotation:
+
+    ``` YAML
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
+
+    The `ssl-passthrough` annotation is required to allow access to the database. The exact format depends on your Ingress controller and any additional customizations. See [Ingress-NGINX annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress configuration keys](https://haproxy-ingress.github.io/docs/configuration/keys/) for current annotation formats.
 
 ## Test your external access  
 

--- a/content/operate/kubernetes/7.8.6/networking/ingressorroutespec.md
+++ b/content/operate/kubernetes/7.8.6/networking/ingressorroutespec.md
@@ -12,25 +12,29 @@ url: '/operate/kubernetes/7.8.6/networking/ingressorroutespec/'
 ---
 An Ingress is an API resource that provides a standardized and flexible way to manage external access to services running within a Kubernetes cluster.
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Install Ingress controller
 
 Redis Enterprise for Kubernetes supports the Ingress controllers below:
 * [HAProxy](https://haproxy-ingress.github.io/)
-* [NGINX](https://kubernetes.github.io/ingress-nginx/)
 * [Istio](https://istio.io/latest/docs/setup/getting-started/)
+* [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only)
 
 OpenShift users can use [routes]({{< relref "/operate/kubernetes/7.8.6/networking/routes.md" >}}) instead of an Ingress.
 
-Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. `ssl-passthrough` is turned off by default for NGINX but enabled by default for HAProxy.
+Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag.
 
 ## Configure DNS
 
-1. Choose the hostname (FQDN) you will use to access your database according to the recommended naming conventions below, replacing `<placeholders>` with your own values.
+1. Choose the API hostname and database hostname suffix you will use, replacing `<placeholders>` with your own values. The recommended formats are:
 
-     REC API hostname: `api-<rec-name>-<rec-namespace>.<subdomain>`
-     REAADB hostname: `-db-<rec-name>-<rec-namespace>.<subdomain>`
-     
-     We recommend using a wildcard (`*`) in place of the database name, followed by the hostname suffix.
+     * REC API hostname (`apiFqdnUrl`): `api-<rec-name>-<rec-namespace>.<subdomain>`
+     * Database hostname suffix (`dbFqdnSuffix`): `-db-<rec-name>-<rec-namespace>.<subdomain>`
+
+     The operator appends each database name to `dbFqdnSuffix` to build the per-database hostname. For example, a database named `mydb` with the suffix above resolves to `mydb-db-<rec-name>-<rec-namespace>.<subdomain>`. For the wildcard DNS record, use `*` in place of the database name followed by the suffix.
 
 1. Retrieve the `EXTERNAL-IP` of your Ingress controller's `LoadBalancer` service.
 
@@ -60,16 +64,17 @@ Edit the RedisEnterpriseCluster (REC) spec to add the `ingressOrRouteSpec` field
 * Add any additional annotations required for your ingress controller. See [NGINX docs](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) or [HAproxy docs](https://haproxy-ingress.github.io/docs/configuration/keys/) for more information.
 
 ```sh
-kubectl patch rec  <rec-name> --type merge --patch "{\"spec\": \
+kubectl patch rec <rec-name> --type merge --patch "{\"spec\": \
     {\"ingressOrRouteSpec\": \
       {\"apiFqdnUrl\": \"api-<rec-name>-<rec-namespace>.example.com\", \
       \"dbFqdnSuffix\": \"-db-<rec-name>-<rec-namespace>.example.com\", \
       \"ingressAnnotations\": \
-       {\"<kubernetes | github>.io/ingress.class\": \
-       \"<ingress-controller>\", \
-       \"<ingress-controller-annotation>/ssl-passthrough\": \ \"true\"}, \
+       {\"kubernetes.io/ingress.class\": \"<ingress-controller>\", \
+       \"<ingress-controller-annotation>/ssl-passthrough\": \"true\"}, \
       \"method\": \"ingress\"}}}"
 ```
+
+Set `<ingress-controller>` to `haproxy` or `nginx`. The operator validates that `ingressAnnotations` includes `kubernetes.io/ingress.class` and is the only annotation key it requires; add any other controller-specific annotations alongside it.
 
 ### OpenShift routes
 

--- a/content/operate/kubernetes/7.8.6/networking/istio-ingress.md
+++ b/content/operate/kubernetes/7.8.6/networking/istio-ingress.md
@@ -57,7 +57,7 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
 1. On a different namespace from `istio-system`, create a `Gateway` custom resource file (`redis-gateway.yaml` in this example).
 
     - Replace `.istio.k8s.my.example.com` with the domain that matches your DNS record.
-    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod (most common is `istio: ingress`).
+    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod. A default `istioctl install` deploys the gateway with label `istio: ingressgateway`.
     - TLS passthrough mode is required to allow secure access to the database.
 
     ```yaml
@@ -72,9 +72,9 @@ To configure Istio to work with the Redis Kubernetes operator, we will use two c
       - hosts:
         - '*.istio.k8s.my.example.com'
         port:
-          name: https
+          name: tls
           number: 443
-          protocol: HTTPS
+          protocol: TLS
         tls:
           mode: PASSTHROUGH
     ```

--- a/content/operate/kubernetes/active-active/create-reaadb.md
+++ b/content/operate/kubernetes/active-active/create-reaadb.md
@@ -25,7 +25,7 @@ To create an Active-Active database, make sure you've completed all the followin
 
 3. Configure the REC [`ingressOrRoutes` field]({{< relref "/operate/kubernetes/networking/ingressorroutespec" >}}) and [create DNS records]({{< relref "/operate/kubernetes/networking/ingressorroutespec#configure-dns/" >}}).
    * REC API hostname (`api-<rec-name>-<rec-namespace>.<subdomain>`)
-   * Database hostname suffix (`-db-<rec-name>-<rec-namespace>.<subdomain>`)
+   * Database hostname suffix (`.db-<rec-name>-<rec-namespace>.<subdomain>`)
 
 4. [Prepare participating clusters]({{< relref "/operate/kubernetes/active-active/prepare-clusters" >}})
    * RERC name (`<rerc-name`>)
@@ -127,7 +127,7 @@ Example cluster 1:
 * RERC name: `rerc-ohare`
 * RERC secret name: `redis-enterprise-rerc-ohare`
 * API FQDN: `api-rec-chicago-ns-illinois.example.com`
-* DB FQDN suffix: `-db-rec-chicago-ns-illinois.example.com`
+* DB FQDN suffix: `.db-rec-chicago-ns-illinois.example.com`
 
 Example cluster 2:
 
@@ -136,5 +136,5 @@ Example cluster 2:
 * RERC name: `rerc-raegan`
 * RERC secret name: `redis-enterprise-rerc-reagan`
 * API FQDN: `api-rec-arlington-ns-virginia.example.com`
-* DB FQDN suffix: `-db-rec-arlington-ns-virginia.example.com`
+* DB FQDN suffix: `.db-rec-arlington-ns-virginia.example.com`
 

--- a/content/operate/kubernetes/active-active/edit-clusters.md
+++ b/content/operate/kubernetes/active-active/edit-clusters.md
@@ -86,7 +86,7 @@ To communicate with other clusters, all participating clusters need access to th
       recName: rec-boston
       recNamespace: ns-massachusetts
       apiFqdnUrl: test-example-api-rec-boston-ns-massachusetts.example.com
-      dbFqdnSuffix: -example-cluster-rec-boston-ns-massachusetts.example.com
+      dbFqdnSuffix: .example-cluster-rec-boston-ns-massachusetts.example.com
       secretName: redis-enterprise-rerc-logan
     ```
 

--- a/content/operate/kubernetes/active-active/edit-rerc.md
+++ b/content/operate/kubernetes/active-active/edit-rerc.md
@@ -26,7 +26,7 @@ The following example edits the `dbFqdnSuffix` field for the RERC named `rerc-oh
 
 ```sh
 kubectl patch rerc rerc-ohare --type merge --patch \
-'{"spec":{"dbFqdnSuffix": "-example2-cluster-rec-chicago-ns-illinois.example.com"}}'
+'{"spec":{"dbFqdnSuffix": ".example2-cluster-rec-chicago-ns-illinois.example.com"}}'
 ```
 
 ## Update RERC secret

--- a/content/operate/kubernetes/active-active/prepare-clusters.md
+++ b/content/operate/kubernetes/active-active/prepare-clusters.md
@@ -23,7 +23,7 @@ Before you prepare your clusters to participate in an Active-Active database, ma
 
 3. Configure the REC [`ingressOrRoutes` field]({{< relref "/operate/kubernetes/networking/ingressorroutespec" >}}) and [create DNS records]({{< relref "/operate/kubernetes/networking/ingressorroutespec#configure-dns/" >}}).
    * REC API hostname (`api-<rec-name>-<rec-namespace>.<subdomain>`)
-   * Database hostname suffix (`-db-<rec-name>-<rec-namespace>.<subdomain>`)
+   * Database hostname suffix (`.db-<rec-name>-<rec-namespace>.<subdomain>`)
 
 Next you'll [collect credentials](#collect-rec-credentials) for your participating clusters and create secrets for the RedisEnterprsieRemoteCluster (RERC) to use.
 
@@ -135,7 +135,7 @@ Example cluster 1:
 * RERC name: `rerc-ohare`
 * RERC secret name: `redis-enterprise-rerc-ohare`
 * API FQDN: `api-rec-chicago-ns-illinois.example.com`
-* DB FQDN suffix: `-db-rec-chicago-ns-illinois.example.com`
+* DB FQDN suffix: `.db-rec-chicago-ns-illinois.example.com`
 
 Example cluster 2:
 
@@ -144,4 +144,4 @@ Example cluster 2:
 * RERC name: `rerc-raegan`
 * RERC secret name: `redis-enterprise-rerc-reagan`
 * API FQDN: `api-rec-arlington-ns-virginia.example.com`
-* DB FQDN suffix: `-db-rec-arlington-ns-virginia.example.com`
+* DB FQDN suffix: `.db-rec-arlington-ns-virginia.example.com`

--- a/content/operate/kubernetes/networking/_index.md
+++ b/content/operate/kubernetes/networking/_index.md
@@ -23,7 +23,7 @@ Connect applications to your Redis Enterprise databases:
 
 Choose the appropriate method for your environment to enable external access:
 
-- [Ingress routing]({{< relref "/operate/kubernetes/networking/ingress" >}}) - Use NGINX or HAProxy ingress controllers with `ingress` API resources
+- [Ingress routing]({{< relref "/operate/kubernetes/networking/ingress" >}}) - Use HAProxy ingress controller with `ingress` API resources (the community NGINX ingress controller is retired)
 - [Istio ingress routing]({{< relref "/operate/kubernetes/networking/istio-ingress" >}}) - Use Istio service mesh with `Gateway` and `VirtualService` API resources
 - [OpenShift routes]({{< relref "/operate/kubernetes/networking/routes" >}}) - Use OpenShift-specific route resources for external traffic
 

--- a/content/operate/kubernetes/networking/database-connectivity.md
+++ b/content/operate/kubernetes/networking/database-connectivity.md
@@ -113,9 +113,9 @@ To access databases from outside the Kubernetes cluster, you need to configure e
 
 Redis Enterprise for Kubernetes only supports the following ingress controllers for external database access:
 
-- NGINX Ingress - Supports SSL passthrough for Redis connections
-- HAProxy Ingress - Built-in SSL passthrough support  
-- Istio Gateway - Service mesh integration with advanced traffic management
+- HAProxy Ingress - Built-in SSL passthrough support.
+- Istio Gateway - Service mesh integration with advanced traffic management.
+- Ingress-NGINX - SSL passthrough is off by default; start the controller with `--enable-ssl-passthrough`. The community `kubernetes/ingress-nginx` project is retired (maintenance ended March 2026); existing deployments only.
 
 See [Ingress routing]({{< relref "/operate/kubernetes/networking/ingress" >}}) for detailed configuration steps.
 

--- a/content/operate/kubernetes/networking/ingress.md
+++ b/content/operate/kubernetes/networking/ingress.md
@@ -11,18 +11,21 @@ linkTitle: Ingress routing
 weight: 5
 ---
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio as shown below, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Prerequisites
 
 Before creating an Ingress, you'll need:
 
  - A RedisEnterpriseDatabase (REDB) with TLS enabled for client connections
- - A supported Ingress controller with `ssl-passthrough` enabled
-    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/)
-        - Be sure to use the `kubernetes/ingress-nginx` controller and NOT the `nginxinc/kubernetes-ingress` controller.
+ - An Ingress controller with `ssl-passthrough` enabled. Options include:
     - [HAProxy Ingress](https://haproxy-ingress.github.io/docs/getting-started/)
+    - [Ingress-NGINX Controller](https://kubernetes.github.io/ingress-nginx/deploy/) (retired; existing deployments only)
     - To use Istio for your Ingress resources, see [Configure Istio for external routing]({{< relref "/operate/kubernetes/networking/istio-ingress" >}})
 
-{{<note>}}Make sure your Ingress controller has `ssl-passthrough`enabled. This is enabled by default for HAProxy, but disabled by default for NGINX. See the [NGINX User Guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details. {{</note>}}
+{{<note>}}Make sure your Ingress controller has `ssl-passthrough` enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag. See the [Ingress-NGINX TLS guide](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) for details.{{</note>}}
 
 ## Create an Ingress resource
 
@@ -44,7 +47,7 @@ Before creating an Ingress, you'll need:
 
 1. Create a DNS entry that resolves your chosen database hostname to the IP address for the Ingress controller's LoadBalancer.  
 
-1. Create the Ingress resource YAML file.  
+1. Create the Ingress resource YAML file.
 
     ``` YAML
     apiVersion: networking.k8s.io/v1
@@ -54,6 +57,7 @@ Before creating an Ingress, you'll need:
       annotations:
         <controller-specific-annotations-below>
     spec:
+      ingressClassName: <haproxy | nginx>
       rules:
       - host: <my-db-hostname>
         http:
@@ -65,23 +69,23 @@ Before creating an Ingress, you'll need:
                 name: <db-name>
                 port:
                   name: redis
-    ```  
-
-    For HAProxy, insert the following into the `annotations` section:  
-
-    ``` YAML
-    kubernetes.io/ingress.class: haproxy
-     ingress.kubernetes.io/ssl-passthrough: "true"
     ```
 
-    For NGINX, insert the following into the `annotations` section:  
+    Set `ingressClassName` to match the `IngressClass` your controller installed. The deprecated `kubernetes.io/ingress.class` annotation is no longer accepted by recent controller versions, so use `ingressClassName` instead.
+
+    For HAProxy, add the following annotation:
 
     ``` YAML
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-    ```  
+    ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
 
-    The `ssl-passthrough` annotation is required to allow access to the database. The specific format changes depending on your Ingress controller and any additional customizations. See [NGINX Configuration annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress Options](https://www.haproxy.com/documentation/kubernetes/latest/configuration/ingress/) for updated annotation formats.  
+    For Ingress-NGINX, add the following annotation:
+
+    ``` YAML
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    ```
+
+    The `ssl-passthrough` annotation is required to allow access to the database. The exact format depends on your Ingress controller and any additional customizations. See [Ingress-NGINX annotations](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) and [HAProxy Ingress configuration keys](https://haproxy-ingress.github.io/docs/configuration/keys/) for current annotation formats.
 
 ## Test your external access  
 

--- a/content/operate/kubernetes/networking/ingress.md
+++ b/content/operate/kubernetes/networking/ingress.md
@@ -12,7 +12,7 @@ weight: 5
 ---
 
 {{<warning>}}
-The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio as shown below, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio as shown below.
 {{</warning>}}
 
 ## Prerequisites

--- a/content/operate/kubernetes/networking/ingressorroutespec.md
+++ b/content/operate/kubernetes/networking/ingressorroutespec.md
@@ -11,25 +11,29 @@ weight: 30
 ---
 An Ingress is an API resource that provides a standardized and flexible way to manage external access to services running within a Kubernetes cluster.
 
+{{<warning>}}
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+{{</warning>}}
+
 ## Install Ingress controller
 
 Redis Enterprise for Kubernetes supports the Ingress controllers below:
 * [HAProxy](https://haproxy-ingress.github.io/)
-* [NGINX](https://kubernetes.github.io/ingress-nginx/)
 * [Istio](https://istio.io/latest/docs/setup/getting-started/)
+* [Ingress-NGINX](https://kubernetes.github.io/ingress-nginx/) (retired; existing deployments only)
 
 OpenShift users can use [routes]({{< relref "/operate/kubernetes/networking/routes" >}}) instead of an Ingress.
 
-Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. `ssl-passthrough` is turned off by default for NGINX but enabled by default for HAProxy.
+Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled. It is on by default for HAProxy and off by default for Ingress-NGINX. For Ingress-NGINX, start the controller with the `--enable-ssl-passthrough` flag.
 
 ## Configure DNS
 
-1. Choose the hostname (FQDN) you will use to access your database according to the recommended naming conventions below, replacing `<placeholders>` with your own values.
+1. Choose the API hostname and database hostname suffix you will use, replacing `<placeholders>` with your own values. The recommended formats are:
 
-     REC API hostname: `api-<rec-name>-<rec-namespace>.<subdomain>`
-     REAADB hostname: `-db-<rec-name>-<rec-namespace>.<subdomain>`
-     
-     We recommend using a wildcard (`*`) in place of the database name, followed by the hostname suffix.
+     * REC API hostname (`apiFqdnUrl`): `api-<rec-name>-<rec-namespace>.<subdomain>`
+     * Database hostname suffix (`dbFqdnSuffix`): `-db-<rec-name>-<rec-namespace>.<subdomain>`
+
+     The operator appends each database name to `dbFqdnSuffix` to build the per-database hostname. For example, a database named `mydb` with the suffix above resolves to `mydb-db-<rec-name>-<rec-namespace>.<subdomain>`. For the wildcard DNS record, use `*` in place of the database name followed by the suffix.
 
 1. Retrieve the `EXTERNAL-IP` of your Ingress controller's `LoadBalancer` service.
 
@@ -59,16 +63,17 @@ Edit the RedisEnterpriseCluster (REC) spec to add the `ingressOrRouteSpec` field
 * Add any additional annotations required for your ingress controller. See [NGINX docs](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/) or [HAproxy docs](https://haproxy-ingress.github.io/docs/configuration/keys/) for more information.
 
 ```sh
-kubectl patch rec  <rec-name> --type merge --patch "{\"spec\": \
+kubectl patch rec <rec-name> --type merge --patch "{\"spec\": \
     {\"ingressOrRouteSpec\": \
       {\"apiFqdnUrl\": \"api-<rec-name>-<rec-namespace>.example.com\", \
       \"dbFqdnSuffix\": \"-db-<rec-name>-<rec-namespace>.example.com\", \
       \"ingressAnnotations\": \
-       {\"<kubernetes | github>.io/ingress.class\": \
-       \"<ingress-controller>\", \
-       \"<ingress-controller-annotation>/ssl-passthrough\": \ \"true\"}, \
+       {\"kubernetes.io/ingress.class\": \"<ingress-controller>\", \
+       \"<ingress-controller-annotation>/ssl-passthrough\": \"true\"}, \
       \"method\": \"ingress\"}}}"
 ```
+
+Set `<ingress-controller>` to `haproxy` or `nginx`. The operator validates that `ingressAnnotations` includes `kubernetes.io/ingress.class` and is the only annotation key it requires; add any other controller-specific annotations alongside it.
 
 ### OpenShift routes
 

--- a/content/operate/kubernetes/networking/ingressorroutespec.md
+++ b/content/operate/kubernetes/networking/ingressorroutespec.md
@@ -12,7 +12,7 @@ weight: 30
 An Ingress is an API resource that provides a standardized and flexible way to manage external access to services running within a Kubernetes cluster.
 
 {{<warning>}}
-The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio, or migrate to a [Gateway API](https://gateway-api.sigs.k8s.io/) implementation.
+The community [Ingress-NGINX controller](https://github.com/kubernetes/ingress-nginx) (`kubernetes/ingress-nginx`) is retired. Best-effort maintenance ended in March 2026 and the project no longer ships releases, bug fixes, or security updates. If you are not already using it, use HAProxy or Istio.
 {{</warning>}}
 
 ## Install Ingress controller
@@ -31,9 +31,9 @@ Install your chosen Ingress controller, making sure `ssl-passthrough` is enabled
 1. Choose the API hostname and database hostname suffix you will use, replacing `<placeholders>` with your own values. The recommended formats are:
 
      * REC API hostname (`apiFqdnUrl`): `api-<rec-name>-<rec-namespace>.<subdomain>`
-     * Database hostname suffix (`dbFqdnSuffix`): `-db-<rec-name>-<rec-namespace>.<subdomain>`
+     * Database hostname suffix (`dbFqdnSuffix`): `.db-<rec-name>-<rec-namespace>.<subdomain>`
 
-     The operator appends each database name to `dbFqdnSuffix` to build the per-database hostname. For example, a database named `mydb` with the suffix above resolves to `mydb-db-<rec-name>-<rec-namespace>.<subdomain>`. For the wildcard DNS record, use `*` in place of the database name followed by the suffix.
+     The operator appends each database name to `dbFqdnSuffix` to build the per-database hostname. For example, a database named `mydb` with the suffix above resolves to `mydb.db-<rec-name>-<rec-namespace>.<subdomain>`. For the wildcard DNS record, replace the database name with `*`, which resolves to `*.db-<rec-name>-<rec-namespace>.<subdomain>`.
 
 1. Retrieve the `EXTERNAL-IP` of your Ingress controller's `LoadBalancer` service.
 
@@ -66,7 +66,7 @@ Edit the RedisEnterpriseCluster (REC) spec to add the `ingressOrRouteSpec` field
 kubectl patch rec <rec-name> --type merge --patch "{\"spec\": \
     {\"ingressOrRouteSpec\": \
       {\"apiFqdnUrl\": \"api-<rec-name>-<rec-namespace>.example.com\", \
-      \"dbFqdnSuffix\": \"-db-<rec-name>-<rec-namespace>.example.com\", \
+      \"dbFqdnSuffix\": \".db-<rec-name>-<rec-namespace>.example.com\", \
       \"ingressAnnotations\": \
        {\"kubernetes.io/ingress.class\": \"<ingress-controller>\", \
        \"<ingress-controller-annotation>/ssl-passthrough\": \"true\"}, \
@@ -84,7 +84,7 @@ Set `<ingress-controller>` to `haproxy` or `nginx`. The operator validates that 
 kubectl patch rec <rec-name> --type merge --patch "{\"spec\": \
      {\"ingressOrRouteSpec\": \
      {\"apiFqdnUrl\": \"api-<rec-name>-<rec-namespace>.example.com\" \ 
-     \"dbFqdnSuffix\": \"-db-<rec-name>-<rec-namespace>.example.com\", \
+     \"dbFqdnSuffix\": \".db-<rec-name>-<rec-namespace>.example.com\", \
      \"method\": \"openShiftRoute\"}}}"
 ```
 

--- a/content/operate/kubernetes/networking/istio-ingress.md
+++ b/content/operate/kubernetes/networking/istio-ingress.md
@@ -60,7 +60,7 @@ When using Istio ingress for Redis on Kubernetes, avoid partial wildcard hostnam
 1. On a different namespace from `istio-system`, create a `Gateway` custom resource file (`redis-gateway.yaml` in this example).
 
     - Replace `.istio.k8s.my.example.com` with the domain that matches your DNS record.
-    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod (most common is `istio: ingress`).
+    - Replace `<selector-label>` with the label set on your Istio ingress gateway pod. A default `istioctl install` deploys the gateway with label `istio: ingressgateway`.
     - TLS passthrough mode is required to allow secure access to the database.
 
     ```yaml
@@ -75,9 +75,9 @@ When using Istio ingress for Redis on Kubernetes, avoid partial wildcard hostnam
       - hosts:
         - '*.istio.k8s.my.example.com'
         port:
-          name: https
+          name: tls
           number: 443
-          protocol: HTTPS
+          protocol: TLS
         tls:
           mode: PASSTHROUGH
     ```

--- a/content/operate/kubernetes/release-notes/previous-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/previous-releases/_index.md
@@ -9,7 +9,7 @@ description: Release notes for versions of Redis Enterprise for Kubernetes relea
   more than 18 months ago.
 hideListLinks: true
 linkTitle: Previous versions
-weight: 91
+weight: 100
 ---
 Below are archived release notes for Redis Enterprise for Kubernetes versions released more than 18 months ago.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code; risk is limited to readers following updated hostname or ingress configuration examples.
> 
> **Overview**
> This PR updates **Redis Enterprise for Kubernetes** networking and Active-Active documentation across versioned (`7.4.6`, `7.8.x`, `7.22`) and unversioned paths, plus embedded RERC YAML samples.
> 
> **Ingress-NGINX:** Adds prominent warnings that the community `kubernetes/ingress-nginx` controller is retired (maintenance ended March 2026). Docs now steer new deployments toward **HAProxy** or **Istio** (and mention **Gateway API** on some pages), while listing Ingress-NGINX only for existing deployments with `--enable-ssl-passthrough` called out.
> 
> **Ingress resource examples:** Sample `Ingress` manifests now use **`spec.ingressClassName`** instead of documenting `kubernetes.io/ingress.class` on the Ingress rule; HAProxy/NGINX examples drop redundant `ingress.class` annotations and keep ssl-passthrough annotations only.
> 
> **Istio:** `Gateway` examples change port **`protocol`/`name` from HTTPS to TLS** for passthrough on 443, and the default gateway selector is documented as **`istio: ingressgateway`**.
> 
> **Active-Active / RERC:** `dbFqdnSuffix` in embeds and several Active-Active guides switches from a leading hyphen (e.g. `-db-...`) to a **leading dot** (e.g. `.db-...`). Unversioned `ingressorroutespec` aligns REC patch examples and hostname explanation with **`.db-<rec>-<ns>.<domain>`** and how the operator concatenates database names.
> 
> **`ingressOrRouteSpec`:** Clarifies DNS naming, fixes `kubectl patch` JSON (including `kubernetes.io/ingress.class` in examples), and notes operator validation for that annotation key.
> 
> **Minor:** Networking index blurbs and database-connectivity controller lists updated; previous K8s release-notes index **weight** `91` → `100`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfb7c162897cbb962468146cb77f82f21da1815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->