### PR TITLE
RS: Added links to module upgrade from RS DB upgrade

### DIFF
--- a/content/operate/rs/7.22/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/7.22/installing-upgrading/upgrading/upgrade-database.md
@@ -111,6 +111,8 @@ To upgrade a database:
         rladmin upgrade db <database name | database ID> redis_version <version> preserve_roles
         ```
 
+    - For module upgrade options, see [Upgrade modules]({{< relref "/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module" >}}).
+
 1. Check the Redis database compatibility version for the database to confirm the upgrade.  
 
     To do so:

--- a/content/operate/rs/7.8/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/7.8/installing-upgrading/upgrading/upgrade-database.md
@@ -108,6 +108,8 @@ To upgrade a database:
         rladmin upgrade db <database name | database ID> redis_version <version> preserve_roles
         ```
 
+    - For module upgrade options, see [Upgrade modules]({{< relref "/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module" >}}).
+
 1. Check the Redis database compatibility version for the database to confirm the upgrade.  
 
     To do so:

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-database.md
@@ -140,6 +140,8 @@ To upgrade a database:
     rladmin upgrade db <database name | database ID> redis_version <version> preserve_roles
     ```
 
+    For module upgrade options, see [Upgrade modules]({{< relref "/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module" >}}).
+
 1. Use [`rladmin status databases extra all`]({{< relref "/operate/rs/references/cli-utilities/rladmin/status#status-databases" >}}) to display a list of the databases in your cluster and their current Redis database compatibility version. Verify that the Redis version is set to the expected value.
 
     ```sh


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only cross-links with no product or operational behavior changes.
> 
> **Overview**
> Adds a cross-link from the Redis Software **Upgrade database** docs to the shared **Upgrade modules** page, placed alongside the `rladmin` / `redis_version` upgrade steps.
> 
> The same bullet appears in the current (`content/operate/rs/...`), 7.8, and 7.22 versioned upgrade-database topics so readers upgrading a DB can find module-specific upgrade guidance without hunting elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486a972c73bb607d7d615ac7a51899a263d9c2d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->