### PR TITLE
DEV/OP: (cmds) update ACL info for the new array data type

### DIFF
--- a/content/commands/arcount.md
+++ b/content/commands/arcount.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- '@array'
+- "@read"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/ardel.md
+++ b/content/commands/ardel.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@write"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/ardelrange.md
+++ b/content/commands/ardelrange.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@write"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arget.md
+++ b/content/commands/arget.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/argetrange.md
+++ b/content/commands/argetrange.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/argrep.md
+++ b/content/commands/argrep.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- '@array'
+- "@read"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arinfo.md
+++ b/content/commands/arinfo.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arinsert.md
+++ b/content/commands/arinsert.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@write"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arlastitems.md
+++ b/content/commands/arlastitems.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arlen.md
+++ b/content/commands/arlen.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/armget.md
+++ b/content/commands/armget.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/armset.md
+++ b/content/commands/armset.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@write"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arnext.md
+++ b/content/commands/arnext.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arop.md
+++ b/content/commands/arop.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arring.md
+++ b/content/commands/arring.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@write"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arscan.md
+++ b/content/commands/arscan.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@read"
+- "@array"
+- "@slow"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arseek.md
+++ b/content/commands/arseek.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@write"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/commands/arset.md
+++ b/content/commands/arset.md
@@ -1,6 +1,8 @@
 ---
 acl_categories:
-- ARRAY
+- "@write"
+- "@array"
+- "@fast"
 arguments:
 - key_spec_index: 0
   name: key

--- a/content/operate/oss_and_stack/management/security/acl.md
+++ b/content/operate/oss_and_stack/management/security/acl.md
@@ -289,6 +289,7 @@ The following is a list of command categories and their meanings:
 
 * <a id="admin"></a>**admin** - Administrative commands. Normal applications will never need to use
   these. Includes [`REPLICAOF`](/commands/replicaof), [`CONFIG`](/commands/config), [`DEBUG`](/commands/debug), [`SAVE`](/commands/save), [`MONITOR`](/commands/monitor), [`ACL`](/commands/acl), [`SHUTDOWN`](/commands/shutdown), etc.
+* <a id="array"></a>**array** - Data type: all array related commands.
 * <a id="bitmap"></a>**bitmap** - Data type: all bitmap related commands.
 * <a id="blocking"></a>**blocking** - Potentially blocking the connection until released by another
   command.


### PR DESCRIPTION
Updated main ACL page (for OSS). Also updated the per-command ACL category info. from 8.8-GA bits (Docker).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to command YAML and the ACL reference; no runtime or security behavior changes.
> 
> **Overview**
> Documents ACL metadata for the preview **array** data type so it matches Redis 8.8-style categorization.
> 
> Each array command page now lists **`@read` or `@write`**, **`@array`**, and **`@fast` or `@slow`** in front matter (replacing a lone **`ARRAY`** entry). Read vs write and fast vs slow follow the same pattern as other types (e.g. hash commands). The OSS **ACL** guide adds an **`array`** command category describing all array-related commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfc64115acc24c0f153f186ac98ba0bc4c90489c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->