### PR TITLE
RS: Added large-key anti-patterns and OOM risk guidance to Auto Tiering docs

### DIFF
--- a/content/operate/rs/7.22/databases/auto-tiering/_index.md
+++ b/content/operate/rs/7.22/databases/auto-tiering/_index.md
@@ -39,10 +39,11 @@ Auto Tiering is ideal when your:
 
 Auto Tiering is not recommended for:
 
-- Long key names (all key names are stored in RAM)
-- Broad access patterns (any value could be pulled into RAM)
-- Large working sets (working set is stored in RAM)
-- Frequently moved data (moving to and from RAM too often can impact performance)
+- A large number of keys or long key names. All key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+- Broad access patterns (any value could be pulled into RAM).
+- Large working sets (working set is stored in RAM).
+- Frequently moved data (moving to and from RAM too often can impact performance).
+- Large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
 
 Auto Tiering is not intended to be used for persistent storage. Redis Enterprise Software database persistent and ephemeral storage should be on different disks, either local or attached.
 
@@ -120,6 +121,8 @@ Keys or values larger than 4GB will be stored in RAM only, and warnings will app
 ```sh
 # WARNING: key too big for disk driver, size: 4703717276, key: subactinfo:htable
 ```
+
+If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
 
 ## Next steps
 

--- a/content/operate/rs/7.22/databases/auto-tiering/quickstart.md
+++ b/content/operate/rs/7.22/databases/auto-tiering/quickstart.md
@@ -25,6 +25,16 @@ with a single node are:
 1. Create a new database with Auto Tiering enabled.
 1. Connect to your new database.
 
+## Before deployment
+
+Before you set up a flash-enabled cluster and create an Auto Tiering database, consider the following:
+
+- Avoid a large number of keys or long key names. With Auto Tiering, all key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+
+- Avoid large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
+
+- Databases cannot store keys or values larger than 4GB in flash storage. Keys or values larger than 4GB are stored in RAM only. If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
+
 ## Install Redis Enterprise Software
 
 ### Bare metal, VM, Cloud instance

--- a/content/operate/rs/7.4/databases/auto-tiering/_index.md
+++ b/content/operate/rs/7.4/databases/auto-tiering/_index.md
@@ -39,10 +39,11 @@ Auto Tiering is ideal when your:
 
 Auto Tiering is not recommended for:
 
-- Long key names (all key names are stored in RAM)
-- Broad access patterns (any value could be pulled into RAM)
-- Large working sets (working set is stored in RAM)
-- Frequently moved data (moving to and from RAM too often can impact performance)
+- A large number of keys or long key names. All key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+- Broad access patterns (any value could be pulled into RAM).
+- Large working sets (working set is stored in RAM).
+- Frequently moved data (moving to and from RAM too often can impact performance).
+- Large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
 
 Auto Tiering is not intended to be used for persistent storage. Redis Enterprise Software database persistent and ephemeral storage should be on different disks, either local or attached.
 
@@ -109,6 +110,18 @@ On-premises environments support more deployment options than other environments
 {{<note>}} Enabling Auto Tiering for Active-Active distributed databases requires validating and getting the Redis technical team's approval first . {{</note>}}
 
 {{<warning>}} Auto Tiering is not supported running on network attached storage (NAS), storage area network (SAN), or with local HDD drives. {{</warning>}}
+
+## Size limits for keys and values
+
+Auto Tiering databases cannot store keys or values larger than 4GB in flash storage.
+
+Keys or values larger than 4GB will be stored in RAM only, and warnings will appear in the Redis logs similar to:
+
+```sh
+# WARNING: key too big for disk driver, size: 4703717276, key: subactinfo:htable
+```
+
+If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
 
 ## Next steps
 

--- a/content/operate/rs/7.4/databases/auto-tiering/quickstart.md
+++ b/content/operate/rs/7.4/databases/auto-tiering/quickstart.md
@@ -25,6 +25,16 @@ with a single node are:
 1. Create a new database with Auto Tiering enabled.
 1. Connect to your new database.
 
+## Before deployment
+
+Before you set up a flash-enabled cluster and create an Auto Tiering database, consider the following:
+
+- Avoid a large number of keys or long key names. With Auto Tiering, all key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+
+- Avoid large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
+
+- Databases cannot store keys or values larger than 4GB in flash storage. Keys or values larger than 4GB are stored in RAM only. If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
+
 ## Install Redis Enterprise Software
 
 ### Bare metal, VM, Cloud instance

--- a/content/operate/rs/7.8/databases/auto-tiering/_index.md
+++ b/content/operate/rs/7.8/databases/auto-tiering/_index.md
@@ -39,10 +39,11 @@ Auto Tiering is ideal when your:
 
 Auto Tiering is not recommended for:
 
-- Long key names (all key names are stored in RAM)
-- Broad access patterns (any value could be pulled into RAM)
-- Large working sets (working set is stored in RAM)
-- Frequently moved data (moving to and from RAM too often can impact performance)
+- A large number of keys or long key names. All key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+- Broad access patterns (any value could be pulled into RAM).
+- Large working sets (working set is stored in RAM).
+- Frequently moved data (moving to and from RAM too often can impact performance).
+- Large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
 
 Auto Tiering is not intended to be used for persistent storage. Redis Enterprise Software database persistent and ephemeral storage should be on different disks, either local or attached.
 
