### PR TITLE
OP: add Redis Open Source release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes.md
@@ -12,6 +12,25 @@ min-version-rs: blah
 weight: 60
 ---
 
+## Redis Open Source 8.2.7 (June 2026)
+
+Update urgency: `HIGH`: There are critical bugs that may affect a subset of users.
+
+### Bug fixes
+
+- [#15175](https://github.com/redis/redis/pull/15175), RediSearch/RediSearch[#9262](https://github.com/redisearch/redisearch/pull/9262) Redis fails to start on AArch64.
+- [#14537](https://github.com/redis/redis/pull/14537) `SCAN`: restore original filter order (revert change introduced in 8.2).
+- [#14816](https://github.com/redis/redis/pull/14816) setModuleEnumConfig() passing prefixed name to module callbacks.
+- [#14623](https://github.com/redis/redis/pull/14623) Streams: `XTRIM`/`XADD` with approx mode (`~`) don’t delete entries for `DELREF`/`ACKED` strategies.
+- [#14552](https://github.com/redis/redis/pull/14552) Streams: Incorrect behavior when using `XDELEX...`ACKED` after `XGROUP DESTROY`.
+- [#14420](https://github.com/redis/redis/pull/14420) Shutdown blocked client not being properly reset after shutdown cancellation.
+- [#14415](https://github.com/redis/redis/pull/14415) Potential crash in `lookupKey()` when `executing_client` is NULL.
+- [#14417](https://github.com/redis/redis/pull/14417) `CLUSTER FORGET` - heap-buffer-overflow.
+- [#15188](https://github.com/redis/redis/pull/15188) `cluster-announce-ip` rejecting hostnames (regression).
+- [#14667](https://github.com/redis/redis/pull/14667), [#14886](https://github.com/redis/redis/pull/14886) Potential TCP stalls/deadlocks.
+- RediSearch/RediSearch[#9484](https://github.com/redisearch/redisearch/pull/9484) Shard crash during background index scan of JSON documents with vector fields on Active-Active (CRDT) databases (MOD-15542).
+- RediSearch/RediSearch[#9635](https://github.com/redisearch/redisearch/pull/9635) Severe latency spikes and shard unresponsiveness when `EXPIRE` or `EXPIREAT` operations run concurrently with queries on large indexes (MOD-14930).
+
 ## Redis Open Source 8.2.6 (May 2026)
 
 Update urgency: `SECURITY`: There are security fixes in the release.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
@@ -19,7 +19,7 @@ Update urgency: `HIGH`: There are critical bugs that may affect a subset of user
 ### Bug fixes
 
 - [#15175](https://github.com/redis/redis/pull/15175), RediSearch/RediSearch[#9262](https://github.com/redisearch/redisearch/pull/9262) Redis fails to start on AArch64.
-- [#15163](https://github.com/redis/redis/pull/15163) `MULTI` queue memory incorrect memory accounting .
+- [#15163](https://github.com/redis/redis/pull/15163) `MULTI` queue memory incorrect memory accounting.
 - [#14581](https://github.com/redis/redis/pull/14581) Rare server hang at shutdown.
 - [#14545](https://github.com/redis/redis/pull/14545) ACL: AOF loading fails if ACL rules are changed and don't allow some commands in `MULTI`-`EXEC`.
 - [#14537](https://github.com/redis/redis/pull/14537) `SCAN`: restore original filter order (revert change introduced in 8.2).

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
@@ -12,6 +12,27 @@ min-version-rs: blah
 weight: 40
 ---
 
+## Redis Open Source 8.4.4 (June 2026)
+
+Update urgency: `HIGH`: There are critical bugs that may affect a subset of users.
+
+### Bug fixes
+
+- [#15175](https://github.com/redis/redis/pull/15175), RediSearch/RediSearch[#9262](https://github.com/redisearch/redisearch/pull/9262) Redis fails to start on AArch64.
+- [#15163](https://github.com/redis/redis/pull/15163) `MULTI` queue memory incorrect memory accounting .
+- [#14581](https://github.com/redis/redis/pull/14581) Rare server hang at shutdown.
+- [#14545](https://github.com/redis/redis/pull/14545) ACL: AOF loading fails if ACL rules are changed and don't allow some commands in `MULTI`-`EXEC`.
+- [#14537](https://github.com/redis/redis/pull/14537) `SCAN`: restore original filter order (revert change introduced in 8.2).
+- [#14816](https://github.com/redis/redis/pull/14816) setModuleEnumConfig() passing prefixed name to module callbacks.
+- [#14659](https://github.com/redis/redis/pull/14659) ACL: Key-pattern bypass in `MSETEX`.
+- [#14623](https://github.com/redis/redis/pull/14623) Streams: `XTRIM`/`XADD` with approx mode (`~`) don’t delete entries for `DELREF`/`ACKED` strategies.
+- [#14552](https://github.com/redis/redis/pull/14552) Streams: Incorrect behavior when using `XDELEX...`ACKED` after `XGROUP DESTROY`.
+- [#14848](https://github.com/redis/redis/pull/14848) Crash during command processing on replicas performing full synchronization.
+- [#15188](https://github.com/redis/redis/pull/15188) `cluster-announce-ip` rejecting hostnames (regression).
+- [#14667](https://github.com/redis/redis/pull/14667), [#14886](https://github.com/redis/redis/pull/14886) Potential TCP stalls/deadlocks.
+- RediSearch/RediSearch[#9484](https://github.com/redisearch/redisearch/pull/9484) Shard crash during background index scan of JSON documents with vector fields on Active-Active (CRDT) databases (MOD-15542).
+- RediSearch/RediSearch[#9635](https://github.com/redisearch/redisearch/pull/9635) Severe latency spikes and shard unresponsiveness when `EXPIRE` or `EXPIREAT` operations run concurrently with queries on large indexes (MOD-14930).
+
 ## Redis Open Source 8.4.3 (May 2026)
 
 Update urgency: `SECURITY`: There are security fixes in the release.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
@@ -19,7 +19,7 @@ Update urgency: `HIGH`: There are critical bugs that may affect a subset of user
 ### Bug fixes
 
 - [#15175](https://github.com/redis/redis/pull/15175), RediSearch/RediSearch[#9262](https://github.com/redisearch/redisearch/pull/9262) Redis fails to start on AArch64.
-- [#15163](https://github.com/redis/redis/pull/15163) `MULTI` queue memory incorrect memory accounting .
+- [#15163](https://github.com/redis/redis/pull/15163) `MULTI` queue memory incorrect memory accounting.
 - [#15115](https://github.com/redis/redis/pull/15115) Under-copy in the Lua debugger.
 - [#15094](https://github.com/redis/redis/pull/15094) Cluster crash when `CLIENT KILL` unsubscribes `SSUBSCRIBE` client inside `EXEC`.
 - [#14963](https://github.com/redis/redis/pull/14963) `XREADGROUP`: consumer replication inconsistency.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
@@ -12,6 +12,31 @@ min-version-rs: blah
 weight: 20
 ---
 
+## Redis Open Source 8.6.4 (June 2026)
+
+Update urgency: `HIGH`: There are critical bugs that may affect a subset of users.
+
+### Bug fixes
+
+- [#15175](https://github.com/redis/redis/pull/15175), RediSearch/RediSearch[#9262](https://github.com/redisearch/redisearch/pull/9262) Redis fails to start on AArch64.
+- [#15163](https://github.com/redis/redis/pull/15163) `MULTI` queue memory incorrect memory accounting .
+- [#15115](https://github.com/redis/redis/pull/15115) Under-copy in the Lua debugger.
+- [#15094](https://github.com/redis/redis/pull/15094) Cluster crash when `CLIENT KILL` unsubscribes `SSUBSCRIBE` client inside `EXEC`.
+- [#14963](https://github.com/redis/redis/pull/14963) `XREADGROUP`: consumer replication inconsistency.
+- [#14934](https://github.com/redis/redis/pull/14934) Client output buffer memory tracking not accounting for copy-avoided bulk string references.
+- [#14970](https://github.com/redis/redis/pull/14970) Sentinel config injection via `SENTINEL SET`.
+- [#14982](https://github.com/redis/redis/pull/14982) `SCAN` commands: integer overflow in `COUNT` parameter.
+- [#15073](https://github.com/redis/redis/pull/15073) `CLIENT TRACKING`: self-overlap returning non-zero loop index.
+- [#15059](https://github.com/redis/redis/pull/15059) Use-after-free.
+- [#15037](https://github.com/redis/redis/pull/15037) `XINFO STREAM`: wrong value in the per-slot memory tracking.
+- [#15034](https://github.com/redis/redis/pull/15034), [#15081](https://github.com/redis/redis/pull/15081) Issues processing corrupt RDB data.
+- [#15021](https://github.com/redis/redis/pull/15021) `HEXPIRE`: overflow on fields count.
+- [#14942](https://github.com/redis/redis/pull/14942) Fix `COMMAND GETKEYS for PFMERGE` with no source keys.
+- [#15188](https://github.com/redis/redis/pull/15188) `cluster-announce-ip` rejecting hostnames (regression).
+- [#14667](https://github.com/redis/redis/pull/14667), [#14886](https://github.com/redis/redis/pull/14886) Potential TCP stalls/deadlocks.
+- RediSearch/RediSearch[#9484](https://github.com/redisearch/redisearch/pull/9484) Shard crash during background index scan of JSON documents with vector fields on Active-Active (CRDT) databases (MOD-15542).
+- RediSearch/RediSearch[#9635](https://github.com/redisearch/redisearch/pull/9635) Severe latency spikes and shard unresponsiveness when `EXPIRE` or `EXPIREAT` operations run concurrently with queries on large indexes (MOD-14930).
+
 ## Redis Open Source 8.6.3 (May 2026)
 
 Update urgency: `SECURITY`: There are security fixes in the release.


### PR DESCRIPTION
8.2.7
8.4.4
8.6.4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions to release-note markdown; no runtime or configuration behavior changes.
> 
> **Overview**
> Adds **June 2026** patch release sections at the top of three Redis Open Source release-note pages: **8.2.7** (`redisos-8.2-release-notes.md`), **8.4.4** (`redisos-8.4-release-notes.md`), and **8.6.4** (`redisos-8.6-release-notes.md`). Each new block uses **HIGH** update urgency and a **Bug fixes** list with upstream Redis/RediSearch PR links.
> 
> Shared fixes across lines include AArch64 startup failure, `SCAN` filter-order revert, streams/`XTRIM`/`XADD`/`XDELEX` issues, `cluster-announce-ip` hostname regression, TCP stall/deadlock fixes, and RediSearch Active-Active vector-index and `EXPIRE`-under-query latency fixes. **8.4.4** and **8.6.4** add more core-server items (e.g. ACL/`MSETEX`, replica sync crash on 8.4.4; Sentinel injection, `SCAN` `COUNT` overflow, corrupt RDB, use-after-free on 8.6.4).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b765de7fa585881b18b09110e80ea601517ad8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->