### PR TITLE
DOC-6660 Claude slash command to make doc plan from a JIRA ticket

### DIFF
--- a/.claude/commands/docs/make-plan-from-jira-ticket.md
+++ b/.claude/commands/docs/make-plan-from-jira-ticket.md
@@ -10,8 +10,10 @@ edit any files until I approve the plan.
    `DOC-XXXX` key from the start of the branch name. If there isn't one, stop
    and tell me.
 
-2. **Read the ticket.** Use the Atlassian MCP tools to fetch the issue from
-   Redis Labs (cloudId `06f73ca7-8f2c-4392-b40a-08288e9d0ba3`). Pull:
+2. **Read the ticket.** Use the Atlassian MCP tools to fetch the issue. If
+   you don't already have a cloudId, call `getAccessibleAtlassianResources`
+   first and pick the entry whose URL is `redislabs.atlassian.net`. Then
+   pull:
    - summary, description, status, assignee
    - comments / discussion
    - any linked issues or Confluence pages worth a look

--- a/.claude/commands/docs/make-plan-from-jira-ticket.md
+++ b/.claude/commands/docs/make-plan-from-jira-ticket.md
@@ -1,0 +1,51 @@
+---
+description: Build a doc plan from the Jira ticket implied by the current branch
+argument-hint: (no args — uses current branch)
+---
+
+You're going to plan new documentation based on a Jira ticket. Don't write or
+edit any files until I approve the plan.
+
+1. **Find the ticket.** Run `git branch --show-current` and extract the
+   `DOC-XXXX` key from the start of the branch name. If there isn't one, stop
+   and tell me.
+
+2. **Read the ticket.** Use the Atlassian MCP tools to fetch the issue from
+   Redis Labs (cloudId `06f73ca7-8f2c-4392-b40a-08288e9d0ba3`). Pull:
+   - summary, description, status, assignee
+   - comments / discussion
+   - any linked issues or Confluence pages worth a look
+
+   Treat the ticket as a request for new documentation.
+
+3. **Check whether the work is already shipped.** Look at the ticket's
+   `status.statusCategory.key`. If it's `done` (e.g. "Complete", "Done",
+   "Closed"), the doc has almost certainly already been written — don't
+   fabricate a new plan. Instead, run an audit:
+
+   - Find the merged work with `git log --all --oneline --grep=DOC-XXXX`.
+   - Read each file those commits touched (use the diffs from `git show`
+     to see exactly what was added).
+   - Compare the shipped content against the ticket's brief, description,
+     and any acceptance criteria in comments.
+   - Present a short coverage table: each thing the ticket asked for vs.
+     whether it shipped, with the file path for anything that did.
+   - Call out any gaps (asks that weren't covered, or that may have been
+     deferred to a different page).
+   - **Do not call `ExitPlanMode`** — there's nothing new to plan. Ask the
+     user which of these they want next: (a) plan a follow-up for any
+     gaps, (b) point at a different `DOC-NNNN` branch, (c) stop. Wait for
+     their pick before doing anything else.
+
+   Otherwise (ticket is still open / in progress), continue to step 4.
+
+4. **Draft a plan.** Produce an outline covering:
+   - which page(s) to add or change, and where they sit in the docs tree
+     (check neighbouring `_index.md` files to pick the right home)
+   - section headings for each new or changed page
+   - key points, examples, or diagrams the ticket calls for
+   - anything the ticket leaves ambiguous that I should decide before you start
+
+5. **Get sign-off.** Present the plan and call `ExitPlanMode` so I can approve
+   it. Frame it so the default is "go ahead and implement" — I'll only push
+   back if I want changes.


### PR DESCRIPTION
Note: you need the Atlassian/JIRA plugin enabled in Claude for this to work smoothly.

It basically seems to work OK, but all suggestions are welcome :-) 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new Claude command markdown doc only; no runtime code paths or data-handling logic are changed.
> 
> **Overview**
> Adds a new Claude slash command definition at `.claude/commands/docs/make-plan-from-jira-ticket.md` that guides Claude to infer a `DOC-XXXX` Jira key from the current branch, fetch the issue via Atlassian MCP, and produce a docs plan for approval.
> 
> It also introduces a *done-ticket* flow that audits already-merged work (via `git log`/`git show`), reports coverage vs. ticket asks, and avoids entering plan mode when the ticket is already complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cf3757bf98419211f65a99f97949573e75feb79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->