### PR TITLE
RS: Removed CM UI instructions to view cluster license

### DIFF
--- a/content/operate/rs/7.22/clusters/configure/license-keys.md
+++ b/content/operate/rs/7.22/clusters/configure/license-keys.md
@@ -26,17 +26,7 @@ Trial mode requires a trial license. If you do not provide a license when you cr
 
 ## View cluster license key
 
-To view the cluster license key, use:
-
-- Cluster Manager UI
-
-    1. Go to **Cluster > Configuration > General > License** to see the cluster license details.
-
-    1. Select **Change** to view the cluster license key.
-
-- REST API - [`GET /v1/license`]({{< relref "/operate/rs/7.22/references/rest-api/requests/license#get-license" >}})
-
-    For a list of returned fields, see the [response section]({{< relref "/operate/rs/7.22/references/rest-api/requests/license#get-response" >}}).
+To view the cluster license key, use a [`GET /v1/license`]({{< relref "/operate/rs/7.22/references/rest-api/requests/license#get-license" >}}) REST API request. For a list of returned fields, see the [response section]({{< relref "/operate/rs/7.22/references/rest-api/requests/license#get-response" >}}).
 
 {{<note>}}
 As of version 7.2, Redis Enterprise enforces shard limits by shard types, RAM or flash, instead of the total number of shards. The flash shards limit only appears in the UI if Auto Tiering is enabled.

--- a/content/operate/rs/7.4/clusters/configure/license-keys.md
+++ b/content/operate/rs/7.4/clusters/configure/license-keys.md
@@ -26,17 +26,7 @@ Trial mode requires a trial license. If you do not provide a license when you cr
 
 ## View cluster license key
 
-To view the cluster license key, use:
-
-- Cluster Manager UI
-
-    1. Go to **Cluster > Configuration > General > License** to see the cluster license details.
-
-    1. Select **Change** to view the cluster license key.
-
-- REST API - [`GET /v1/license`]({{< relref "/operate/rs/7.4/references/rest-api/requests/license#get-license" >}})
-
-    For a list of returned fields, see the [response section]({{< relref "/operate/rs/7.4/references/rest-api/requests/license#get-response" >}}).
+To view the cluster license key, use a [`GET /v1/license`]({{< relref "/operate/rs/7.4/references/rest-api/requests/license#get-license" >}}) REST API request. For a list of returned fields, see the [response section]({{< relref "/operate/rs/7.4/references/rest-api/requests/license#get-response" >}}).
 
 {{<note>}}
 As of version 7.2, Redis Enterprise enforces shard limits by shard types, RAM or flash, instead of the total number of shards. The flash shards limit only appears in the UI if Auto Tiering is enabled.

--- a/content/operate/rs/7.8/clusters/configure/license-keys.md
+++ b/content/operate/rs/7.8/clusters/configure/license-keys.md
@@ -26,17 +26,7 @@ Trial mode requires a trial license. If you do not provide a license when you cr
 
 ## View cluster license key
 
-To view the cluster license key, use:
-
-- Cluster Manager UI
-
-    1. Go to **Cluster > Configuration > General > License** to see the cluster license details.
-
-    1. Select **Change** to view the cluster license key.
-
-- REST API - [`GET /v1/license`]({{< relref "/operate/rs/7.8/references/rest-api/requests/license#get-license" >}})
-
-    For a list of returned fields, see the [response section]({{< relref "/operate/rs/7.8/references/rest-api/requests/license#get-response" >}}).
+To view the cluster license key, use a [`GET /v1/license`]({{< relref "/operate/rs/7.8/references/rest-api/requests/license#get-license" >}}) REST API request. For a list of returned fields, see the [response section]({{< relref "/operate/rs/7.8/references/rest-api/requests/license#get-response" >}}).
 
 {{<note>}}
 As of version 7.2, Redis Enterprise enforces shard limits by shard types, RAM or flash, instead of the total number of shards. The flash shards limit only appears in the UI if Auto Tiering is enabled.

--- a/content/operate/rs/clusters/configure/license-keys.md
+++ b/content/operate/rs/clusters/configure/license-keys.md
@@ -25,17 +25,7 @@ Trial mode requires a trial license. If you do not provide a license when you cr
 
 ## View cluster license key
 
-To view the cluster license key, use:
-
-- Cluster Manager UI
-
-    1. Go to **Cluster > Configuration > General > License** to see the cluster license details.
-
-    1. Select **Change** to view the cluster license key.
-
-- REST API - [`GET /v1/license`]({{< relref "/operate/rs/references/rest-api/requests/license#get-license" >}})
-
-    For a list of returned fields, see the [response section]({{< relref "/operate/rs/references/rest-api/requests/license#get-response" >}}).
+To view the cluster license key, use a [`GET /v1/license`]({{< relref "/operate/rs/references/rest-api/requests/license#get-license" >}}) REST API request. For a list of returned fields, see the [response section]({{< relref "/operate/rs/references/rest-api/requests/license#get-response" >}}).
 
 {{<note>}}
 As of version 7.2, Redis Software enforces shard limits by shard types, RAM or flash, instead of the total number of shards. The flash shards limit only appears in the UI if Auto Tiering is enabled.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to operator guidance; no product code or security behavior changes.
> 
> **Overview**
> The **View cluster license key** section in Redis Enterprise / Redis Software `license-keys` docs is updated across the versioned paths (`7.22`, `7.4`, `7.8`) and the main `operate/rs` tree.
> 
> **Cluster Manager UI** steps (navigate to **Cluster > Configuration > General > License**, then **Change** to see the key) are removed. Viewing the key is documented only via **`GET /v1/license`**, with version-appropriate relrefs to the license REST API response fields.
> 
> Other sections (for example **Update cluster license**, which still describes UI upload/change) are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca228e26c0b9470225daa0efa853dba083ef0e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->