### PR TITLE
RS: Added LDAP OR filter known issue to RS release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -215,6 +215,8 @@ The following table provides a snapshot of supported platforms as of this Redis 
 
 ## Known issues
 
+- RS196225: After upgrading to Redis Software version 8.0.x, previously working LDAP filters that use an `OR` clause to match multiple attributes can fail to find a unique DN for some users.
+
 - RS193156: Active Directory LDAP authentication can fail in the Cluster Manager UI after upgrading to Redis Software version 8.0.16-33 due to an issue with LDAP TLS client certificate handling. Users previously authenticated through Active Directory can no longer sign in to the Cluster Manager UI after the upgrade.
 
     As a workaround, configure an LDAP client certificate using an [update cluster certificates]({{<relref "/operate/rs/references/rest-api/requests/cluster/certificates">}}) REST API request:

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-81.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-81.md
@@ -110,6 +110,8 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known issues
 
+- RS196225: After upgrading to Redis Software version 8.0.x, previously working LDAP filters that use an `OR` clause to match multiple attributes can fail to find a unique DN for some users.
+
 - RS155734: Endpoint availability metrics do not work as expected due to a calculation error.
 
 ## Known limitations

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -188,6 +188,8 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known issues
 
+- RS196225: After upgrading to Redis Software version 8.0.x, previously working LDAP filters that use an `OR` clause to match multiple attributes can fail to find a unique DN for some users.
+
 - RS155734: Endpoint availability metrics do not work as expected due to a calculation error.
 
 ## Known limitations

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-6-54.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-6-54.md
@@ -152,6 +152,8 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known issues
 
+- RS196225: After upgrading to Redis Software version 8.0.x, previously working LDAP filters that use an `OR` clause to match multiple attributes can fail to find a unique DN for some users.
+
 - RS180550: You cannot set up SSO when the Cluster Manager UI is exposed through an IPv6-based load balancer or gateway.
 
     As a workaround, use an IPv4-based address for the SSO service base address, or register a DNS name that resolves to the IPv6 address.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to release notes; no product code or configuration behavior changes in this PR.
> 
> **Overview**
> Documents **RS196225** across Redis Software **8.0.x** release notes: after upgrading to 8.0.x, LDAP filters that use an **`OR`** clause to match multiple attributes may stop resolving a unique DN for some users, even when they worked before.
> 
> The new entry is added at the top of **Known issues** on the 8.0.x hub (`_index.md`) and on individual build pages **8.0.6-54**, **8.0.10-81**, and **8.0.20-19**, using the same wording everywhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d81933f9de551f0f93146d49a0d86af24436d35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->