### PR TITLE
Render admonitions with hugo shortcodes

### DIFF
--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -454,6 +454,7 @@ def transform_page(src: Path, staging: Path, moved_slugs: list[str]) -> None:
     text = src.read_text(encoding="utf-8")
     text = _BLOCKQUOTE_RE.sub("", text)
     text = _ANSI_RE.sub("", text)
+    text = _MYST_ADMONITION.sub(_myst_admonition_repl, text)
     text = _SPHINX_BOX.sub(_sphinx_box_repl, text)
     text = _DOCS_REDISVL_DEEP.sub(_docs_redisvl_deep_repl, text)
     text = _DOCS_REDISVL_SHALLOW.sub(

--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -335,6 +335,32 @@ _BROKEN_API_CLI_LINK = re.compile(
 )
 
 
+# Non-notebook (.rst) pages are rendered by sphinx_markdown_builder, which turns
+# admonitions (.. warning::, .. note::, ...) into a "#### TITLE" heading rather
+# than a fenced directive. That output loses the admonition's extent, but the
+# builder glues the first body paragraph directly under the heading (no blank
+# line), so we wrap that paragraph in the matching shortcode. Multi-paragraph
+# admonitions are under-wrapped (only the first paragraph is boxed) — safe, valid
+# Hugo; over-wrapping would instead swallow unrelated body text that follows.
+_SPHINX_BOX = re.compile(
+    r"^#### (WARNING|NOTE|TIP|IMPORTANT|CAUTION|DANGER|ATTENTION|HINT|ERROR|SEE ALSO)"
+    r"[ \t]*\n(.+?)(?=\n[ \t]*\n|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+_SPHINX_BOX_SHORTCODE = {
+    "WARNING": "warning", "CAUTION": "warning", "DANGER": "warning",
+    "ATTENTION": "warning", "ERROR": "warning",
+    "NOTE": "note", "IMPORTANT": "note", "SEE ALSO": "note",
+    "TIP": "tip", "HINT": "tip",
+}
+
+
+def _sphinx_box_repl(m: re.Match) -> str:
+    sc = _SPHINX_BOX_SHORTCODE[m.group(1)]
+    body = m.group(2).rstrip()
+    return f"{{{{< {sc} >}}}}\n{body}\n{{{{< /{sc} >}}}}"
+
+
 def _docs_redisvl_deep_repl(m: re.Match) -> str:
     return f'{{{{< relref "{m.group(1)}{m.group(2)}" >}}}}'
 
@@ -383,6 +409,7 @@ def transform_page(src: Path, staging: Path, moved_slugs: list[str]) -> None:
     text = src.read_text(encoding="utf-8")
     text = _BLOCKQUOTE_RE.sub("", text)
     text = _ANSI_RE.sub("", text)
+    text = _SPHINX_BOX.sub(_sphinx_box_repl, text)
     text = _DOCS_REDISVL_DEEP.sub(_docs_redisvl_deep_repl, text)
     text = _DOCS_REDISVL_SHALLOW.sub(
         lambda m: f"https://redis.io/docs/latest/develop/ai/redisvl/{m.group(1)}", text)

--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -390,10 +390,13 @@ def _myst_admonition_repl(m: re.Match) -> str:
 # The body therefore ends at the first blank line, EOF, or the start of a
 # following block (another heading or a list item) even when no blank line
 # separates them, so a glued-on heading/list is never pulled into the shortcode.
+# Admonitions nested in a list item are indented by the builder ("  #### NOTE"),
+# so the heading may carry leading whitespace; we capture that indent and re-emit
+# the shortcode at the same level to keep it inside the list item.
 _SPHINX_BOX = re.compile(
-    r"^#### (WARNING|NOTE|TIP|IMPORTANT|CAUTION|DANGER|ATTENTION|HINT|ERROR|SEE ALSO)"
+    r"^([ \t]*)#### (WARNING|NOTE|TIP|IMPORTANT|CAUTION|DANGER|ATTENTION|HINT|ERROR|SEE ALSO)"
     r"[ \t]*\n(.+?)"
-    r"(?=\n[ \t]*\n|\n#{1,6}[ \t]|\n[ \t]*[-*+][ \t]|\n[ \t]*[0-9]+[.)][ \t]|\Z)",
+    r"(?=\n[ \t]*\n|\n[ \t]*#{1,6}[ \t]|\n[ \t]*[-*+][ \t]|\n[ \t]*[0-9]+[.)][ \t]|\Z)",
     re.DOTALL | re.MULTILINE,
 )
 _SPHINX_BOX_SHORTCODE = {
@@ -405,9 +408,10 @@ _SPHINX_BOX_SHORTCODE = {
 
 
 def _sphinx_box_repl(m: re.Match) -> str:
-    sc = _SPHINX_BOX_SHORTCODE[m.group(1)]
-    body = m.group(2).rstrip()
-    return f"{{{{< {sc} >}}}}\n{body}\n{{{{< /{sc} >}}}}"
+    indent = m.group(1)
+    sc = _SPHINX_BOX_SHORTCODE[m.group(2)]
+    body = m.group(3).rstrip()
+    return f"{indent}{{{{< {sc} >}}}}\n{body}\n{indent}{{{{< /{sc} >}}}}"
 
 
 def _docs_redisvl_deep_repl(m: re.Match) -> str:

--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -387,9 +387,13 @@ def _myst_admonition_repl(m: re.Match) -> str:
 # line), so we wrap that paragraph in the matching shortcode. Multi-paragraph
 # admonitions are under-wrapped (only the first paragraph is boxed) — safe, valid
 # Hugo; over-wrapping would instead swallow unrelated body text that follows.
+# The body therefore ends at the first blank line, EOF, or the start of a
+# following block (another heading or a list item) even when no blank line
+# separates them, so a glued-on heading/list is never pulled into the shortcode.
 _SPHINX_BOX = re.compile(
     r"^#### (WARNING|NOTE|TIP|IMPORTANT|CAUTION|DANGER|ATTENTION|HINT|ERROR|SEE ALSO)"
-    r"[ \t]*\n(.+?)(?=\n[ \t]*\n|\Z)",
+    r"[ \t]*\n(.+?)"
+    r"(?=\n[ \t]*\n|\n#{1,6}[ \t]|\n[ \t]*[-*+][ \t]|\n[ \t]*[0-9]+[.)][ \t]|\Z)",
     re.DOTALL | re.MULTILINE,
 )
 _SPHINX_BOX_SHORTCODE = {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-time text transforms only in the docs sync script; no runtime, auth, or data paths affected.
> 
> **Overview**
> Extends the RedisVL docs sync **post-processing** in `build/redisvl_docs_sync.py` so Sphinx-generated Markdown from `.rst` pages gets the same styled callouts as notebooks.
> 
> After `sphinx_markdown_builder` turns `.. warning::` / `.. note::` into plain `#### TITLE` headings (often with the first paragraph glued underneath), a new regex pass finds those headings, maps titles to the site’s **note**, **warning**, and **tip** Hugo shortcodes, and wraps the captured body. Boundaries stop at blank lines, the next heading, or list items so following content is not swallowed; leading indent is preserved for admonitions inside lists. The step runs in `transform_page` right after the existing MyST fenced-admonition conversion.
> 
> Multi-paragraph admonitions may only box the first paragraph by design (documented as safer than over-wrapping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 373aaf4b2cdf314ef8e7ab63a7240cf6f21bd9e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->