### PR TITLE
DOC-6676 reinstate archive link to preview version of RDI

### DIFF
--- a/content/integrate/redis-data-integration/rdi-archive.md
+++ b/content/integrate/redis-data-integration/rdi-archive.md
@@ -6,7 +6,6 @@ categories:
 - operate
 - rc
 description: Describes where to view the preview version for RDI products
-draft: true
 linkTitle: Preview
 weight: 999
 ---


### PR DESCRIPTION
There are some people still using it after all...

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only visibility change with no application or security impact.
> 
> **Overview**
> **Re-publishes** the RDI **Preview** archive page by removing `draft: true` from `rdi-archive.md` front matter so it appears in the docs site again.
> 
> The page body is unchanged: it still points readers to the [archived RDI preview docs](https://docs.redis.com/rdi-preview/rdi/) and notes that current GA docs supersede preview content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b236b5a30e66d8d3c274b09550e62de567fb62b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->