### PR TITLE
DEV: (cmds) align each page with canonical layout - phase 1

### DIFF
--- a/content/commands/bf.madd.md
+++ b/content/commands/bf.madd.md
@@ -55,21 +55,6 @@ If `key` does not exist - a new Bloom filter is created with default error rate,
 One or more items to add.
 </details>
 
-## Redis Software and Redis Cloud compatibility
-
-| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
-|:----------------------|:-----------------|:------|
-| <span title="Supported">&#x2705; Supported</span><br /> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Supported">&#x2705; Free & Fixed</nobr></span> |  |
-
-## Return information
-
-Returns one of these replies:
-
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each element is either
-  - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - where "1" means that the item has been added successfully, and "0" means that such item was already added to the filter (which could be wrong)
-  - [] when the item cannot be added because the filter is full
-- [] on error (invalid arguments, wrong key type, etc.)
-
 ## Examples
 
 {{< highlight bash >}}
@@ -78,6 +63,12 @@ redis> BF.MADD bf item1 item2 item2
 2) (integer) 1
 3) (integer) 0
 {{< / highlight >}}
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Supported">&#x2705; Supported</span><br /> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Supported">&#x2705; Free & Fixed</nobr></span> |  |
 
 ## Return information
 

--- a/content/commands/setex.md
+++ b/content/commands/setex.md
@@ -76,10 +76,6 @@ TTL mykey
 GET mykey
 {{% /redis-cli %}}
 
