### PR TITLE
FF: update banner

### DIFF
--- a/content/develop/ai/featureform/_index.md
+++ b/content/develop/ai/featureform/_index.md
@@ -8,7 +8,7 @@ categories:
 description: Build feature engineering workflows with Redis Feature Form.
 linkTitle: Redis Feature Form
 weight: 60
-bannerText: Redis Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
+bannerText: Redis Feature Form is currently in preview and subject to change. Feature Form Docker images are available on Docker Hub; contact your Redis account team for a license key to deploy.
 bannerChildren: true
 ---
 

--- a/content/operate/featureform/_index.md
+++ b/content/operate/featureform/_index.md
@@ -8,7 +8,7 @@ categories:
 description: Deploy and operate Feature Form on Kubernetes.
 linkTitle: Redis Feature Form
 weight: 50
-bannerText: Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
+bannerText: Feature Form is currently in preview and subject to change. Feature Form Docker images are available on Docker Hub; contact your Redis account team for a license key to deploy.
 bannerChildren: true
 ---
 

--- a/content/operate/featureform/auth.md
+++ b/content/operate/featureform/auth.md
@@ -8,7 +8,7 @@ categories:
 description: Manage Feature Form auth and RBAC
 linkTitle: Authentication and RBAC
 weight: 70
-bannerText: Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
+bannerText: Feature Form is currently in preview and subject to change. Feature Form Docker images are available on Docker Hub; contact your Redis account team for a license key to deploy.
 bannerChildren: true
 ---
 Feature Form separates deployment-wide administration from workspace-scoped actions. A workspace is the isolation boundary, but membership and permissions are managed separately through RBAC bindings.

--- a/content/operate/featureform/deploy.md
+++ b/content/operate/featureform/deploy.md
@@ -8,7 +8,7 @@ categories:
 description: Deploy and operate Feature Form on Kubernetes.
 linkTitle: Deploy
 weight: 60
-bannerText: Feature Form is currently in preview and subject to change. To request access to the Feature Form Docker image, contact your Redis account team.
+bannerText: Feature Form is currently in preview and subject to change. Feature Form Docker images are available on Docker Hub; contact your Redis account team for a license key to deploy.
 bannerChildren: true
 ---
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change updating the Feature Form preview banner text; no product or deployment logic is affected.
> 
> **Overview**
> Updates the **Feature Form preview banner** across the develop and operate docs to clarify that Docker images are available on Docker Hub and that a Redis-provided license key is required to deploy, replacing the prior “request access to the Docker image” messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60c87ce1f0e30f1bd37ec081ca7d07dde83013d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->