### PR TITLE
DOC-6730 added Snowflake to RDI supported sources table

### DIFF
--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -11,3 +11,4 @@
 | AlloyDB for PostgreSQL | 14.2, 15.7 | - | 14.2, 15.7 |
 | AWS Aurora/PostgreSQL | 15 | 15 | - |
 | Neon | 14, 15, 16, 17 | - | - |
+| Snowflake | - | - | - |

--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -11,4 +11,4 @@
 | AlloyDB for PostgreSQL | 14.2, 15.7 | - | 14.2, 15.7 |
 | AWS Aurora/PostgreSQL | 15 | 15 | - |
 | Neon | 14, 15, 16, 17 | - | - |
-| Snowflake | - | - | - |
+| Snowflake (preview) | - | - | - | 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a markdown embed with no product or security impact.
> 
> **Overview**
> Adds **Snowflake (preview)** to the shared RDI supported source databases table in `rdi-supported-source-versions.md`, with version columns set to `-` (no specific version matrix yet). That embed appears on several RDI pages (overview, architecture, prepare-dbs, installation requirements), so Snowflake will show up wherever supported sources are listed.
> 
> Also corrects the **Neon** table row formatting (removes a stray leading `-` on the row).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c53dde613d7d78998dbcbcc60527b0343427a583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->