-## See also
-
-[`TTL`]({{< relref "/commands/ttl" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -99,3 +95,7 @@ GET mykey
 [Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
 
 {{< /multitabs >}}
+
+## See also
+
+[`TTL`]({{< relref "/commands/ttl" >}})

--- a/content/commands/ts.info.md
+++ b/content/commands/ts.info.md
@@ -52,50 +52,6 @@ is key name of the time series.
 is an optional flag to get a more detailed information about the chunks.
 </details>
 
-## Redis Software and Redis Cloud compatibility
-
-| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
-|:----------------------|:-----------------|:------|
-| <span title="Supported">&#x2705; Supported</span><br /> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Supported">&#x2705; Free & Fixed</nobr></span> |  |
-
-## Return information
-
-{{< multitabs id="ts-info-return-info"
-    tab1="RESP2"
-    tab2="RESP3" >}}
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with information about the time series as flattened name-value pairs:
-
-| Name<br>[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) | Description
-| ---------------------------- | -
-| `totalSamples`    | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Total number of samples in this time series
-| `memoryUsage`     | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Total number of bytes allocated for this time series, which is the sum of <br> - The memory used for storing the series' configuration parameters (retention period, duplication policy, etc.)<br>- The memory used for storing the series' compaction rules<br>- The memory used for storing the series' labels (key-value pairs)<br>- The memory used for storing the chunks (chunk header + compressed/uncompressed data)
-| `firstTimestamp`  | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> First timestamp present in this time series (Unix timestamp in milliseconds)
-| `lastTimestamp`   | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Last timestamp present in this time series  (Unix timestamp in milliseconds)
-| `retentionTime`   | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> The retention period, in milliseconds, for this time series
-| `chunkCount`      | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of chunks used for this time series
-| `chunkSize`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> The initial allocation size, in bytes, for the data part of each new chunk.<br>Actual chunks may consume more memory. Changing the chunk size (using [`TS.ALTER`]({{< relref "commands/ts.alter/" >}})) does not affect existing chunks.
-| `chunkType`       | [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})<br> The chunks type: `compressed` or `uncompressed`
-| `duplicatePolicy` | [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) or [Nil reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br> The [duplicate policy]({{< relref "develop/data-types/timeseries/configuration#duplicate_policy" >}}) of this time series
-| `labels`          | [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) or [Nil reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br> Metadata labels of this time series<br> Each element is a 2-elements [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})) representing (label, value)
-| `sourceKey`       | [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) or [Nil reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br>Key name for source time series in case the current series is a target of a [compaction rule]({{< relref "commands/ts.createrule" >}})
-| `rules`           | [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}})<br> [Compaction rules]({{< relref "commands/ts.createrule" >}}) defined in this time series<br> Each rule is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with 4 elements:<br>- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): The compaction key<br>- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The bucket duration<br>- [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}): The aggregator<br>- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The alignment (since RedisTimeSeries v1.8)
-
-When [`DEBUG`]({{< relref "/commands/debug" >}}) is specified, the response also contains:
-
-| Name<br>[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) | Description
-| ---------------------------- | -
-| `keySelfName`     | [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br> Name of the key
-| `Chunks`          | [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with information about the chunks<br>Each element is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of information about a single chunk in a name([Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}))-value pairs:<br>- `startTimestamp` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - First timestamp present in the chunk<br>- `endTimestamp` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - Last timestamp present in the chunk<br>- `samples` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - Total number of samples in the chunk<br>- `size` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - the chunk's internal data size (without overheads) in bytes<br>- `bytesPerSample` - [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) (double) - Ratio of `size` and `samples`
-
--tab-sep-
-
-[Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) with information about the time series. The map contains the same fields as described in the RESP2 response, but organized as key-value pairs in a map structure rather than a flattened array.
-
-When [`DEBUG`]({{< relref "/commands/debug" >}}) is specified, the response also contains the additional `keySelfName` and `Chunks` fields as described above.
-
-{{< /multitabs >}}
-
 ## Examples
 
 <details open>
@@ -194,6 +150,50 @@ Query the time series using DEBUG to get more information about the chunks.
 {{< / highlight >}}
 
 </details>
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Supported">&#x2705; Supported</span><br /> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Supported">&#x2705; Free & Fixed</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="ts-info-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with information about the time series as flattened name-value pairs:
+
+| Name<br>[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) | Description
+| ---------------------------- | -
+| `totalSamples`    | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Total number of samples in this time series
+| `memoryUsage`     | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Total number of bytes allocated for this time series, which is the sum of <br> - The memory used for storing the series' configuration parameters (retention period, duplication policy, etc.)<br>- The memory used for storing the series' compaction rules<br>- The memory used for storing the series' labels (key-value pairs)<br>- The memory used for storing the chunks (chunk header + compressed/uncompressed data)
+| `firstTimestamp`  | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> First timestamp present in this time series (Unix timestamp in milliseconds)
+| `lastTimestamp`   | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Last timestamp present in this time series  (Unix timestamp in milliseconds)
+| `retentionTime`   | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> The retention period, in milliseconds, for this time series
+| `chunkCount`      | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> Number of chunks used for this time series
+| `chunkSize`       | [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}})<br> The initial allocation size, in bytes, for the data part of each new chunk.<br>Actual chunks may consume more memory. Changing the chunk size (using [`TS.ALTER`]({{< relref "commands/ts.alter/" >}})) does not affect existing chunks.
+| `chunkType`       | [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})<br> The chunks type: `compressed` or `uncompressed`
+| `duplicatePolicy` | [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) or [Nil reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br> The [duplicate policy]({{< relref "develop/data-types/timeseries/configuration#duplicate_policy" >}}) of this time series
+| `labels`          | [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) or [Nil reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br> Metadata labels of this time series<br> Each element is a 2-elements [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})) representing (label, value)
+| `sourceKey`       | [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) or [Nil reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br>Key name for source time series in case the current series is a target of a [compaction rule]({{< relref "commands/ts.createrule" >}})
+| `rules`           | [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}})<br> [Compaction rules]({{< relref "commands/ts.createrule" >}}) defined in this time series<br> Each rule is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with 4 elements:<br>- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): The compaction key<br>- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The bucket duration<br>- [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}): The aggregator<br>- [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): The alignment (since RedisTimeSeries v1.8)
+
+When [`DEBUG`]({{< relref "/commands/debug" >}}) is specified, the response also contains:
+
+| Name<br>[Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) | Description
+| ---------------------------- | -
+| `keySelfName`     | [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})<br> Name of the key
+| `Chunks`          | [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) with information about the chunks<br>Each element is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of information about a single chunk in a name([Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}))-value pairs:<br>- `startTimestamp` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - First timestamp present in the chunk<br>- `endTimestamp` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - Last timestamp present in the chunk<br>- `samples` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - Total number of samples in the chunk<br>- `size` - [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) - the chunk's internal data size (without overheads) in bytes<br>- `bytesPerSample` - [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) (double) - Ratio of `size` and `samples`
+
+-tab-sep-
+
+[Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) with information about the time series. The map contains the same fields as described in the RESP2 response, but organized as key-value pairs in a map structure rather than a flattened array.
+
+When [`DEBUG`]({{< relref "/commands/debug" >}}) is specified, the response also contains the additional `keySelfName` and `Chunks` fields as described above.
+
+{{< /multitabs >}}
 
 ## See also
 

