### PR TITLE
DOC-6689 added pub/sub failover details

### DIFF
--- a/content/develop/clients/failover.md
+++ b/content/develop/clients/failover.md
@@ -28,11 +28,17 @@ Some Redis client libraries support
 [Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. Use this page
 to get a general overview of the concepts and then see the documentation for
-your client library to learn how to configure it for failover and failback:
+your client library to learn how to configure it for failover and failback.
 
-- [Jedis]({{< relref "/develop/clients/jedis/failover" >}})
-- [redis-py]({{< relref "/develop/clients/redis-py/failover" >}}) (preview)
-- [Lettuce]({{< relref "/develop/clients/lettuce/failover" >}}) (preview)
+Note that not all clients currently support failover for [pub/sub]({{< relref "/develop/pubsub" >}})
+connections. The table below lists the clients that have basic failover and
+pub/sub failover support.
+
+| Client | Basic failover | Pub/sub failover |
+| :-- | :-- | :-- |
+| [Jedis]({{< relref "/develop/clients/jedis/failover" >}}) | Yes | No |
+| [redis-py]({{< relref "/develop/clients/redis-py/failover" >}}) | Yes  (Preview) | No |
+| [Lettuce]({{< relref "/develop/clients/lettuce/failover" >}}) | Yes (Preview) | Yes |
 
 ## Concepts
 

--- a/content/develop/clients/failover.md
+++ b/content/develop/clients/failover.md
@@ -30,15 +30,16 @@ to improve the availability of connections to Redis databases. Use this page
 to get a general overview of the concepts and then see the documentation for
 your client library to learn how to configure it for failover and failback.
 
-Note that not all clients currently support failover for [pub/sub]({{< relref "/develop/pubsub" >}})
-connections. The table below lists the clients that have basic failover and
-pub/sub failover support.
+## Supported client libraries
 
-| Client | Basic failover | Pub/sub failover |
-| :-- | :-- | :-- |
-| [Jedis]({{< relref "/develop/clients/jedis/failover" >}}) | Yes | No |
-| [redis-py]({{< relref "/develop/clients/redis-py/failover" >}}) | Yes  (Preview) | No |
-| [Lettuce]({{< relref "/develop/clients/lettuce/failover" >}}) | Yes (Preview) | Yes |
+The table below lists the clients that support client-side geographic failover
+along with their release state and available features.
+
+| Client | Basic failover | Pub/sub failover | OSS Cluster failover | Failback |
+| :-- | :-- | :-- | :-- | :-- |
+| [Jedis]({{< relref "/develop/clients/jedis/failover" >}}) | Yes | No | No | Yes |
+| [redis-py]({{< relref "/develop/clients/redis-py/failover" >}}) | Yes  (Preview) | Yes | Yes | Yes |
+| [Lettuce]({{< relref "/develop/clients/lettuce/failover" >}}) | Yes (Preview) | Yes | No | Yes |
 
 ## Concepts
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to the failover overview; no runtime, security, or data-handling impact.
> 
> **Overview**
> The **client-side geographic failover** overview page now uses a **Supported client libraries** section with a feature matrix instead of a short bullet list of links.
> 
> The table compares **Jedis**, **redis-py**, and **Lettuce** on **basic failover**, **pub/sub failover**, **OSS Cluster failover**, and **failback**, including preview labels where applicable. Intro copy was tightened so readers are directed to per-client docs after scanning capabilities at a glance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55b9c760a2666f29345fb62cb8343b7a206fd495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->