### PR TITLE
DEV: (cmds) add missing RS/RC compat info to array cmd pages

### DIFF
--- a/content/commands/arcount.md
+++ b/content/commands/arcount.md
@@ -60,6 +60,12 @@ ARSET myarray 5 "b"
 ARCOUNT myarray
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/ardel.md
+++ b/content/commands/ardel.md
@@ -79,6 +79,12 @@ ARDEL myarray 0 2
 ARCOUNT myarray
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/ardelrange.md
+++ b/content/commands/ardelrange.md
@@ -82,6 +82,12 @@ ARGET myarray 0
 ARGET myarray 4
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arget.md
+++ b/content/commands/arget.md
@@ -77,6 +77,12 @@ ARGET myarray 0
 ARGET myarray 1
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/argetrange.md
+++ b/content/commands/argetrange.md
@@ -84,6 +84,12 @@ ARGETRANGE myarray 0 3
 ARGETRANGE myarray 3 0
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/argrep.md
+++ b/content/commands/argrep.md
@@ -177,6 +177,12 @@ ARGREP log 0 4 EXACT "info: ready"
 ARGREP log - + MATCH "error" NOCASE LIMIT 1
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arinfo.md
+++ b/content/commands/arinfo.md
@@ -114,6 +114,12 @@ ARINSERT myarray "d"
 ARINFO myarray
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arinsert.md
+++ b/content/commands/arinsert.md
@@ -78,6 +78,12 @@ ARGET myarray 1
 ARNEXT myarray
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arlastitems.md
+++ b/content/commands/arlastitems.md
@@ -90,6 +90,12 @@ ARLASTITEMS log 2
 ARLASTITEMS log 2 REV
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arlen.md
+++ b/content/commands/arlen.md
@@ -67,6 +67,12 @@ ARLEN myarray
 ARCOUNT myarray
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/armget.md
+++ b/content/commands/armget.md
@@ -77,6 +77,12 @@ ARMSET myarray 0 "a" 1 "b" 5 "c"
 ARMGET myarray 0 1 5 3
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/armset.md
+++ b/content/commands/armset.md
@@ -82,6 +82,12 @@ ARGET myarray 5
 ARGET myarray 100
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arnext.md
+++ b/content/commands/arnext.md
@@ -70,6 +70,12 @@ ARINSERT myarray "b"
 ARNEXT myarray
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arop.md
+++ b/content/commands/arop.md
@@ -144,6 +144,12 @@ AROP flags 0 2 AND
 AROP flags 0 2 OR
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arring.md
+++ b/content/commands/arring.md
@@ -90,6 +90,12 @@ ARCOUNT readings
 ARLASTITEMS readings 3
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arscan.md
+++ b/content/commands/arscan.md
@@ -103,6 +103,12 @@ ARSCAN myarray 0 10
 ARSCAN myarray 0 10 LIMIT 2
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arseek.md
+++ b/content/commands/arseek.md
@@ -77,6 +77,12 @@ ARINSERT myarray "c"
 ARNEXT myarray
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"

--- a/content/commands/arset.md
+++ b/content/commands/arset.md
@@ -86,6 +86,12 @@ ARGET myarray 2
 ARGET myarray 4
 {{% /redis-cli %}}
 
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
 ## Return information
 
 {{< multitabs id="return-info"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only, repetitive markdown additions with no runtime or build logic changes.
> 
> **Overview**
> Adds the **Redis Software and Redis Cloud compatibility** section to **19** preview **array** command reference pages (`ARCOUNT`, `ARDEL`, `ARGET`, `ARSET`, `ARGREP`, etc.), inserted after **Examples** and before **Return information**.
> 
> Each page uses the same compatibility table as other commands: **Standard** and **Active-Active** are marked not supported (❌) on both Redis Software and Redis Cloud, with an empty Notes column—documenting that these OSS preview array commands are not available on managed offerings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88779901f7c8924c12191c8a52b6afdd24618923. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->