### PR TITLE
RS & k8s: Enabling clustering for Active-Active DBs after creation

### DIFF
--- a/content/operate/kubernetes/active-active/create-reaadb.md
+++ b/content/operate/kubernetes/active-active/create-reaadb.md
@@ -89,7 +89,10 @@ Example REAADB named `reaadb-boeing` linked to the REC named `rec-chicago` with 
 
 {{<embed-yaml "k8s/reaadb-boeing.md" "reaadb-boeing.yaml">}}
 
-{{<note>}}Sharding is disabled on Active-Active databases created with a `shardCount` of 1. Sharding cannot be enabled after database creation. {{</note>}}
+{{<note>}}
+- Sharding is disabled on Active-Active databases created with a `shardCount` of 1.
+- To enable sharding after database creation, update the `shardCount` in the REAADB file. Using other methods could cause data synchronization issues.
+{{</note>}}
 
 For more details on RERC fields, see the [RERC API reference]({{<relref "/operate/kubernetes/reference/api/redis_enterprise_remote_cluster_api">}}).
 

--- a/content/operate/rs/databases/active-active/create.md
+++ b/content/operate/rs/databases/active-active/create.md
@@ -173,9 +173,18 @@ After you create the Active-Active database, you can set the TLS mode to **Requi
         
     - Clear the **Enable sharding** option to use only one shard, which allows you to use [multi-key operations]({{<relref "/operate/rs/databases/durability-ha/clustering#multikey-operations">}}) without the limitations.
 
-    {{<note>}}
-You cannot enable or turn off database clustering after the Active-Active database is created.
-    {{</note>}}
+        {{<note>}}
+You cannot turn off database clustering after the Active-Active database is created.
+        {{</note>}}
+
+        To enable clustering after the Active-Active database is created, use the [`crdb-cli crdb update`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/update" >}}) command to update `shards_count`:
+
+        ```sh
+        crdb-cli crdb update --crdb-guid <crdb-guid> --default-db-config '{"shards_count": <primary_shards_count>}'
+        ```
+        {{< warning >}}
+Do not increase the shard count using other methods, as they could cause data synchronization issues.
+        {{< /warning >}}
 
 - [**OSS Cluster API**]({{< relref "/operate/rs/databases/configure/oss-cluster-api.md" >}}) - The OSS Cluster API configuration allows access to multiple endpoints for increased throughput. The OSS Cluster API setting applies to all instances of the Active-Active database across participating clusters.
 

--- a/content/operate/rs/databases/active-active/get-started.md
+++ b/content/operate/rs/databases/active-active/get-started.md
@@ -145,9 +145,18 @@ Each Active-Active instance must have a unique fully-qualified domain name (FQDN
 
         - Turn off **Sharding** to use only one shard and avoid [Multi-key command]({{< relref "/operate/rs/databases/durability-ha/clustering" >}}) limitations.
 
-        {{< note >}}
-You cannot enable or turn off database clustering after the Active-Active database is created.
-        {{< /note >}}
+            {{< note >}}
+You cannot turn off database clustering after the Active-Active database is created.
+            {{< /note >}}
+
+            To enable clustering after the Active-Active database is created, use the [`crdb-cli crdb update`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/update" >}}) command to update `shards_count`:
+
+            ```sh
+            crdb-cli crdb update --crdb-guid <crdb-guid> --default-db-config '{"shards_count": <primary_shards_count>}'
+            ```
+            {{< warning >}}
+Do not increase the shard count using other methods, as they could cause data synchronization issues.
+            {{< /warning >}}
 
 1. Click **Create**.
 

--- a/content/operate/rs/databases/active-active/manage.md
+++ b/content/operate/rs/databases/active-active/manage.md
@@ -15,7 +15,7 @@ You can configure and manage your Active-Active database from either the Cluster
 
 ## Database settings
 
-Most Active-Active database settings can be changed after database creation. One notable exception is database clustering, which can't be turned on or off after the database has been created.
+Most Active-Active database settings can be changed after database creation, except for database clustering, which can't be turned off later.
 
 As of Redis Software version 8.0.16, the Cluster Manager UI supports both [global](#change-global-configuration) and [local](#change-local-configuration) configuration changes for Active-Active databases. In earlier versions, configuration changes made in the Cluster Manager UI applied only to the local instance and required additional manual updates for each participating cluster.
 
@@ -104,6 +104,18 @@ If a warning symbol appears next to a setting on the **Global** configuration ta
 On the **Local** configuration tab, any locally configured settings that differ from the global settings are marked with a **Local configuration** label:
 
 {{<image filename="images/rs/screenshots/databases/active-active-databases/local-config-tag.png" alt="A local configuration label appears next to Memory eviction allkeys-lru." >}}
+
+### Enable clustering after database creation
+
+To enable clustering after the Active-Active database is created, use the [`crdb-cli crdb update`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/update" >}}) command to update `shards_count`:
+
+```sh
+crdb-cli crdb update --crdb-guid <crdb-guid> --default-db-config '{"shards_count": <primary_shards_count>}'
+```
+
+{{< warning >}}
+Do not use other methods to enable clustering after database creation, as they could cause data synchronization issues.
+{{< /warning >}}
 
 ## Participating clusters
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Updates **Redis Software** and **Kubernetes** docs so Active-Active databases can **enable clustering/sharding after creation**, while still stating clustering **cannot be turned off** later.
> 
> For RS, creation and manage pages document **`crdb-cli crdb update`** with `shards_count` in `default-db-config`, plus warnings not to change shard count by other means (sync risk). For K8s **REAADB**, the note now says to raise **`shardCount` in the REAADB** spec instead of implying sharding is permanently disabled when created with one shard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93791a04ba53d677835eede5209323121ac4154f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->