### PR TITLE
Convert myST admonitions to hugo shortcodes

### DIFF
--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -338,8 +338,8 @@ _BROKEN_API_CLI_LINK = re.compile(
 # Markdown attributes, breaking the build. Convert them to the site's alert
 # shortcodes instead.
 _MYST_ADMONITION = re.compile(
-    r"^```\{(note|warning|tip|important|caution|danger|attention|hint|error)\}"
-    r"[^\n]*\n(.*?)\n```[ \t]*$",
+    r"^(`{3,})\{(note|warning|tip|important|caution|danger|attention|hint|error)\}"
+    r"[^\n]*\n(.*?)\n\1[ \t]*$",
     re.DOTALL | re.MULTILINE,
 )
 _ADMONITION_SHORTCODE = {
@@ -351,8 +351,8 @@ _ADMONITION_SHORTCODE = {
 
 
 def _myst_admonition_repl(m: re.Match) -> str:
-    sc = _ADMONITION_SHORTCODE[m.group(1)]
-    return f"{{{{< {sc} >}}}}\n{m.group(2)}\n{{{{< /{sc} >}}}}"
+    sc = _ADMONITION_SHORTCODE[m.group(2)]
+    return f"{{{{< {sc} >}}}}\n{m.group(3)}\n{{{{< /{sc} >}}}}"
 
 
 def _docs_redisvl_deep_repl(m: re.Match) -> str:

--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -333,6 +333,26 @@ _IMAGE_STATIC = re.compile(r"!\[([^]]*)\]\(_static/([^)]+)\)")
 _BROKEN_API_CLI_LINK = re.compile(
     r'\[([^\]]+)\]\(\{\{<\s*relref\s+"(?:\.\./)?api/cli"\s*>\}\}\)'
 )
+# MyST/Sphinx admonition directives (```{warning} ... ```) survive nbconvert as
+# fenced blocks whose `{name}` info string Hugo's goldmark tries to parse as
+# Markdown attributes, breaking the build. Convert them to the site's alert
+# shortcodes instead.
+_MYST_ADMONITION = re.compile(
+    r"^```\{(note|warning|tip|important|caution|danger|attention|hint|error)\}"
+    r"[^\n]*\n(.*?)\n```[ \t]*$",
+    re.DOTALL | re.MULTILINE,
+)
+_ADMONITION_SHORTCODE = {
+    "note": "note", "important": "note",
+    "warning": "warning", "caution": "warning", "danger": "warning",
+    "attention": "warning", "error": "warning",
+    "tip": "tip", "hint": "tip",
+}
+
+
+def _myst_admonition_repl(m: re.Match) -> str:
+    sc = _ADMONITION_SHORTCODE[m.group(1)]
+    return f"{{{{< {sc} >}}}}\n{m.group(2)}\n{{{{< /{sc} >}}}}"
 
 
 def _docs_redisvl_deep_repl(m: re.Match) -> str:
@@ -383,6 +403,7 @@ def transform_page(src: Path, staging: Path, moved_slugs: list[str]) -> None:
     text = src.read_text(encoding="utf-8")
     text = _BLOCKQUOTE_RE.sub("", text)
     text = _ANSI_RE.sub("", text)
+    text = _MYST_ADMONITION.sub(_myst_admonition_repl, text)
     text = _DOCS_REDISVL_DEEP.sub(_docs_redisvl_deep_repl, text)
     text = _DOCS_REDISVL_SHALLOW.sub(
         lambda m: f"https://redis.io/docs/latest/develop/ai/redisvl/{m.group(1)}", text)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-time content transformation in `redisvl_docs_sync.py` only; no runtime, auth, or data-path changes.
> 
> **Overview**
> **Fixes Hugo build failures** for synced RedisVL pages where nbconvert leaves MyST/Sphinx admonitions as fenced blocks like `` `{warning}` ``; goldmark treats the `{name}` info string as Markdown attributes and errors.
> 
> The **redisvl docs sync** pipeline now runs a new transform in `transform_page` (right after ANSI/blockquote cleanup) that matches those fences and rewrites them to the site’s **`{{< note >}}` / `{{< warning >}}` / `{{< tip >}}`** shortcodes. Several MyST types (e.g. `caution`, `danger`, `hint`) are **collapsed** onto the three shortcode kinds via a small mapping table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 234897bcdd9743a34086e2a0df85e234169b083a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->