--- a/content/commands/ts.mrange.md
+++ b/content/commands/ts.mrange.md
@@ -349,60 +349,6 @@ When combined with `AGGREGATION` the `GROUPBY`/`REDUCE` is applied post aggregat
 
 <note><b>Note:</b> An `MRANGE` command cannot be part of a transaction when running on a Redis cluster.</note>
 
-## Redis Software and Redis Cloud compatibility
-
-| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
-|:----------------------|:-----------------|:------|
-| <span title="Supported">&#x2705; Supported</span><br /> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Supported">&#x2705; Free & Fixed</nobr></span> |  |
-
-## Return information
-
-{{< multitabs id="ts-mrange-return-info"
-    tab1="RESP2"
-    tab2="RESP3" >}}
-
-If `GROUPBY label REDUCE reducer` is not specified:
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): for each time series matching the specified filters, the following is reported:
-- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): The time series key name
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): label-value pairs ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}))
-  - By default, an empty array is reported
-  - If `WITHLABELS` is specified, all labels associated with this time series are reported
-  - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined)
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): timestamp-value pairs ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) representing all samples/aggregations matching the range
-
-If `GROUPBY label REDUCE reducer` is specified:
-
-[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): for each group of time series matching the specified filters, the following is reported:
-- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) with the format `label=value` where `label` is the `GROUPBY` label argument
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): label-value pairs ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})):
-  - By default, an empty array is reported
-  - If `WITHLABELS` is specified, the `GROUPBY` label argument and value are reported
-  - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined or label does not have the same value for all grouped time series)
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): either a single pair ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})): the `GROUPBY` label argument and value, or empty array
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a single pair ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})):  the string `__reducer__` and the reducer argument
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a single pair ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})): the string `__source__` and the time series key names separated by ","
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): timestamp-value pairs ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) representing all samples/aggregations matching the range
-
--tab-sep-
-
-If `GROUPBY label REDUCE reducer` is not specified:
-
-[Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}): for each time series matching the specified filters, the following is reported:
-- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): The time series key name
-- [Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) or [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): label-value pairs
-  - By default, an empty map is reported
-  - If `WITHLABELS` is specified, all labels associated with this time series are reported as a map
-  - If `SELECTED_LABELS label...` is specified, the selected labels are reported as a map (null value when no such label defined)
-- Additional metadata including aggregators information
-- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): timestamp-value pairs ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}})) representing all samples/aggregations matching the range
-
-If `GROUPBY label REDUCE reducer` is specified:
-
-Similar structure as RESP2 but with map-based organization for labels and metadata, and double values instead of string values.
-
-{{< /multitabs >}}
-
 ## Examples
 
 <details open>
