### PR TITLE
DEV: add banner to modules API page

### DIFF
--- a/content/develop/reference/modules/modules-api-ref.md
+++ b/content/develop/reference/modules/modules-api-ref.md
@@ -1,4 +1,5 @@
 ---
+bannerText: This page is generated automatically from the Redis source code. To report an issue, please [open one on the redis/redis repo](https://github.com/redis/redis/issues/new?title=Feedback%20on%20Modules%20API%20reference).
 categories:
 - docs
 - develop
@@ -10,6 +11,7 @@ categories:
 - kubernetes
 - clients
 description: Reference for the Redis Modules API
+hideEditLinks: true
 linkTitle: API reference
 title: Modules API reference
 weight: 1

--- a/layouts/partials/meta-links.html
+++ b/layouts/partials/meta-links.html
@@ -32,6 +32,7 @@
 {{ end }}
 
 <nav class="flex flex-col gap-3 pb-3 w-52 text-redis-pencil-600 border-b border-b-redis-pen-700 border-opacity-50">
+  {{ if not .Params.hideEditLinks }}
   <a {{ printf "href=%q" $editURL | safeHTMLAttr }} target="_blank" class="group inline-flex items-center gap-1  hover:text-redis-pen-400 mt-auto self-start">
     <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
       <path d="M11 44q-1.2 0-2.1-.9Q8 42.2 8 41V7q0-1.2.9-2.1Q9.8 4 11 4h17l12 12v7.8h-3V18H26V7H11v34h15v3Zm0-3V7v34Zm26.8-11.15 1.4 1.4-8.2 8.2V42h2.55l8.2-8.2 1.4 1.4-8.8 8.8H29v-5.35Zm5.35 5.35-5.35-5.35 3.05-3.05q.45-.45 1.05-.45.6 0 1.05.45l3.25 3.25q.45.45.45 1.05 0 .6-.45 1.05Z" fill="currentColor" />
@@ -44,6 +45,7 @@
     </svg>
     Create an issue
   </a>
+  {{ end }}
   {{ if $markdownURL }}
   <a href="#" onclick="downloadMarkdown('{{ $markdownURL }}', '{{ $filename }}'); return false;" class="group inline-flex items-center gap-1  hover:text-redis-pen-400 mt-auto self-start">
     <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">


### PR DESCRIPTION
This PR adds a banner to a page containing 100% generated-from-source information. The banner contains a link that prompts the reader to open an issue on the redis/redis repo rather than on ours. It also adds new front matter to hide the "Edit this page" and "Create an issue" links, since they're essentially irrelevant for this page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Hugo front matter and a conditional in the meta-links partial; no runtime or security impact.
> 
> **Overview**
> The **Modules API reference** page is auto-generated from `redis/redis`, so this PR steers feedback to the right place and trims misleading doc actions.
> 
> It adds **`bannerText`** on `modules-api-ref.md` telling readers the page is generated automatically and linking them to open issues on **redis/redis** instead of this docs repo. It sets **`hideEditLinks: true`** on that page and updates **`meta-links.html`** so **Edit this page** and **Create an issue** are omitted when that flag is set (download Markdown stays available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30382426692e9cf8c291bb28614054411f24494e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->