### PR TITLE
Add /tmp/** to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@
 **/__pycache__/
 venv/**
 node_modules/
-tmp/**
+/tmp/**
 package-lock.json 
 .hugo_build.lock
 .vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 **/__pycache__/
 venv/**
 node_modules/
+tmp/**
 package-lock.json 
 .hugo_build.lock
 .vscode/


### PR DESCRIPTION
This is a useful change for me because I'm always temporarily adding stuff to docs/tmp while working on various projects. I can now do so with impunity and zero consequences.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates `.gitignore`; no runtime, build, or security behavior changes.
> 
> **Overview**
> Adds **`/tmp/**`** to **`.gitignore`** so anything under a **repository-root `tmp/`** directory stays untracked.
> 
> This is separate from the existing **`/content/tmp/`** entry, which only covers Hugo content under `content/tmp/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f946eaaf62e636a06f272feff2fe0708a8e437a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->