### PR TITLE
RS: Copied OpenSSL version change to RS 8.0.16 and later release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -113,6 +113,10 @@ The following changes affect behavior and validation in Redis Search:
 
 - Improved handling of expired records, memory constraints, and malformed fields.
 
+### OpenSSL version
+
+Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
@@ -154,6 +154,10 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 - Upgrading to this Redis Software version can cause LDAP authentication to fail with "certificate signed by unknown authority" errors if your cluster currently uses LDAP authentication. This issue will be fixed in an upcoming maintenance release.
 
+### OpenSSL version
+
+Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+
 ### Deprecations
 
 #### API deprecations

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
@@ -52,6 +52,10 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
+### OpenSSL version
+
+Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+
 ### Supported platforms
 
 The following table provides a snapshot of supported platforms as of this Redis Software release. See the [supported platforms reference]({{< relref "/operate/rs/references/supported-platforms" >}}) for more details about operating system compatibility.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
@@ -149,6 +149,10 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 - `crdb_controller` is now enabled by default.
 
+### OpenSSL version
+
+Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
@@ -51,6 +51,10 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
+### OpenSSL version
+
+Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits with no product or configuration code changes.
> 
> **Overview**
> Adds a **Version changes → OpenSSL version** note to Redis Software **8.0.x** release documentation: **8.0.16 and later require OpenSSL 3.3 or later**.
> 
> The same heading and sentence are inserted in the **8.0.x** index (`_index.md`) and in per-build pages **8.0.16-29**, **8.0.16-33**, **8.0.18-23**, and **8.0.18-36**, placed before **Reserved ports** or **Supported platforms** depending on the page structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558fa0a4f1049ce1379793f5b66d3a5064ee1948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->