### PR TITLE
DOC-6695 add note about CSC support != CLIENT TRACKING command

### DIFF
--- a/content/develop/clients/client-side-caching.md
+++ b/content/develop/clients/client-side-caching.md
@@ -93,6 +93,9 @@ The following client libraries support CSC from the stated version onwards:
 | [`Jedis`]({{< relref "/develop/clients/jedis/connect#connect-using-client-side-caching" >}}) | v5.2.0 |
 | [`node-redis`]({{< relref "/develop/clients/nodejs/connect#connect-using-client-side-caching" >}}) | v5.1.0 |
 
+Note that some other clients support the [`CLIENT TRACKING`]({{< relref "/commands/client-tracking" >}}) command to configure CSC on the server, but this does not mean they support the
+features required for CSC themselves.
+
 ## Which commands can cache data?
 
 All read-only commands (with the `@read`


### PR DESCRIPTION
Closes #3392

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or API behavior impact.
> 
> **Overview**
> Adds a short clarification after the **Which client libraries support client-side caching?** version table: supporting [`CLIENT TRACKING`]({{< relref "/commands/client-tracking" >}}) to turn on server-side tracking is **not** the same as a client implementing full client-side caching (local cache, invalidations, etc.).
> 
> This addresses confusion where readers might assume any client that can send `CLIENT TRACKING` is listed as CSC-capable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de881eda9e7dee39c8fc3ec206b9c5e7b0bf9656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->