@@ -109,6 +110,18 @@ On-premises environments support more deployment options than other environments
 {{<note>}} Enabling Auto Tiering for Active-Active distributed databases requires validating and getting the Redis technical team's approval first . {{</note>}}
 
 {{<warning>}} Auto Tiering is not supported running on network attached storage (NAS), storage area network (SAN), or with local HDD drives. {{</warning>}}
+
+## Size limits for keys and values
+
+Auto Tiering databases cannot store keys or values larger than 4GB in flash storage.
+
+Keys or values larger than 4GB will be stored in RAM only, and warnings will appear in the Redis logs similar to:
+
+```sh
+# WARNING: key too big for disk driver, size: 4703717276, key: subactinfo:htable
+```
+
+If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
 
 ## Next steps
 

--- a/content/operate/rs/7.8/databases/auto-tiering/quickstart.md
+++ b/content/operate/rs/7.8/databases/auto-tiering/quickstart.md
@@ -25,6 +25,16 @@ with a single node are:
 1. Create a new database with Auto Tiering enabled.
 1. Connect to your new database.
 
+## Before deployment
+
+Before you set up a flash-enabled cluster and create an Auto Tiering database, consider the following:
+
+- Avoid a large number of keys or long key names. With Auto Tiering, all key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+
+- Avoid large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
+
+- Databases cannot store keys or values larger than 4GB in flash storage. Keys or values larger than 4GB are stored in RAM only. If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
+
 ## Install Redis Enterprise Software
 
 ### Bare metal, VM, Cloud instance

--- a/content/operate/rs/databases/flash/_index.md
+++ b/content/operate/rs/databases/flash/_index.md
@@ -47,21 +47,23 @@ Flex requires the Speedb driver, while Auto Tiering can use either RocksDB or Sp
 
 ## Use cases
 
-The benefits associated with Flex are dependent on the use case.
+The benefits associated with Flex and Auto Tiering are dependent on the use case.
 
-Flex is ideal when your:
+Flex and Auto Tiering are ideal when your:
 
 - working set is significantly smaller than your dataset (high RAM hit rate)
 - average key size is smaller than average value size
 - most recent data is the most frequently used (high RAM hit rate)
 
-Flex is not recommended for:
+Flex and Auto Tiering are not recommended for:
 
-- Broad access patterns (any value could be pulled into RAM)
-- Large working sets (working set is stored in RAM)
-- Frequently moved data (moving to and from RAM too often can impact performance)
+- A large number of keys or long key names. With Auto Tiering, all key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+- Broad access patterns (any value could be pulled into RAM).
+- Large working sets (working set is stored in RAM).
+- Frequently moved data (moving to and from RAM too often can impact performance).
+- Large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
 
-Flex is not intended to be used for persistent storage. Redis Software database persistent and ephemeral storage should be on different disks, either local or attached.
+Flex and Auto Tiering are not intended to be used for persistent storage. Redis Software database persistent and ephemeral storage should be on different disks, either local or attached.
 
 ## Where is my data?
 
@@ -138,6 +140,8 @@ Keys or values larger than 4GB will be stored in RAM only, and warnings will app
 ```sh
 # WARNING: key too big for disk driver, size: 4703717276, key: subactinfo:htable
 ```
+
+If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
 
 ## Next steps
 

--- a/content/operate/rs/databases/flash/quickstart.md
+++ b/content/operate/rs/databases/flash/quickstart.md
@@ -29,6 +29,16 @@ with a single node are:
 1. Create a new database with Flex enabled.
 1. Connect to your new database.
 
+## Before deployment
+
+Before you set up a flash-enabled cluster and create a Flex or Auto Tiering database, consider the following:
+
+- Avoid a large number of keys or long key names. With Auto Tiering, all key names are stored in RAM regardless of whether their values are on flash. High key count alone can exhaust the RAM limit even when individual key names are short.
+
+- Avoid large collection types (hashes, sets, or lists with millions of elements) whose total serialized size approaches or exceeds the RAM limit. Unlike scalar values, large collections cannot be partially offloaded to flash and must fit in RAM when accessed.
+
+- Databases cannot store keys or values larger than 4GB in flash storage. Keys or values larger than 4GB are stored in RAM only. If oversized keys consume the shard's available RAM, the shard can return out-of-memory errors even when flash storage has free space remaining.
+
 ## Install Redis Software
 
 ### Bare metal, VM, Cloud instance


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no product code or configuration behavior changes.
> 
> **Overview**
> Documentation-only updates across **Redis Enterprise** Auto Tiering (7.4, 7.8, 7.22), versioned quickstarts, and the shared **Flex / Auto Tiering** (`databases/flash`) pages.
> 
> **Anti-patterns and sizing:** The “not recommended” guidance is expanded and normalized to bullet lists. It now calls out **high key count and long key names** (all key names stay in RAM), **large collections** (hashes/sets/lists that cannot be partially tiered to flash), and keeps existing warnings on broad access, large working sets, and churn. The combined flash overview applies the same anti-patterns to **both Flex and Auto Tiering** (wording was Flex-only in places).
> 
> **OOM with free flash:** After the existing **4GB flash limit** discussion, docs add that **oversized or RAM-only keys can still cause shard OOM** when RAM is exhausted, even if flash has capacity. **7.4** and **7.8** Auto Tiering overviews gain the full **Size limits for keys and values** section (previously missing vs 7.22).
> 
> **Quick starts:** New **Before deployment** sections on all affected quickstarts summarize these checks before install/cluster setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dda82591a2332a3365a16f307cc4dc120ffdd856. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->