### PR TITLE
Fix wording on Redis client tracking explanation

### DIFF
--- a/content/commands/client-caching.md
+++ b/content/commands/client-caching.md
@@ -46,7 +46,7 @@ Please check the
 [client side caching documentation]({{< relref "/develop/clients/client-side-caching" >}}) for
 background information.
 
-When tracking is enabled Redis, using the [`CLIENT TRACKING`]({{< relref "/commands/client-tracking" >}}) command, it is
+When tracking is enabled in Redis, using the [`CLIENT TRACKING`]({{< relref "/commands/client-tracking" >}}) command, it is
 possible to specify the `OPTIN` or `OPTOUT` options, so that keys
 in read only commands are not automatically remembered by the server to
 be invalidated later. When we are in `OPTIN` mode, we can enable the


### PR DESCRIPTION
Corrected the phrasing for clarity regarding Redis client tracking.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or behavioral impact.
> 
> **Overview**
> Updates the **CLIENT CACHING** command docs so the sentence about [`CLIENT TRACKING`]({{< relref "/commands/client-tracking" >}}) reads *“When tracking is enabled **in** Redis”* instead of the awkward *“When tracking is enabled Redis”*, clarifying that tracking is a Redis feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb96366d10d9245ad2313b6b8b43a17ffe3d70a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->