### PR TITLE
RS: Added note to upgrade Replica Of destination DB before the source DB

### DIFF
--- a/content/operate/rs/7.22/databases/import-export/replica-of/_index.md
+++ b/content/operate/rs/7.22/databases/import-export/replica-of/_index.md
@@ -211,6 +211,10 @@ make sure that you disable **Replica Of** before you direct clients to the desti
 This avoids a full sync that can overwrite your data.
 {{% /warning %}}
 
+## Upgrade order
+
+When you [upgrade]({{< relref "/operate/rs/7.22/installing-upgrading/upgrading/upgrade-database" >}}) a Replica Of database, upgrade the destination database before the source database to avoid possible replication failures.
+
 ## Active-Passive replication backlog
 
 In addition to the [database replication backlog]({{< relref "/operate/rs/7.22/databases/durability-ha/replication#database-replication-backlog" >}}), active-passive databases maintain a replication backlog (per shard) to synchronize the database instances between clusters.

--- a/content/operate/rs/7.22/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/7.22/installing-upgrading/upgrading/upgrade-database.md
@@ -63,6 +63,8 @@ Before upgrading a database:
 
     Use the Cluster Manager UI to display the **Configuration** tab for the cluster. The tab displays the cluster version information and the Redis database compatibility version.
 
+- For [Replica Of databases]({{< relref "/operate/rs/7.22/databases/import-export/replica-of/" >}}), upgrade the destination database before the source database.
+
 - Check client compatibility with the database version.
 
     If you run Redis Stack commands with Go-Redis versions 9 and later or Lettuce versions 6 and later, set the client’s protocol version to RESP2 before upgrading your database to Redis version 7.2 to prevent potential application issues due to RESP3 breaking changes. See [Client prerequisites for Redis 7.2 upgrade]({{< relref "/operate/rs/7.22/references/compatibility/resp#client-prerequisites-for-redis-72-upgrade" >}}) for more details and examples.

--- a/content/operate/rs/7.4/databases/import-export/replica-of/_index.md
+++ b/content/operate/rs/7.4/databases/import-export/replica-of/_index.md
@@ -206,6 +206,10 @@ make sure that you disable **Replica Of** before you direct clients to the desti
 This avoids a full sync that can overwrite your data.
 {{% /warning %}}
 
+## Upgrade order
+
+When you [upgrade]({{< relref "/operate/rs/7.4/installing-upgrading/upgrading/upgrade-database" >}}) a Replica Of database, upgrade the destination database before the source database to avoid possible replication failures.
+
 ## Active-Passive replication backlog
 
 In addition to the [database replication backlog]({{< relref "/operate/rs/7.4/databases/durability-ha/replication#database-replication-backlog" >}}), active-passive databases maintain a replication backlog (per shard) to synchronize the database instances between clusters.

--- a/content/operate/rs/7.4/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/7.4/installing-upgrading/upgrading/upgrade-database.md
@@ -60,6 +60,8 @@ Before upgrading a database:
 
     Use the Cluster Manager UI to display the **Configuration** tab for the cluster. The tab displays the cluster version information and the Redis database compatibility version.
 
+- For [Replica Of databases]({{< relref "/operate/rs/7.4/databases/import-export/replica-of/" >}}), upgrade the destination database before the source database.
+
 - Check client compatibility with the database version.
 
     If you run Redis Stack commands with Go-Redis versions 9 and later or Lettuce versions 6 and later, set the client’s protocol version to RESP2 before upgrading your database to Redis version 7.2 to prevent potential application issues due to RESP3 breaking changes. See [Client prerequisites for Redis 7.2 upgrade]({{< relref "/operate/rs/7.4/references/compatibility/resp#client-prerequisites-for-redis-72-upgrade" >}}) for more details and examples.

--- a/content/operate/rs/7.8/databases/import-export/replica-of/_index.md
+++ b/content/operate/rs/7.8/databases/import-export/replica-of/_index.md
@@ -206,6 +206,10 @@ make sure that you disable **Replica Of** before you direct clients to the desti
 This avoids a full sync that can overwrite your data.
 {{% /warning %}}
 
+## Upgrade order
+
+When you [upgrade]({{< relref "/operate/rs/7.8/installing-upgrading/upgrading/upgrade-database" >}}) a Replica Of database, upgrade the destination database before the source database to avoid possible replication failures.
+
 ## Active-Passive replication backlog
 
 In addition to the [database replication backlog]({{< relref "/operate/rs/7.8/databases/durability-ha/replication#database-replication-backlog" >}}), active-passive databases maintain a replication backlog (per shard) to synchronize the database instances between clusters.

--- a/content/operate/rs/7.8/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/7.8/installing-upgrading/upgrading/upgrade-database.md
@@ -62,6 +62,8 @@ Before upgrading a database:
 
     Use the Cluster Manager UI to display the **Configuration** tab for the cluster. The tab displays the cluster version information and the Redis database compatibility version.
 
+- For [Replica Of databases]({{< relref "/operate/rs/7.8/databases/import-export/replica-of/" >}}), upgrade the destination database before the source database.
+
 - Check client compatibility with the database version.
 
     If you run Redis Stack commands with Go-Redis versions 9 and later or Lettuce versions 6 and later, set the client’s protocol version to RESP2 before upgrading your database to Redis version 7.2 to prevent potential application issues due to RESP3 breaking changes. See [Client prerequisites for Redis 7.2 upgrade]({{< relref "/operate/rs/7.8/references/compatibility/resp#client-prerequisites-for-redis-72-upgrade" >}}) for more details and examples.

--- a/content/operate/rs/databases/import-export/replica-of/_index.md
+++ b/content/operate/rs/databases/import-export/replica-of/_index.md
@@ -210,6 +210,10 @@ make sure that you disable **Replica Of** before you direct clients to the desti
 This avoids a full sync that can overwrite your data.
 {{% /warning %}}
 
+## Upgrade order
+
+When you [upgrade]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-database" >}}) a Replica Of database, upgrade the destination database before the source database to avoid possible replication failures.
+
 ## Active-Passive replication backlog
 
 In addition to the [database replication backlog]({{< relref "/operate/rs/databases/durability-ha/replication#database-replication-backlog" >}}), active-passive databases maintain a replication backlog (per shard) to synchronize the database instances between clusters.

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
@@ -49,6 +49,8 @@ Before upgrading a database:
 
     Use the Cluster Manager UI to display the **Configuration** tab for the cluster. The tab displays the cluster version information and the Redis database compatibility version.
 
+- For [Replica Of databases]({{< relref "/operate/rs/databases/import-export/replica-of/" >}}), upgrade the destination database before the source database.
+
 - Check client compatibility with the database version.
 
     If you run Redis Stack commands with Go-Redis versions 9 and later or Lettuce versions 6 and later, set the client’s protocol version to RESP2 before upgrading your database to Redis version 7.2 to prevent potential application issues due to RESP3 breaking changes. See [Client prerequisites for Redis 7.2 upgrade]({{< relref "/operate/rs/references/compatibility/resp#client-prerequisites-for-redis-72-upgrade" >}}) for more details and examples.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration behavior changes.
> 
> **Overview**
> Documents the required **Replica Of** upgrade sequence: upgrade the **destination** database before the **source** to reduce replication failures.
> 
> The same guidance is added in two places across the RS doc trees (unversioned, 7.4, 7.8, 7.22): a new **Upgrade order** section on the Replica Of overview pages, and a matching prerequisite bullet on **Upgrade database** that links to Replica Of.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add1592531a67702bb4cb4e718ba141c449d5087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->