### PR TITLE
DOC-6676 RDI: removed GA note and preview version page

### DIFF
--- a/content/integrate/redis-data-integration/_index.md
+++ b/content/integrate/redis-data-integration/_index.md
@@ -17,7 +17,7 @@ type: integration
 weight: 1
 ---
 
-This is the first General Availability version of Redis Data Integration (RDI).
+Redis Data Integration (RDI) keeps your Redis cache in sync with a primary system-of-record database in near real time.
 
 RDI's purpose is to help Redis customers sync Redis Enterprise with live data from their slow disk based databases in order to:
 

--- a/content/integrate/redis-data-integration/rdi-archive.md
+++ b/content/integrate/redis-data-integration/rdi-archive.md
@@ -6,6 +6,7 @@ categories:
 - operate
 - rc
 description: Describes where to view the preview version for RDI products
+draft: true
 linkTitle: Preview
 weight: 999
 ---


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording and Hugo draft flag; no product or runtime behavior changes.
> 
> **Overview**
> Updates the **Redis Data Integration** landing copy now that RDI is GA: the intro no longer calls out a first GA release and instead states that RDI keeps the Redis cache aligned with a primary system-of-record database in near real time.
> 
> The **Preview** archive page (`rdi-archive.md`) is marked **`draft: true`**, so it should drop out of the published site while the archived preview docs link can remain in source if needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edaec7f70da43dda2157a9933219537f9a42195d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->