### PR TITLE
K8s: wisconsin maint 10 RN

### DIFF
--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-15-may2026.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-15-may2026.md
@@ -1,0 +1,27 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: A maintenance release that includes support for Redis Software 7.8.6-263.
+hideListLinks: true
+linkTitle: 7.8.6-15 (May 2026)
+title: Redis Enterprise for Kubernetes 7.8.6-15 (May 2026) release notes
+weight: 17
+---
+
+Redis Enterprise for Kubernetes 7.8.6-15 (May 2026) is a maintenance release that includes support for [Redis Software 7.8.6-263]({{<relref "/operate/rs/release-notes/rs-7-8-releases/" >}}).
+
+For supported distributions, known limitations, and API changes, see [Redis Enterprise for Kubernetes 7.8.6-1 March 2025 release notes]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-march2025" >}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:7.8.6-263`
+- **Operator**: `redislabs/operator:7.8.6-15`
+- **Services Rigger**: `redislabs/k8s-controller:7.8.6-15`
+- **OLM operator bundle** : `v7.8.6-15.0`
+
+## Known limitations
+
+See [7.8.6 releases]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases" >}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.8.6 release notes
 weight: 92
 ---
 
-Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-14 with support for Redis Enterprise Software version 7.8.6-260.
+Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-15 with support for Redis Enterprise Software version 7.8.6-263.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes adding a new release note page and updating the index to point to the latest version.
> 
> **Overview**
> Adds release notes for **Redis Enterprise for Kubernetes `7.8.6-15` (May 2026)**, documenting support for Redis Software `7.8.6-263` and publishing updated image/bundle tags.
> 
> Updates the `7.8.6` release-notes index to mark `7.8.6-15` (with Redis Software `7.8.6-263`) as the latest release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 236492147f6033e4d69c560a5243f272c99e018e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->