@@ -596,6 +542,60 @@ Query all time series with the metric label equal to `cpu`, but only return the 
          2) 99
 {{< / highlight >}}
 </details>
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Supported">&#x2705; Supported</span><br /> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Supported">&#x2705; Free & Fixed</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="ts-mrange-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+If `GROUPBY label REDUCE reducer` is not specified:
+
+[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): for each time series matching the specified filters, the following is reported:
+- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): The time series key name
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): label-value pairs ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}))
+  - By default, an empty array is reported
+  - If `WITHLABELS` is specified, all labels associated with this time series are reported
+  - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined)
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): timestamp-value pairs ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) representing all samples/aggregations matching the range
+
+If `GROUPBY label REDUCE reducer` is specified:
+
+[Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): for each group of time series matching the specified filters, the following is reported:
+- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) with the format `label=value` where `label` is the `GROUPBY` label argument
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): label-value pairs ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})):
+  - By default, an empty array is reported
+  - If `WITHLABELS` is specified, the `GROUPBY` label argument and value are reported
+  - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined or label does not have the same value for all grouped time series)
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): either a single pair ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})): the `GROUPBY` label argument and value, or empty array
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a single pair ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})):  the string `__reducer__` and the reducer argument
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): a single pair ([Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})): the string `__source__` and the time series key names separated by ","
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): timestamp-value pairs ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) representing all samples/aggregations matching the range
+
+-tab-sep-
+
+If `GROUPBY label REDUCE reducer` is not specified:
+
+[Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}): for each time series matching the specified filters, the following is reported:
+- [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): The time series key name
+- [Map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) or [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): label-value pairs
+  - By default, an empty map is reported
+  - If `WITHLABELS` is specified, all labels associated with this time series are reported as a map
+  - If `SELECTED_LABELS label...` is specified, the selected labels are reported as a map (null value when no such label defined)
+- Additional metadata including aggregators information
+- [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}): timestamp-value pairs ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}})) representing all samples/aggregations matching the range
+
+If `GROUPBY label REDUCE reducer` is specified:
+
+Similar structure as RESP2 but with map-based organization for labels and metadata, and double values instead of string values.
+
+{{< /multitabs >}}
 
 ## See also
 

