### PR TITLE
K8s: yellow sub maint 10

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-40-may2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-40-may2026.md
@@ -1,0 +1,35 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: Maintenance release to support Redis Software version 7.22.2-133 with bug and security fixes.
+hideListLinks: true
+linkTitle: 7.22.2-40 (May 2026)
+title: Redis for Kubernetes 7.22.2-40 (May 2026) release notes
+weight: 17
+---
+
+## Highlights
+
+This is a maintenance release of Redis for Kubernetes to support Redis Software version 7.22.2-133. For supported distributions and known limitations, see the [7.22.2 releases]({{< relref "/operate/kubernetes/release-notes/7-22-2-releases/" >}}).
+
+## Downloads
+
+- **Redis Software**: `redislabs/redis:7.22.2-133`
+- **Operator**: `redislabs/operator:7.22.2-40`
+- **Services Rigger**: `redislabs/k8s-controller:7.22.2-40`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-40`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `v7.22.2-40.0`
+- **Redis Software**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-133`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-40`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-40`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-40`
+
+## Known limitations
+
+See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.22.2 release notes
 weight: 90
 ---
 
-Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-39 with support for Redis Enterprise Software version 7.22.2-116.
+Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-40 with support for Redis Enterprise Software version 7.22.2-133.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only release notes and index text updates with no product or runtime behavior changes.
> 
> **Overview**
> Adds release notes for **Redis for Kubernetes 7.22.2-40 (May 2026)**, a maintenance release aligned with **Redis Software 7.22.2-133**, including container image tags for the operator, services rigger, call-home client, and OpenShift/OLM bundle references.
> 
> Updates the **7.22.2 releases** index so the latest called-out version moves from **7.22.2-39** / **7.22.2-116** to **7.22.2-40** / **7.22.2-133**; known limitations still point at the shared 7.22.2 section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd73b0f8dffa3f51b81855a5018453cd087329b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->