### PR TITLE
RedisModule_GetClusterNodeInfo - Clarify ip argument buffer size

### DIFF
--- a/content/develop/reference/modules/modules-api-ref.md
+++ b/content/develop/reference/modules/modules-api-ref.md
@@ -5506,9 +5506,9 @@ or the node ID does not exist from the POV of this local node, `REDISMODULE_ERR`
 is returned.
 
 The arguments `ip`, `master_id`, `port` and `flags` can be NULL in case we don't
-need to populate back certain info. If an `ip` and `master_id` (only populated
+need to populate back certain info. If an `ip` and/or `master_id` (only populated
 if the instance is a slave) are specified, they point to buffers holding
-at least `REDISMODULE_NODE_ID_LEN` bytes. The strings written back as `ip`
+at least `INET6_ADDRSTRLEN` (46) and `REDISMODULE_NODE_ID_LEN` bytes, respectively. The strings written back as `ip`
 and `master_id` are not null terminated.
 
 The list of flags reported is the following:


### PR DESCRIPTION
Corrected the wording to clarify that both 'ip' and 'master_id' can be NULL independently, and updated the byte length requirements for the strings written back.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reference-only change to module API documentation; no runtime or security impact.
> 
> **Overview**
> Updates the **`RedisModule_GetClusterNodeInfo`** API reference so optional output buffers are described correctly.
> 
> Callers may pass **`ip`** and **`master_id`** independently (not only together): wording changes from “`ip` and `master_id`” to “`ip` and/or `master_id`”. Buffer sizes are split: **`ip`** needs at least **`INET6_ADDRSTRLEN` (46)** bytes; **`master_id`** still needs **`REDISMODULE_NODE_ID_LEN`**. Both remain non–null-terminated when written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 520e750d0f4f719a2b9f33e81513e088328f7e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->