--- a/content/commands/vadd.md
+++ b/content/commands/vadd.md
@@ -114,10 +114,6 @@ So, the additional amount of memory is approximately `0.33 × 64 × 8 ≈ 169.6`
 If you don't have a recall quality problem, the default is acceptable, and uses a minimal amount of memory.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -141,3 +137,7 @@ One of the following:
 * [Simple error reply](../../develop/reference/protocol-spec#simple-errors): if the command was malformed.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vcard.md
+++ b/content/commands/vcard.md
@@ -36,10 +36,6 @@ VCARD word_embeddings
 is the name of the key that holds the vector set.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -59,3 +55,7 @@ is the name of the key that holds the vector set.
 [Integer reply](../../develop/reference/protocol-spec#integers): 0 if the key doesn't exist or the number of elements contained in the vector set.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vdim.md
+++ b/content/commands/vdim.md
@@ -38,10 +38,6 @@ If the vector set was created using the `REDUCE` option for dimensionality reduc
 is the name of the key that holds the vector set.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -65,3 +61,7 @@ One of the following:
 * [Simple error reply](../../develop/reference/protocol-spec#simple-errors): if the key does not exist.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vemb.md
+++ b/content/commands/vemb.md
@@ -67,10 +67,6 @@ is the name of the element whose vector you want to retrieve.
 returns the raw vector data, its quantization type, and metadata such as norm and range.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -108,3 +104,7 @@ One of the following:
     1. (Only for q8): The quantization range as a [double](../../develop/reference/protocol-spec#doubles). Multiply this by integer components to recover normalized values.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vgetattr.md
+++ b/content/commands/vgetattr.md
@@ -41,10 +41,6 @@ is the name of the key that holds the vector set.
 is the name of the element whose attributes you want to retrieve.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -68,3 +64,7 @@ One of the following:
 * [Null reply](../../develop/reference/protocol-spec#nulls) for unknown key or element, or when no attributes exist for the given key/element pair.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vinfo.md
+++ b/content/commands/vinfo.md
@@ -47,10 +47,6 @@ VINFO word_embeddings
 is the name of the key that holds the vector set.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -74,3 +70,7 @@ One of the following:
 * [Null reply](../../develop/reference/protocol-spec#nulls) for unknown key.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vismember.md
+++ b/content/commands/vismember.md
@@ -46,10 +46,6 @@ is the name of the key that holds the vector set.
 is the name of the element you want to check for membership.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -69,3 +65,7 @@ is the name of the element you want to check for membership.
 [Boolean reply](../../develop/reference/protocol-spec#booleans): `false` if the element does not exist in the vector set, or the key does not exist. `true` if the element exists in the vector set.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vlinks.md
+++ b/content/commands/vlinks.md
@@ -55,10 +55,6 @@ is the name of the element whose HNSW neighbors you want to inspect.
 includes similarity scores for each neighbor.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -85,3 +81,7 @@ One of the following:
 * [Null reply](../../develop/reference/protocol-spec#nulls) for unknown keys and/or elements.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vrandmember.md
+++ b/content/commands/vrandmember.md
@@ -108,10 +108,6 @@ is the name of the key that holds the vector set.
 specifies the number of elements to return. Positive values return distinct elements; negative values allow duplicates.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -137,3 +133,7 @@ One of the following:
 * [Array reply](../../develop/reference/protocol-spec#arrays) (empty array) for unknown keys when a count is specified.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vrem.md
+++ b/content/commands/vrem.md
@@ -50,10 +50,6 @@ is the name of the key that holds the vector set.
 is the name of the element to remove from the vector set.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -73,3 +69,7 @@ is the name of the element to remove from the vector set.
 [Boolean reply](../../develop/reference/protocol-spec#booleans): false if either element or key do not exist; true if the element was removed.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vsetattr.md
+++ b/content/commands/vsetattr.md
@@ -55,10 +55,6 @@ is the name of the element whose attributes you want to set or remove.
 is a valid JSON string. Use an empty string (`""`) to delete the attributes.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -82,3 +78,7 @@ One of the following:
 * [Simple error reply](../../develop/reference/protocol-spec/#simple-errors) for improperly specified attribute string.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vsim.md
+++ b/content/commands/vsim.md
@@ -135,10 +135,6 @@ forces an exact linear scan of all elements, bypassing the HNSW graph. Use for b
 executes the search in the main thread instead of a background thread. Useful for small vector sets or benchmarks. This may block the server during execution.
 </details>
 
-## Related topics
-
-- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
@@ -168,3 +164,7 @@ One of the following:
 * With the `WITHSCORES` and `WITHATTRIBS` options, a [Map reply](../../develop/reference/protocol-spec#maps) with matching [bulk string]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) elements (keys), and an additional array (values) with the following elements: (1) a [double reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}})  for the score and (2) a [bulk string]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}) representing the JSON attribute associated with the element or [null]({{< relref "/develop/reference/protocol-spec#nulls" >}}) for the elements missing an attribute.
 
 {{< /multitabs >}}
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})


### PR DESCRIPTION
This is the first of four phases to align all the command pages to a common canonical layout. These are the simplest changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only section reordering in Markdown; no runtime, API, or security impact.
> 
> **Overview**
> Phase 1 aligns selected command reference pages in `content/commands/` to a shared **canonical section order** by moving blocks only (no substantive command behavior changes).
> 
> **Examples before compatibility/returns:** On `ts.info.md` and `ts.mrange.md`, **Redis Software and Redis Cloud compatibility** and **Return information** now appear **after** **Examples** instead of between arguments and examples.
> 
> **Footer sections last:** `setex.md` moves **See also** below **Return information**. All touched `v*` vector-set pages move **Related topics** from above compatibility to **after** **Return information** (same pattern as `vadd.md`, `vcard.md`, etc.).
> 
> **`bf.madd.md`:** **Examples** precede compatibility/returns; **Return information** is expressed with the standard `multitabs` RESP2/RESP3 pattern (replacing the older pre-examples return block in the diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00e8d1c1ca6859fcb63da54ffdd52084546338ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->