### PR TITLE
Add rdb-cli to internal utilities list

### DIFF
--- a/content/operate/rs/7.22/references/cli-utilities/_index.md
+++ b/content/operate/rs/7.22/references/cli-utilities/_index.md
@@ -39,6 +39,7 @@ Do not use these tools for normal operations.
 | debuginfo | Collects cluster information. |
 | dmc-cli | Configure and monitor the DMC proxy. |
 | pdns_control | Sends commands to a running PowerDNS nameserver. |
+| [rdb-cli](https://github.com/redis/librdb) | Parse and convert RDB files. |
 | redis_ctl | Stops or starts Redis instances. |
 | rl_rdbloader | Load RDB backup files to a server. |
 | rlutil | Maintenance utility. |

--- a/content/operate/rs/7.4/references/cli-utilities/_index.md
+++ b/content/operate/rs/7.4/references/cli-utilities/_index.md
@@ -39,6 +39,7 @@ Do not use these tools for normal operations.
 | debuginfo | Collects cluster information. |
 | dmc-cli | Configure and monitor the DMC proxy. |
 | pdns_control | Sends commands to a running PowerDNS nameserver. |
+| [rdb-cli](https://github.com/redis/librdb) | Parse and convert RDB files. |
 | redis_ctl | Stops or starts Redis instances. |
 | rl_rdbloader | Load RDB backup files to a server. |
 | rlutil | Maintenance utility. |

--- a/content/operate/rs/7.8/references/cli-utilities/_index.md
+++ b/content/operate/rs/7.8/references/cli-utilities/_index.md
@@ -39,6 +39,7 @@ Do not use these tools for normal operations.
 | debuginfo | Collects cluster information. |
 | dmc-cli | Configure and monitor the DMC proxy. |
 | pdns_control | Sends commands to a running PowerDNS nameserver. |
+| [rdb-cli](https://github.com/redis/librdb) | Parse and convert RDB files. |
 | redis_ctl | Stops or starts Redis instances. |
 | rl_rdbloader | Load RDB backup files to a server. |
 | rlutil | Maintenance utility. |

--- a/content/operate/rs/references/cli-utilities/_index.md
+++ b/content/operate/rs/references/cli-utilities/_index.md
@@ -38,6 +38,7 @@ Do not use these tools for normal operations.
 | debuginfo | Collects cluster information. |
 | dmc-cli | Configure and monitor the DMC proxy. |
 | pdns_control | Sends commands to a running PowerDNS nameserver. |
+| [rdb-cli](https://github.com/redis/librdb) | Parse and convert RDB files. |
 | redis_ctl | Stops or starts Redis instances. |
 | rl_rdbloader | Load RDB backup files to a server. |
 | rlutil | Maintenance utility. |


### PR DESCRIPTION
## Summary
- Adds the `rdb-cli` utility (from https://github.com/redis/librdb) to the Internal utilities table across all Redis Software CLI utilities pages.

## Test plan
- [ ] Verify rendered pages list `rdb-cli` in the internal utilities table on each affected version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a new row/link to existing reference tables with no product or code behavior impact.
> 
> **Overview**
> Adds `rdb-cli` (linking to `https://github.com/redis/librdb`) to the **Internal utilities** table on Redis Software/Enterprise CLI utilities reference pages, describing it as a tool to parse and convert RDB files across the unversioned page and versions `7.4`, `7.8`, and `7.22`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c69e56c008f0e22e8075c4b89ae332a511a947b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->