### PR TITLE
RS: Clarified that one Redis license can only be used on one cluster

### DIFF
--- a/content/operate/rs/7.22/clusters/configure/license-keys.md
+++ b/content/operate/rs/7.22/clusters/configure/license-keys.md
@@ -14,6 +14,8 @@ url: '/operate/rs/7.22/clusters/configure/license-keys/'
 The cluster license key enables Redis Enterprise Software features and determines shard usage and limits.
 You can add or update a cluster key at any time.
 
+A single license can only be deployed on a single cluster. Each cluster, including passive or cold standby clusters used for disaster recovery, requires its own separate license, regardless of whether all clusters are active simultaneously.
+
 ## Trial mode
 
 Trial mode allows all features to be enabled during the trial period.

--- a/content/operate/rs/7.4/clusters/configure/license-keys.md
+++ b/content/operate/rs/7.4/clusters/configure/license-keys.md
@@ -14,6 +14,8 @@ url: '/operate/rs/7.4/clusters/configure/license-keys/'
 The cluster license key enables Redis Enterprise Software features and determines shard usage and limits.
 You can add or update a cluster key at any time.
 
+A single license can only be deployed on a single cluster. Each cluster, including passive or cold standby clusters used for disaster recovery, requires its own separate license, regardless of whether all clusters are active simultaneously.
+
 ## Trial mode
 
 Trial mode allows all features to be enabled during the trial period.

--- a/content/operate/rs/7.8/clusters/configure/license-keys.md
+++ b/content/operate/rs/7.8/clusters/configure/license-keys.md
@@ -14,6 +14,8 @@ url: '/operate/rs/7.8/clusters/configure/license-keys/'
 The cluster license key enables Redis Enterprise Software features and determines shard usage and limits.
 You can add or update a cluster key at any time.
 
+A single license can only be deployed on a single cluster. Each cluster, including passive or cold standby clusters used for disaster recovery, requires its own separate license, regardless of whether all clusters are active simultaneously.
+
 ## Trial mode
 
 Trial mode allows all features to be enabled during the trial period.

--- a/content/operate/rs/clusters/configure/license-keys.md
+++ b/content/operate/rs/clusters/configure/license-keys.md
@@ -13,6 +13,8 @@ weight: 20
 The cluster license key enables Redis Software features and determines shard usage and limits.
 You can add or update a cluster key at any time.
 
+A single license can only be deployed on a single cluster. Each cluster, including passive or cold standby clusters used for disaster recovery, requires its own separate license, regardless of whether all clusters are active simultaneously.
+
 ## Trial mode
 
 Trial mode allows all features to be enabled during the trial period.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies licensing constraints; no product or API behavior is modified.
> 
> **Overview**
> Clarifies Redis Enterprise/Software licensing docs to state that **one license can only be used on a single cluster**, and that *passive/cold-standby disaster recovery clusters still require their own license*.
> 
> Applies the same clarification across the versioned `license-keys.md` pages (`rs`, `7.4`, `7.8`, `7.22`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 519ab5db55cbdc11280acf044a244a72fc49387b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->