### PR TITLE
RS: Removed search/export logs CM UI limitation from RS 8.0.20 release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -216,8 +216,6 @@ The following legacy UI features are not yet available in the new Cluster Manage
 
     Use [`crdb-cli crdb purge-instance`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/purge-instance" >}}) instead.
 
-- Search and export the log.
-
 ## Security
 
 #### Redis Open Source security fixes compatibility


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that removes an outdated Cluster Manager UI limitation from the 8.0.20-19 release notes.
> 
> **Overview**
> Removes the “Search and export the log” item from the **Cluster Manager UI limitations** section in `rs-8-0-20-19.md`, updating the 8.0.20-19 release notes to no longer list this capability as missing in the new UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a7b6a111a133b67942923f8ca6764159f286a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->