### PR TITLE
RS: Added warning against writing to Replica Of destination and instructions to enforce read-only access

### DIFF
--- a/content/operate/rs/7.22/databases/import-export/replica-of/_index.md
+++ b/content/operate/rs/7.22/databases/import-export/replica-of/_index.md
@@ -22,6 +22,10 @@ all write commands are synchronized from the sources to the destination.
 Replica Of lets you distribute the read load of your application across multiple databases or
 synchronize the database, either within Redis Enterprise or external to Redis Enterprise, to another database.
 
+{{< warning >}}
+Do not write directly to a Replica Of destination database, because it can result in replication errors, data inconsistencies, or data loss. See [Enforce read-only access]({{<relref "/operate/rs/7.22/databases/import-export/replica-of/create#enforce-read-only-access">}}) for details and instructions.
+{{< /warning >}}
+
 You can [create Active-Passive]({{< relref "/operate/rs/7.22/databases/import-export/replica-of/create.md" >}}) databases on Redis Enterprise Software or Redis Cloud.
 
 [Active-Active Geo-Distribution (CRDB)]({{< relref "/operate/rs/7.22/databases/active-active" >}})

--- a/content/operate/rs/7.22/databases/import-export/replica-of/create.md
+++ b/content/operate/rs/7.22/databases/import-export/replica-of/create.md
@@ -146,6 +146,33 @@ To use a database from a Redis Open Source cluster as a Replica Of source:
 
 1. Select **Save**.
 
+### Enforce read-only access
+
+Writing directly to a Replica Of destination database is not supported and can result in replication errors, data inconsistencies, or data loss.
+
+As of Redis Software version 7.22.0-95, you can set `replica_read_only` to `true` when you [create a Replica Of database]({{<relref "operate/rs/7.22/references/rest-api/requests/bdbs#post-bdbs-v2">}}) using the REST API. When enabled, the destination database rejects all write operations to prevent accidental writes. Replication remains one-way from source to destination. You cannot change `replica_read_only` after database creation.
+
+To enforce read-only access when you create a Replica Of destination database:
+
+```sh
+POST https://<host>:<port>/v2/bdbs
+{
+  "name": "readonly-replica-db",
+  "memory_size": 1073741824,
+  "replica_sources": [
+    {
+      "uri": "redis://admin:<password>@<source-host>:<port>"
+    }
+  ],
+  "replica_read_only": true,
+  // Additional fields
+}
+```
+
+For additional database configuration fields, see the [BDB object]({{<relref "/operate/rs/7.22/references/rest-api/objects/bdb">}}) reference.
+
+For Redis Software versions earlier than 7.22.0-95, there is no product-level enforcement preventing writes to the destination database, so you should configure your application to direct all write operations exclusively to the source database.
+
 ## Configure TLS for Replica Of
 
 When you enable TLS for Replica Of, the Replica Of synchronization traffic uses TLS certificates to authenticate the communication between the source and destination clusters.

--- a/content/operate/rs/databases/import-export/replica-of/_index.md
+++ b/content/operate/rs/databases/import-export/replica-of/_index.md
@@ -21,6 +21,10 @@ all write commands are synchronized from the sources to the destination.
 Replica Of lets you distribute the read load of your application across multiple databases or
 synchronize the database, either within Redis Software or external to Redis Software, to another database.
 
+{{< warning >}}
+Do not write directly to a Replica Of destination database, because it can result in replication errors, data inconsistencies, or data loss. See [Enforce read-only access]({{<relref "/operate/rs/databases/import-export/replica-of/create#enforce-read-only-access">}}) for details and instructions.
+{{< /warning >}}
+
 You can [create Active-Passive]({{< relref "/operate/rs/databases/import-export/replica-of/create.md" >}}) databases on Redis Software or Redis Cloud.
 
 [Active-Active Geo-Distribution (CRDB)]({{< relref "/operate/rs/databases/active-active" >}})

--- a/content/operate/rs/databases/import-export/replica-of/create.md
+++ b/content/operate/rs/databases/import-export/replica-of/create.md
@@ -145,6 +145,33 @@ To use a database from a Redis Open Source cluster as a Replica Of source:
 
 1. Select **Save**.
 
+### Enforce read-only access
+
+Writing directly to a Replica Of destination database is not supported and can result in replication errors, data inconsistencies, or data loss.
+
+As of Redis Software version 7.22.0-95, you can set `replica_read_only` to `true` when you [create a Replica Of database]({{<relref "operate/rs/references/rest-api/requests/bdbs#post-bdbs-v2">}}) using the REST API. When enabled, the destination database rejects all write operations to prevent accidental writes. Replication remains one-way from source to destination. You cannot change `replica_read_only` after database creation.
+
+To enforce read-only access when you create a Replica Of destination database:
+
+```sh
+POST https://<host>:<port>/v2/bdbs
+{
+  "name": "readonly-replica-db",
+  "memory_size": 1073741824,
+  "replica_sources": [
+    {
+      "uri": "redis://admin:<password>@<source-host>:<port>"
+    }
+  ],
+  "replica_read_only": true,
+  // Additional fields
+}
+```
+
+For additional database configuration fields, see the [BDB object]({{<relref "/operate/rs/references/rest-api/objects/bdb">}}) reference.
+
+For Redis Software versions earlier than 7.22.0-95, there is no product-level enforcement preventing writes to the destination database, so you should configure your application to direct all write operations exclusively to the source database.
+
 ## Configure TLS for Replica Of
 
 When you enable TLS for Replica Of, the Replica Of synchronization traffic uses TLS certificates to authenticate the communication between the source and destination clusters.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no product behavior or code paths are modified.
> 
> **Overview**
> Adds a new warning on both versioned (`/7.22/`) and unversioned Replica Of overview pages advising users **not to write to destination databases**, with links to remediation.
> 
> Extends the corresponding Replica Of creation docs with an **“Enforce read-only access”** section describing the `replica_read_only` REST API field (available starting 7.22.0-95), including an example `POST /v2/bdbs` payload and notes about immutability and behavior on earlier versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b08edcc03f028a96b2f5eb3197e7f3600d4085e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->