### PR TITLE
DOC-6708 investigate better ai facing return value info

### DIFF
--- a/content/commands/bf.add.md
+++ b/content/commands/bf.add.md
@@ -66,18 +66,4 @@ redis> BF.ADD bf item1
 
 ## Return information
 
-{{< multitabs id="bf-add-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-One of the following:
-* [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}): `1` for successfully adding an item, or `0` if there's a probability that the item was already added to the filter.
-* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when the filter is full.
-
--tab-sep-
-
-One of the following:
-* [Boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}): `true` for successfully adding an item, or `false` if there's a probability that the item was already added to the filter.
-* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong key type, or when the filter is full.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/content/commands/hget.md
+++ b/content/commands/hget.md
@@ -78,18 +78,4 @@ HGET myhash field2
 
 ## Return information
 
-{{< multitabs id="hget-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-One of the following:
-* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): The value associated with the field.
-* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): If the field is not present in the hash or key does not exist.
-
--tab-sep-
-
-One of the following:
-* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): The value associated with the field.
-* [Null reply](../../develop/reference/protocol-spec#nulls): If the field is not present in the hash or key does not exist.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/content/commands/hgetall.md
+++ b/content/commands/hgetall.md
@@ -81,14 +81,4 @@ HGETALL myhash
 
 ## Return information
 
-{{< multitabs id="hgetall-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-[Array reply](../../develop/reference/protocol-spec#arrays): a list of fields and their values, or an empty list when key does not exist.
-
--tab-sep-
-
-[Map reply](../../develop/reference/protocol-spec#maps): a map of fields and their values, or an empty list when key does not exist.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/content/commands/hincrby.md
+++ b/content/commands/hincrby.md
@@ -84,14 +84,4 @@ HINCRBY myhash field -10
 
 ## Return information
 
-{{< multitabs id="hincrby-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-[Integer reply](../../develop/reference/protocol-spec#integers): the value of the field after the increment operation.
-
--tab-sep-
-
-[Integer reply](../../develop/reference/protocol-spec#integers): the value of the field after the increment operation.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/content/commands/xadd.md
+++ b/content/commands/xadd.md
@@ -343,18 +343,4 @@ eger) 2
 
 ## Return information
 
-{{< multitabs id="xadd-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-One of the following:
-* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion. When using IDMP and a duplicate is detected, returns the ID of the original entry.
-* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): if the NOMKSTREAM option is given and the key doesn't exist.
-
--tab-sep-
-
-One of the following:
-* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion. When using IDMP and a duplicate is detected, returns the ID of the original entry.
-* [Null reply](../../develop/reference/protocol-spec#nulls): if the NOMKSTREAM option is given and the key doesn't exist.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/content/commands/xrange.md
+++ b/content/commands/xrange.md
@@ -282,14 +282,4 @@ XRANGE writers - + COUNT 2
 
 ## Return information
 
-{{< multitabs id="xrange-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-[Array reply](../../develop/reference/protocol-spec#arrays): a list of stream entries with IDs matching the specified range.
-
--tab-sep-
-
-[Array reply](../../develop/reference/protocol-spec#arrays): a list of stream entries with IDs matching the specified range.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/content/commands/zadd.md
+++ b/content/commands/zadd.md
@@ -203,22 +203,4 @@ ZRANGE myzset 0 -1 WITHSCORES
 
 ## Return information
 
-{{< multitabs id="zadd-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-Any of the following:
-* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.
-* [Integer reply](../../develop/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.
-* [Integer reply](../../develop/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.
-* [Bulk string reply](../../develop/reference/protocol-spec#bulk-strings): the updated score of the member when the _INCR_ option is used.
-
--tab-sep-
-
-Any of the following:
-* [Null reply](../../develop/reference/protocol-spec#nulls): if the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options.
-* [Integer reply](../../develop/reference/protocol-spec#integers): the number of new members when the _CH_ option is not used.
-* [Integer reply](../../develop/reference/protocol-spec#integers): the number of new or updated members when the _CH_ option is used.
-* [Double reply](../../develop/reference/protocol-spec#doubles): the updated score of the member when the _INCR_ option is used.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/content/commands/zrange.md
+++ b/content/commands/zrange.md
@@ -248,14 +248,4 @@ ZRANGE myzset -2 -1
 
 ## Return information
 
-{{< multitabs id="zrange-return-info" 
-    tab1="RESP2" 
-    tab2="RESP3" >}}
-
-[Array reply](../../develop/reference/protocol-spec#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given.
-
--tab-sep-
-
-[Array reply](../../develop/reference/protocol-spec#arrays): a list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given.
-
-{{< /multitabs >}}
+{{< return-info >}}

--- a/data/commands_returns_core.json
+++ b/data/commands_returns_core.json
@@ -1,0 +1,474 @@
+{
+  "_meta": {
+    "module": "core",
+    "returns_format_version": "1",
+    "scope_note": "Hash, set, sorted-set and stream commands. All entries verified against Redis 8.2.1 via tools/resp_inspect.py. Examples reflect real observed replies.",
+    "universal_errors": "Per spec §6, transient and universal errors are not enumerated per command. Type-specific commands return `WRONGTYPE Operation against a key holding the wrong kind of value` when the target key holds a value of an incompatible type."
+  },
+
+  "HSET": {
+    "returns": {
+      "summary": "Number of fields newly added to the hash (existing fields updated in place do not count).",
+      "resp2": { "type": "integer",
+                 "summary": "Count of fields newly created. Updates to existing fields are not counted." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "two new fields", "args": ["h", "f1", "v1", "f2", "v2"], "resp2": 2 },
+        { "label": "update existing", "args": ["h", "f1", "v9"],            "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HGET": {
+    "returns": {
+      "summary": "Value of the field, or null if the field or key does not exist.",
+      "resp2": {
+        "oneof": [
+          { "when": "field exists in the hash", "type": "bulk_string",
+            "summary": "Value associated with the field." },
+          { "when": "field or key does not exist", "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "field exists",  "args": ["h", "title"], "resp2": "Beloved" },
+        { "label": "field missing", "args": ["h", "nope"],  "resp2": null }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HMGET": {
+    "returns": {
+      "summary": "Values for the requested fields, in the same order, with null in the position of any field not present in the hash.",
+      "resp2": {
+        "type": "array",
+        "summary": "Values for the requested fields, in the requested order. Missing fields are returned as null in their position.",
+        "items": {
+          "type": "bulk_string", "nullable": true,
+          "summary": "Field value, or null if the field is not in the hash. A missing key behaves the same as a hash with no matching fields (every position is null)."
+        }
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "mixed present/missing", "args": ["h", "title", "nope", "country"],
+          "resp2": ["Beloved", null, "US"] }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HGETALL": {
+    "returns": {
+      "summary": "All field-value pairs from the hash at the key, in arbitrary order. Empty if the key does not exist.",
+      "resp2": {
+        "type": "kv_array",
+        "summary": "Flat array of alternating field names and values, in arbitrary order. Empty array if the key does not exist.",
+        "key_type": "bulk_string",
+        "value_type": { "type": "bulk_string", "summary": "Field value." }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "Map of field names to values; map keys are unordered. Empty map if the key does not exist.",
+        "key_type": "bulk_string",
+        "value_type": { "type": "bulk_string", "summary": "Field value." }
+      },
+      "examples": [
+        { "label": "key exists",
+          "args": ["h"],
+          "resp2": ["title", "Beloved", "country", "US"],
+          "resp3": {"title": "Beloved", "country": "US"} },
+        { "label": "key missing",
+          "args": ["h:missing"],
+          "resp2": [],
+          "resp3": {} }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HEXISTS": {
+    "returns": {
+      "summary": "Whether the field exists in the hash.",
+      "resp2": { "type": "integer",
+                 "summary": "1 if the field exists, 0 if it does not exist or the key is missing." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "field exists",  "args": ["h", "title"], "resp2": 1 },
+        { "label": "field missing", "args": ["h", "nope"],  "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HKEYS": {
+    "returns": {
+      "summary": "Field names of the hash, in arbitrary order. Empty if the key does not exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "Field names of the hash, in arbitrary order. Empty array if the key does not exist.",
+        "items": { "type": "bulk_string", "summary": "Field name." }
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "key exists",  "args": ["h"], "resp2": ["title", "country", "price"] }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HVALS": {
+    "returns": {
+      "summary": "Field values of the hash, in arbitrary order. Empty if the key does not exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "Field values of the hash, in arbitrary order. Empty array if the key does not exist.",
+        "items": { "type": "bulk_string", "summary": "Field value." }
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "key exists", "args": ["h"], "resp2": ["Beloved", "US", "15.00"] }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HLEN": {
+    "returns": {
+      "summary": "Number of fields in the hash.",
+      "resp2": { "type": "integer",
+                 "summary": "Number of fields in the hash, or 0 if the key does not exist." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "key exists",  "args": ["h"],         "resp2": 3 },
+        { "label": "key missing", "args": ["h:missing"], "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HDEL": {
+    "returns": {
+      "summary": "Number of fields actually removed (fields named but not present do not count).",
+      "resp2": { "type": "integer",
+                 "summary": "Number of fields removed from the hash. Named-but-absent fields and missing keys both contribute 0." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "remove existing", "args": ["h", "title"], "resp2": 1 },
+        { "label": "remove missing",  "args": ["h", "nope"],  "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HSTRLEN": {
+    "returns": {
+      "summary": "String length of the field's value, or 0 if the field or key does not exist.",
+      "resp2": { "type": "integer",
+                 "summary": "Length of the string stored at the field, or 0 if the field or key is missing. Note: returns 0 (not null) for absent fields." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "field exists",  "args": ["h", "title"], "resp2": 7 },
+        { "label": "field missing", "args": ["h", "nope"],  "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "HINCRBY": {
+    "returns": {
+      "summary": "Value of the field after the increment.",
+      "resp2": { "type": "integer",
+                 "summary": "Field value after the increment. The field is created with value 0 before incrementing if it did not exist." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "increment existing", "args": ["h", "counter", "5"], "resp2": 5 },
+        { "label": "increment again",    "args": ["h", "counter", "5"], "resp2": 10 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "SADD": {
+    "returns": {
+      "summary": "Number of members newly added to the set (members already present are not counted).",
+      "resp2": { "type": "integer",
+                 "summary": "Count of members newly added. Members that were already in the set are not counted." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "all new",    "args": ["s", "a", "b", "c"], "resp2": 3 },
+        { "label": "duplicate",  "args": ["s", "a"],           "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "SCARD": {
+    "returns": {
+      "summary": "Number of members in the set.",
+      "resp2": { "type": "integer",
+                 "summary": "Cardinality (number of members) of the set, or 0 if the key does not exist." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "key exists",  "args": ["s"],         "resp2": 3 },
+        { "label": "key missing", "args": ["s:missing"], "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "SISMEMBER": {
+    "returns": {
+      "summary": "Whether the value is a member of the set.",
+      "resp2": { "type": "integer",
+                 "summary": "1 if the value is a member of the set, 0 if it is not or the key does not exist." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "is member",     "args": ["s", "a"], "resp2": 1 },
+        { "label": "not member",    "args": ["s", "z"], "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "SMEMBERS": {
+    "returns": {
+      "summary": "All members of the set, in arbitrary order. Empty if the key does not exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "All members of the set, in arbitrary order. Empty array if the key does not exist.",
+        "items": { "type": "bulk_string", "summary": "Member value." }
+      },
+      "resp3": {
+        "type": "set",
+        "summary": "All members of the set; sets are unordered by definition. Empty set if the key does not exist.",
+        "items": { "type": "bulk_string", "summary": "Member value." }
+      },
+      "examples": [
+        { "label": "key exists",
+          "args": ["s"],
+          "resp2": ["a", "b", "c"],
+          "resp3": ["a", "b", "c"],
+          "note": "RESP3 set is rendered here as a JSON array (per §3.1). Set semantics — unordered, unique — apply." }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "SREM": {
+    "returns": {
+      "summary": "Number of members actually removed (members named but not present do not count).",
+      "resp2": { "type": "integer",
+                 "summary": "Number of members removed from the set. Members not present and missing keys both contribute 0." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "remove existing", "args": ["s", "a"], "resp2": 1 },
+        { "label": "remove missing",  "args": ["s", "z"], "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "ZADD": {
+    "returns": {
+      "summary": "Number of new members added (default), or the updated score (with INCR), or null when an XX/NX/LT/GT condition aborts the operation.",
+      "resp2": {
+        "oneof": [
+          { "when": "XX/NX/LT/GT aborted the operation", "type": "null",
+            "summary": "Operation aborted by a conflict with one of the XX/NX/LT/GT options." },
+          { "when": "CH not used", "type": "integer",
+            "summary": "Number of members newly added (not counting score updates)." },
+          { "when": "CH used", "type": "integer",
+            "summary": "Number of members newly added plus number whose score was changed." },
+          { "when": "INCR used", "type": "bulk_string",
+            "summary": "Updated score of the member, as a string." }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "XX/NX/LT/GT aborted the operation", "type": "null" },
+          { "when": "CH not used", "type": "integer",
+            "summary": "Number of members newly added (not counting score updates)." },
+          { "when": "CH used", "type": "integer",
+            "summary": "Number of members newly added plus number whose score was changed." },
+          { "when": "INCR used", "type": "double",
+            "summary": "Updated score of the member." }
+        ]
+      },
+      "examples": [
+        { "label": "two new members", "args": ["z", "1", "a", "2", "b"], "resp2": 2 },
+        { "label": "INCR existing",   "args": ["z", "INCR", "0.5", "a"], "resp2": "1.5", "resp3": 1.5 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "ZCARD": {
+    "returns": {
+      "summary": "Number of members in the sorted set.",
+      "resp2": { "type": "integer",
+                 "summary": "Cardinality (number of members) of the sorted set, or 0 if the key does not exist." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "key exists", "args": ["z"], "resp2": 3 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "ZSCORE": {
+    "returns": {
+      "summary": "Score of the member, or null if the member or key is missing.",
+      "resp2": {
+        "oneof": [
+          { "when": "member exists", "type": "bulk_string",
+            "summary": "Score of the member (double-precision floating point), as a string." },
+          { "when": "member or key missing", "type": "null" }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "member exists", "type": "double",
+            "summary": "Score of the member." },
+          { "when": "member or key missing", "type": "null" }
+        ]
+      },
+      "examples": [
+        { "label": "member exists",  "args": ["z", "alpha"], "resp2": "1", "resp3": 1.0 },
+        { "label": "member missing", "args": ["z", "nope"],  "resp2": null }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "ZRANK": {
+    "returns": {
+      "summary": "Zero-based position of the member in ascending-score order, or null if the member or key is missing.",
+      "resp2": {
+        "oneof": [
+          { "when": "member exists", "type": "integer",
+            "summary": "Zero-based rank of the member in ascending-score order." },
+          { "when": "member or key missing", "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "member exists",  "args": ["z", "beta"], "resp2": 1 },
+        { "label": "member missing", "args": ["z", "nope"], "resp2": null }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "ZRANGE": {
+    "returns": {
+      "summary": "Members in the specified range, in ascending score order. With WITHSCORES, each member is paired with its score, but RESP2 and RESP3 carry the pairing differently.",
+      "resp2": {
+        "oneof": [
+          { "when": "WITHSCORES not specified", "type": "array",
+            "summary": "Members in ascending score order; ties broken lexicographically.",
+            "items": { "type": "bulk_string", "summary": "Member." } },
+          { "when": "WITHSCORES specified", "type": "kv_array",
+            "summary": "Flat array of alternating member and score, in ascending score order. Scores are bulk strings encoding doubles.",
+            "key_type": "bulk_string",
+            "value_type": { "type": "bulk_string", "summary": "Score, as a string." } }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "WITHSCORES not specified", "type": "array",
+            "summary": "Members in ascending score order; ties broken lexicographically.",
+            "items": { "type": "bulk_string", "summary": "Member." } },
+          { "when": "WITHSCORES specified", "type": "array",
+            "summary": "Array of [member, score] 2-tuples, in ascending score order.",
+            "items": {
+              "type": "tuple",
+              "prefixItems": [
+                { "name": "member", "type": "bulk_string" },
+                { "name": "score",  "type": "double" }
+              ]
+            } }
+        ]
+      },
+      "examples": [
+        { "label": "default range",
+          "args": ["z", "0", "-1"],
+          "resp2": ["alpha", "beta", "gamma"],
+          "resp3": ["alpha", "beta", "gamma"] },
+        { "label": "WITHSCORES",
+          "args": ["z", "0", "-1", "WITHSCORES"],
+          "resp2": ["alpha", "1", "beta", "2", "gamma", "3"],
+          "resp3": [["alpha", 1.0], ["beta", 2.0], ["gamma", 3.0]],
+          "note": "Structural divergence: RESP2 flattens member/score pairs into a single array; RESP3 emits each pair as a 2-tuple." }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "XADD": {
+    "returns": {
+      "summary": "ID of the added entry, or null with NOMKSTREAM when the key does not exist.",
+      "resp2": {
+        "oneof": [
+          { "when": "entry added", "type": "bulk_string",
+            "summary": "ID of the added entry, in `<ms>-<seq>` form. Auto-generated when `*` is supplied; otherwise the user-specified ID is returned." },
+          { "when": "NOMKSTREAM set and key does not exist", "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "auto id",         "args": ["s", "*", "f", "v"],                 "resp2": "1780671400587-0",
+          "note": "ID format is `<ms>-<seq>`; the example value will differ across runs." },
+        { "label": "NOMKSTREAM miss", "args": ["NOMKSTREAM", "s:missing", "*", "f", "v"], "resp2": null }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "XLEN": {
+    "returns": {
+      "summary": "Number of entries in the stream.",
+      "resp2": { "type": "integer",
+                 "summary": "Number of entries in the stream at the key, or 0 if the key does not exist." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "key exists",  "args": ["s"],         "resp2": 2 },
+        { "label": "key missing", "args": ["s:missing"], "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "XRANGE": {
+    "returns": {
+      "summary": "Stream entries within the specified ID range, in ascending ID order.",
+      "resp2": {
+        "type": "array",
+        "summary": "Stream entries within the specified ID range, in ascending ID order.",
+        "items": {
+          "type": "tuple",
+          "summary": "One stream entry: ID followed by its field/value pairs.",
+          "prefixItems": [
+            { "name": "id", "type": "bulk_string",
+              "summary": "Entry ID, in `<ms>-<seq>` form." },
+            { "name": "fields", "type": "kv_array",
+              "key_type": "bulk_string",
+              "value_type": { "type": "bulk_string" },
+              "summary": "Flat array of alternating field names and values, in insertion order." }
+          ]
+        }
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "two entries",
+          "args": ["s", "-", "+"],
+          "resp2": [
+            ["1780671400587-0", ["f1", "v1"]],
+            ["1780671400611-0", ["f2", "v2"]]
+          ] }
+      ]
+    },
+    "returns_status": "verified"
+  }
+}

--- a/data/commands_returns_core.json
+++ b/data/commands_returns_core.json
@@ -3,7 +3,7 @@
     "module": "core",
     "returns_format_version": "1",
     "scope_note": "Hash, set, sorted-set and stream commands. All entries verified against Redis 8.2.1 via tools/resp_inspect.py. Examples reflect real observed replies.",
-    "universal_errors": "Per spec §6, transient and universal errors are not enumerated per command. Type-specific commands return `WRONGTYPE Operation against a key holding the wrong kind of value` when the target key holds a value of an incompatible type."
+    "universal_errors": "Per spec §6, errors emitted uniformly across the family are documented here rather than per command: `WRONGTYPE Operation against a key holding the wrong kind of value` (type-specific commands when the key holds an incompatible value), `ERR wrong number of arguments for '<cmd>' command` (arity mismatch on any command), and module-not-loaded / transient operational errors (OOM, LOADING, MASTERDOWN, etc.). Command-specific errors — `hash value is not an integer` for HINCRBY, `INCR option supports a single increment-element pair` for ZADD, `Invalid stream ID specified as stream command argument` for XADD/XRANGE, etc. — ARE enumerated per command."
   },
 
   "HSET": {
@@ -178,9 +178,19 @@
 
   "HINCRBY": {
     "returns": {
-      "summary": "Value of the field after the increment.",
-      "resp2": { "type": "integer",
-                 "summary": "Field value after the increment. The field is created with value 0 before incrementing if it did not exist." },
+      "summary": "Value of the field after the increment, or an error when the field's current value isn't an integer or the result would overflow.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "integer",
+            "summary": "Field value after the increment. The field is created with value 0 before incrementing if it did not exist." },
+          { "when": "field's stored value isn't an integer", "type": "simple_error",
+            "messages": [{ "value": "hash value is not an integer",
+                           "summary": "The field exists but its value can't be parsed as an integer." }] },
+          { "when": "result would overflow signed 64-bit integer range", "type": "simple_error",
+            "messages": [{ "value": "increment or decrement would overflow",
+                           "summary": "The increment would push the field's value outside the signed 64-bit range." }] }
+        ]
+      },
       "resp3": "same_as_resp2",
       "examples": [
         { "label": "increment existing", "args": ["h", "counter", "5"], "resp2": 5 },
@@ -272,7 +282,7 @@
 
   "ZADD": {
     "returns": {
-      "summary": "Number of new members added (default), or the updated score (with INCR), or null when an XX/NX/LT/GT condition aborts the operation.",
+      "summary": "Number of new members added (default), the updated score (with INCR), null when an XX/NX/LT/GT condition aborts the operation, or an error for incompatible option combinations or non-numeric scores.",
       "resp2": {
         "oneof": [
           { "when": "XX/NX/LT/GT aborted the operation", "type": "null",
@@ -282,7 +292,15 @@
           { "when": "CH used", "type": "integer",
             "summary": "Number of members newly added plus number whose score was changed." },
           { "when": "INCR used", "type": "bulk_string",
-            "summary": "Updated score of the member, as a string." }
+            "summary": "Updated score of the member, as a string." },
+          { "when": "INCR is given with more than one member", "type": "simple_error",
+            "messages": [{ "value": "INCR option supports a single increment-element pair" }] },
+          { "when": "XX and NX are both specified", "type": "simple_error",
+            "messages": [{ "value": "XX and NX options at the same time are not compatible" }] },
+          { "when": "GT, LT, or NX are combined in an unsupported way", "type": "simple_error",
+            "messages": [{ "value": "GT, LT, and/or NX options at the same time are not compatible" }] },
+          { "when": "a score argument is not a valid float", "type": "simple_error",
+            "messages": [{ "value": "value is not a valid float" }] }
         ]
       },
       "resp3": {
@@ -293,7 +311,15 @@
           { "when": "CH used", "type": "integer",
             "summary": "Number of members newly added plus number whose score was changed." },
           { "when": "INCR used", "type": "double",
-            "summary": "Updated score of the member." }
+            "summary": "Updated score of the member." },
+          { "when": "INCR is given with more than one member", "type": "simple_error",
+            "messages": [{ "value": "INCR option supports a single increment-element pair" }] },
+          { "when": "XX and NX are both specified", "type": "simple_error",
+            "messages": [{ "value": "XX and NX options at the same time are not compatible" }] },
+          { "when": "GT, LT, or NX are combined in an unsupported way", "type": "simple_error",
+            "messages": [{ "value": "GT, LT, and/or NX options at the same time are not compatible" }] },
+          { "when": "a score argument is not a valid float", "type": "simple_error",
+            "messages": [{ "value": "value is not a valid float" }] }
         ]
       },
       "examples": [
@@ -408,12 +434,21 @@
 
   "XADD": {
     "returns": {
-      "summary": "ID of the added entry, or null with NOMKSTREAM when the key does not exist.",
+      "summary": "ID of the added entry, null with NOMKSTREAM when the key does not exist, or an error when the supplied ID is malformed or not strictly greater than the stream's current top ID.",
       "resp2": {
         "oneof": [
           { "when": "entry added", "type": "bulk_string",
             "summary": "ID of the added entry, in `<ms>-<seq>` form. Auto-generated when `*` is supplied; otherwise the user-specified ID is returned." },
-          { "when": "NOMKSTREAM set and key does not exist", "type": "null" }
+          { "when": "NOMKSTREAM set and key does not exist", "type": "null" },
+          { "when": "supplied ID is not greater than the stream's current top ID", "type": "simple_error",
+            "messages": [{ "value": "The ID specified in XADD is equal or smaller than the target stream top item",
+                           "summary": "Stream entry IDs must be strictly increasing." }] },
+          { "when": "supplied ID is the special 0-0", "type": "simple_error",
+            "messages": [{ "value": "The ID specified in XADD must be greater than 0-0",
+                           "summary": "0-0 is reserved as a marker and may not be used as an entry ID." }] },
+          { "when": "supplied ID cannot be parsed", "type": "simple_error",
+            "messages": [{ "value": "Invalid stream ID specified as stream command argument",
+                           "summary": "The ID must be in `<ms>-<seq>` form, `<ms>`, or one of the auto-generation markers (`*`, `*-N`)." }] }
         ]
       },
       "resp3": "same_as_resp2",
@@ -442,22 +477,27 @@
 
   "XRANGE": {
     "returns": {
-      "summary": "Stream entries within the specified ID range, in ascending ID order.",
+      "summary": "Stream entries within the specified ID range in ascending ID order, or an error when a range bound cannot be parsed.",
       "resp2": {
-        "type": "array",
-        "summary": "Stream entries within the specified ID range, in ascending ID order.",
-        "items": {
-          "type": "tuple",
-          "summary": "One stream entry: ID followed by its field/value pairs.",
-          "prefixItems": [
-            { "name": "id", "type": "bulk_string",
-              "summary": "Entry ID, in `<ms>-<seq>` form." },
-            { "name": "fields", "type": "kv_array",
-              "key_type": "bulk_string",
-              "value_type": { "type": "bulk_string" },
-              "summary": "Flat array of alternating field names and values, in insertion order." }
-          ]
-        }
+        "oneof": [
+          { "when": "success", "type": "array",
+            "summary": "Stream entries within the specified ID range, in ascending ID order.",
+            "items": {
+              "type": "tuple",
+              "summary": "One stream entry: ID followed by its field/value pairs.",
+              "prefixItems": [
+                { "name": "id", "type": "bulk_string",
+                  "summary": "Entry ID, in `<ms>-<seq>` form." },
+                { "name": "fields", "type": "kv_array",
+                  "key_type": "bulk_string",
+                  "value_type": { "type": "bulk_string" },
+                  "summary": "Flat array of alternating field names and values, in insertion order." }
+              ]
+            } },
+          { "when": "a range bound cannot be parsed", "type": "simple_error",
+            "messages": [{ "value": "Invalid stream ID specified as stream command argument",
+                           "summary": "Range bounds must be `-`, `+`, `<ms>-<seq>`, `<ms>`, or `(<id>` for exclusive bounds." }] }
+        ]
       },
       "resp3": "same_as_resp2",
       "examples": [

--- a/data/commands_returns_redisbloom.json
+++ b/data/commands_returns_redisbloom.json
@@ -1,0 +1,267 @@
+{
+  "_meta": {
+    "module": "redisbloom",
+    "returns_format_version": "1",
+    "scope_note": "Bloom filter (BF.*) and Cuckoo filter (CF.*) commands. All entries verified against Redis 8.2.1 + RedisBloom 8.2.0 via tools/resp_inspect.py.",
+    "universal_errors": "Per spec §6: `WRONGTYPE` if the key holds a value of an incompatible type, and module-not-loaded errors are not enumerated per command. Per-command operational errors (filter is full, item exists for BF.RESERVE, etc.) ARE enumerated where they're part of the documented contract."
+  },
+
+  "BF.RESERVE": {
+    "returns": {
+      "summary": "Confirms a new Bloom filter was created at the key.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "simple_string", "value": "OK",
+            "summary": "Filter created with the requested error rate and capacity." },
+          { "when": "key already exists", "type": "simple_error",
+            "messages": [{ "value": "item exists",
+                           "summary": "A key already exists at this name. Use a different key or delete the existing one first." }] }
+        ]
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "new filter",  "args": ["bf:demo", "0.01", "1000"], "resp2": "OK" },
+        { "label": "key exists",
+          "args": ["bf:demo", "0.01", "1000"],
+          "resp2": null,
+          "note": "Returns an error reply (`item exists`); the example shows null because errors are raised as exceptions by most client libraries." }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "BF.ADD": {
+    "returns": {
+      "summary": "Whether the item was newly added to the filter.",
+      "resp2": { "type": "integer",
+                 "summary": "1 if the item was newly added; 0 if it was probably already present (Bloom filters may report false positives)." },
+      "resp3": { "type": "boolean",
+                 "summary": "true if the item was newly added; false if it was probably already present (Bloom filters may report false positives)." },
+      "examples": [
+        { "label": "newly added",     "args": ["bf:demo", "item_a"], "resp2": 1, "resp3": true },
+        { "label": "probably present","args": ["bf:demo", "item_a"], "resp2": 0, "resp3": false }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "BF.MADD": {
+    "returns": {
+      "summary": "Per-item add results, one per requested item, in the same order as the request.",
+      "resp2": {
+        "type": "array",
+        "summary": "Per-item add results, in request order.",
+        "items": { "type": "integer",
+                   "summary": "1 if newly added, 0 if probably already present." }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "Per-item add results, in request order.",
+        "items": { "type": "boolean",
+                   "summary": "true if newly added, false if probably already present." }
+      },
+      "examples": [
+        { "label": "three new items", "args": ["bf:demo", "x", "y", "z"],
+          "resp2": [1, 1, 1], "resp3": [true, true, true] }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "BF.EXISTS": {
+    "returns": {
+      "summary": "Whether the item is probably in the filter.",
+      "resp2": { "type": "integer",
+                 "summary": "1 if the item is probably present (subject to the configured false-positive rate); 0 if definitely not." },
+      "resp3": { "type": "boolean",
+                 "summary": "true if the item is probably present (subject to the configured false-positive rate); false if definitely not." },
+      "examples": [
+        { "label": "probably present", "args": ["bf:demo", "item_a"], "resp2": 1, "resp3": true },
+        { "label": "definitely not",   "args": ["bf:demo", "unknown"], "resp2": 0, "resp3": false }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "BF.MEXISTS": {
+    "returns": {
+      "summary": "Per-item membership results, one per requested item, in the same order as the request.",
+      "resp2": {
+        "type": "array",
+        "summary": "Per-item membership results, in request order.",
+        "items": { "type": "integer",
+                   "summary": "1 if probably present, 0 if definitely not." }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "Per-item membership results, in request order.",
+        "items": { "type": "boolean",
+                   "summary": "true if probably present, false if definitely not." }
+      },
+      "examples": [
+        { "label": "mixed",
+          "args": ["bf:demo", "item_a", "unknown"],
+          "resp2": [1, 0], "resp3": [true, false] }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "BF.CARD": {
+    "returns": {
+      "summary": "Number of items added to the filter.",
+      "resp2": { "type": "integer",
+                 "summary": "Count of items added to the filter, or 0 if the key does not exist." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "non-empty filter", "args": ["bf:demo"], "resp2": 5 },
+        { "label": "missing key",      "args": ["bf:demo:missing"], "resp2": 0 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "BF.INFO": {
+    "returns": {
+      "summary": "Bloom filter metrics: capacity, current size, filter count, items inserted, and expansion rate. Field set is fixed; values are integers.",
+      "resp2": {
+        "type": "kv_array",
+        "summary": "Flat array of alternating metric name and integer value. Field set is fixed.",
+        "key_type": "bulk_string",
+        "value_type": { "type": "integer" },
+        "fields": [
+          { "name": "Capacity",                 "type": "integer", "summary": "Configured capacity at filter creation." },
+          { "name": "Size",                     "type": "integer", "summary": "Memory footprint in bytes." },
+          { "name": "Number of filters",        "type": "integer", "summary": "Number of sub-filters currently allocated (scales up under load)." },
+          { "name": "Number of items inserted", "type": "integer", "summary": "Total items added since the filter was created." },
+          { "name": "Expansion rate",           "type": "integer", "summary": "Configured expansion factor when a sub-filter fills." }
+        ]
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "Map of metric name to integer value. Field set is fixed; keys are unordered.",
+        "key_type": "bulk_string",
+        "value_type": { "type": "integer" },
+        "fields": [
+          { "name": "Capacity",                 "type": "integer", "summary": "Configured capacity at filter creation." },
+          { "name": "Size",                     "type": "integer", "summary": "Memory footprint in bytes." },
+          { "name": "Number of filters",        "type": "integer", "summary": "Number of sub-filters currently allocated (scales up under load)." },
+          { "name": "Number of items inserted", "type": "integer", "summary": "Total items added since the filter was created." },
+          { "name": "Expansion rate",           "type": "integer", "summary": "Configured expansion factor when a sub-filter fills." }
+        ]
+      },
+      "examples": [
+        { "label": "default filter",
+          "args": ["bf:demo"],
+          "resp2": ["Capacity", 1000, "Size", 1480, "Number of filters", 1, "Number of items inserted", 5, "Expansion rate", 2],
+          "resp3": {"Capacity": 1000, "Size": 1480, "Number of filters": 1, "Number of items inserted": 5, "Expansion rate": 2} }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "CF.RESERVE": {
+    "returns": {
+      "summary": "Confirms a new Cuckoo filter was created at the key.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "simple_string", "value": "OK" },
+          { "when": "key already exists", "type": "simple_error",
+            "messages": [{ "value": "item exists" }] }
+        ]
+      },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "new filter", "args": ["cf:demo", "1000"], "resp2": "OK" }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "CF.ADD": {
+    "returns": {
+      "summary": "Whether the item was added to the Cuckoo filter.",
+      "resp2": { "type": "integer",
+                 "summary": "1 if added successfully. The Cuckoo filter may report failures if it cannot find space; in practice this manifests as an error rather than 0." },
+      "resp3": { "type": "boolean",
+                 "summary": "true if added successfully." },
+      "examples": [
+        { "label": "added", "args": ["cf:demo", "item_a"], "resp2": 1, "resp3": true }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "CF.EXISTS": {
+    "returns": {
+      "summary": "Whether the item is probably in the Cuckoo filter.",
+      "resp2": { "type": "integer",
+                 "summary": "1 if the item is probably present (subject to the filter's false-positive rate); 0 if definitely not." },
+      "resp3": { "type": "boolean",
+                 "summary": "true if the item is probably present; false if definitely not." },
+      "examples": [
+        { "label": "probably present", "args": ["cf:demo", "item_a"], "resp2": 1, "resp3": true },
+        { "label": "definitely not",   "args": ["cf:demo", "unknown"], "resp2": 0, "resp3": false }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "CF.COUNT": {
+    "returns": {
+      "summary": "Approximate number of times the item was added (capped by filter precision; unlike Bloom filters, Cuckoo filters can count multi-insertions).",
+      "resp2": { "type": "integer",
+                 "summary": "Approximate count of how many times the item was added. May overcount due to hash collisions; will return 0 if the item is definitely not present." },
+      "resp3": "same_as_resp2",
+      "examples": [
+        { "label": "present once", "args": ["cf:demo", "item_a"], "resp2": 1 }
+      ]
+    },
+    "returns_status": "verified"
+  },
+
+  "CF.INFO": {
+    "returns": {
+      "summary": "Cuckoo filter metrics: size, bucket layout, insertion/deletion counts, expansion settings.",
+      "resp2": {
+        "type": "kv_array",
+        "summary": "Flat array of alternating metric name and integer value. Field set is fixed.",
+        "key_type": "bulk_string",
+        "value_type": { "type": "integer" },
+        "fields": [
+          { "name": "Size",                     "type": "integer", "summary": "Memory footprint in bytes." },
+          { "name": "Number of buckets",        "type": "integer", "summary": "Bucket count in the filter." },
+          { "name": "Number of filters",        "type": "integer", "summary": "Number of sub-filters currently allocated." },
+          { "name": "Number of items inserted", "type": "integer", "summary": "Successful inserts since creation." },
+          { "name": "Number of items deleted",  "type": "integer", "summary": "Successful deletes since creation." },
+          { "name": "Bucket size",              "type": "integer", "summary": "Items per bucket." },
+          { "name": "Expansion rate",           "type": "integer", "summary": "Expansion factor when full." },
+          { "name": "Max iterations",           "type": "integer", "summary": "Max iterations attempted to make room before reporting failure." }
+        ]
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "Map of metric name to integer value. Field set is fixed; keys are unordered.",
+        "key_type": "bulk_string",
+        "value_type": { "type": "integer" },
+        "fields": [
+          { "name": "Size",                     "type": "integer", "summary": "Memory footprint in bytes." },
+          { "name": "Number of buckets",        "type": "integer", "summary": "Bucket count in the filter." },
+          { "name": "Number of filters",        "type": "integer", "summary": "Number of sub-filters currently allocated." },
+          { "name": "Number of items inserted", "type": "integer", "summary": "Successful inserts since creation." },
+          { "name": "Number of items deleted",  "type": "integer", "summary": "Successful deletes since creation." },
+          { "name": "Bucket size",              "type": "integer", "summary": "Items per bucket." },
+          { "name": "Expansion rate",           "type": "integer", "summary": "Expansion factor when full." },
+          { "name": "Max iterations",           "type": "integer", "summary": "Max iterations attempted to make room before reporting failure." }
+        ]
+      },
+      "examples": [
+        { "label": "default filter",
+          "args": ["cf:demo"],
+          "resp2": ["Size", 1080, "Number of buckets", 512, "Number of filters", 1, "Number of items inserted", 3, "Number of items deleted", 0, "Bucket size", 2, "Expansion rate", 1, "Max iterations", 20],
+          "resp3": {"Size": 1080, "Number of buckets": 512, "Number of filters": 1, "Number of items inserted": 3, "Number of items deleted": 0, "Bucket size": 2, "Expansion rate": 1, "Max iterations": 20} }
+      ]
+    },
+    "returns_status": "verified"
+  }
+}

--- a/data/commands_returns_redisbloom.json
+++ b/data/commands_returns_redisbloom.json
@@ -3,7 +3,7 @@
     "module": "redisbloom",
     "returns_format_version": "1",
     "scope_note": "Bloom filter (BF.*) and Cuckoo filter (CF.*) commands. All entries verified against Redis 8.2.1 + RedisBloom 8.2.0 via tools/resp_inspect.py.",
-    "universal_errors": "Per spec §6: `WRONGTYPE` if the key holds a value of an incompatible type, and module-not-loaded errors are not enumerated per command. Per-command operational errors (filter is full, item exists for BF.RESERVE, etc.) ARE enumerated where they're part of the documented contract."
+    "universal_errors": "Per spec §6, errors that apply uniformly across the command family are documented here rather than per command: `WRONGTYPE Operation against a key holding the wrong kind of value` (key holds a non-filter type), `ERR wrong number of arguments for '<cmd>' command` (arity mismatch), and module-not-loaded errors. Command-specific operational errors (such as `non scaling filter is full` for BF.ADD/BF.MADD or `item exists` for BF.RESERVE/CF.RESERVE) ARE enumerated per command."
   },
 
   "BF.RESERVE": {
@@ -32,11 +32,26 @@
 
   "BF.ADD": {
     "returns": {
-      "summary": "Whether the item was newly added to the filter.",
-      "resp2": { "type": "integer",
-                 "summary": "1 if the item was newly added; 0 if it was probably already present (Bloom filters may report false positives)." },
-      "resp3": { "type": "boolean",
-                 "summary": "true if the item was newly added; false if it was probably already present (Bloom filters may report false positives)." },
+      "summary": "Whether the item was newly added to the filter, or an error when the filter is full and not configured to scale.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "integer",
+            "summary": "1 if the item was newly added; 0 if it was probably already present (Bloom filters may report false positives)." },
+          { "when": "filter is full and was created with NONSCALING",
+            "type": "simple_error",
+            "messages": [{ "value": "non scaling filter is full",
+                           "summary": "The filter was created with NONSCALING and has no room for further items." }] }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "boolean",
+            "summary": "true if the item was newly added; false if it was probably already present (Bloom filters may report false positives)." },
+          { "when": "filter is full and was created with NONSCALING",
+            "type": "simple_error",
+            "messages": [{ "value": "non scaling filter is full" }] }
+        ]
+      },
       "examples": [
         { "label": "newly added",     "args": ["bf:demo", "item_a"], "resp2": 1, "resp3": true },
         { "label": "probably present","args": ["bf:demo", "item_a"], "resp2": 0, "resp3": false }
@@ -47,18 +62,28 @@
 
   "BF.MADD": {
     "returns": {
-      "summary": "Per-item add results, one per requested item, in the same order as the request.",
+      "summary": "Per-item add results, in request order, or an error when the filter is full and not configured to scale.",
       "resp2": {
-        "type": "array",
-        "summary": "Per-item add results, in request order.",
-        "items": { "type": "integer",
-                   "summary": "1 if newly added, 0 if probably already present." }
+        "oneof": [
+          { "when": "success", "type": "array",
+            "summary": "Per-item add results, in request order.",
+            "items": { "type": "integer",
+                       "summary": "1 if newly added, 0 if probably already present." } },
+          { "when": "filter is full and was created with NONSCALING",
+            "type": "simple_error",
+            "messages": [{ "value": "non scaling filter is full" }] }
+        ]
       },
       "resp3": {
-        "type": "array",
-        "summary": "Per-item add results, in request order.",
-        "items": { "type": "boolean",
-                   "summary": "true if newly added, false if probably already present." }
+        "oneof": [
+          { "when": "success", "type": "array",
+            "summary": "Per-item add results, in request order.",
+            "items": { "type": "boolean",
+                       "summary": "true if newly added, false if probably already present." } },
+          { "when": "filter is full and was created with NONSCALING",
+            "type": "simple_error",
+            "messages": [{ "value": "non scaling filter is full" }] }
+        ]
       },
       "examples": [
         { "label": "three new items", "args": ["bf:demo", "x", "y", "z"],
@@ -180,11 +205,26 @@
 
   "CF.ADD": {
     "returns": {
-      "summary": "Whether the item was added to the Cuckoo filter.",
-      "resp2": { "type": "integer",
-                 "summary": "1 if added successfully. The Cuckoo filter may report failures if it cannot find space; in practice this manifests as an error rather than 0." },
-      "resp3": { "type": "boolean",
-                 "summary": "true if added successfully." },
+      "summary": "Whether the item was added to the Cuckoo filter, or an error when the filter is full and cannot accommodate further items.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "integer",
+            "summary": "1 if added successfully." },
+          { "when": "filter has no space and cannot expand within MAXITERATIONS",
+            "type": "simple_error",
+            "messages": [{ "value": "Filter is full",
+                           "summary": "Cuckoo filter could not find a slot for the item within its `MAXITERATIONS` budget. Either the filter is genuinely full (with `EXPANSION 0`) or contention is high." }] }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "boolean",
+            "summary": "true if added successfully." },
+          { "when": "filter has no space and cannot expand within MAXITERATIONS",
+            "type": "simple_error",
+            "messages": [{ "value": "Filter is full" }] }
+        ]
+      },
       "examples": [
         { "label": "added", "args": ["cf:demo", "item_a"], "resp2": 1, "resp3": true }
       ]

--- a/layouts/_default/single.json
+++ b/layouts/_default/single.json
@@ -21,6 +21,7 @@
 {{- $summary := (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace -}}
 {{- $tags := .Params.categories | default (slice) -}}
 {{- $lastUpdated := .Lastmod.Format "2006-01-02T15:04:05Z07:00" -}}
+{{- $returnsEntry := partial "returns-data.html" . -}}
 
 {
   "id": {{ $id | jsonify }},
@@ -29,5 +30,7 @@
   "summary": {{ $summary | jsonify }},
   "content": {{ $content | jsonify }},
   "tags": {{ $tags | jsonify }},
-  "last_updated": {{ $lastUpdated | jsonify }}
+  "last_updated": {{ $lastUpdated | jsonify }}{{ if $returnsEntry }},
+  "returns": {{ $returnsEntry.returns | jsonify }},
+  "returns_status": {{ $returnsEntry.returns_status | jsonify }}{{ end }}
 }

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -18,7 +18,9 @@
   "relatedPages": {{ .Params.relatedPages | jsonify }}{{ end }}{{ if .Params.scope }},
   "scope": {{ .Params.scope | jsonify }}{{ end }},
   "tableOfContents": {{ partial "toc-from-markdown.html" . }},
-  "codeExamples": {{ partial "code-examples-json.html" . }}
+  "codeExamples": {{ partial "code-examples-json.html" . }}{{ $returnsEntry := partial "returns-data.html" . }}{{ if $returnsEntry }},
+  "returns": {{ $returnsEntry.returns | jsonify }},
+  "returns_status": {{ $returnsEntry.returns_status | jsonify }}{{ end }}
 }
 ```
 

--- a/layouts/partials/markdown-return-info.html
+++ b/layouts/partials/markdown-return-info.html
@@ -1,25 +1,24 @@
-{{- /*
-  Process return-info shortcodes in raw markdown content.
+{{- /* Process return-info shortcodes in raw markdown content (called
+       from `process-markdown-content.html` for the .md and .json output
+       paths).
 
-  Called from `process-markdown-content.html` before the multitabs
-  partial. Replaces every `{{< return-info >}}` tag with the contents
-  of the corresponding pre-rendered prose file under
-  `assets/returns-prose/<slug>.md`. The injected content contains a
-  `{{< multitabs >}}` block which is then expanded by the subsequent
-  multitabs partial in the same pipeline.
+       Replaces every `{{< return-info >}}` tag with the markdown body
+       rendered directly from the page's entry in
+       `data/commands_returns_<module>.json`. Single source of truth —
+       no intermediate file reads.
 
-  Input dict:
-    - RawContent: markdown body string
-    - Page:       current Hugo page (for the title → slug derivation)
+       Input dict:
+         RawContent: markdown body string
+         Page:       current Hugo page
 */ -}}
 
 {{- $content := .RawContent -}}
-{{- $title := .Page.Title -}}
-{{- $slug := $title | lower | replaceRE " " "-" -}}
-{{- $path := printf "assets/returns-prose/%s.md" $slug -}}
-{{- if fileExists $path -}}
-  {{- $body := readFile $path -}}
-  {{- /* The shortcode tag may appear with or without spaces. Match both. */ -}}
+{{- $page := .Page -}}
+{{- $entry := partial "returns-data.html" $page -}}
+
+{{- if $entry -}}
+  {{- $body := partial "returns/render-returns-md.html" (dict "returns" $entry.returns "cmd" $page.Title) -}}
   {{- $content = $content | replaceRE `\{\{<\s*return-info(\s+[^>]*)?\s*>\}\}` $body -}}
 {{- end -}}
+
 {{- return $content -}}

--- a/layouts/partials/markdown-return-info.html
+++ b/layouts/partials/markdown-return-info.html
@@ -1,0 +1,25 @@
+{{- /*
+  Process return-info shortcodes in raw markdown content.
+
+  Called from `process-markdown-content.html` before the multitabs
+  partial. Replaces every `{{< return-info >}}` tag with the contents
+  of the corresponding pre-rendered prose file under
+  `assets/returns-prose/<slug>.md`. The injected content contains a
+  `{{< multitabs >}}` block which is then expanded by the subsequent
+  multitabs partial in the same pipeline.
+
+  Input dict:
+    - RawContent: markdown body string
+    - Page:       current Hugo page (for the title → slug derivation)
+*/ -}}
+
+{{- $content := .RawContent -}}
+{{- $title := .Page.Title -}}
+{{- $slug := $title | lower | replaceRE " " "-" -}}
+{{- $path := printf "assets/returns-prose/%s.md" $slug -}}
+{{- if fileExists $path -}}
+  {{- $body := readFile $path -}}
+  {{- /* The shortcode tag may appear with or without spaces. Match both. */ -}}
+  {{- $content = $content | replaceRE `\{\{<\s*return-info(\s+[^>]*)?\s*>\}\}` $body -}}
+{{- end -}}
+{{- return $content -}}

--- a/layouts/partials/process-markdown-content.html
+++ b/layouts/partials/process-markdown-content.html
@@ -62,6 +62,11 @@
 {{- $content = $content | replaceRE "&gt;" ">" -}}
 {{- $content = $content | replaceRE "&amp;" "&" -}}
 
+{{- /* Process return-info shortcodes — inserts pre-rendered prose from
+       assets/returns-prose/. Must run before markdown-multitabs.html
+       because the injected content contains multitabs syntax. */ -}}
+{{- $content = partial "markdown-return-info.html" (dict "RawContent" $content "Page" .Page) -}}
+
 {{- /* Process multitabs shortcodes to expand tab content */ -}}
 {{- $content = partial "markdown-multitabs.html" (dict "RawContent" $content "Site" .Site) -}}
 {{- /* Final unescape of HTML entities */ -}}

--- a/layouts/partials/returns-data.html
+++ b/layouts/partials/returns-data.html
@@ -1,0 +1,24 @@
+{{/*
+  returns-data partial
+
+  Looks up the current page's command entry across every
+  `commands_returns_<module>` data file. Returns the matched entry
+  (with `returns` and `returns_status` keys) or `false` if not found.
+
+  Skips files whose name ends `_shared` — those hold $ref targets only.
+
+  Usage:
+      {{ $entry := partial "returns-data.html" . }}
+      {{ if $entry }} ... {{ end }}
+*/}}
+
+{{- $cmdName := .Title -}}
+{{- $found := false -}}
+{{- range $key, $data := .Site.Data -}}
+  {{- if and (hasPrefix $key "commands_returns_") (not (hasSuffix $key "_shared")) -}}
+    {{- with index $data $cmdName -}}
+      {{- $found = . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- return $found -}}

--- a/layouts/partials/returns/render-branch.html
+++ b/layouts/partials/returns/render-branch.html
@@ -34,9 +34,11 @@
       {{- $val = index $m "value" | default "" -}}
     {{- end -}}
     {{- if gt $i 0 -}}{{- $msgList = printf "%s; " $msgList -}}{{- end -}}
-    {{- $msgList = printf "%s%s" $msgList $val -}}
+    {{- $msgList = printf "%s`%s`" $msgList $val -}}
   {{- end -}}
-  {{- $result = printf "* %s in these cases: %s." $link $msgList -}}
+  {{- /* New single-error format: include the `when` predicate as an
+         italic suffix (matching how other oneof branches render). */ -}}
+  {{- $result = printf "* %s: %s%s." $link $msgList $suffix -}}
 {{- else if eq $type "null" -}}
   {{- $result = printf "* %s%s." $link $suffix -}}
 {{- else if and (eq $type "simple_string") $value -}}

--- a/layouts/partials/returns/render-branch.html
+++ b/layouts/partials/returns/render-branch.html
@@ -1,0 +1,79 @@
+{{- /* Render one branch of a oneof as a bulleted list item with optional
+       trailing italic `when` clause. Containers expand into sub-bullets.
+
+       Input dict:
+         node:   the branch ReplySpec
+         proto:  "2" or "3"
+
+       Returns: single bullet (possibly multi-line if expanded), no trailing newline.
+*/ -}}
+{{- $node := .node -}}
+{{- $proto := .proto -}}
+{{- $type := $node.type -}}
+{{- $when := index $node "when" -}}
+{{- $summary := index $node "summary" | default "" -}}
+{{- $value := index $node "value" -}}
+
+{{- $suffix := "" -}}
+{{- if and $when (not (in (slice "default" "success") $when)) -}}
+  {{- $suffix = printf " _(when %s)_" $when -}}
+{{- end -}}
+
+{{- $link := partial "returns/type-link.html" (dict "type" $type "proto" $proto) -}}
+
+{{- $result := "" -}}
+
+{{- if eq $type "simple_error" -}}
+  {{- $msgs := index $node "messages" | default (slice) -}}
+  {{- $msgList := "" -}}
+  {{- range $i, $m := $msgs -}}
+    {{- $val := "" -}}
+    {{- if (eq (printf "%T" $m) "string") -}}
+      {{- $val = $m -}}
+    {{- else -}}
+      {{- $val = index $m "value" | default "" -}}
+    {{- end -}}
+    {{- if gt $i 0 -}}{{- $msgList = printf "%s; " $msgList -}}{{- end -}}
+    {{- $msgList = printf "%s%s" $msgList $val -}}
+  {{- end -}}
+  {{- $result = printf "* %s in these cases: %s." $link $msgList -}}
+{{- else if eq $type "null" -}}
+  {{- $result = printf "* %s%s." $link $suffix -}}
+{{- else if and (eq $type "simple_string") $value -}}
+  {{- $body := printf "%s: `%s`." $link $value -}}
+  {{- if $summary -}}{{- $body = printf "%s %s" $body $summary -}}{{- end -}}
+  {{- $result = printf "* %s%s" $body $suffix -}}
+{{- else -}}
+  {{- $head := "" -}}
+  {{- if $summary -}}
+    {{- $head = printf "* %s: %s%s" $link $summary $suffix -}}
+  {{- else -}}
+    {{- $head = printf "* %s%s" $link $suffix -}}
+  {{- end -}}
+
+  {{- /* Container expansion */ -}}
+  {{- $tail := "" -}}
+  {{- if eq $type "array" -}}
+    {{- with $node.items -}}
+      {{- $tail = partial "returns/render-items.html" (dict "items" . "proto" $proto "indent" "  ") -}}
+    {{- end -}}
+  {{- else if eq $type "set" -}}
+    {{- with $node.items -}}
+      {{- $tail = partial "returns/render-items.html" (dict "items" . "proto" $proto "indent" "  ") -}}
+    {{- end -}}
+  {{- else if eq $type "tuple" -}}
+    {{- $tail = partial "returns/render-tuple.html" (dict "node" $node "proto" $proto "indent" "  ") -}}
+  {{- else if or (eq $type "map") (eq $type "kv_array") -}}
+    {{- with $node.fields -}}
+      {{- $tail = partial "returns/render-fields.html" (dict "fields" . "proto" $proto "indent" "  ") -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if $tail -}}
+    {{- $result = printf "%s\n%s" $head (strings.TrimSuffix "\n" $tail) -}}
+  {{- else -}}
+    {{- $result = $head -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $result -}}

--- a/layouts/partials/returns/render-error-group.html
+++ b/layouts/partials/returns/render-error-group.html
@@ -1,0 +1,43 @@
+{{- /* Render a run of consecutive simple_error branches as a single
+       bullet with a sub-list of cases. Used when a `oneof` has 2+
+       error branches in a row, to avoid the repetitive
+       "Simple error reply: ... / Simple error reply: ..." pattern.
+
+       Input dict:
+         branches: list of simple_error branch dicts (each has type=simple_error
+                   and one or more `messages` plus an optional `when`)
+         proto:    "2" or "3"
+
+       Returns: markdown — single bullet with nested sub-bullets,
+                no trailing newline.
+*/ -}}
+{{- $branches := .branches -}}
+{{- $proto := .proto -}}
+{{- $link := partial "returns/type-link.html" (dict "type" "simple_error" "proto" $proto) -}}
+
+{{- $out := printf "* %s, in any of the following cases:" $link -}}
+
+{{- range $b := $branches -}}
+  {{- $msgs := index $b "messages" | default (slice) -}}
+  {{- $msgList := "" -}}
+  {{- range $i, $m := $msgs -}}
+    {{- $val := "" -}}
+    {{- if (eq (printf "%T" $m) "string") -}}
+      {{- $val = $m -}}
+    {{- else -}}
+      {{- $val = index $m "value" | default "" -}}
+    {{- end -}}
+    {{- if gt $i 0 -}}{{- $msgList = printf "%s; " $msgList -}}{{- end -}}
+    {{- $msgList = printf "%s`%s`" $msgList $val -}}
+  {{- end -}}
+
+  {{- $when := index $b "when" -}}
+  {{- $suffix := "" -}}
+  {{- if and $when (not (in (slice "default" "success") $when)) -}}
+    {{- $suffix = printf " _(when %s)_" $when -}}
+  {{- end -}}
+
+  {{- $out = printf "%s\n  - %s%s" $out $msgList $suffix -}}
+{{- end -}}
+
+{{- return $out -}}

--- a/layouts/partials/returns/render-examples.html
+++ b/layouts/partials/returns/render-examples.html
@@ -1,0 +1,45 @@
+{{- /* Render the `examples` list as a markdown bullet list.
+
+       Input dict:
+         examples: list of example dicts (label, args, resp2, optional resp3, optional note)
+         cmd:      command name string
+
+       Returns: markdown string. Empty if there are no examples.
+*/ -}}
+{{- $examples := .examples -}}
+{{- $cmd := .cmd -}}
+{{- $out := "" -}}
+
+{{- if $examples -}}
+  {{- $out = "**Examples:**\n\n" -}}
+  {{- range $ex := $examples -}}
+    {{- $label := index $ex "label" | default "" -}}
+    {{- $args := index $ex "args" | default (slice) -}}
+    {{- $argsStr := delimit $args " " -}}
+    {{- $head := printf "`%s %s`" $cmd $argsStr -}}
+    {{- $head = strings.TrimSpace $head -}}
+    {{- if $label -}}
+      {{- $head = printf "%s _(%s)_" $head $label -}}
+    {{- end -}}
+    {{- $out = printf "%s- %s\n" $out $head -}}
+
+    {{- /* Strict JSON-serialised comparison so `0 != false`, `1 != true` */ -}}
+    {{- $r2json := (index $ex "resp2") | jsonify -}}
+    {{- $r3json := "" -}}
+    {{- if (isset $ex "resp3") -}}
+      {{- $r3json = (index $ex "resp3") | jsonify -}}
+    {{- end -}}
+    {{- if and $r3json (ne $r3json $r2json) -}}
+      {{- $out = printf "%s  - RESP2: `%s`\n" $out $r2json -}}
+      {{- $out = printf "%s  - RESP3: `%s`\n" $out $r3json -}}
+    {{- else -}}
+      {{- $out = printf "%s  - Reply: `%s`\n" $out $r2json -}}
+    {{- end -}}
+
+    {{- with index $ex "note" -}}
+      {{- $out = printf "%s  - Note: %s\n" $out . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $out -}}

--- a/layouts/partials/returns/render-examples.html
+++ b/layouts/partials/returns/render-examples.html
@@ -3,11 +3,17 @@
        Input dict:
          examples: list of example dicts (label, args, resp2, optional resp3, optional note)
          cmd:      command name string
+         proto:    optional. If "2" or "3", render only that protocol's
+                   reply value (no RESP2/RESP3 prefix) — used in the
+                   HTML tabs view where each tab shows one protocol.
+                   If empty, render the side-by-side form used by the
+                   .md/.json output paths.
 
        Returns: markdown string. Empty if there are no examples.
 */ -}}
 {{- $examples := .examples -}}
 {{- $cmd := .cmd -}}
+{{- $proto := .proto | default "" -}}
 {{- $out := "" -}}
 
 {{- if $examples -}}
@@ -29,7 +35,14 @@
     {{- if (isset $ex "resp3") -}}
       {{- $r3json = (index $ex "resp3") | jsonify -}}
     {{- end -}}
-    {{- if and $r3json (ne $r3json $r2json) -}}
+
+    {{- if eq $proto "2" -}}
+      {{- $out = printf "%s  - Reply: `%s`\n" $out $r2json -}}
+    {{- else if eq $proto "3" -}}
+      {{- $val := $r3json -}}
+      {{- if not $val -}}{{- $val = $r2json -}}{{- end -}}
+      {{- $out = printf "%s  - Reply: `%s`\n" $out $val -}}
+    {{- else if and $r3json (ne $r3json $r2json) -}}
       {{- $out = printf "%s  - RESP2: `%s`\n" $out $r2json -}}
       {{- $out = printf "%s  - RESP3: `%s`\n" $out $r3json -}}
     {{- else -}}

--- a/layouts/partials/returns/render-fields.html
+++ b/layouts/partials/returns/render-fields.html
@@ -1,0 +1,60 @@
+{{- /* Render a map/kv_array's `fields` enumeration as sub-bullets.
+
+       Input dict:
+         fields:  list of field specs
+         proto:   "2" or "3"
+         indent:  current indent string
+
+       Returns: markdown lines, indented, with trailing newline.
+*/ -}}
+{{- $fields := .fields -}}
+{{- $proto := .proto -}}
+{{- $indent := .indent | default "" -}}
+{{- $out := "" -}}
+
+{{- range $f := $fields -}}
+  {{- $fname := $f.name -}}
+  {{- $when := index $f "when" -}}
+  {{- $optional := index $f "optional" -}}
+  {{- $fwhen := "" -}}
+  {{- if $when -}}{{- $fwhen = printf " _(when %s)_" $when -}}{{- end -}}
+  {{- $fopt := "" -}}
+  {{- if and $optional (not $when) -}}{{- $fopt = " _(optional)_" -}}{{- end -}}
+
+  {{- $oneof := index $f "oneof" -}}
+  {{- if $oneof -}}
+    {{- $out = printf "%s%s- `%s`%s%s: one of —\n" $out $indent $fname $fwhen $fopt -}}
+    {{- range $branch := $oneof -}}
+      {{- $bmd := partial "returns/render-branch.html" (dict "node" $branch "proto" $proto) -}}
+      {{- range $line := split $bmd "\n" -}}
+        {{- $out = printf "%s%s  %s\n" $out $indent $line -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $ftype := index $f "type" -}}
+    {{- if $ftype -}}
+      {{- $flink := partial "returns/type-link.html" (dict "type" $ftype "proto" $proto) -}}
+      {{- $fsum := index $f "summary" | default "" -}}
+      {{- $line := printf "%s- `%s`: %s%s%s" $indent $fname $flink $fwhen $fopt -}}
+      {{- if $fsum -}}{{- $line = printf "%s — %s" $line $fsum -}}{{- end -}}
+      {{- $out = printf "%s%s\n" $out $line -}}
+      {{- /* Recurse for nested containers */ -}}
+      {{- if eq $ftype "tuple" -}}
+        {{- $sub := partial "returns/render-tuple.html" (dict "node" $f "proto" $proto "indent" (printf "%s  " $indent)) -}}
+        {{- $out = printf "%s%s" $out $sub -}}
+      {{- else if eq $ftype "array" -}}
+        {{- with $f.items -}}
+          {{- $sub := partial "returns/render-items.html" (dict "items" . "proto" $proto "indent" (printf "%s  " $indent)) -}}
+          {{- $out = printf "%s%s" $out $sub -}}
+        {{- end -}}
+      {{- else if or (eq $ftype "map") (eq $ftype "kv_array") -}}
+        {{- with $f.fields -}}
+          {{- $sub := partial "returns/render-fields.html" (dict "fields" . "proto" $proto "indent" (printf "%s  " $indent)) -}}
+          {{- $out = printf "%s%s" $out $sub -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $out -}}

--- a/layouts/partials/returns/render-items.html
+++ b/layouts/partials/returns/render-items.html
@@ -1,0 +1,40 @@
+{{- /* Render an array's items spec as a sub-bullet ("- Each item: …").
+       Recurses for nested containers.
+
+       Input dict:
+         items:   the items ReplySpec
+         proto:   "2" or "3"
+         indent:  current indent (e.g. "  ")
+
+       Returns: markdown lines, indented appropriately, with trailing newline.
+*/ -}}
+{{- $items := .items -}}
+{{- $proto := .proto -}}
+{{- $indent := .indent | default "" -}}
+
+{{- $type := $items.type -}}
+{{- $summary := index $items "summary" | default "" -}}
+{{- $link := partial "returns/type-link.html" (dict "type" $type "proto" $proto) -}}
+
+{{- $head := printf "%s- Each item: %s" $indent $link -}}
+{{- if $summary -}}
+  {{- $head = printf "%s — %s" $head $summary -}}
+{{- end -}}
+{{- $out := printf "%s\n" $head -}}
+
+{{- if eq $type "tuple" -}}
+  {{- $sub := partial "returns/render-tuple.html" (dict "node" $items "proto" $proto "indent" (printf "%s  " $indent)) -}}
+  {{- $out = printf "%s%s" $out $sub -}}
+{{- else if eq $type "array" -}}
+  {{- with $items.items -}}
+    {{- $sub := partial "returns/render-items.html" (dict "items" . "proto" $proto "indent" (printf "%s  " $indent)) -}}
+    {{- $out = printf "%s%s" $out $sub -}}
+  {{- end -}}
+{{- else if or (eq $type "map") (eq $type "kv_array") -}}
+  {{- with $items.fields -}}
+    {{- $sub := partial "returns/render-fields.html" (dict "fields" . "proto" $proto "indent" (printf "%s  " $indent)) -}}
+    {{- $out = printf "%s%s" $out $sub -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $out -}}

--- a/layouts/partials/returns/render-returns-md.html
+++ b/layouts/partials/returns/render-returns-md.html
@@ -1,0 +1,51 @@
+{{- /* Render a full `returns` block as the markdown body used in the
+       `## Return information` section for the .md and .json AI-facing
+       outputs.
+
+       Input dict:
+         returns: the returns block (with resp2, resp3, optional examples)
+         cmd:     command name (used in examples)
+
+       Returns: markdown body, no leading or trailing newline.
+       Structure:
+         **RESP2:**
+
+         <rendered resp2 spec>
+
+         **RESP3:**
+
+         <rendered resp3 spec>
+
+         **Examples:**
+
+         <rendered examples>
+*/ -}}
+{{- $returns := .returns -}}
+{{- $cmd := .cmd -}}
+
+{{- /* Resolve same_as_* for each protocol */ -}}
+{{- $resp2 := index $returns "resp2" -}}
+{{- $resp3 := index $returns "resp3" -}}
+{{- if eq (printf "%T" $resp2) "string" -}}
+  {{- if eq $resp2 "same_as_resp3" -}}{{- $resp2 = $resp3 -}}{{- end -}}
+{{- end -}}
+{{- if eq (printf "%T" $resp3) "string" -}}
+  {{- if eq $resp3 "same_as_resp2" -}}{{- $resp3 = (index $returns "resp2") -}}{{- end -}}
+{{- end -}}
+
+{{- $resp2md := partial "returns/render-spec.html" (dict "node" $resp2 "proto" "2") -}}
+{{- $resp3md := partial "returns/render-spec.html" (dict "node" $resp3 "proto" "3") -}}
+
+{{- $out := "**RESP2:**\n\n" -}}
+{{- $out = printf "%s%s\n" $out (strings.TrimSuffix "\n" $resp2md) -}}
+{{- $out = printf "%s\n**RESP3:**\n\n" $out -}}
+{{- $out = printf "%s%s\n" $out (strings.TrimSuffix "\n" $resp3md) -}}
+
+{{- with index $returns "examples" -}}
+  {{- $exmd := partial "returns/render-examples.html" (dict "examples" . "cmd" $cmd) -}}
+  {{- if $exmd -}}
+    {{- $out = printf "%s\n%s" $out (strings.TrimSuffix "\n" $exmd) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $out -}}

--- a/layouts/partials/returns/render-spec.html
+++ b/layouts/partials/returns/render-spec.html
@@ -20,9 +20,40 @@
 {{- $oneof := index $node "oneof" -}}
 {{- if $oneof -}}
   {{- $out = "One of the following:\n" -}}
+
+  {{- /* Walk branches, buffering consecutive simple_error ones so that
+         runs of 2+ get rendered as a single bullet with a sublist. */ -}}
+  {{- $pending := slice -}}
   {{- range $branch := $oneof -}}
-    {{- $b := partial "returns/render-branch.html" (dict "node" $branch "proto" $proto) -}}
-    {{- $out = printf "%s%s\n" $out $b -}}
+    {{- $btype := index $branch "type" | default "" -}}
+    {{- if eq $btype "simple_error" -}}
+      {{- $pending = $pending | append $branch -}}
+    {{- else -}}
+      {{- /* Flush any buffered error branches first */ -}}
+      {{- if $pending -}}
+        {{- if gt (len $pending) 1 -}}
+          {{- $g := partial "returns/render-error-group.html" (dict "branches" $pending "proto" $proto) -}}
+          {{- $out = printf "%s%s\n" $out $g -}}
+        {{- else -}}
+          {{- $b := partial "returns/render-branch.html" (dict "node" (index $pending 0) "proto" $proto) -}}
+          {{- $out = printf "%s%s\n" $out $b -}}
+        {{- end -}}
+        {{- $pending = slice -}}
+      {{- end -}}
+      {{- $b := partial "returns/render-branch.html" (dict "node" $branch "proto" $proto) -}}
+      {{- $out = printf "%s%s\n" $out $b -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- /* Flush trailing error buffer */ -}}
+  {{- if $pending -}}
+    {{- if gt (len $pending) 1 -}}
+      {{- $g := partial "returns/render-error-group.html" (dict "branches" $pending "proto" $proto) -}}
+      {{- $out = printf "%s%s\n" $out $g -}}
+    {{- else -}}
+      {{- $b := partial "returns/render-branch.html" (dict "node" (index $pending 0) "proto" $proto) -}}
+      {{- $out = printf "%s%s\n" $out $b -}}
+    {{- end -}}
   {{- end -}}
 {{- else -}}
   {{- $type := $node.type -}}

--- a/layouts/partials/returns/render-spec.html
+++ b/layouts/partials/returns/render-spec.html
@@ -1,0 +1,86 @@
+{{- /* Render a ReplySpec to markdown.
+
+       Input dict:
+         node:    the ReplySpec dict (a oneof, typed node, or $ref)
+         proto:   "2" or "3"
+
+       Returns: multi-line markdown string. No leading indent on first line.
+                Nested expansion uses two-space sub-indent.
+
+       Companion partials:
+         - returns/render-branch.html
+         - returns/render-items.html
+         - returns/render-tuple.html
+         - returns/render-fields.html
+*/ -}}
+{{- $node := .node -}}
+{{- $proto := .proto -}}
+{{- $out := "" -}}
+
+{{- $oneof := index $node "oneof" -}}
+{{- if $oneof -}}
+  {{- $out = "One of the following:\n" -}}
+  {{- range $branch := $oneof -}}
+    {{- $b := partial "returns/render-branch.html" (dict "node" $branch "proto" $proto) -}}
+    {{- $out = printf "%s%s\n" $out $b -}}
+  {{- end -}}
+{{- else -}}
+  {{- $type := $node.type -}}
+  {{- if $type -}}
+    {{- $link := partial "returns/type-link.html" (dict "type" $type "proto" $proto) -}}
+    {{- $summary := $node.summary | default "" -}}
+    {{- $value := index $node "value" -}}
+
+    {{- if eq $type "null" -}}
+      {{- $out = printf "%s.\n" $link -}}
+    {{- else if and (eq $type "simple_string") $value -}}
+      {{- $line := printf "%s: `%s`." $link $value -}}
+      {{- if $summary -}}{{- $line = printf "%s %s" $line $summary -}}{{- end -}}
+      {{- $out = printf "%s\n" $line -}}
+    {{- else -}}
+      {{- /* Default leaf line: link + (optional) summary */ -}}
+      {{- if $summary -}}
+        {{- $out = printf "%s: %s\n" $link $summary -}}
+      {{- else -}}
+        {{- $out = printf "%s.\n" $link -}}
+      {{- end -}}
+
+      {{- /* Container expansion */ -}}
+      {{- if or (eq $type "array") (eq $type "set") -}}
+        {{- with $node.items -}}
+          {{- $sub := partial "returns/render-items.html" (dict "items" . "proto" $proto "indent" "  ") -}}
+          {{- $out = printf "%s%s" $out $sub -}}
+        {{- end -}}
+      {{- else if eq $type "tuple" -}}
+        {{- $sub := partial "returns/render-tuple.html" (dict "node" $node "proto" $proto "indent" "  ") -}}
+        {{- $out = printf "%s%s" $out $sub -}}
+      {{- else if or (eq $type "map") (eq $type "kv_array") -}}
+        {{- with $node.fields -}}
+          {{- $sub := partial "returns/render-fields.html" (dict "fields" . "proto" $proto "indent" "  ") -}}
+          {{- $out = printf "%s%s" $out $sub -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- /* simple_error / bulk_error: append messages list */ -}}
+      {{- if or (eq $type "simple_error") (eq $type "bulk_error") -}}
+        {{- $msgs := index $node "messages" -}}
+        {{- if $msgs -}}
+          {{- $msgList := "" -}}
+          {{- range $i, $m := $msgs -}}
+            {{- $val := "" -}}
+            {{- if (eq (printf "%T" $m) "string") -}}
+              {{- $val = $m -}}
+            {{- else -}}
+              {{- $val = index $m "value" | default "" -}}
+            {{- end -}}
+            {{- if gt $i 0 -}}{{- $msgList = printf "%s; " $msgList -}}{{- end -}}
+            {{- $msgList = printf "%s%s" $msgList $val -}}
+          {{- end -}}
+          {{- $out = printf "%sCases: %s.\n" $out $msgList -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- return $out -}}

--- a/layouts/partials/returns/render-tuple.html
+++ b/layouts/partials/returns/render-tuple.html
@@ -1,0 +1,68 @@
+{{- /* Render a tuple's prefixItems (named positions) and optional `rest`
+       as sub-bullets.
+
+       Input dict:
+         node:    the tuple ReplySpec (with .prefixItems and optional .rest)
+         proto:   "2" or "3"
+         indent:  current indent string
+
+       Returns: markdown lines, indented, with trailing newline.
+*/ -}}
+{{- $node := .node -}}
+{{- $proto := .proto -}}
+{{- $indent := .indent | default "" -}}
+{{- $out := "" -}}
+
+{{- range $i, $item := index $node "prefixItems" -}}
+  {{- $iname := index $item "name" | default (printf "[%d]" $i) -}}
+  {{- $when := index $item "when" -}}
+  {{- $optional := index $item "optional" -}}
+  {{- $iwhen := "" -}}
+  {{- if $when -}}{{- $iwhen = printf " _(when %s)_" $when -}}{{- end -}}
+  {{- $iopt := "" -}}
+  {{- if and $optional (not $when) -}}{{- $iopt = " _(optional)_" -}}{{- end -}}
+
+  {{- $oneof := index $item "oneof" -}}
+  {{- if $oneof -}}
+    {{- $out = printf "%s%s- `%s`%s%s: one of —\n" $out $indent $iname $iwhen $iopt -}}
+    {{- range $branch := $oneof -}}
+      {{- $bmd := partial "returns/render-branch.html" (dict "node" $branch "proto" $proto) -}}
+      {{- /* Add two-space sub-indent to each line of the branch output */ -}}
+      {{- range $line := split $bmd "\n" -}}
+        {{- $out = printf "%s%s  %s\n" $out $indent $line -}}
+      {{- end -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $itype := index $item "type" -}}
+    {{- if $itype -}}
+      {{- $ilink := partial "returns/type-link.html" (dict "type" $itype "proto" $proto) -}}
+      {{- $isum := index $item "summary" | default "" -}}
+      {{- $line := printf "%s- `%s`: %s%s%s" $indent $iname $ilink $iwhen $iopt -}}
+      {{- if $isum -}}{{- $line = printf "%s — %s" $line $isum -}}{{- end -}}
+      {{- $out = printf "%s%s\n" $out $line -}}
+      {{- /* Recurse for nested containers */ -}}
+      {{- if eq $itype "tuple" -}}
+        {{- $sub := partial "returns/render-tuple.html" (dict "node" $item "proto" $proto "indent" (printf "%s  " $indent)) -}}
+        {{- $out = printf "%s%s" $out $sub -}}
+      {{- else if eq $itype "array" -}}
+        {{- with $item.items -}}
+          {{- $sub := partial "returns/render-items.html" (dict "items" . "proto" $proto "indent" (printf "%s  " $indent)) -}}
+          {{- $out = printf "%s%s" $out $sub -}}
+        {{- end -}}
+      {{- else if or (eq $itype "map") (eq $itype "kv_array") -}}
+        {{- with $item.fields -}}
+          {{- $sub := partial "returns/render-fields.html" (dict "fields" . "proto" $proto "indent" (printf "%s  " $indent)) -}}
+          {{- $out = printf "%s%s" $out $sub -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- with index $node "rest" -}}
+  {{- $out = printf "%s%s- Followed by repeating elements:\n" $out $indent -}}
+  {{- $sub := partial "returns/render-items.html" (dict "items" . "proto" $proto "indent" (printf "%s  " $indent)) -}}
+  {{- $out = printf "%s%s" $out $sub -}}
+{{- end -}}
+
+{{- return $out -}}

--- a/layouts/partials/returns/type-link.html
+++ b/layouts/partials/returns/type-link.html
@@ -1,0 +1,60 @@
+{{- /* Render a markdown link to the RESP protocol-spec for a given type tag.
+
+       Input dict:
+         type:   spec type tag (e.g. "bulk_string", "integer", "null", "kv_array")
+         proto:  "2" or "3" — affects the link text for the null type
+                 (RESP2 uses "Nil reply" linking to bulk-strings; RESP3 uses
+                  "Null reply" linking to nulls).
+
+       Returns: markdown link, e.g. `[Bulk string reply](../../develop/reference/protocol-spec#bulk-strings)`.
+*/ -}}
+{{- $type := .type -}}
+{{- $proto := .proto -}}
+{{- $base := "../../develop/reference/protocol-spec" -}}
+
+{{- $text := "" -}}
+{{- $anchor := "" -}}
+
+{{- if eq $type "null" -}}
+  {{- if eq $proto "2" -}}
+    {{- $text = "Nil reply" -}}{{- $anchor = "bulk-strings" -}}
+  {{- else -}}
+    {{- $text = "Null reply" -}}{{- $anchor = "nulls" -}}
+  {{- end -}}
+{{- else if eq $type "simple_string" -}}
+  {{- $text = "Simple string reply" -}}{{- $anchor = "simple-strings" -}}
+{{- else if eq $type "bulk_string" -}}
+  {{- $text = "Bulk string reply" -}}{{- $anchor = "bulk-strings" -}}
+{{- else if eq $type "verbatim_string" -}}
+  {{- $text = "Verbatim string reply" -}}{{- $anchor = "verbatim-strings" -}}
+{{- else if eq $type "integer" -}}
+  {{- $text = "Integer reply" -}}{{- $anchor = "integers" -}}
+{{- else if eq $type "double" -}}
+  {{- $text = "Double reply" -}}{{- $anchor = "doubles" -}}
+{{- else if eq $type "boolean" -}}
+  {{- $text = "Boolean reply" -}}{{- $anchor = "booleans" -}}
+{{- else if eq $type "big_number" -}}
+  {{- $text = "Big number reply" -}}{{- $anchor = "big-numbers" -}}
+{{- else if eq $type "array" -}}
+  {{- $text = "Array reply" -}}{{- $anchor = "arrays" -}}
+{{- else if eq $type "map" -}}
+  {{- $text = "Map reply" -}}{{- $anchor = "maps" -}}
+{{- else if eq $type "set" -}}
+  {{- $text = "Set reply" -}}{{- $anchor = "sets" -}}
+{{- else if eq $type "push" -}}
+  {{- $text = "Push reply" -}}{{- $anchor = "pushes" -}}
+{{- else if eq $type "simple_error" -}}
+  {{- $text = "Simple error reply" -}}{{- $anchor = "simple-errors" -}}
+{{- else if eq $type "bulk_error" -}}
+  {{- $text = "Bulk error reply" -}}{{- $anchor = "bulk-errors" -}}
+{{- else if eq $type "kv_array" -}}
+  {{- /* kv_array is a flat alternating array at the wire level */ -}}
+  {{- $text = "Array reply" -}}{{- $anchor = "arrays" -}}
+{{- else if eq $type "tuple" -}}
+  {{- /* tuple is an array with positional shape at the wire level */ -}}
+  {{- $text = "Array reply" -}}{{- $anchor = "arrays" -}}
+{{- else -}}
+  {{- $text = $type -}}{{- $anchor = "" -}}
+{{- end -}}
+
+{{- return (printf "[%s](%s#%s)" $text $base $anchor) -}}

--- a/layouts/shortcodes/return-info.html
+++ b/layouts/shortcodes/return-info.html
@@ -1,0 +1,78 @@
+{{/*
+  return-info shortcode
+
+  Renders the `## Return information` body for the current command page
+  by reading the pre-rendered prose file from `assets/returns-prose/`
+  and building a generic-tabs widget for the RESP2/RESP3 split.
+
+  The pre-rendered prose file is produced by
+  `tools/render_returns_to_prose.py` from the JSON spec in
+  `data/commands_returns_<module>.json`. The file's body is structured
+  as:
+
+      {{< multitabs id="..."
+          tab1="RESP2"
+          tab2="RESP3" >}}
+      <RESP2 content>
+      -tab-sep-
+      <RESP3 content>
+      {{< /multitabs >}}
+
+      **Examples:**
+      ...
+
+  We can't recursively expand the multitabs shortcode from inside this
+  shortcode (Hugo doesn't run shortcode resolution on dynamically-loaded
+  text). Instead, parse the prose file directly and call the
+  `components/generic-tabs.html` partial that multitabs itself uses.
+
+  Usage in source files:
+      ## Return information
+
+      {{< return-info >}}
+*/}}
+
+{{- $title := .Page.Title -}}
+{{- $slug := .Get "slug" | default ($title | lower | replaceRE " " "-") -}}
+{{- $path := printf "assets/returns-prose/%s.md" $slug -}}
+{{- if not (fileExists $path) -}}
+  <!-- return-info: no prose file at {{ $path }} for `{{ $title }}` -->
+{{- else -}}
+  {{- $body := readFile $path -}}
+
+  {{- /* Extract the RESP2 / RESP3 sections from inside the multitabs block. */ -}}
+  {{- $mtPattern := `(?s)\{\{<\s*multitabs[^>]*>\}\}\s*(.*?)\s*\{\{<\s*/multitabs\s*>\}\}` -}}
+  {{- $mtMatch := findRE $mtPattern $body 1 -}}
+  {{- $afterMt := "" -}}
+  {{- $resp2 := "" -}}
+  {{- $resp3 := "" -}}
+  {{- if $mtMatch -}}
+    {{- $mtBlock := index $mtMatch 0 -}}
+    {{- $inner := replaceRE `\{\{<\s*multitabs[^>]*>\}\}\s*` "" $mtBlock -}}
+    {{- $inner = replaceRE `\s*\{\{<\s*/multitabs\s*>\}\}` "" $inner -}}
+    {{- $parts := split $inner "-tab-sep-" -}}
+    {{- if ge (len $parts) 2 -}}
+      {{- $resp2 = index $parts 0 | strings.TrimSpace -}}
+      {{- $resp3 = index $parts 1 | strings.TrimSpace -}}
+    {{- end -}}
+    {{- /* Anything after the closing tag (Examples section, etc.) */ -}}
+    {{- $afterMt = replaceRE `(?s)^.*?\{\{<\s*/multitabs\s*>\}\}\s*` "" $body -}}
+  {{- end -}}
+
+  {{- /* Build tabs and render */ -}}
+  {{- if and $resp2 $resp3 -}}
+    {{- $tabs := slice
+        (dict "title" "RESP2" "content" ($resp2 | markdownify))
+        (dict "title" "RESP3" "content" ($resp3 | markdownify))
+    -}}
+    {{- partial "components/generic-tabs.html" (dict "id" (printf "%s-return-info" $slug) "tabs" $tabs) -}}
+    {{- if and $afterMt (gt (len (strings.TrimSpace $afterMt)) 0) -}}
+      <div class="returns-examples">
+      {{- $afterMt | strings.TrimSpace | markdownify -}}
+      </div>
+    {{- end -}}
+  {{- else -}}
+    {{- /* Fallback: render the whole file as markdown */ -}}
+    {{- $body | markdownify -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/shortcodes/return-info.html
+++ b/layouts/shortcodes/return-info.html
@@ -2,29 +2,12 @@
   return-info shortcode
 
   Renders the `## Return information` body for the current command page
-  by reading the pre-rendered prose file from `assets/returns-prose/`
-  and building a generic-tabs widget for the RESP2/RESP3 split.
+  by walking the JSON spec in `data/commands_returns_<module>.json`
+  directly and emitting a generic-tabs widget plus an examples section.
 
-  The pre-rendered prose file is produced by
-  `tools/render_returns_to_prose.py` from the JSON spec in
-  `data/commands_returns_<module>.json`. The file's body is structured
-  as:
-
-      {{< multitabs id="..."
-          tab1="RESP2"
-          tab2="RESP3" >}}
-      <RESP2 content>
-      -tab-sep-
-      <RESP3 content>
-      {{< /multitabs >}}
-
-      **Examples:**
-      ...
-
-  We can't recursively expand the multitabs shortcode from inside this
-  shortcode (Hugo doesn't run shortcode resolution on dynamically-loaded
-  text). Instead, parse the prose file directly and call the
-  `components/generic-tabs.html` partial that multitabs itself uses.
+  No intermediate pre-rendered files; the JSON in `data/` is the single
+  source of truth. The same rendering logic powers the .md/.json output
+  paths via `layouts/partials/markdown-return-info.html`.
 
   Usage in source files:
       ## Return information
@@ -32,47 +15,40 @@
       {{< return-info >}}
 */}}
 
-{{- $title := .Page.Title -}}
-{{- $slug := .Get "slug" | default ($title | lower | replaceRE " " "-") -}}
-{{- $path := printf "assets/returns-prose/%s.md" $slug -}}
-{{- if not (fileExists $path) -}}
-  <!-- return-info: no prose file at {{ $path }} for `{{ $title }}` -->
-{{- else -}}
-  {{- $body := readFile $path -}}
+{{- $cmd := .Page.Title -}}
+{{- $entry := partial "returns-data.html" .Page -}}
 
-  {{- /* Extract the RESP2 / RESP3 sections from inside the multitabs block. */ -}}
-  {{- $mtPattern := `(?s)\{\{<\s*multitabs[^>]*>\}\}\s*(.*?)\s*\{\{<\s*/multitabs\s*>\}\}` -}}
-  {{- $mtMatch := findRE $mtPattern $body 1 -}}
-  {{- $afterMt := "" -}}
-  {{- $resp2 := "" -}}
-  {{- $resp3 := "" -}}
-  {{- if $mtMatch -}}
-    {{- $mtBlock := index $mtMatch 0 -}}
-    {{- $inner := replaceRE `\{\{<\s*multitabs[^>]*>\}\}\s*` "" $mtBlock -}}
-    {{- $inner = replaceRE `\s*\{\{<\s*/multitabs\s*>\}\}` "" $inner -}}
-    {{- $parts := split $inner "-tab-sep-" -}}
-    {{- if ge (len $parts) 2 -}}
-      {{- $resp2 = index $parts 0 | strings.TrimSpace -}}
-      {{- $resp3 = index $parts 1 | strings.TrimSpace -}}
-    {{- end -}}
-    {{- /* Anything after the closing tag (Examples section, etc.) */ -}}
-    {{- $afterMt = replaceRE `(?s)^.*?\{\{<\s*/multitabs\s*>\}\}\s*` "" $body -}}
+{{- if not $entry -}}
+  <!-- return-info: no entry for `{{ $cmd }}` in any commands_returns_* data file -->
+{{- else -}}
+  {{- $returns := $entry.returns -}}
+
+  {{- /* Resolve same_as_* for each protocol */ -}}
+  {{- $r2 := index $returns "resp2" -}}
+  {{- $r3 := index $returns "resp3" -}}
+  {{- if eq (printf "%T" $r2) "string" -}}
+    {{- if eq $r2 "same_as_resp3" -}}{{- $r2 = $r3 -}}{{- end -}}
+  {{- end -}}
+  {{- if eq (printf "%T" $r3) "string" -}}
+    {{- if eq $r3 "same_as_resp2" -}}{{- $r3 = (index $returns "resp2") -}}{{- end -}}
   {{- end -}}
 
-  {{- /* Build tabs and render */ -}}
-  {{- if and $resp2 $resp3 -}}
-    {{- $tabs := slice
-        (dict "title" "RESP2" "content" ($resp2 | markdownify))
-        (dict "title" "RESP3" "content" ($resp3 | markdownify))
-    -}}
-    {{- partial "components/generic-tabs.html" (dict "id" (printf "%s-return-info" $slug) "tabs" $tabs) -}}
-    {{- if and $afterMt (gt (len (strings.TrimSpace $afterMt)) 0) -}}
+  {{- $r2md := partial "returns/render-spec.html" (dict "node" $r2 "proto" "2") -}}
+  {{- $r3md := partial "returns/render-spec.html" (dict "node" $r3 "proto" "3") -}}
+
+  {{- $slug := $cmd | lower | replaceRE "[. ]" "-" -}}
+  {{- $tabs := slice
+      (dict "title" "RESP2" "content" ($r2md | markdownify))
+      (dict "title" "RESP3" "content" ($r3md | markdownify))
+  -}}
+  {{- partial "components/generic-tabs.html" (dict "id" (printf "%s-return-info" $slug) "tabs" $tabs) -}}
+
+  {{- with index $returns "examples" -}}
+    {{- $exmd := partial "returns/render-examples.html" (dict "examples" . "cmd" $cmd) -}}
+    {{- if $exmd -}}
       <div class="returns-examples">
-      {{- $afterMt | strings.TrimSpace | markdownify -}}
+      {{- $exmd | markdownify -}}
       </div>
     {{- end -}}
-  {{- else -}}
-    {{- /* Fallback: render the whole file as markdown */ -}}
-    {{- $body | markdownify -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/shortcodes/return-info.html
+++ b/layouts/shortcodes/return-info.html
@@ -36,19 +36,19 @@
   {{- $r2md := partial "returns/render-spec.html" (dict "node" $r2 "proto" "2") -}}
   {{- $r3md := partial "returns/render-spec.html" (dict "node" $r3 "proto" "3") -}}
 
+  {{- /* Per-protocol examples — each tab gets its own. */ -}}
+  {{- $examples := index $returns "examples" -}}
+  {{- if $examples -}}
+    {{- $r2ex := partial "returns/render-examples.html" (dict "examples" $examples "cmd" $cmd "proto" "2") -}}
+    {{- $r3ex := partial "returns/render-examples.html" (dict "examples" $examples "cmd" $cmd "proto" "3") -}}
+    {{- if $r2ex -}}{{- $r2md = printf "%s\n\n%s" $r2md $r2ex -}}{{- end -}}
+    {{- if $r3ex -}}{{- $r3md = printf "%s\n\n%s" $r3md $r3ex -}}{{- end -}}
+  {{- end -}}
+
   {{- $slug := $cmd | lower | replaceRE "[. ]" "-" -}}
   {{- $tabs := slice
       (dict "title" "RESP2" "content" ($r2md | markdownify))
       (dict "title" "RESP3" "content" ($r3md | markdownify))
   -}}
   {{- partial "components/generic-tabs.html" (dict "id" (printf "%s-return-info" $slug) "tabs" $tabs) -}}
-
-  {{- with index $returns "examples" -}}
-    {{- $exmd := partial "returns/render-examples.html" (dict "examples" . "cmd" $cmd) -}}
-    {{- if $exmd -}}
-      <div class="returns-examples">
-      {{- $exmd | markdownify -}}
-      </div>
-    {{- end -}}
-  {{- end -}}
 {{- end -}}

--- a/tools/corpus_returns_extracted.json
+++ b/tools/corpus_returns_extracted.json
@@ -1,0 +1,10010 @@
+{
+  "_meta": {
+    "command_count": 560,
+    "extracted_count": 530,
+    "tier_distribution": {
+      "auto": 390,
+      "stub": 140,
+      "missing": 30
+    }
+  },
+  "ACL CAT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "An array of elements representing ACL categories or commands in a given category."
+          },
+          {
+            "type": "simple_error",
+            "summary": "The command returns an error if an invalid category name is given."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ACL DELUSER": {
+    "returns": {
+      "summary": "The number of users that were deleted. This number will not always match the number of arguments since certain users may not exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of users that were deleted. This number will not always match the number of arguments since certain users may not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ACL DRYRUN": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` on success."
+          },
+          {
+            "type": "bulk_string",
+            "summary": "An error describing why the user can't execute the command."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ACL GENPASS": {
+    "returns": {
+      "summary": "Pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "Pseudorandom data. By default it contains 64 bytes, representing 256 bits of data. If `bits` was given, the output string length is the number of specified bits (rounded to the next multiple of 4) divided by 4."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ACL GETUSER": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "A list of ACL rule definitions for the user."
+          },
+          {
+            "type": "null",
+            "when": "user does not exist"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "A set of ACL rule definitions for the user."
+          },
+          {
+            "type": "null",
+            "when": "user does not exist"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "ACL HELP": {
+    "returns": {
+      "summary": "A list of subcommands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of subcommands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ACL LIST": {
+    "returns": {
+      "summary": "An array of elements.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array of elements.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ACL LOAD": {
+    "returns": {
+      "summary": "`OK` on success. The command may fail with an error for several reasons: if the file is not readable, if there is an error inside the file, and in such cases, the error will be reported to the user in the error. Finally, the command will fail if the server is not configured to use an external ACL file.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` on success. The command may fail with an error for several reasons: if the file is not readable, if there is an error inside the file, and in such cases, the error will be reported to the user in the error. Finally, the command will fail if the server is not configured to use an external ACL file.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ACL LOG": {
+    "returns": {
+      "summary": "When called to show security events: * : an array of elements representing ACL security events. When called with `RESET`: * : `OK` if the security log was cleared.",
+      "resp2": {
+        "type": "array",
+        "summary": "When called to show security events: * : an array of elements representing ACL security events. When called with `RESET`: * : `OK` if the security log was cleared.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ACL SAVE": {
+    "returns": {
+      "summary": "`OK`. The command may fail with an error for several reasons: if the file cannot be written or if the server is not configured to use an external ACL file.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`. The command may fail with an error for several reasons: if the file cannot be written or if the server is not configured to use an external ACL file.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ACL SETUSER": {
+    "returns": {
+      "summary": "`OK`. If the rules contain errors, the error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`. If the rules contain errors, the error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ACL USERS": {
+    "returns": {
+      "summary": "List of existing ACL users.",
+      "resp2": {
+        "type": "array",
+        "summary": "List of existing ACL users.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ACL WHOAMI": {
+    "returns": {
+      "summary": "The username of the current connection.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The username of the current connection."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "APPEND": {
+    "returns": {
+      "summary": "The length of the string after the append operation.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the string after the append operation."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARCOUNT": {
+    "returns": {
+      "summary": "The number of non-empty elements, or 0 if key does not exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of non-empty elements, or 0 if key does not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARDEL": {
+    "returns": {
+      "summary": "Number of elements deleted.",
+      "resp2": {
+        "type": "integer",
+        "summary": "Number of elements deleted."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARDELRANGE": {
+    "returns": {
+      "summary": "Number of elements deleted.",
+      "resp2": {
+        "type": "integer",
+        "summary": "Number of elements deleted."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARGET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The value at the given index."
+          },
+          {
+            "type": "null",
+            "when": "key or index does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARGETRANGE": {
+    "returns": {
+      "resp2": {
+        "type": "array",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ARGREP": {
+    "returns": {
+      "summary": "Indices of the matching elements, in the same order in which the range is traversed (ascending when `start <= end`, descending when `start > end`). When `WITHVALUES` is given, a flat array of alternating index-value pairs: `[idx1, val1, idx2, val2, ...]`. An empty array is returned when the key does not exist or no element matches.",
+      "resp2": {
+        "type": "array",
+        "summary": "Indices of the matching elements, in the same order in which the range is traversed (ascending when `start <= end`, descending when `start > end`). When `WITHVALUES` is given, a flat array of alternating index-value pairs: `[idx1, val1, idx2, val2, ...]`. An empty array is returned when the key does not exist or no element matches.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ARINFO": {
+    "returns": {
+      "resp2": {
+        "type": "array",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "ARINSERT": {
+    "returns": {
+      "summary": "The last index where a value was inserted.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The last index where a value was inserted."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARLASTITEMS": {
+    "returns": {
+      "resp2": {
+        "type": "array",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ARLEN": {
+    "returns": {
+      "summary": "The length of the array (max index + 1), or 0 if key does not exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the array (max index + 1), or 0 if key does not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARMGET": {
+    "returns": {
+      "resp2": {
+        "type": "array",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ARMSET": {
+    "returns": {
+      "summary": "Number of new slots that were set (previously empty).",
+      "resp2": {
+        "type": "integer",
+        "summary": "Number of new slots that were set (previously empty)."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARNEXT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The next index ARINSERT would use. Returns 0 for missing keys or when no insert happened yet.",
+            "when": "no insert happened yet"
+          },
+          {
+            "type": "null",
+            "when": "the insertion cursor is exhausted (next insert would overflow)"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "AROP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "Result of the operation."
+          },
+          {
+            "type": "integer",
+            "summary": "Integer result for MATCH, USED, AND, OR, XOR."
+          },
+          {
+            "type": "null",
+            "when": "no elements match the operation"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARRING": {
+    "returns": {
+      "summary": "The last index where a value was inserted.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The last index where a value was inserted."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARSCAN": {
+    "returns": {
+      "summary": "Flat array of index-value pairs: [idx1, val1, idx2, val2, ...].",
+      "resp2": {
+        "type": "array",
+        "summary": "Flat array of index-value pairs: [idx1, val1, idx2, val2, ...].",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ARSEEK": {
+    "returns": {
+      "summary": "1 if the cursor was set, 0 if the key does not exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "1 if the cursor was set, 0 if the key does not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ARSET": {
+    "returns": {
+      "summary": "Number of new slots that were set (previously empty).",
+      "resp2": {
+        "type": "integer",
+        "summary": "Number of new slots that were set (previously empty)."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ASKING": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "AUTH": {
+    "returns": {
+      "summary": "`OK`, or an error if the password, or username/password pair, is invalid.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`, or an error if the password, or username/password pair, is invalid.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BF.ADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` for successfully adding an item, or `0` if there's a probability that the item was already added to the filter.",
+            "when": "there's a probability that the item was already added to the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "`true` for successfully adding an item, or `false` if there's a probability that the item was already added to the filter.",
+            "when": "there's a probability that the item was already added to the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "BF.CARD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The number of items detected as unique that were added to the Bloom filter (items that caused at least one bit to be set in at least one sub-filter), or `0` when the given `key` does not exist.",
+            "when": "the given `key` does not exist"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full.\n\nNote: when `key` exists"
+              },
+              {
+                "value": "`BF.CARD` returns the same value as `BF.INFO key ITEMS`"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BF.EXISTS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` means that, with high probability, `item` was already added to the filter, and `0` means that either the `key` does not exist or that the `item` had not been added to the filter."
+          },
+          {
+            "type": "simple_error",
+            "summary": "If invalid arguments are passed."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "`true` means that, with high probability, `item` was already added to the filter, and `false` means that either `key` does not exist or that `item` had not been added to the filter."
+          },
+          {
+            "type": "simple_error",
+            "summary": "If invalid arguments are passed or `key` is not of the correct type."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "BF.INFO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "A singleton with an representing the value of the requested property."
+          },
+          {
+            "type": "array",
+            "summary": "An with and pairs."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the key does not exist"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "With and pairs."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the key does not exist"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "BF.INSERT": {
+    "returns": {
+      "summary": "One of the following: where each element is one of these options: * , where each element is one of the following options: * `1` for successfully adding an item, or `0` if there's a probability that the item was already added to the filter. * when the item cannot be added because the filter is full. * when the number of arguments or key type is wrong, and also when `NOCREATE` is specified and `key` does not exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "One of the following: where each element is one of these options: * , where each element is one of the following options: * `1` for successfully adding an item, or `0` if there's a probability that the item was already added to the filter. * when the item cannot be added because the filter is full. * when the number of arguments or key type is wrong, and also when `NOCREATE` is specified and `key` does not exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "One of the following: where each element is one of these options: * , where each element is one of the following options: * `true` for successfully adding an item, or `false` if there's a probability that the item was already added to the filter. * when the item cannot be added because the filter is full. * when the number of arguments or key type is wrong, and also when `NOCREATE` is specified and `key` does not exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "BF.LOADCHUNK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when invalid data was passed"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BF.MADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Where each element is either * an , where `1` means that the item has been added successfully, and `0` means there's a probability that the item was already added to the filter. * a when the item cannot be added because the filter is full.",
+            "when": "the item cannot be added because the filter is full"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "key not found"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Where each element is either * a , where `true` means that the item has been added successfully, and `false` means there's a probability that the item was already added to the filter. * a when the item cannot be added because the filter is full.",
+            "when": "the item cannot be added because the filter is full"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "key not found"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "BF.MEXISTS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of , where `1` means that, with high probability, `item` was already added to the filter, and `0` means that `key` does not exist or that `item` was definitely not added to the filter."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "in these cases: invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the key was not found"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of , where `true` means that, with high probability, `item` was already added to the filter, and `false` means that `key` does not exist or that `item` was definitely not added to the filter."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "in these cases: invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the key was not found"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "BF.RESERVE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if the filter was created successfully.",
+            "when": "the filter was created successfully"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "the key already exists"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BF.SCANDUMP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "A two-element array of an (_Iterator_) and a (_Data_)."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "the key was not found"
+              },
+              {
+                "value": "the key is of the wrong type.\n\nThe Iterator is passed as input to the next invocation of `BF.SCANDUMP`. If _Iterator_ is 0"
+              },
+              {
+                "value": "then it means iteration has completed.\n\nThe iterator-data pair should also be passed to [`BF.LOADCHUNK`](https://redis.io/docs/latest/commands/bf.loadchunk/) when restoring the filter"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BGREWRITEAOF": {
+    "returns": {
+      "summary": "A simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success. The command may reply with an error in certain cases, as documented above.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "A simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success. The command may reply with an error in certain cases, as documented above."
+      },
+      "resp3": {
+        "type": "bulk_string",
+        "summary": "A simple string reply indicating that the rewriting started or is about to start ASAP when the call is executed with success. The command may reply with an error in certain cases, as documented above."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "BGSAVE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "Background saving started",
+            "summary": "`Background saving started`."
+          },
+          {
+            "type": "simple_string",
+            "value": "Background saving scheduled",
+            "summary": "`Background saving scheduled`."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BITCOUNT": {
+    "returns": {
+      "summary": "The number of bits set to 1.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of bits set to 1."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BITFIELD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Each entry being the corresponding result of the sub-command given at the same position."
+          },
+          {
+            "type": "null",
+            "when": "OVERFLOW FAIL was given and overflows or underflows are detected"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BITFIELD_RO": {
+    "returns": {
+      "summary": "Each entry being the corresponding result of the sub-command given at the same position.",
+      "resp2": {
+        "type": "array",
+        "summary": "Each entry being the corresponding result of the sub-command given at the same position.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "BITOP": {
+    "returns": {
+      "summary": "The size of the string stored in the destination key is equal to the size of the longest input string.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The size of the string stored in the destination key is equal to the size of the longest input string."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BITPOS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The position of the first bit set to 1 or 0 according to the request."
+          },
+          {
+            "type": "integer",
+            "summary": "`-1`. In case the `bit` argument is 1 and the string is empty or composed of just zero bytes If we look for set bits (the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned. If we look for clear bits (the bit argument is 0) and the string only contains bits set to 1, the function returns the first bit not part of the string on the right. So if the string is three bytes set to the value `0xff` the command `BITPOS key 0` will return 24, since up to bit 23 all the bits are 1. The function considers the right of the string as padded with zeros if you look for clear bits and specify no range or the _start_ argument **only**. However, this behavior changes if you are looking for clear bits and specify a range with both _start_ and _end_. If a clear bit isn't found in the specified range, the function returns -1 as the user specified a clear range and there are no 0 bits in that range.",
+            "when": "the `bit` argument is 1 and the string is empty or composed of just zero bytes If we look for set bits (the bit argument is 1) and the string is empty or composed of just zero bytes, -1 is returned"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BLMOVE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The element being popped from the _source_ and pushed to the _destination_."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BLMPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "no element could be popped and the _timeout_ is reached"
+          },
+          {
+            "type": "array",
+            "summary": "A two-element array with the first element being the name of the key from which elements were popped, and the second element being an array of the popped elements."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BLPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "array",
+            "summary": "The key from which the element was popped and the value of the popped element."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BRPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "array",
+            "summary": "The key from which the element was popped and the value of the popped element."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BRPOPLPUSH": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The element being popped from _source_ and pushed to _destination_."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BZMPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "no element could be popped"
+          },
+          {
+            "type": "array",
+            "summary": "A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BZPOPMAX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "no element could be popped and the _timeout_ expired"
+          },
+          {
+            "type": "array",
+            "summary": "The keyname, popped member, and its score."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "BZPOPMIN": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "no element could be popped and the _timeout_ expired"
+          },
+          {
+            "type": "array",
+            "summary": "The keyname, popped member, and its score."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CF.ADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` for successfully adding an item to the filter."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "`true` for successfully adding an item to the filter."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CF.ADDNX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` for successfully adding an item to the filter or `0` if the item's fingerprint already exists in the filter.",
+            "when": "the item's fingerprint already exists in the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "`true` for successfully adding an item to the filter or `false` if the item's fingerprint already exists in the filter.",
+            "when": "the item's fingerprint already exists in the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the filter is full"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CF.COUNT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": ", where a positive value is an estimation of the number of times `item` was added to the filter. An overestimation is possible, but not an underestimation. `0` means that `key` does not exist or that `item` had not been added to the filter. See the note in ."
+          },
+          {
+            "type": "bulk_string",
+            "note": "Type could not be detected from prose."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CF.DEL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` for successfully deleting an item, or `0` if no such item was found in the filter.",
+            "when": "no such item was found in the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "`true` for successfully deleting an item, or `false` if no such item was found in the filter.",
+            "when": "no such item was found in the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CF.EXISTS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` means that, with high probability, `item` was already added to the filter, and `0` means that either the `key` does not exist or that the `item` had not been added to the filter."
+          },
+          {
+            "type": "simple_error",
+            "summary": "If invalid arguments are passed."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "`true` means that, with high probability, `item` was already added to the filter, and `false` means that either `key` does not exist or that `item` had not been added to the filter."
+          },
+          {
+            "type": "simple_error",
+            "summary": "If invalid arguments are passed or `key` is not of the correct type."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CF.INFO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "With argument name () and value () pairs."
+          },
+          {
+            "type": "simple_error",
+            "summary": "If invalid arguments are passed, `key` does not exist, or `key` is not of the correct type."
+          }
+        ]
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "* with argument name () and value () pairs. * if invalid arguments are passed, `key` does not exist, or `key` is not of the correct type.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "CF.INSERT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": ", where each element is an : `1` when the item is added successfully, or `-1` when the item cannot be added because the filter is full.",
+            "when": "the item is added successfully, or `-1` when the item cannot be added because the filter is full"
+          },
+          {
+            "type": "simple_error",
+            "summary": "When the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist."
+          }
+        ]
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "* , where each element is either a of `true` for successfully adding an item, or an of `-1` when the item cannot be added because the filter is full. * when the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "CF.INSERTNX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": ", where each element is an : `0` when the item's fingerprint already exists in the filter, `1` when the item is added successfully, or `-1` when the item cannot be added because the filter is full.",
+            "when": "the item's fingerprint already exists in the filter, `1` when the item is added successfully, or `-1` when the item cannot be added because the filter is full"
+          },
+          {
+            "type": "simple_error",
+            "summary": "When the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist."
+          }
+        ]
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "* , where each element is an : `0` means that the item's fingerprint already exists in the filter, `1` for successfully adding an item, or `-1` when the item cannot be added because the filter is full. * when the number of arguments or key type is incorrect, and also when `NOCREATE` is specified and `key` does not exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "CF.LOADCHUNK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when invalid data was passed"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CF.MEXISTS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of , where `1` means that, with high probability, `item` was already added to the filter, and `0` means that `key` does not exist or that `item` was definitely not added to the filter. See note in ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "in these cases: invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the key was not found"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of , where `true` means that, with high probability, `item` was already added to the filter, and `false` means that `key` does not exist or that `item` was definitely not added to the filter."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "in these cases: invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when the key was not found"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CF.RESERVE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if the filter was created successfully.",
+            "when": "the filter was created successfully"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "the key already exists"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CF.SCANDUMP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "A two-element array of an (_Iterator_) and a (_Data_)."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "the key was not found"
+              },
+              {
+                "value": "the key is of the wrong type.\n\nThe Iterator is passed as input to the next invocation of `CF.SCANDUMP`. If _Iterator_ is 0"
+              },
+              {
+                "value": "then it means iteration has completed.\n\nThe iterator-data pair should also be passed to [`CF.LOADCHUNK`](https://redis.io/docs/latest/commands/cf.loadchunk/) when restoring the filter"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT CACHING": {
+    "returns": {
+      "summary": "`OK` or an error if the argument is not \"yes\" or \"no\".",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` or an error if the argument is not \"yes\" or \"no\".",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT GETNAME": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The connection name of the current connection."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT GETREDIR": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` when not redirecting notifications to any client.",
+            "when": "not redirecting notifications to any client"
+          },
+          {
+            "type": "integer",
+            "summary": "`-1` if client tracking is not enabled.",
+            "when": "client tracking is not enabled"
+          },
+          {
+            "type": "integer",
+            "summary": "The ID of the client to which notification are being redirected."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT HELP": {
+    "returns": {
+      "summary": "A list of subcommands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of subcommands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CLIENT ID": {
+    "returns": {
+      "summary": "The ID of the client.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The ID of the client."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT INFO": {
+    "returns": {
+      "summary": "A unique string for the current client, as described at the `CLIENT LIST` page.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A unique string for the current client, as described at the `CLIENT LIST` page."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT KILL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` when called in 3 argument format and the connection has been closed.",
+            "when": "called in 3 argument format and the connection has been closed"
+          },
+          {
+            "type": "integer",
+            "summary": "When called in filter/value format, the number of clients killed.",
+            "when": "called in filter/value format, the number of clients killed"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT LIST": {
+    "returns": {
+      "summary": "Information and statistics about client connections.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "Information and statistics about client connections."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT NO EVICT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if the command was successful.",
+            "when": "the command was successful"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "wrong number of"
+              },
+              {
+                "value": "invalid arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT NO TOUCH": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if the command was successful.",
+            "when": "the command was successful"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "wrong number of"
+              },
+              {
+                "value": "invalid arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT PAUSE": {
+    "returns": {
+      "summary": "`OK` or an error if the timeout is invalid.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` or an error if the timeout is invalid.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT REPLY": {
+    "returns": {
+      "summary": "`OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` when called with `ON`. When called with either `OFF` or `SKIP` sub-commands, no reply is made.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT SETINFO": {
+    "returns": {
+      "summary": "`OK` if the attribute name was successfully set.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the attribute name was successfully set.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT SETNAME": {
+    "returns": {
+      "summary": "`OK` if the connection name was successfully set.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the connection name was successfully set.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT TRACKING": {
+    "returns": {
+      "summary": "`OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the connection was successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT TRACKINGINFO": {
+    "returns": {
+      "summary": "A list of tracking information sections and their respective values.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of tracking information sections and their respective values.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "A list of tracking information sections and their respective values.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "CLIENT UNBLOCK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` if the client was unblocked successfully.",
+            "when": "the client was unblocked successfully"
+          },
+          {
+            "type": "integer",
+            "summary": "`0` if the client wasn't unblocked.",
+            "when": "the client wasn't unblocked"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLIENT UNPAUSE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER ADDSLOTS": {
+    "returns": {
+      "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER ADDSLOTSRANGE": {
+    "returns": {
+      "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER BUMPEPOCH": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "`BUMPED` if the epoch was incremented.",
+            "when": "the epoch was incremented"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "`STILL` if the node already has the greatest configured epoch in the cluster.",
+            "when": "the node already has the greatest configured epoch in the cluster"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER COUNTKEYSINSLOT": {
+    "returns": {
+      "summary": "The number of keys in the specified hash slot, or an error if the hash slot is invalid.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of keys in the specified hash slot, or an error if the hash slot is invalid."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER DELSLOTS": {
+    "returns": {
+      "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER DELSLOTSRANGE": {
+    "returns": {
+      "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER FAILOVER": {
+    "returns": {
+      "summary": "`OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was accepted and a manual failover is going to be attempted. An error if the operation cannot be executed, for example if the client is connected to a node that is already a master.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER FLUSHSLOTS": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER FORGET": {
+    "returns": {
+      "summary": "`OK` if the command was executed successfully. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was executed successfully. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER GETKEYSINSLOT": {
+    "returns": {
+      "summary": "An array with up to count elements.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array with up to count elements.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CLUSTER HELP": {
+    "returns": {
+      "summary": "A list of subcommands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of subcommands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CLUSTER INFO": {
+    "returns": {
+      "summary": "A map between named fields and values in the form of `<field>:<value>` lines separated by newlines composed by the two bytes `CRLF`.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A map between named fields and values in the form of `<field>:<value>` lines separated by newlines composed by the two bytes `CRLF`."
+      },
+      "resp3": {
+        "type": "bulk_string",
+        "summary": "A map between named fields and values in the form of <field>:<value> lines separated by newlines composed by the two bytes CRLF."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER KEYSLOT": {
+    "returns": {
+      "summary": "The hash slot number for the specified key.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The hash slot number for the specified key."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER LINKS": {
+    "returns": {
+      "summary": "An array of maps where each map contains various attributes and their values of a cluster link.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array of maps where each map contains various attributes and their values of a cluster link.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "An array of where each map contains various attributes and their values of a cluster link.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "CLUSTER MEET": {
+    "returns": {
+      "summary": "`OK` if the command was successful. If the address or port specified are invalid an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. If the address or port specified are invalid an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER MIGRATION": {
+    "returns": {
+      "summary": "For the `IMPORT` subcommand: : task ID on success, or error message on failure. For the `CANCEL` subcommand: : number of cancelled tasks. For the `STATUS` subcommand: : a list of migration task details. Each task is represented as an array containing field-value pairs: - `id`: Task identifier - `slots`: Slot range being imported or migrated - `source`: Source node ID - `dest`: Destination node ID - `operation`: Operation type (\"import\" or \"migrate\") - `state`: Current state (\"completed\", \"in_progress\", etc.) - `last_error`: Last error message (empty if none) - `retries`: Number of retry attempts - `create_time`: Task creation timestamp - `start_time`: Task start timestamp - `end_time`: Task completion timestamp (if completed) - `write_pause_ms`: Write pause duration in milliseconds.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "For the `IMPORT` subcommand: : task ID on success, or error message on failure. For the `CANCEL` subcommand: : number of cancelled tasks. For the `STATUS` subcommand: : a list of migration task details. Each task is represented as an array containing field-value pairs: - `id`: Task identifier - `slots`: Slot range being imported or migrated - `source`: Source node ID - `dest`: Destination node ID - `operation`: Operation type (\"import\" or \"migrate\") - `state`: Current state (\"completed\", \"in_progress\", etc.) - `last_error`: Last error message (empty if none) - `retries`: Number of retry attempts - `create_time`: Task creation timestamp - `start_time`: Task start timestamp - `end_time`: Task completion timestamp (if completed) - `write_pause_ms`: Write pause duration in milliseconds."
+      },
+      "resp3": {
+        "type": "bulk_string",
+        "summary": "For the `IMPORT` subcommand: : task ID on success, or error message on failure. For the `CANCEL` subcommand: : number of cancelled tasks. For the `STATUS` subcommand: : a list of migration task details. Each task is represented as an array containing field-value pairs: - `id`: Task identifier - `slots`: Slot range being migrated - `source`: Source node ID - `dest`: Destination node ID - `operation`: Operation type (typically \"migrate\") - `state`: Current state (\"completed\", \"in_progress\", etc.) - `last_error`: Last error message (empty if none) - `retries`: Number of retry attempts - `create_time`: Task creation timestamp - `start_time`: Task start timestamp - `end_time`: Task completion timestamp (if completed) - `write_pause_ms`: Write pause duration in milliseconds."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER MYID": {
+    "returns": {
+      "summary": "The node ID.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The node ID."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER MYSHARDID": {
+    "returns": {
+      "summary": "The node's shard ID.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The node's shard ID."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER NODES": {
+    "returns": {
+      "summary": "The serialized cluster configuration.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The serialized cluster configuration."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER REPLICAS": {
+    "returns": {
+      "summary": "A list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CLUSTER REPLICATE": {
+    "returns": {
+      "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER RESET": {
+    "returns": {
+      "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER SAVECONFIG": {
+    "returns": {
+      "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was successful. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER SETSLOT": {
+    "returns": {
+      "summary": "All the sub-commands return `OK` if the command was successful. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "All the sub-commands return `OK` if the command was successful. Otherwise an error is returned."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER SHARDS": {
+    "returns": {
+      "summary": "A nested list of a map of hash ranges and shard nodes describing individual shards.",
+      "resp2": {
+        "type": "array",
+        "summary": "A nested list of a map of hash ranges and shard nodes describing individual shards.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "A nested list of of hash ranges and shard nodes describing individual shards.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "CLUSTER SLAVES": {
+    "returns": {
+      "summary": "A list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of replica nodes replicating from the specified master node provided in the same format used by `CLUSTER NODES`.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CLUSTER SLOT STATS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "A nested list of slot usage statistics."
+          },
+          {
+            "type": "bulk_string",
+            "note": "Type could not be detected from prose."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CLUSTER SLOTS": {
+    "returns": {
+      "summary": "Nested list of slot ranges with networking information.",
+      "resp2": {
+        "type": "array",
+        "summary": "Nested list of slot ranges with networking information.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CMS.INCRBY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of representing updated min-counts of each of the provided items in the sketch."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "missing key"
+              },
+              {
+                "value": "overflow"
+              },
+              {
+                "value": "wrong key type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CMS.INFO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of and pairs containing sketch information."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "missing key"
+              },
+              {
+                "value": "wrong key type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "Of and pairs containing sketch information."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "missing key"
+              },
+              {
+                "value": "wrong key type"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "CMS.INITBYDIM": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If the given key already exists."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CMS.INITBYPROB": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If the given key already exists."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CMS.MERGE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "non-existent key"
+              },
+              {
+                "value": "destination key is not of the same width and/"
+              },
+              {
+                "value": "depth"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CMS.QUERY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of representing the min-counts of each of the provided items in the sketch."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "missing key"
+              },
+              {
+                "value": "wrong key type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "COMMAND": {
+    "returns": {
+      "summary": "A nested list of command details. The order of the commands in the array is random.",
+      "resp2": {
+        "type": "array",
+        "summary": "A nested list of command details. The order of the commands in the array is random.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "COMMAND COUNT": {
+    "returns": {
+      "summary": "The number of commands returned by `COMMAND`.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of commands returned by `COMMAND`."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "COMMAND DOCS": {
+    "returns": {
+      "summary": "A map, as a flattened array, where each key is a command name, and each value is the documentary information.",
+      "resp2": {
+        "type": "array",
+        "summary": "A map, as a flattened array, where each key is a command name, and each value is the documentary information.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "A map where each key is a command name, and each value is the documentary information.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "COMMAND GETKEYS": {
+    "returns": {
+      "summary": "List of keys from the given command.",
+      "resp2": {
+        "type": "array",
+        "summary": "List of keys from the given command.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "A list of keys from the given command.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "COMMAND GETKEYSANDFLAGS": {
+    "returns": {
+      "summary": "A list of keys from the given command and their usage flags.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of keys from the given command and their usage flags.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "COMMAND HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "COMMAND INFO": {
+    "returns": {
+      "summary": "A nested list of command details.",
+      "resp2": {
+        "type": "array",
+        "summary": "A nested list of command details.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "COMMAND LIST": {
+    "returns": {
+      "summary": "A list of command names.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of command names.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CONFIG GET": {
+    "returns": {
+      "summary": "A list of configuration parameters matching the provided arguments.",
+      "resp2": {
+        "type": "kv_array",
+        "summary": "A list of configuration parameters matching the provided arguments.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "A list of configuration parameters matching the provided arguments.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "CONFIG HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "CONFIG RESETSTAT": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CONFIG REWRITE": {
+    "returns": {
+      "summary": "`OK` when the configuration was rewritten properly. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` when the configuration was rewritten properly. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "CONFIG SET": {
+    "returns": {
+      "summary": "`OK` when the configuration was set properly. Otherwise an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` when the configuration was set properly. Otherwise an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "COPY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` if _source_ was copied.",
+            "when": "_source_ was copied"
+          },
+          {
+            "type": "integer",
+            "summary": "`0` if _source_ was not copied.",
+            "when": "_source_ was not copied"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DBSIZE": {
+    "returns": {
+      "summary": "The number of keys in the currently-selected database.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of keys in the currently-selected database."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DECR": {
+    "returns": {
+      "summary": "The value of the key after decrementing it.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The value of the key after decrementing it."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DECRBY": {
+    "returns": {
+      "summary": "The value of the key after decrementing it.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The value of the key after decrementing it."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DEL": {
+    "returns": {
+      "summary": "The number of keys that were removed.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of keys that were removed."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DELEX": {
+    "returns": {
+      "summary": "One of the following: - : 0 if not deleted (the key does not exist or a specified `IFEQ/IFNE/IFDEQ/IFDNE` condition is false), or 1 if deleted. - if the key exists but holds a value that is not a string and one of `IFEQ, IFNE, IFDEQ,` or `IFDNE` is specified.",
+      "resp2": {
+        "type": "integer",
+        "summary": "One of the following: - : 0 if not deleted (the key does not exist or a specified `IFEQ/IFNE/IFDEQ/IFDNE` condition is false), or 1 if deleted. - if the key exists but holds a value that is not a string and one of `IFEQ, IFNE, IFDEQ,` or `IFDNE` is specified."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DIGEST": {
+    "returns": {
+      "summary": "One of the following: - if the key does not exist. - if the key exists but holds a value which is not a string. - the hash digest of the value stored in the key as a hexadecimal string.",
+      "resp2": {
+        "type": "null",
+        "summary": "One of the following: - if the key does not exist. - if the key exists but holds a value which is not a string. - the hash digest of the value stored in the key as a hexadecimal string."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DISCARD": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "DUMP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The serialized value of the key."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ECHO": {
+    "returns": {
+      "summary": "The given string.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The given string."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "EVAL": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "EVAL_RO": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "EVALSHA": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "EVALSHA_RO": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "EXEC": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Each element being the reply to each of the commands in the atomic transaction."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "EXISTS": {
+    "returns": {
+      "summary": "The number of keys that exist from those specified as arguments.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of keys that exist from those specified as arguments."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "EXPIRE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+            "when": "the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the timeout was set.",
+            "when": "the timeout was set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "EXPIREAT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments.",
+            "when": "the timeout was not set; for example, the key doesn't exist, or the operation was skipped because of the provided arguments"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the timeout was set.",
+            "when": "the timeout was set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "EXPIRETIME": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The expiration Unix timestamp in seconds."
+          },
+          {
+            "type": "integer",
+            "summary": "`-1` if the key exists but has no associated expiration time.",
+            "when": "the key exists but has no associated expiration time"
+          },
+          {
+            "type": "integer",
+            "summary": "`-2` if the key does not exist.",
+            "when": "the key does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FAILOVER": {
+    "returns": {
+      "summary": "`OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the command was accepted and a coordinated failover is in progress. An error if the operation cannot be executed.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FCALL": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "FCALL_RO": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "FLUSHALL": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FLUSHDB": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT._LIST": {
+    "returns": {
+      "summary": "Of index names as .",
+      "resp2": {
+        "type": "array",
+        "summary": "Of index names as .",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "set",
+        "summary": "Of index names as ."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "FT.AGGREGATE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Where each row is an array reply representing a single aggregate result. The at position `1` does not represent a valid value."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existent index"
+              },
+              {
+                "value": "invalid query syntax"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "fields": [
+              {
+                "name": "attributes",
+                "type": "array",
+                "summary": "Attribute names.",
+                "items": {
+                  "type": "bulk_string"
+                },
+                "note": "Items inferred as bulk_string; verify."
+              },
+              {
+                "name": "format",
+                "type": "simple_string",
+                "summary": "Result format."
+              },
+              {
+                "name": "results",
+                "type": "array",
+                "summary": "Aggregated data.",
+                "items": {
+                  "type": "map",
+                  "key_type": "bulk_string",
+                  "value_type": {
+                    "type": "bulk_string"
+                  },
+                  "note": "Field set within nested maps not enumerated; verify."
+                }
+              },
+              {
+                "name": "total_results",
+                "type": "integer",
+                "summary": "Total number of results."
+              },
+              {
+                "name": "warning",
+                "type": "array",
+                "summary": "Warning messages.",
+                "items": {
+                  "type": "bulk_string"
+                },
+                "note": "Items inferred as bulk_string; verify."
+              }
+            ]
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existent index"
+              },
+              {
+                "value": "invalid query syntax"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.ALIASADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "alias already exists"
+              },
+              {
+                "value": "index does not exist"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.ALIASDEL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "alias does not exist"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.ALIASUPDATE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "index does not exist"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.ALTER": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "invalid schema syntax"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.CONFIG-GET": {
+    "returns": {
+      "summary": "Of , where each sub-array contains a configuration option name and its value.",
+      "resp2": {
+        "type": "array",
+        "summary": "Of , where each sub-array contains a configuration option name and its value.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "Where keys are configuration option names and values are their corresponding values.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "FT.CONFIG-HELP": {
+    "returns": {
+      "summary": "Of help information.",
+      "resp2": {
+        "type": "array",
+        "summary": "Of help information.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "FT.CONFIG-SET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid option"
+              },
+              {
+                "value": "invalid value"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.CREATE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "index already exists"
+              },
+              {
+                "value": "invalid schema syntax"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.CURSOR-DEL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "cursor does not exist"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.CURSOR-READ": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "With search results and metadata."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "cursor not found"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "With structured search results and metadata."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "cursor not found"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.DICTADD": {
+    "returns": {
+      "summary": "The number of new terms added to the dictionary.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of new terms added to the dictionary."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.DICTDEL": {
+    "returns": {
+      "summary": "The number of terms deleted from the dictionary.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of terms deleted from the dictionary."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.DICTDUMP": {
+    "returns": {
+      "summary": "Of dictionary terms.",
+      "resp2": {
+        "type": "array",
+        "summary": "Of dictionary terms.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "set",
+        "summary": "Of dictionary terms."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "FT.DROPINDEX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.EXPLAIN": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "Containing the query execution plan."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.EXPLAINCLI": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of containing the query execution plan in CLI format."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.HYBRID": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "With the first element being the total number of results, followed by document IDs and their field-value pairs as ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "fields": [
+              {
+                "name": "total_results",
+                "type": "integer",
+                "summary": "Total number of results."
+              },
+              {
+                "name": "execution_time",
+                "type": "double",
+                "summary": "Hybrid query execution time."
+              },
+              {
+                "name": "warnings",
+                "type": "array",
+                "summary": "Warning messages indicating partial results due to index errors or `MAXPREFIXEXPANSIONS`, out-of-memory conditions, and `TIMEOUT` reached.",
+                "items": {
+                  "type": "bulk_string"
+                },
+                "note": "Items inferred as bulk_string; verify."
+              },
+              {
+                "name": "results",
+                "type": "array",
+                "summary": "Document information.",
+                "items": {
+                  "type": "map",
+                  "key_type": "bulk_string",
+                  "value_type": {
+                    "type": "bulk_string"
+                  },
+                  "note": "Field set within nested maps not enumerated; verify."
+                }
+              }
+            ]
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.INFO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of key-value pairs containing index information and statistics."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "Containing index information and statistics as key-value pairs."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.PROFILE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "With two elements: search results and profiling information."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "With two keys: `Results` containing search results and `Profile` containing profiling information."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.SEARCH": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "With the first element being the total number of results, followed by document IDs and their field-value pairs as ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "fields": [
+              {
+                "name": "total_results",
+                "type": "integer",
+                "summary": "Total number of results."
+              },
+              {
+                "name": "results",
+                "type": "array",
+                "summary": "Document information.",
+                "items": {
+                  "type": "map",
+                  "key_type": "bulk_string",
+                  "value_type": {
+                    "type": "bulk_string"
+                  },
+                  "note": "Field set within nested maps not enumerated; verify."
+                }
+              },
+              {
+                "name": "attributes",
+                "type": "array",
+                "summary": "Attribute names.",
+                "items": {
+                  "type": "bulk_string"
+                },
+                "note": "Items inferred as bulk_string; verify."
+              },
+              {
+                "name": "format",
+                "type": "simple_string",
+                "summary": "Result format."
+              },
+              {
+                "name": "warning",
+                "type": "array",
+                "summary": "Warning messages.",
+                "items": {
+                  "type": "bulk_string"
+                },
+                "note": "Items inferred as bulk_string; verify."
+              }
+            ]
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "syntax error in query"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.SPELLCHECK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of spell check results for each term."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "With a `results` key containing spell check results for each term."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.SUGADD": {
+    "returns": {
+      "summary": "Number of elements added to the suggestion dictionary.",
+      "resp2": {
+        "type": "integer",
+        "summary": "Number of elements added to the suggestion dictionary."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.SUGDEL": {
+    "returns": {
+      "summary": "1 if the suggestion was deleted, 0 if it was not found.",
+      "resp2": {
+        "type": "integer",
+        "summary": "1 if the suggestion was deleted, 0 if it was not found."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.SUGGET": {
+    "returns": {
+      "summary": "Of the top suggestions matching the prefix, optionally with a score after each entry.",
+      "resp2": {
+        "type": "array",
+        "summary": "Of the top suggestions matching the prefix, optionally with a score after each entry.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "FT.SUGLEN": {
+    "returns": {
+      "summary": "Number of suggestions in the dictionary.",
+      "resp2": {
+        "type": "integer",
+        "summary": "Number of suggestions in the dictionary."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.SYNDUMP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of synonym terms and their associated synonym groups."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "Where keys are synonym terms and values are arrays of their associated synonym groups."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FT.SYNUPDATE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FT.TAGVALS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of distinct tag values as ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "not a tag field"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "set",
+            "summary": "Of distinct tag values as ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "no such index"
+              },
+              {
+                "value": "not a tag field"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "FUNCTION DELETE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FUNCTION DUMP": {
+    "returns": {
+      "summary": "The serialized payload.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The serialized payload."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FUNCTION FLUSH": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FUNCTION HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "FUNCTION KILL": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FUNCTION LIST": {
+    "returns": {
+      "summary": "Information about functions and libraries.",
+      "resp2": {
+        "type": "array",
+        "summary": "Information about functions and libraries.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "FUNCTION LOAD": {
+    "returns": {
+      "summary": "The library name that was loaded.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The library name that was loaded."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FUNCTION RESTORE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "FUNCTION STATS": {
+    "returns": {
+      "summary": "Information about the function that's currently running and information about the available execution engines.",
+      "resp2": {
+        "type": "array",
+        "summary": "Information about the function that's currently running and information about the available execution engines.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "Information about the function that's currently running and information about the available execution engines.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "GEOADD": {
+    "returns": {
+      "summary": "When used without optional arguments, the number of elements added to the sorted set (excluding score updates). If the CH option is specified, the number of elements that were changed (added or updated).",
+      "resp2": {
+        "type": "integer",
+        "summary": "When used without optional arguments, the number of elements added to the sorted set (excluding score updates). If the CH option is specified, the number of elements that were changed (added or updated)."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GEODIST": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "Distance as a double (represented as a string) in the specified units."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GEOHASH": {
+    "returns": {
+      "summary": "An array where each element is the Geohash corresponding to each member name passed as an argument to the command.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array where each element is the Geohash corresponding to each member name passed as an argument to the command.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "GEOPOS": {
+    "returns": {
+      "summary": "An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as elements of the array.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command. Non-existing elements are reported as elements of the array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "GEORADIUS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "If no `WITH*` option is specified, an of matched member names.",
+            "when": "no `WITH*` option is specified, an [Array reply]("
+          },
+          {
+            "type": "array",
+            "summary": "If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an of arrays, where each sub-array represents a single item: 1. The distance from the center as a floating point number, in the same unit specified in the radius. 1. The Geohash integer. 1. The coordinates as a two items x,y array (longitude,latitude). For example, the command `GEORADIUS Sicily 15 37 200 km WITHCOORD WITHDIST` will return each item in the following way: `[\"Palermo\",\"190.4424\",[\"13.361389338970184\",\"38.115556395496299\"]]`.",
+            "when": "`WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply]("
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GEORADIUS_RO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "If no `WITH*` option is specified, an of matched member names.",
+            "when": "no `WITH*` option is specified, an [Array reply]("
+          },
+          {
+            "type": "array",
+            "summary": "If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an of arrays, where each sub-array represents a single item: * The distance from the center as a floating point number, in the same unit specified in the radius. * The Geohash integer. * The coordinates as a two items x,y array (longitude,latitude).",
+            "when": "`WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply]("
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GEORADIUSBYMEMBER": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "If no `WITH*` option is specified, an of matched member names.",
+            "when": "no `WITH*` option is specified, an [Array reply]("
+          },
+          {
+            "type": "array",
+            "summary": "If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an of arrays, where each sub-array represents a single item: * The distance from the center as a floating point number, in the same unit specified in the radius. * The Geohash integer. * The coordinates as a two items x,y array (longitude,latitude).",
+            "when": "`WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply]("
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GEORADIUSBYMEMBER_RO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "If no `WITH*` option is specified, an of matched member names.",
+            "when": "no `WITH*` option is specified, an [Array reply]("
+          },
+          {
+            "type": "array",
+            "summary": "If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an of arrays, where each sub-array represents a single item: * The distance from the center as a floating point number, in the same unit specified in the radius. * The Geohash integer. * The coordinates as a two items x,y array (longitude,latitude).",
+            "when": "`WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply]("
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GEOSEARCH": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "If no `WITH*` option is specified, an of matched member names.",
+            "when": "no `WITH*` option is specified, an [Array reply]("
+          },
+          {
+            "type": "array",
+            "summary": "If `WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an of arrays, where each sub-array represents a single item: * The distance from the center as a floating point number, in the same unit specified in the radius. * The Geohash integer. * The coordinates as a two items x,y array (longitude,latitude).",
+            "when": "`WITHCOORD`, `WITHDIST`, or `WITHHASH` options are specified, the command returns an [Array reply]("
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GEOSEARCHSTORE": {
+    "returns": {
+      "summary": "The number of elements in the resulting set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements in the resulting set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The value of the key."
+          },
+          {
+            "type": "null",
+            "when": "the key does not exist"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The value of the key."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "GETBIT": {
+    "returns": {
+      "summary": "The bit value stored at _offset_, one of the following: * : `0`. * : `1`.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The bit value stored at _offset_, one of the following: * : `0`. * : `1`."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GETDEL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The value of the key."
+          },
+          {
+            "type": "null",
+            "when": "the key does not exist or if the key's value type is not a string"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GETEX": {
+    "returns": {
+      "summary": "The value of `key` : if `key` does not exist.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The value of `key` : if `key` does not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GETRANGE": {
+    "returns": {
+      "summary": "The substring of the string value stored at key, determined by the offsets start and end (both are inclusive).",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "GETSET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The old value stored at the key."
+          },
+          {
+            "type": "null",
+            "when": "the key does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HDEL": {
+    "returns": {
+      "summary": "The number of fields that were removed from the hash, excluding any specified but non-existing fields.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of fields that were removed from the hash, excluding any specified but non-existing fields."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HELLO": {
+    "returns": {
+      "summary": "A list of server properties. : if the `protover` requested does not exist.",
+      "resp2": {
+        "type": "map",
+        "summary": "A list of server properties. : if the `protover` requested does not exist.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HEXISTS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if the hash does not contain the field, or the key does not exist.",
+            "when": "the hash does not contain the field, or the key does not exist"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the hash contains the field.",
+            "when": "the hash contains the field"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HEXPIRE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": ". For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `0` if the specified NX | XX | GT | LT condition has not been met. - : `1` if the expiration time was set/updated. - : `2` when `HEXPIRE`/`HPEXPIRE` is called with 0 seconds/milliseconds or when `HEXPIREAT`/`HPEXPIREAT` is called with a past Unix time in seconds/milliseconds.",
+            "when": "no such field exists in the provided hash key, or the provided key does not exist"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If parsing failed, mandatory arguments are missing, unknown arguments are specified, or argument values are of the wrong type or out of range. - if the provided key exists but is not a hash."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HEXPIREAT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": ". For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `0` if the specified NX, XX, GT, or LT condition has not been met. - : `1` if the expiration time was set/updated. - : `2` when `HEXPIRE` or `HPEXPIRE` is called with 0 seconds or milliseconds, or when `HEXPIREAT` or `HPEXPIREAT` is called with a past Unix time in seconds or milliseconds.",
+            "when": "no such field exists in the provided hash key, or the provided key does not exist"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If parsing failed, mandatory arguments are missing, unknown arguments are specified, or argument values are of the wrong type or out of range. - if the provided key exists but is not a hash."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HEXPIRETIME": {
+    "returns": {
+      "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the expiration (Unix timestamp) in seconds.",
+      "resp2": {
+        "type": "array",
+        "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the expiration (Unix timestamp) in seconds.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HGET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The value associated with the field."
+          },
+          {
+            "type": "null",
+            "when": "the field is not present in the hash or key does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HGETALL": {
+    "returns": {
+      "summary": "A list of fields and their values, or an empty list when key does not exist.",
+      "resp2": {
+        "type": "kv_array",
+        "summary": "A list of fields and their values, or an empty list when key does not exist.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "A map of fields and their values, or an empty list when key does not exist.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        }
+      }
+    },
+    "returns_status": "auto"
+  },
+  "HGETDEL": {
+    "returns": {
+      "summary": "A list of deleted fields and their values or `nil` for fields that do not exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of deleted fields and their values or `nil` for fields that do not exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HGETEX": {
+    "returns": {
+      "summary": "* : a list of values associated with the given fields, in the same order as they are requested.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : a list of values associated with the given fields, in the same order as they are requested.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Field value."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HINCRBY": {
+    "returns": {
+      "summary": "The value of the field after the increment operation.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The value of the field after the increment operation."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HINCRBYFLOAT": {
+    "returns": {
+      "summary": "The value of the field after the increment operation.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The value of the field after the increment operation."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HKEYS": {
+    "returns": {
+      "summary": "A list of fields in the hash, or an empty list when the key does not exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of fields in the hash, or an empty list when the key does not exist.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Field name."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HLEN": {
+    "returns": {
+      "summary": "The number of fields in the hash, or 0 when the key does not exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of fields in the hash, or 0 when the key does not exist."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "The number of the fields in the hash, or 0 when the key does not exist."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "HMGET": {
+    "returns": {
+      "summary": "A list of values associated with the given fields, in the same order as they are requested.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of values associated with the given fields, in the same order as they are requested.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Field value."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HMSET": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HOTKEYS GET": {
+    "returns": {
+      "summary": "One of the following: - when tracking data is available, containing a single array with alternating field names and values. - when no tracking has been started or data has been reset.",
+      "resp2": {
+        "type": "array",
+        "summary": "One of the following: - when tracking data is available, containing a single array with alternating field names and values. - when no tracking has been started or data has been reset.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "One of the following: - when tracking data is available, containing a single with field names and values. - when no tracking has been started or data has been reset.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "HOTKEYS HELP": {
+    "returns": {
+      "summary": "Returns an with the list of `HOTKEYS` subcommands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "Returns an with the list of `HOTKEYS` subcommands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HOTKEYS RESET": {
+    "returns": {
+      "summary": "One of the following: - : `OK` when resources are successfully released. - : when tracking is currently active.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "One of the following: - : `OK` when resources are successfully released. - : when tracking is currently active.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HOTKEYS START": {
+    "returns": {
+      "summary": "One of the following: - reply: `OK` when tracking is successfully started. - : when invalid parameters are provided.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "One of the following: - reply: `OK` when tracking is successfully started. - : when invalid parameters are provided.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HOTKEYS STOP": {
+    "returns": {
+      "summary": "One of the following: - : `OK` when tracking is successfully stopped. - : when tracking is not currently active.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "One of the following: - : `OK` when tracking is successfully stopped. - : when tracking is not currently active.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HPERSIST": {
+    "returns": {
+      "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : `1` the expiration was removed.",
+      "resp2": {
+        "type": "array",
+        "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : `1` the expiration was removed.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HPEXPIRE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": ". For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `0` if the specified NX, XX, GT, or LT condition has not been met. - : `1` if the expiration time was set/updated. - : `2` when `HEXPIRE` or `HPEXPIRE` is called with 0 seconds or milliseconds, or when `HEXPIREAT` or `HPEXPIREAT` is called with a past Unix time in seconds or milliseconds.",
+            "when": "no such field exists in the provided hash key, or the provided key does not exist"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If parsing failed, mandatory arguments are missing, unknown arguments are specified, or argument values are of the wrong type or out of range. - if the provided key exists but is not a hash."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HPEXPIREAT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": ". For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `0` if the specified NX, XX, GT, or LT condition has not been met. - : `1` if the expiration time was set/updated. - : `2` when `HEXPIRE` or `HPEXPIRE` is called with 0 seconds or milliseconds, or when `HEXPIREAT` or `HPEXPIREAT` is called with a past Unix time in seconds or milliseconds.",
+            "when": "no such field exists in the provided hash key, or the provided key does not exist"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If parsing failed, mandatory arguments are missing, unknown arguments are specified, or argument values are of the wrong type or out of range. - if the provided key exists but is not a hash."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HPEXPIRETIME": {
+    "returns": {
+      "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the expiration (Unix timestamp) in milliseconds.",
+      "resp2": {
+        "type": "array",
+        "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the expiration (Unix timestamp) in milliseconds.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HPTTL": {
+    "returns": {
+      "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the TTL in milliseconds.",
+      "resp2": {
+        "type": "array",
+        "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the TTL in milliseconds.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HRANDFIELD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the key doesn't exist"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "A single, randomly selected field when the `count` option is not used.",
+            "when": "the `count` option is not used"
+          },
+          {
+            "type": "array",
+            "summary": "A list containing `count` fields when the `count` option is used, or an empty array if the key does not exists.",
+            "when": "the `count` option is used, or an empty array if the key does not exists"
+          },
+          {
+            "type": "array",
+            "summary": "A list of fields and their values when `count` and `WITHVALUES` were both used.",
+            "when": "`count` and `WITHVALUES` were both used"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HSCAN": {
+    "returns": {
+      "summary": "A two-element array. * The first element is a that represents an unsigned 64-bit number, the cursor. * The second element is an of field/value pairs that were scanned. When the `NOVALUES` flag (since Redis 7.4) is used, only the field names are returned.",
+      "resp2": {
+        "type": "tuple",
+        "summary": "A two-element array. * The first element is a that represents an unsigned 64-bit number, the cursor. * The second element is an of field/value pairs that were scanned. When the `NOVALUES` flag (since Redis 7.4) is used, only the field names are returned.",
+        "prefixItems": [
+          {
+            "type": "bulk_string"
+          },
+          {
+            "type": "bulk_string"
+          }
+        ],
+        "note": "Two-element tuple inferred from prose; element types/names not enumerated."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HSET": {
+    "returns": {
+      "summary": "The number of fields that were added.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of fields that were added."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HSETEX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if no fields were set.",
+            "when": "no fields were set"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if all the fields wereset.",
+            "when": "all the fields wereset"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HSETNX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if the field already exists in the hash and no operation was performed.",
+            "when": "the field already exists in the hash and no operation was performed"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the field is a new field in the hash and the value was set.",
+            "when": "the field is a new field in the hash and the value was set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HSTRLEN": {
+    "returns": {
+      "summary": "The string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The string length of the value associated with the _field_, or zero when the _field_ isn't present in the hash or the _key_ doesn't exist at all."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "HTTL": {
+    "returns": {
+      "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the TTL in seconds.",
+      "resp2": {
+        "type": "array",
+        "summary": "* . For each field: - : `-2` if no such field exists in the provided hash key, or the provided key does not exist. - : `-1` if the field exists but has no associated expiration set. - : the TTL in seconds.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "HVALS": {
+    "returns": {
+      "summary": "A list of values in the hash, or an empty list when the key does not exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of values in the hash, or an empty list when the key does not exist.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Field value."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "INCR": {
+    "returns": {
+      "summary": "The value of the key after the increment.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The value of the key after the increment."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "INCRBY": {
+    "returns": {
+      "summary": "The value of the key after the increment.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The value of the key after the increment."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "INCRBYFLOAT": {
+    "returns": {
+      "summary": "The value of the key after the increment.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The value of the key after the increment."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "INCREX": {
+    "returns": {
+      "summary": "A two-element array: 1. **New value** \u2014 the value of the key after the increment, or the unchanged current value when an out-of-bounds result caused the operation to be skipped. 2. **Actual increment** \u2014 the increment that was actually applied. May differ from the requested increment when `SATURATE` caps the result at a bound, and is always `0` when an out-of-bounds result caused the operation to be skipped. Both elements are in integer mode (default or `BYINT`), or representing the float values in `BYFLOAT` mode.",
+      "resp2": {
+        "type": "tuple",
+        "summary": "A two-element array: 1. **New value** \u2014 the value of the key after the increment, or the unchanged current value when an out-of-bounds result caused the operation to be skipped. 2. **Actual increment** \u2014 the increment that was actually applied. May differ from the requested increment when `SATURATE` caps the result at a bound, and is always `0` when an out-of-bounds result caused the operation to be skipped. Both elements are in integer mode (default or `BYINT`), or representing the float values in `BYFLOAT` mode.",
+        "prefixItems": [
+          {
+            "type": "bulk_string"
+          },
+          {
+            "type": "bulk_string"
+          }
+        ],
+        "note": "Two-element tuple inferred from prose; element types/names not enumerated."
+      },
+      "resp3": {
+        "type": "tuple",
+        "summary": "A two-element array: 1. **New value** \u2014 the value of the key after the increment, or the unchanged current value when an out-of-bounds result caused the operation to be skipped. 2. **Actual increment** \u2014 the increment that was actually applied. May differ from the requested increment when `SATURATE` caps the result at a bound, and is always `0` when an out-of-bounds result caused the operation to be skipped. Both elements are in integer mode (default or `BYINT`), or in `BYFLOAT` mode.",
+        "prefixItems": [
+          {
+            "type": "bulk_string"
+          },
+          {
+            "type": "bulk_string"
+          }
+        ],
+        "note": "Two-element tuple inferred from prose; element types/names not enumerated."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "INFO": {
+    "returns": {
+      "summary": "A map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines. Lines can contain a section name (starting with a `#` character) or a property. All the properties are in the form of `field:value` terminated by `\\r\\n`.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines. Lines can contain a section name (starting with a `#` character) or a property. All the properties are in the form of `field:value` terminated by `\\r\\n`."
+      },
+      "resp3": {
+        "type": "verbatim_string",
+        "summary": "A map of info fields, one field per line in the form of `<field>:<value>` where the value can be a comma separated map like `<key>=<val>`. Also contains section header lines starting with `#` and blank lines. Lines can contain a section name (starting with a `#` character) or a property. All the properties are in the form of `field:value` terminated by `\\r\\n`."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "JSON.ARRAPPEND": {
+    "returns": {
+      "summary": "With `$`-based path argument: of or , where each element is the array's new length, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new length, or if the matching value is not an array.",
+      "resp2": {
+        "type": "array",
+        "summary": "With `$`-based path argument: of or , where each element is the array's new length, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new length, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the array's new length, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new length, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.ARRINDEX": {
+    "returns": {
+      "summary": "With `$`-based path argument: of or , where each element is the first position in the array, `-1` if unfound, or `null` if the matching value is not an array. With `.`-based path argument: representing the first position in the array, `-1` if unfound, or if the matching value is not an array.",
+      "resp2": {
+        "type": "array",
+        "summary": "With `$`-based path argument: of or , where each element is the first position in the array, `-1` if unfound, or `null` if the matching value is not an array. With `.`-based path argument: representing the first position in the array, `-1` if unfound, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the first position in the array, `-1` if unfound, or `null` if the matching value is not an array. With `.`-based path argument: representing the first position in the array, `-1` if unfound, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.ARRINSERT": {
+    "returns": {
+      "summary": "With `$`-based path argument: of or , where each element is the array's new size, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new size, or if the matching value is not an array.",
+      "resp2": {
+        "type": "array",
+        "summary": "With `$`-based path argument: of or , where each element is the array's new size, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new size, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the array's new size, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new size, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.ARRLEN": {
+    "returns": {
+      "summary": "With `$`-based path argument: of or , where each element is the array length, or `null` if the matching value is not an array. With `.`-based path argument: representing the array length, or if the matching value is not an array.",
+      "resp2": {
+        "type": "array",
+        "summary": "With `$`-based path argument: of or , where each element is the array length, or `null` if the matching value is not an array. With `.`-based path argument: representing the array length, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the array length, or `null` if the matching value is not an array. With `.`-based path argument: representing the array length, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.ARRPOP": {
+    "returns": {
+      "summary": "Of or , where each element is the popped JSON value as a string, or `null` if the matching value is not an array.",
+      "resp2": {
+        "type": "array",
+        "summary": "Of or , where each element is the popped JSON value as a string, or `null` if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.ARRTRIM": {
+    "returns": {
+      "summary": "With `$`-based path argument: of or , where each element is the array's new size, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new size, or if the matching value is not an array.",
+      "resp2": {
+        "type": "array",
+        "summary": "With `$`-based path argument: of or , where each element is the array's new size, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new size, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the array's new size, or `null` if the matching value is not an array. With `.`-based path argument: representing the array's new size, or if the matching value is not an array.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.CLEAR": {
+    "returns": {
+      "summary": "The number of matching JSON arrays and objects cleared plus the number of matching JSON numerical values zeroed.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of matching JSON arrays and objects cleared plus the number of matching JSON numerical values zeroed."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "JSON.DEBUG-HELP": {
+    "returns": {
+      "summary": "Of containing helpful messages about the JSON.DEBUG command.",
+      "resp2": {
+        "type": "array",
+        "summary": "Of containing helpful messages about the JSON.DEBUG command.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.DEBUG-MEMORY": {
+    "returns": {
+      "summary": "The value size in bytes.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The value size in bytes."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "JSON.DEL": {
+    "returns": {
+      "summary": "The number of paths deleted (0 or more).",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of paths deleted (0 or more)."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "JSON.GET": {
+    "returns": {
+      "summary": "A JSON-encoded string representing the value(s) at the specified path(s). With a single path, returns the JSON serialization of the value at that path. With multiple paths, returns a JSON object where each key is a path and each value is an array of JSON serializations.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A JSON-encoded string representing the value(s) at the specified path(s). With a single path, returns the JSON serialization of the value at that path. With multiple paths, returns a JSON object where each key is a path and each value is an array of JSON serializations."
+      },
+      "resp3": {
+        "type": "bulk_string",
+        "summary": "A JSON-encoded string with a top-level array containing the value(s) at the specified path(s). With a single path using `$` (default in RESP3), returns a JSON array containing the serialized value. With multiple paths, returns a JSON object where each key is a path and each value is an array of JSON serializations."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "JSON.MERGE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If the operation fails to set the new values."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "JSON.MGET": {
+    "returns": {
+      "summary": "Of or , where each element is the JSON serialization of the value at the corresponding key's path, or `null` if the key or path doesn't exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "Of or , where each element is the JSON serialization of the value at the corresponding key's path, or `null` if the key or path doesn't exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.MSET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If the operation fails to set the new values."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "JSON.NUMINCRBY": {
+    "returns": {
+      "summary": "With `$`-based path argument: containing a JSON-encoded string with the new value(s), or if the matching value is not a number. With `.`-based path argument: representing the stringified new value, if the matching value is not a number, or on error.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "With `$`-based path argument: containing a JSON-encoded string with the new value(s), or if the matching value is not a number. With `.`-based path argument: representing the stringified new value, if the matching value is not a number, or on error."
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the new value, or `null` if the matching value is not a number, or on error. With `.`-based path argument: representing the stringified new value, if the matching value is not a number, or on error.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.NUMMULTBY": {
+    "returns": {
+      "summary": "With `$`-based path argument: containing a JSON-encoded string with the new value(s), or if the matching value is not a number. With `.`-based path argument: representing the stringified new value, if the matching value is not a number, or on error.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "With `$`-based path argument: containing a JSON-encoded string with the new value(s), or if the matching value is not a number. With `.`-based path argument: representing the stringified new value, if the matching value is not a number, or on error."
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the new value, or `null` if the matching value is not a number, or on error. With `.`-based path argument: representing the stringified new value, if the matching value is not a number, or on error.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.OBJKEYS": {
+    "returns": {
+      "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not an object. - An of containing the object's key names if the match is an object. If `path` is a legacy path expression: - if `key` does not exist. - if `path` has no matches. - A if the first match is not an object. - An of containing the object's key names of the first match.",
+      "resp2": {
+        "type": "array",
+        "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not an object. - An of containing the object's key names if the match is an object. If `path` is a legacy path expression: - if `key` does not exist. - if `path` has no matches. - A if the first match is not an object. - An of containing the object's key names of the first match.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.OBJLEN": {
+    "returns": {
+      "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not an object. - An : the number of keys in the object. If `path` is a legacy path expression: - if `key` does not exist. - if `path` has no matches. - A if the first match is not an object. - An : the number of keys in the first match.",
+      "resp2": {
+        "type": "array",
+        "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not an object. - An : the number of keys in the object. If `path` is a legacy path expression: - if `key` does not exist. - if `path` has no matches. - A if the first match is not an object. - An : the number of keys in the first match.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.RESP": {
+    "returns": {
+      "summary": "Representing the JSON value in RESP form, as detailed in the . The mapping from JSON to RESP follows the rules described in the command arguments.",
+      "resp2": {
+        "type": "array",
+        "summary": "Representing the JSON value in RESP form, as detailed in the . The mapping from JSON to RESP follows the rules described in the command arguments.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.SET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "null",
+            "when": "`key` exists but `path` does not exist and cannot be created, or if an `NX` or `XX` condition is unmet"
+          },
+          {
+            "type": "simple_error",
+            "summary": "`(error) expected ...` - if the value is invalid."
+          },
+          {
+            "type": "simple_error",
+            "summary": "`(error) Error occurred on position ... expected ...` - if the path is invalid."
+          },
+          {
+            "type": "simple_error",
+            "summary": "`(error) ERR new objects must be created at the root` - if `key` does not exist and `path` is not root (`$` or `.`)."
+          },
+          {
+            "type": "simple_error",
+            "summary": "`(error) ERR wrong static path` - if a dynamic path expression has no matching locations."
+          },
+          {
+            "type": "simple_error",
+            "summary": "`(error) ERR index out of bounds` - if the path refers to an array index outside the array bounds."
+          },
+          {
+            "type": "simple_error",
+            "summary": "`(error) value out of range for ...` - if one or more values of a FP array are out of range for the given type."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "JSON.STRAPPEND": {
+    "returns": {
+      "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not a string. - An : the new length of the string. If `path` is a legacy path expression: - A if `key` does not exist. - A if `path` has no matches. - A if the first match is not a string. - An : the new length of the string at the first match.",
+      "resp2": {
+        "type": "array",
+        "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not a string. - An : the new length of the string. If `path` is a legacy path expression: - A if `key` does not exist. - A if `path` has no matches. - A if the first match is not a string. - An : the new length of the string at the first match.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.STRLEN": {
+    "returns": {
+      "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not a string. - An : the length of the string. If `path` is a legacy path expression: - if `key` does not exist. - A if `path` has no matches. - A if the first match is not a string. - An : the length of the string at the first match.",
+      "resp2": {
+        "type": "array",
+        "summary": "If `path` is a JSONPath expression: - A if `key` does not exist. - An empty if `path` has no matches. - An where each array element corresponds to one match: - if the match is not a string. - An : the length of the string. If `path` is a legacy path expression: - if `key` does not exist. - A if `path` has no matches. - A if the first match is not a string. - An : the length of the string at the first match.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "JSON.TOGGLE": {
+    "returns": {
+      "summary": "With `$`-based path argument: of or , where each element is the new value (`0` if `false` or `1` if `true`), or `null` if the matching value is not Boolean. With `.`-based path argument: representing the new value (`0` if `false` or `1` if `true`), or if the matching value is not Boolean.",
+      "resp2": {
+        "type": "array",
+        "summary": "With `$`-based path argument: of or , where each element is the new value (`0` if `false` or `1` if `true`), or `null` if the matching value is not Boolean. With `.`-based path argument: representing the new value (`0` if `false` or `1` if `true`), or if the matching value is not Boolean.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of or , where each element is the new value (`0` if `false` or `1` if `true`), or `null` if the matching value is not Boolean. With `.`-based path argument: representing the new value (`0` if `false` or `1` if `true`), or if the matching value is not Boolean.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "JSON.TYPE": {
+    "returns": {
+      "summary": "With `$`-based path argument: of , where each element is the type of the matching value. With `.`-based path argument: representing the type of the matching value.",
+      "resp2": {
+        "type": "array",
+        "summary": "With `$`-based path argument: of , where each element is the type of the matching value. With `.`-based path argument: representing the type of the matching value.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "With `$`-based path argument (default): of of , where each nested array contains the type of the matching value. With `.`-based path argument: of representing the type of the matching value.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "KEYS": {
+    "returns": {
+      "summary": "A list of keys matching _pattern_.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of keys matching _pattern_.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "LASTSAVE": {
+    "returns": {
+      "summary": "UNIX TIME of the last DB save executed with success.",
+      "resp2": {
+        "type": "integer",
+        "summary": "UNIX TIME of the last DB save executed with success."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LATENCY DOCTOR": {
+    "returns": {
+      "summary": "A human readable latency analysis report.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A human readable latency analysis report."
+      },
+      "resp3": {
+        "type": "verbatim_string",
+        "summary": "A human readable latency analysis report."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "LATENCY GRAPH": {
+    "returns": {
+      "summary": "Latency graph.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "Latency graph."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LATENCY HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "LATENCY HISTOGRAM": {
+    "returns": {
+      "summary": "A map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets.",
+      "resp2": {
+        "type": "array",
+        "summary": "A map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "A map where each key is a command name, and each value is a map with the total calls, and an inner map of the histogram time buckets.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "LATENCY HISTORY": {
+    "returns": {
+      "summary": "An array where each element is a two elements array representing the timestamp and the latency of the event.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array where each element is a two elements array representing the timestamp and the latency of the event.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "LATENCY LATEST": {
+    "returns": {
+      "summary": "An array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array where each element is a four elements array representing the event's name, timestamp, latest and all-time latency measurements.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "LATENCY RESET": {
+    "returns": {
+      "summary": "The number of event time series that were reset.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of event time series that were reset."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LCS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The longest common subsequence."
+          },
+          {
+            "type": "integer",
+            "summary": "The length of the longest common subsequence when _LEN_ is given.",
+            "when": "_LEN_ is given"
+          },
+          {
+            "type": "array",
+            "summary": "An array with the LCS length and all the ranges in both the strings when _IDX_ is given.",
+            "when": "_IDX_ is given"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The longest common subsequence."
+          },
+          {
+            "type": "integer",
+            "summary": "The length of the longest common subsequence when _LEN_ is given.",
+            "when": "_LEN_ is given"
+          },
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "A map with the LCS length and all the ranges in both the strings when _IDX_ is given.",
+            "when": "_IDX_ is given"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "LINDEX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "_index_ is out of range"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "The requested element."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LINSERT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The list length after a successful insert operation."
+          },
+          {
+            "type": "integer",
+            "summary": "`0` when the key doesn't exist.",
+            "when": "the key doesn't exist"
+          },
+          {
+            "type": "integer",
+            "summary": "`-1` when the pivot wasn't found.",
+            "when": "the pivot wasn't found"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LLEN": {
+    "returns": {
+      "summary": "The length of the list.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the list."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LMOVE": {
+    "returns": {
+      "summary": "The element being popped and pushed.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The element being popped and pushed."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LMPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "no element could be popped"
+          },
+          {
+            "type": "array",
+            "summary": "A two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LOLWUT": {
+    "returns": {
+      "summary": "A string containing generative computer art and the Redis version.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A string containing generative computer art and the Redis version."
+      },
+      "resp3": {
+        "type": "verbatim_string",
+        "summary": "A string containing generative computer art and the Redis version."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "LPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the key does not exist"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "When called without the _count_ argument, the value of the first element.",
+            "when": "called without the _count_ argument, the value of the first element"
+          },
+          {
+            "type": "array",
+            "summary": "When called with the _count_ argument, a list of popped elements.",
+            "when": "called with the _count_ argument, a list of popped elements"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LPOS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "there is no matching element"
+          },
+          {
+            "type": "integer",
+            "summary": "An integer representing the matching element."
+          },
+          {
+            "type": "array",
+            "summary": "If the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches).",
+            "when": "the COUNT option is given, an array of integers representing the matching elements (or an empty array if there are no matches)"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LPUSH": {
+    "returns": {
+      "summary": "The length of the list after the push operation.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the list after the push operation."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LPUSHX": {
+    "returns": {
+      "summary": "The length of the list after the push operation.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the list after the push operation."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LRANGE": {
+    "returns": {
+      "summary": "A list of elements in the specified range, or an empty array if the key doesn't exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of elements in the specified range, or an empty array if the key doesn't exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "LREM": {
+    "returns": {
+      "summary": "The number of removed elements.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of removed elements."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LSET": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "LTRIM": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MEMORY DOCTOR": {
+    "returns": {
+      "summary": "A memory problems report.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A memory problems report."
+      },
+      "resp3": {
+        "type": "verbatim_string",
+        "summary": "A memory problems report."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "MEMORY HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "MEMORY MALLOC STATS": {
+    "returns": {
+      "summary": "A long string of statistics.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "A long string of statistics."
+      },
+      "resp3": {
+        "type": "verbatim_string",
+        "summary": "A long string of statistics."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "MEMORY PURGE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MEMORY STATS": {
+    "returns": {
+      "summary": "A nested list of memory usage metrics and their values.",
+      "resp2": {
+        "type": "array",
+        "summary": "A nested list of memory usage metrics and their values.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "Memory usage metrics and their values.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "MEMORY USAGE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The memory usage in bytes."
+          },
+          {
+            "type": "null",
+            "when": "the key does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MGET": {
+    "returns": {
+      "summary": "A list of values at the specified keys.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of values at the specified keys.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Field value."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MIGRATE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` on success."
+          },
+          {
+            "type": "simple_string",
+            "value": "NOKEY",
+            "summary": "`NOKEY` when no keys were found in the source instance.",
+            "when": "no keys were found in the source instance"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MODULE HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "MODULE LIST": {
+    "returns": {
+      "summary": "List of loaded modules. Each element in the list represents a represents a module, and is in itself a list of property names and their values. The following properties is reported for each loaded module: * name: the name of the module. * ver: the version of the module.",
+      "resp2": {
+        "type": "array",
+        "summary": "List of loaded modules. Each element in the list represents a represents a module, and is in itself a list of property names and their values. The following properties is reported for each loaded module: * name: the name of the module. * ver: the version of the module.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "List of loaded modules. Each element in the list represents a represents a module, and is a of property names and their values. The following properties is reported for each loaded module: * name: the name of the module. * ver: the version of the module.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "MODULE LOAD": {
+    "returns": {
+      "summary": "`OK` if the module was loaded.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the module was loaded.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MODULE LOADEX": {
+    "returns": {
+      "summary": "`OK` if the module was loaded.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the module was loaded.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MODULE UNLOAD": {
+    "returns": {
+      "summary": "`OK` if the module was unloaded.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the module was unloaded.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MONITOR": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "MOVE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` if _key_ was moved.",
+            "when": "_key_ was moved"
+          },
+          {
+            "type": "integer",
+            "summary": "`0` if _key_ wasn't moved.",
+            "when": "_key_ wasn't moved"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MSET": {
+    "returns": {
+      "summary": "Always `OK` because `MSET` can't fail.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "Always `OK` because `MSET` can't fail."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MSETEX": {
+    "returns": {
+      "summary": "0 if none of the keys were set; 1 if all of the keys were set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "0 if none of the keys were set; 1 if all of the keys were set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MSETNX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if no key was set (at least one key already existed).",
+            "when": "no key was set (at least one key already existed)"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if all the keys were set.",
+            "when": "all the keys were set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "MULTI": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "OBJECT ENCODING": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the key doesn't exist"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "The encoding of the object."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "OBJECT FREQ": {
+    "returns": {
+      "summary": "One of the following: : the counter's value. : if _key_ doesn't exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "One of the following: : the counter's value. : if _key_ doesn't exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "OBJECT HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "OBJECT IDLETIME": {
+    "returns": {
+      "summary": "One of the following: : the idle time in seconds. : if _key_ doesn't exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "One of the following: : the idle time in seconds. : if _key_ doesn't exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "OBJECT REFCOUNT": {
+    "returns": {
+      "summary": "One of the following: : the number of references. : if _key_ doesn't exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "One of the following: : the number of references. : if _key_ doesn't exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PERSIST": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if _key_ does not exist or does not have an associated timeout.",
+            "when": "_key_ does not exist or does not have an associated timeout"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the timeout has been removed.",
+            "when": "the timeout has been removed"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PEXPIRE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if the timeout was not set. For example, if the key doesn't exist, or the operation skipped because of the provided arguments.",
+            "when": "the timeout was not set"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the timeout was set.",
+            "when": "the timeout was set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PEXPIREAT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` if the timeout was set.",
+            "when": "the timeout was set"
+          },
+          {
+            "type": "integer",
+            "summary": "`0` if the timeout was not set. For example, if the key doesn't exist, or the operation was skipped due to the provided arguments.",
+            "when": "the timeout was not set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PEXPIRETIME": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "Expiration Unix timestamp in milliseconds."
+          },
+          {
+            "type": "integer",
+            "summary": "`-1` if the key exists but has no associated expiration time.",
+            "when": "the key exists but has no associated expiration time"
+          },
+          {
+            "type": "integer",
+            "summary": "`-2` if the key does not exist.",
+            "when": "the key does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PFADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` if at least one HyperLogLog internal register was altered.",
+            "when": "at least one HyperLogLog internal register was altered"
+          },
+          {
+            "type": "integer",
+            "summary": "`0` if no HyperLogLog internal registers were altered.",
+            "when": "no HyperLogLog internal registers were altered"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PFCOUNT": {
+    "returns": {
+      "summary": "The approximated number of unique elements observed via `PFADD`.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The approximated number of unique elements observed via `PFADD`."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PFMERGE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PFSELFTEST": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PING": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "PONG",
+            "summary": "`PONG` when no argument is provided.",
+            "when": "no argument is provided"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "The provided argument."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PSETEX": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PSUBSCRIBE": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "PSYNC": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "PTTL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "TTL in milliseconds."
+          },
+          {
+            "type": "integer",
+            "summary": "`-1` if the key exists but has no associated expiration.",
+            "when": "the key exists but has no associated expiration"
+          },
+          {
+            "type": "integer",
+            "summary": "`-2` if the key does not exist.",
+            "when": "the key does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PUBLISH": {
+    "returns": {
+      "summary": "The number of clients that the message was sent to. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of clients that the message was sent to. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PUBSUB CHANNELS": {
+    "returns": {
+      "summary": "A list of active channels, optionally matching the specified pattern.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of active channels, optionally matching the specified pattern.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "PUBSUB HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "PUBSUB NUMPAT": {
+    "returns": {
+      "summary": "The number of patterns all the clients are subscribed to.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of patterns all the clients are subscribed to."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "PUBSUB NUMSUB": {
+    "returns": {
+      "summary": "The number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers.",
+      "resp2": {
+        "type": "array",
+        "summary": "The number of subscribers per channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "PUBSUB SHARDCHANNELS": {
+    "returns": {
+      "summary": "A list of active channels, optionally matching the specified pattern.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of active channels, optionally matching the specified pattern.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "PUBSUB SHARDNUMSUB": {
+    "returns": {
+      "summary": "The number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers.",
+      "resp2": {
+        "type": "array",
+        "summary": "The number of subscribers per shard channel, each even element (including the 0th) is channel name, each odd element is the number of subscribers.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "PUNSUBSCRIBE": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "QUIT": {
+    "returns": {
+      "summary": "OK.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "OK."
+      },
+      "resp3": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      }
+    },
+    "returns_status": "auto"
+  },
+  "RANDOMKEY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the database is empty"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "A random key in database."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the database is empty"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "A random key in the database."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "READONLY": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "READWRITE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "RENAME": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "RENAMENX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` if _key_ was renamed to _newkey_.",
+            "when": "_key_ was renamed to _newkey_"
+          },
+          {
+            "type": "integer",
+            "summary": "`0` if _newkey_ already exists.",
+            "when": "_newkey_ already exists"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "REPLCONF": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "REPLICAOF": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "RESET": {
+    "returns": {
+      "summary": "`RESET`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`RESET`.",
+        "value": "RESET"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "RESTORE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ROLE": {
+    "returns": {
+      "summary": "Where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above.",
+      "resp2": {
+        "type": "array",
+        "summary": "Where the first element is one of `master`, `slave`, or `sentinel`, and the additional elements are role-specific as illustrated above.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "RPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the key does not exist"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "When called without the _count_ argument, the value of the last element.",
+            "when": "called without the _count_ argument, the value of the last element"
+          },
+          {
+            "type": "array",
+            "summary": "When called with the _count_ argument, a list of popped elements.",
+            "when": "called with the _count_ argument, a list of popped elements"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "RPOPLPUSH": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The element being popped and pushed."
+          },
+          {
+            "type": "null",
+            "when": "the source list is empty"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "RPUSH": {
+    "returns": {
+      "summary": "The length of the list after the push operation.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the list after the push operation."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "RPUSHX": {
+    "returns": {
+      "summary": "The length of the list after the push operation.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the list after the push operation."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SADD": {
+    "returns": {
+      "summary": "The number of elements that were added to the set, not including all the elements already present in the set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements that were added to the set, not including all the elements already present in the set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SAVE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SCAN": {
+    "returns": {
+      "summary": "Specifically, an array with two elements. * The first element is a that represents an unsigned 64-bit number, the cursor. * The second element is an with the names of scanned keys.",
+      "resp2": {
+        "type": "array",
+        "summary": "Specifically, an array with two elements. * The first element is a that represents an unsigned 64-bit number, the cursor. * The second element is an with the names of scanned keys.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SCARD": {
+    "returns": {
+      "summary": "The cardinality (number of elements) of the set, or `0` if the key does not exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The cardinality (number of elements) of the set, or `0` if the key does not exist."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "The cardinality (number of elements) of the set, or 0 if the key does not exist."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "SCRIPT DEBUG": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SCRIPT EXISTS": {
+    "returns": {
+      "summary": "An array of integers that correspond to the specified SHA1 digest arguments.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array of integers that correspond to the specified SHA1 digest arguments.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SCRIPT FLUSH": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SCRIPT HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SCRIPT KILL": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SCRIPT LOAD": {
+    "returns": {
+      "summary": "The SHA1 digest of the script added into the script cache.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The SHA1 digest of the script added into the script cache."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SDIFF": {
+    "returns": {
+      "summary": "A list with members of the resulting set.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list with members of the resulting set.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "set",
+        "summary": "A set with the members of the resulting set."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "SDIFFSTORE": {
+    "returns": {
+      "summary": "The number of elements in the resulting set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements in the resulting set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SELECT": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SET": {
+    "returns": {
+      "resp2": {
+        "type": "null",
+        "note": "Prose has nested-conditional structure (e.g. `If X was specified`) that the flat heuristic cannot encode. Full shape requires hand-authoring."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SETBIT": {
+    "returns": {
+      "summary": "The original bit value stored at _offset_.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The original bit value stored at _offset_."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SETEX": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SETNX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if the key was not set.",
+            "when": "the key was not set"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the key was set.",
+            "when": "the key was set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SETRANGE": {
+    "returns": {
+      "summary": "The length of the string after it was modified by the command.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the string after it was modified by the command."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SHUTDOWN": {
+    "returns": {
+      "summary": "`OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if _ABORT_ was specified and shutdown was aborted. On successful shutdown, nothing is returned because the server quits and the connection is closed. On failure, an error is returned.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SINTER": {
+    "returns": {
+      "summary": "An array with the members of the resulting set.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array with the members of the resulting set.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "set",
+        "summary": "A set with the members of the resulting set."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "SINTERCARD": {
+    "returns": {
+      "summary": "The number of elements in the resulting intersection.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements in the resulting intersection."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SINTERSTORE": {
+    "returns": {
+      "summary": "The number of elements in the resulting set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements in the resulting set."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "The number of elements in the result set."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "SISMEMBER": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`0` if the element is not a member of the set, or when the key does not exist.",
+            "when": "the element is not a member of the set, or when the key does not exist"
+          },
+          {
+            "type": "integer",
+            "summary": "`1` if the element is a member of the set.",
+            "when": "the element is a member of the set"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SLAVEOF": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SLOWLOG GET": {
+    "returns": {
+      "summary": "A list of slow log entries per the above format.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of slow log entries per the above format.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SLOWLOG HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SLOWLOG LEN": {
+    "returns": {
+      "summary": "The number of entries in the slow log.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of entries in the slow log."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SLOWLOG RESET": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SMEMBERS": {
+    "returns": {
+      "summary": "An array with all the members of the set.",
+      "resp2": {
+        "type": "array",
+        "summary": "An array with all the members of the set.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "set",
+        "summary": "A set with all the members of the set."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "SMISMEMBER": {
+    "returns": {
+      "summary": "A list representing the membership of the given elements, in the same order as they are requested.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list representing the membership of the given elements, in the same order as they are requested.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SMOVE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "`1` if the element is moved.",
+            "when": "the element is moved"
+          },
+          {
+            "type": "integer",
+            "summary": "`0` if the element is not a member of _source_ and no operation was performed.",
+            "when": "the element is not a member of _source_ and no operation was performed"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SORT": {
+    "returns": {
+      "summary": "Without passing the _STORE_ option, the command returns a list of sorted elements. : when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list.",
+      "resp2": {
+        "type": "array",
+        "summary": "Without passing the _STORE_ option, the command returns a list of sorted elements. : when the _STORE_ option is specified, the command returns the number of sorted elements in the destination list.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SORT_RO": {
+    "returns": {
+      "summary": "A list of sorted elements.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sorted elements.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the key does not exist"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "When called without the _count_ argument, the removed member.",
+            "when": "called without the _count_ argument, the removed member"
+          },
+          {
+            "type": "array",
+            "summary": "When called with the _count_ argument, a list of the removed members.",
+            "when": "called with the _count_ argument, a list of the removed members"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SPUBLISH": {
+    "returns": {
+      "summary": "The number of clients that the message was sent to. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of clients that the message was sent to. Note that in a Redis Cluster, only clients that are connected to the same node as the publishing client are included in the count."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SRANDMEMBER": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "Without the additional _count_ argument, the command returns a randomly selected member, or a when _key_ doesn't exist.",
+            "when": "_key_ doesn't exist"
+          },
+          {
+            "type": "array",
+            "summary": "When the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist.",
+            "when": "the optional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SREM": {
+    "returns": {
+      "summary": "The number of members that were removed from the set, not including non existing members.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members that were removed from the set, not including non existing members."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "Number of members that were removed from the set, not including non existing members."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "SSCAN": {
+    "returns": {
+      "summary": "Specifically, an array with two elements: * The first element is a that represents an unsigned 64-bit number, the cursor. * The second element is an with the names of scanned members.",
+      "resp2": {
+        "type": "array",
+        "summary": "Specifically, an array with two elements: * The first element is a that represents an unsigned 64-bit number, the cursor. * The second element is an with the names of scanned members.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SSUBSCRIBE": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "STRLEN": {
+    "returns": {
+      "summary": "The length of the string stored at key, or 0 when the key does not exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The length of the string stored at key, or 0 when the key does not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SUBSCRIBE": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SUBSTR": {
+    "returns": {
+      "summary": "The substring of the string value stored at key, determined by the offsets start and end (both are inclusive).",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The substring of the string value stored at key, determined by the offsets start and end (both are inclusive)."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SUNION": {
+    "returns": {
+      "summary": "A list with members of the resulting set.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list with members of the resulting set.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "set",
+        "summary": "A set with the members of the resulting set."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "SUNIONSTORE": {
+    "returns": {
+      "summary": "The number of elements in the resulting set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements in the resulting set."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "Number of the elements in the resulting set."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "SUNSUBSCRIBE": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "SWAPDB": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "SYNC": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "TDIGEST.ADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "the value parameter is of the incorrect type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.BYRANK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of as floating-points, populated with value_1, value_2, ..., value_R: * an accurate result when `rank` is `0`, the value of the smallest observation. * an accurate result when `rank` is _n_-1, the value of the largest observation, where _n_ denotes the number of observations added to the sketch. * `inf` when `rank` is equal to _n_ or larger than _n_. * `nan` for all ranks when the given sketch is empty.",
+            "when": "`rank` is `0`, the value of the smallest observation"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "rank parsing errors"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.BYREVRANK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of as floating-points, populated with value_1, value_2, ..., value_R: * an accurate result when `rank` is `0`, the value of the largest observation. * an accurate result when `rank` is _n_-1, the value of the smallest observation, where _n_ denotes the number of observations added to the sketch. * `inf` when `rank` is equal to _n_ or larger than _n_. * `nan` for all ranks when the given sketch is empty.",
+            "when": "`rank` is `0`, the value of the largest observation"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "rank parsing errors"
+              },
+              {
+                "value": "an incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.CDF": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of as floating-points, populated with fraction_1, fraction_2, ..., fraction_N. All values are `nan` if the given sketch is empty.",
+            "when": "the given sketch is empty"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "value parsing errors"
+              },
+              {
+                "value": "an incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of populated with fraction_1, fraction_2, ..., fraction_N. All values are `nan` if the given sketch is empty.",
+            "when": "the given sketch is empty"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "value parsing errors"
+              },
+              {
+                "value": "an incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.CREATE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect key type"
+              },
+              {
+                "value": "incorrect keyword"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.INFO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "With information about the given sketch as name-value pairs: | Name<br> | Description | ---------------------------- | - | `Compression` | <br> The compression (controllable trade-off between accuracy and memory consumption) of the sketch | `Capacity` | <br> Size of the buffer used for storing the centroids and for the incoming unmerged observations | `Merged nodes` | <br> Number of merged observations | `Unmerged nodes` | <br> Number of buffered nodes (uncompressed observations) | `Merged weight` | <br> Weight of values of the merged nodes | `Unmerged weight` | <br> Weight of values of the unmerged nodes (uncompressed observations) | `Observations` | <br> Number of observations added to the sketch | `Total compressions` | <br> Number of times this sketch compressed data together | `Memory usage` | <br> Number of bytes allocated for the sketch."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "an incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "With information about the given sketch as name-value pairs: | Name<br> | Description | ---------------------------- | - | `Compression` | <br> The compression (controllable trade-off between accuracy and memory consumption) of the sketch | `Capacity` | <br> Size of the buffer used for storing the centroids and for the incoming unmerged observations | `Merged nodes` | <br> Number of merged observations | `Unmerged nodes` | <br> Number of buffered nodes (uncompressed observations) | `Merged weight` | <br> Weight of values of the merged nodes | `Unmerged weight` | <br> Weight of values of the unmerged nodes (uncompressed observations) | `Observations` | <br> Number of observations added to the sketch | `Total compressions` | <br> Number of times this sketch compressed data together | `Memory usage` | <br> Number of bytes allocated for the sketch."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "an incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.MAX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "As floating-point representing the maximum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.",
+            "when": "the sketch is empty"
+          },
+          {
+            "type": "simple_string",
+            "summary": "In these cases: incorrect number of arguments or incorrect key type."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "double",
+            "summary": "Representing the maximum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.",
+            "when": "the sketch is empty"
+          },
+          {
+            "type": "simple_string",
+            "summary": "In these cases: incorrect number of arguments or incorrect key type."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.MERGE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if successful.",
+            "when": "successful"
+          },
+          {
+            "type": "simple_error",
+            "summary": "In the following cases: incorrect key type, incorrect keyword, or incorrect number of arguments."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.MIN": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "As floating-point representing the minimum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.",
+            "when": "the sketch is empty"
+          },
+          {
+            "type": "simple_string",
+            "summary": "In these cases: incorrect number of arguments or incorrect key type."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "double",
+            "summary": "Representing the minimum observation value from the given sketch. The result is always accurate. `nan` is returned if the sketch is empty.",
+            "when": "the sketch is empty"
+          },
+          {
+            "type": "simple_string",
+            "summary": "In these cases: incorrect number of arguments or incorrect key type."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.QUANTILE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of as floating-point estimates, populated with value_1, value_2, ..., value_N. * an accurate result when `quantile` is `0`, the value of the smallest observation. * an accurate result when `quantile` is `1`, the value of the largest observation. * `nan` for all quantiles when the given sketch is empty.",
+            "when": "`quantile` is `0`, the value of the smallest observation"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "quantile parsing errors"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of as estimates, populated with value_1, value_2, ..., value_N. * an accurate result when `quantile` is `0`, the value of the smallest observation. * an accurate result when `quantile` is `1`, the value of the largest observation. * `nan` for all quantiles when the given sketch is empty.",
+            "when": "`quantile` is `0`, the value of the smallest observation"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "quantile parsing errors"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.RANK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of populated with rank_1, rank_2, ..., rank_V: * `-1` when `value` is smaller than the value of the smallest observation. * The number of observations when `value` is larger than the value of the largest observation. * Otherwise, an estimation of the number of (_observations smaller than `value`_ + _half the observations equal to `value`_). `0` is the rank of the value of the smallest observation. _n_-1 is the rank of the value of the largest observation, where _n_ denotes the number of observations added to the sketch. All values are `-2` if the sketch is empty.",
+            "when": "`value` is smaller than the value of the smallest observation"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "quantile parsing errors"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.RESET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "key does not exist"
+              },
+              {
+                "value": "is of the wrong type"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.REVRANK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of populated with revrank_1, revrank_2, ..., revrank_V: * `-1` when `value` is larger than the value of the largest observation. * The number of observations when `value` is smaller than the value of the smallest observation. * Otherwise, an estimation of the number of (_observations larger than `value`_ + _half the observations equal to `value`_). `0` is the reverse rank of the value of the largest observation. _n_-1 is the rank of the value of the smallest observation, where _n_ denotes the number of observations added to the sketch. All values are `-2` if the sketch is empty.",
+            "when": "`value` is larger than the value of the largest observation"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "quantile parsing errors"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TDIGEST.TRIMMED_MEAN": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "As a floating-point estimation of the mean value."
+          },
+          {
+            "type": "bulk_string",
+            "note": "Type could not be detected from prose."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "quantiles out of range [0..1]"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "double",
+            "summary": "As an estimation of the mean value."
+          },
+          {
+            "type": "bulk_string",
+            "note": "Type could not be detected from prose."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "the given key does not exist"
+              },
+              {
+                "value": "is of an incorrect type"
+              },
+              {
+                "value": "quantiles out of range [0..1]"
+              },
+              {
+                "value": "incorrect number of arguments"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TIME": {
+    "returns": {
+      "summary": "Specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count.",
+      "resp2": {
+        "type": "tuple",
+        "summary": "Specifically, a two-element array consisting of the Unix timestamp in seconds and the microseconds' count.",
+        "prefixItems": [
+          {
+            "type": "bulk_string"
+          },
+          {
+            "type": "bulk_string"
+          }
+        ],
+        "note": "Two-element tuple inferred from prose; element types/names not enumerated."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TOPK.ADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of containing either dropped elements or ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existant key"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of containing either dropped elements or ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existant key"
+              },
+              {
+                "value": "key of the incorrect type"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TOPK.COUNT": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of representing the count of each specified item. For non-existant items, `0` is returned."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existant key"
+              },
+              {
+                "value": "key of the incorrect type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TOPK.INCRBY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of containing either dropped elements or ."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existant key"
+              },
+              {
+                "value": "key of the incorrect type"
+              },
+              {
+                "value": "an incorrect increment (less than 0"
+              },
+              {
+                "value": "greater than 100"
+              },
+              {
+                "value": "000)"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TOPK.INFO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of and pairs. For decay, a is used to represent the floating point value."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existant key"
+              },
+              {
+                "value": "key of the incorrect type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "Of and pairs. For decay, a is used to represent the floating point value."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "non-existant key"
+              },
+              {
+                "value": "key of the incorrect type"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TOPK.LIST": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of representing the names of items in the given sketch. If `WITHCOUNT` is requested, an of and pairs, representing the names of the items in the sketch together with their counts.",
+            "when": "`WITHCOUNT` is requested, an [array](https://redis"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "non-existant key"
+              },
+              {
+                "value": "key of the incorrect type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TOPK.QUERY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of : `1` if an item is in the Top-K or `0` otherwise.",
+            "when": "an item is in the Top-K or `0` otherwise"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "non-existant key"
+              },
+              {
+                "value": "key of the incorrect type"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "* of : `true` if an item is in the Top-K or `false` otherwise. * in these cases: non-existant key or key of the incorrect type.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "TOPK.RESERVE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "`OK` if executed correctly.",
+            "when": "executed correctly"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "incorrect number of arguments"
+              },
+              {
+                "value": "invalid decay value"
+              },
+              {
+                "value": "key already exists"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TOUCH": {
+    "returns": {
+      "summary": "The number of touched keys.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of touched keys."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.ADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The timestamp of the upserted sample. If the sample is ignored (see `IGNORE` in ), the reply will be the largest timestamp in the time series.",
+            "when": "the sample is ignored (see `IGNORE` in [`TS"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "duplication policy is `BLOCK`"
+              },
+              {
+                "value": "when `timestamp` is older than the retention period compared to the maximum existing timestamp"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.ALTER": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` when the time series is altered successfully.",
+            "when": "the time series is altered successfully"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "key does not exist"
+              },
+              {
+                "value": "etc"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.CREATE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` when the time series is created successfully.",
+            "when": "the time series is created successfully"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "key already exists"
+              },
+              {
+                "value": "etc"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.CREATERULE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` when the compaction rule is created successfully.",
+            "when": "the compaction rule is created successfully"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "`sourceKey` does not exist"
+              },
+              {
+                "value": "`destKey` does not exist"
+              },
+              {
+                "value": "`sourceKey` is already a destination of a compaction rule"
+              },
+              {
+                "value": "`destKey` is already a source"
+              },
+              {
+                "value": "a destination of a compaction rule"
+              },
+              {
+                "value": "`sourceKey` and `destKey` are identical"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.DECRBY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The timestamp of the upserted sample. If the sample is ignored (see `IGNORE` in ), the reply will be the largest timestamp in the time series.",
+            "when": "the sample is ignored (see `IGNORE` in [`TS"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when `timestamp` is not equal to"
+              },
+              {
+                "value": "higher than the maximum existing timestamp"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.DEL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The number of samples that were deleted."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "`timestamp` is older than the retention period compared to the maximum existing timestamp"
+              },
+              {
+                "value": "when an affected compaction bucket cannot be recalculated"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.DELETERULE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "value": "OK",
+            "summary": "`OK` when the compaction rule is deleted successfully.",
+            "when": "the compaction rule is deleted successfully"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "when such rule does not exist"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.GET": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of a single (, ) pair representing (timestamp, value) of the sample with the highest timestamp."
+          },
+          {
+            "type": "array",
+            "summary": "An empty when the time series is empty.",
+            "when": "the time series is empty"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "key does not exist"
+              },
+              {
+                "value": "etc"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.INCRBY": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The timestamp of the upserted sample. If the sample is ignored (see `IGNORE` in ), the reply will be the largest timestamp in the time series.",
+            "when": "the sample is ignored (see `IGNORE` in [`TS"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "when `timestamp` is not equal to"
+              },
+              {
+                "value": "higher than the maximum existing timestamp"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.INFO": {
+    "returns": {
+      "summary": "With information about the time series as flattened name-value pairs: | Name<br> | Description | ---------------------------- | - | `totalSamples` | <br> Total number of samples in this time series | `memoryUsage` | <br> Total number of bytes allocated for this time series, which is the sum of <br> - The memory used for storing the series' configuration parameters (retention period, duplication policy, etc.)<br>- The memory used for storing the series' compaction rules<br>- The memory used for storing the series' labels (key-value pairs)<br>- The memory used for storing the chunks (chunk header + compressed/uncompressed data) | `firstTimestamp` | <br> First timestamp present in this time series (Unix timestamp in milliseconds) | `lastTimestamp` | <br> Last timestamp present in this time series (Unix timestamp in milliseconds) | `retentionTime` | <br> The retention period, in milliseconds, for this time series | `chunkCount` | <br> Number of chunks used for this time series | `chunkSize` | <br> The initial allocation size, in bytes, for the data part of each new chunk.<br>Actual chunks may consume more memory. Changing the chunk size (using ) does not affect existing chunks. | `chunkType` | <br> The chunks type: `compressed` or `uncompressed` | `duplicatePolicy` | or <br> The of this time series | `labels` | or <br> Metadata labels of this time series<br> Each element is a 2-elements of (, ) representing (label, value) | `sourceKey` | or <br>Key name for source time series in case the current series is a target of a | `rules` | <br> defined in this time series<br> Each rule is an with 4 elements:<br>- : The compaction key<br>- : The bucket duration<br>- : The aggregator<br>- : The alignment (since RedisTimeSeries v1.8) When is specified, the response also contains: | Name<br> | Description | ---------------------------- | - | `keySelfName` | <br> Name of the key | `Chunks` | with information about the chunks<br>Each element is an of information about a single chunk in a name()-value pairs:<br>- `startTimestamp` - - First timestamp present in the chunk<br>- `endTimestamp` - - Last timestamp present in the chunk<br>- `samples` - - Total number of samples in the chunk<br>- `size` - - the chunk's internal data size (without overheads) in bytes<br>- `bytesPerSample` - (double) - Ratio of `size` and `samples`.",
+      "resp2": {
+        "type": "kv_array",
+        "summary": "With information about the time series as flattened name-value pairs: | Name<br> | Description | ---------------------------- | - | `totalSamples` | <br> Total number of samples in this time series | `memoryUsage` | <br> Total number of bytes allocated for this time series, which is the sum of <br> - The memory used for storing the series' configuration parameters (retention period, duplication policy, etc.)<br>- The memory used for storing the series' compaction rules<br>- The memory used for storing the series' labels (key-value pairs)<br>- The memory used for storing the chunks (chunk header + compressed/uncompressed data) | `firstTimestamp` | <br> First timestamp present in this time series (Unix timestamp in milliseconds) | `lastTimestamp` | <br> Last timestamp present in this time series (Unix timestamp in milliseconds) | `retentionTime` | <br> The retention period, in milliseconds, for this time series | `chunkCount` | <br> Number of chunks used for this time series | `chunkSize` | <br> The initial allocation size, in bytes, for the data part of each new chunk.<br>Actual chunks may consume more memory. Changing the chunk size (using ) does not affect existing chunks. | `chunkType` | <br> The chunks type: `compressed` or `uncompressed` | `duplicatePolicy` | or <br> The of this time series | `labels` | or <br> Metadata labels of this time series<br> Each element is a 2-elements of (, ) representing (label, value) | `sourceKey` | or <br>Key name for source time series in case the current series is a target of a | `rules` | <br> defined in this time series<br> Each rule is an with 4 elements:<br>- : The compaction key<br>- : The bucket duration<br>- : The aggregator<br>- : The alignment (since RedisTimeSeries v1.8) When is specified, the response also contains: | Name<br> | Description | ---------------------------- | - | `keySelfName` | <br> Name of the key | `Chunks` | with information about the chunks<br>Each element is an of information about a single chunk in a name()-value pairs:<br>- `startTimestamp` - - First timestamp present in the chunk<br>- `endTimestamp` - - Last timestamp present in the chunk<br>- `samples` - - Total number of samples in the chunk<br>- `size` - - the chunk's internal data size (without overheads) in bytes<br>- `bytesPerSample` - (double) - Ratio of `size` and `samples`.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "With information about the time series. The map contains the same fields as described in the RESP2 response, but organized as key-value pairs in a map structure rather than a flattened array. When is specified, the response also contains the additional `keySelfName` and `Chunks` fields as described above.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "TS.MADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": ", where each element is an representing the timestamp of a upserted sample. For each element that is ignored (see `IGNORE` in ), the reply element value will be the largest timestamp in the time series."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid arguments"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "duplication policy is `BLOCK`"
+              },
+              {
+                "value": "when `timestamp` is older than the retention period compared to the maximum existing timestamp"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.MGET": {
+    "returns": {
+      "summary": "For each time series matching the specified filters, the following is reported: - : The time series key name - : label-value pairs (, ) - By default, an empty array is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined) - : a single timestamp-value pair (, ).",
+      "resp2": {
+        "type": "array",
+        "summary": "For each time series matching the specified filters, the following is reported: - : The time series key name - : label-value pairs (, ) - By default, an empty array is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined) - : a single timestamp-value pair (, ).",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "For each time series matching the specified filters, the following is reported: - : The time series key name - or : label-value pairs - By default, an empty array is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported as a map - If `SELECTED_LABELS label...` is specified, the selected labels are reported as a map (null value when no such label defined) - : a single timestamp-value pair (, ).",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "TS.MRANGE": {
+    "returns": {
+      "summary": "If `GROUPBY label REDUCE reducer` is not specified: : for each time series matching the specified filters, the following is reported: - : The time series key name - : label-value pairs (, ) - By default, an empty array is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined) - : timestamp-value pairs (, ) representing all samples/aggregations matching the range If `GROUPBY label REDUCE reducer` is specified: : for each group of time series matching the specified filters, the following is reported: - with the format `label=value` where `label` is the `GROUPBY` label argument - : label-value pairs (, ): - By default, an empty array is reported - If `WITHLABELS` is specified, the `GROUPBY` label argument and value are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined or label does not have the same value for all grouped time series) - : either a single pair (, ): the `GROUPBY` label argument and value, or empty array - : a single pair (, ): the string `__reducer__` and the reducer argument - : a single pair (, ): the string `__source__` and the time series key names separated by \",\" - : timestamp-value pairs (, ) representing all samples/aggregations matching the range.",
+      "resp2": {
+        "type": "array",
+        "summary": "If `GROUPBY label REDUCE reducer` is not specified: : for each time series matching the specified filters, the following is reported: - : The time series key name - : label-value pairs (, ) - By default, an empty array is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined) - : timestamp-value pairs (, ) representing all samples/aggregations matching the range If `GROUPBY label REDUCE reducer` is specified: : for each group of time series matching the specified filters, the following is reported: - with the format `label=value` where `label` is the `GROUPBY` label argument - : label-value pairs (, ): - By default, an empty array is reported - If `WITHLABELS` is specified, the `GROUPBY` label argument and value are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported (null value when no such label defined or label does not have the same value for all grouped time series) - : either a single pair (, ): the `GROUPBY` label argument and value, or empty array - : a single pair (, ): the string `__reducer__` and the reducer argument - : a single pair (, ): the string `__source__` and the time series key names separated by \",\" - : timestamp-value pairs (, ) representing all samples/aggregations matching the range.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "If `GROUPBY label REDUCE reducer` is not specified: : for each time series matching the specified filters, the following is reported: - : The time series key name - or : label-value pairs - By default, an empty map is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported as a map - If `SELECTED_LABELS label...` is specified, the selected labels are reported as a map (null value when no such label defined) - Additional metadata including aggregators information - : timestamp-value pairs (, ) representing all samples/aggregations matching the range If `GROUPBY label REDUCE reducer` is specified: Similar structure as RESP2 but with map-based organization for labels and metadata, and double values instead of string values.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "TS.MREVRANGE": {
+    "returns": {
+      "summary": "If `GROUPBY label REDUCE reducer` is not specified: : for each time series matching the specified filters, the following is reported: - : The time series key name - : label-value pairs (, ) - By default, an empty array is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported - : timestamp-value pairs (, ) representing all samples/aggregations matching the range in reverse chronological order If `GROUPBY label REDUCE reducer` is specified: : for each group of time series matching the specified filters, the following is reported: - with the format `label=value` where `label` is the `GROUPBY` label argument - : a single pair (, ): the `GROUPBY` label argument and value - : a single pair (, ): the string `__reducer__` and the reducer argument - : a single pair (, ): the string `__source__` and the time series key names separated by \",\" - : timestamp-value pairs (, ) representing all samples/aggregations matching the range in reverse chronological order.",
+      "resp2": {
+        "type": "array",
+        "summary": "If `GROUPBY label REDUCE reducer` is not specified: : for each time series matching the specified filters, the following is reported: - : The time series key name - : label-value pairs (, ) - By default, an empty array is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported - If `SELECTED_LABELS label...` is specified, the selected labels are reported - : timestamp-value pairs (, ) representing all samples/aggregations matching the range in reverse chronological order If `GROUPBY label REDUCE reducer` is specified: : for each group of time series matching the specified filters, the following is reported: - with the format `label=value` where `label` is the `GROUPBY` label argument - : a single pair (, ): the `GROUPBY` label argument and value - : a single pair (, ): the string `__reducer__` and the reducer argument - : a single pair (, ): the string `__source__` and the time series key names separated by \",\" - : timestamp-value pairs (, ) representing all samples/aggregations matching the range in reverse chronological order.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": {
+        "type": "map",
+        "summary": "If `GROUPBY label REDUCE reducer` is not specified: : for each time series matching the specified filters, the following is reported: - : The time series key name - or : label-value pairs - By default, an empty map is reported - If `WITHLABELS` is specified, all labels associated with this time series are reported as a map - If `SELECTED_LABELS label...` is specified, the selected labels are reported as a map - Additional metadata including aggregators information - : timestamp-value pairs (, ) representing all samples/aggregations matching the range in reverse chronological order If `GROUPBY label REDUCE reducer` is specified: Similar structure as RESP2 but with map-based organization for labels and metadata, and double values instead of string values.",
+        "key_type": "bulk_string",
+        "value_type": {
+          "type": "bulk_string"
+        },
+        "note": "Field set not enumerated by prose; verify."
+      }
+    },
+    "returns_status": "stub"
+  },
+  "TS.QUERYINDEX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Where each element is a : a time series key. The array is empty if no time series matches the filter.",
+            "when": "no time series matches the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid filter expression"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "set",
+            "summary": "Where each element is a : a time series key. The set is empty if no time series matches the filter.",
+            "when": "no time series matches the filter"
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid filter expression"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "TS.RANGE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of (, ) pairs representing (timestamp, value)."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid filter value"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "key does not exist"
+              },
+              {
+                "value": "etc"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TS.REVRANGE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of (, ) pairs representing (timestamp, value) in reverse chronological order."
+          },
+          {
+            "type": "simple_error",
+            "messages": [
+              {
+                "value": "invalid filter value"
+              },
+              {
+                "value": "wrong key type"
+              },
+              {
+                "value": "key does not exist"
+              },
+              {
+                "value": "etc"
+              }
+            ]
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TTL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "TTL in seconds."
+          },
+          {
+            "type": "integer",
+            "summary": "`-1` if the key exists but has no associated expiration.",
+            "when": "the key exists but has no associated expiration"
+          },
+          {
+            "type": "integer",
+            "summary": "`-2` if the key does not exist.",
+            "when": "the key does not exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "TYPE": {
+    "returns": {
+      "summary": "The type of _key_, or `none` when _key_ doesn't exist.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "The type of _key_, or `none` when _key_ doesn't exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "UNLINK": {
+    "returns": {
+      "summary": "The number of keys that were unlinked.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of keys that were unlinked."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "UNSUBSCRIBE": {
+    "returns": {
+      "resp2": {
+        "type": "bulk_string",
+        "note": "Could not detect type from prose."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "UNWATCH": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "VADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "1 if key was added; 0 if key was not added.",
+            "when": "key was added; 0 if key was not added"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If the command was malformed."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "True if key was added; false if key was not added.",
+            "when": "key was added; false if key was not added"
+          },
+          {
+            "type": "simple_error",
+            "summary": "If the command was malformed."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VCARD": {
+    "returns": {
+      "summary": "0 if the key doesn't exist or the number of elements contained in the vector set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "0 if the key doesn't exist or the number of elements contained in the vector set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "VDIM": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "The number of vector set elements."
+          },
+          {
+            "type": "simple_error",
+            "summary": "If the key does not exist."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "VEMB": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of real numbers as , representing the vector."
+          },
+          {
+            "type": "array",
+            "summary": "Consisting of the following elements: 1. The quantization type as a : `fp32`, `bin`, or `q8`. 1. A blob with the following raw data: * 4-byte floats for fp32 (little-endian encoding) * A bitmap for binary quantization * A byte array for q8 1. The L2 norm, as a , of the vector before normalization. 1. (Only for q8): The quantization range as a . Multiply this by integer components to recover normalized values."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Of , representing the vector."
+          },
+          {
+            "type": "array",
+            "summary": "Consisting of the following elements: 1. The quantization type as a : `fp32`, `bin`, or `q8`. 1. A blob with the following raw data: * 4-byte floats for fp32 (little-endian encoding) * A bitmap for binary quantization * A byte array for q8 1. The L2 norm of the vector before normalization. 1. (Only for q8): The quantization range as a . Multiply this by integer components to recover normalized values."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VGETATTR": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "Containing the JSON attribute(s)."
+          },
+          {
+            "type": "bulk_string",
+            "summary": "(null bulk string) for unknown key or element, or when no attributes exist for the given key/element pair.",
+            "when": "no attributes exist for the given key/element pair"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "simple_string",
+            "summary": "Containing the JSON attribute(s)."
+          },
+          {
+            "type": "null",
+            "when": "no attributes exist for the given key/element pair"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VINFO": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Containing metadata and internal details about a vector set, including size, dimensions, quantization type, and graph structure."
+          },
+          {
+            "type": "array",
+            "summary": "(null array reply) for unknown key."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Containing metadata and internal details about a vector set, including size, dimensions, quantization type, and graph structure."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VISMEMBER": {
+    "returns": {
+      "summary": "`0` if the element does not exist in the vector set, or the key does not exist. `1` if the element exists in the vector set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "`0` if the element does not exist in the vector set, or the key does not exist. `1` if the element exists in the vector set."
+      },
+      "resp3": {
+        "type": "boolean",
+        "summary": "`false` if the element does not exist in the vector set, or the key does not exist. `true` if the element exists in the vector set."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VLINKS": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "An of containing the names of adjacent elements as ; interleaved with scores as when used with the `WITHSCORES` option.",
+            "when": "used with the `WITHSCORES` option"
+          },
+          {
+            "type": "simple_error",
+            "summary": "For incorrect syntax."
+          },
+          {
+            "type": "bulk_string",
+            "summary": "(null bulk string) for unknown keys and/or elements."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "An of containing the names of adjacent elements as when used without the `WITHSCORES` option.",
+            "when": "used without the `WITHSCORES` option"
+          },
+          {
+            "type": "array",
+            "summary": "An of containing the names of adjecent elements as , together with their scores as when used with the `WITHSCORES` option.",
+            "when": "used with the `WITHSCORES` option"
+          },
+          {
+            "type": "simple_error",
+            "summary": "For incorrect syntax."
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VRANDMEMBER": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Containing the names of count random elements as ."
+          },
+          {
+            "type": "bulk_string",
+            "summary": "(null bulk string) for unknown keys."
+          },
+          {
+            "type": "array",
+            "summary": "(empty array) for unknown keys when a count is specified.",
+            "when": "a count is specified"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "Containing the names of *count* random elements as ."
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "array",
+            "summary": "(empty array) for unknown keys when a count is specified.",
+            "when": "a count is specified"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VRANGE": {
+    "returns": {
+      "summary": "One of the following: - of elements in lexicographical order within the specified range. - (empty array) if the key doesn't exist.",
+      "resp2": {
+        "type": "array",
+        "summary": "One of the following: - of elements in lexicographical order within the specified range. - (empty array) if the key doesn't exist.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "VREM": {
+    "returns": {
+      "summary": "0 if either element or key do not exist; 1 if the element was removed.",
+      "resp2": {
+        "type": "integer",
+        "summary": "0 if either element or key do not exist; 1 if the element was removed."
+      },
+      "resp3": {
+        "type": "boolean",
+        "summary": "False if either element or key do not exist; true if the element was removed."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VSETATTR": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "integer",
+            "summary": "0 if either the key or element does not exist; 1 if the attributes were successfully added to the element.",
+            "when": "either the key or element does not exist; 1 if the attributes were successfully added to the element"
+          },
+          {
+            "type": "simple_error",
+            "summary": "For improperly specified attribute string."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "boolean",
+            "summary": "False if either the key or element does not exist; true if the attributes were successfully added to the element.",
+            "when": "either the key or element does not exist; true if the attributes were successfully added to the element"
+          },
+          {
+            "type": "simple_error",
+            "summary": "For improperly specified attribute string."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "VSIM": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "simple_error",
+            "summary": "For an unknown element."
+          },
+          {
+            "type": "array",
+            "summary": "(empty array) for an unknown key."
+          },
+          {
+            "type": "array",
+            "summary": "With matching elements."
+          },
+          {
+            "type": "array",
+            "summary": "With the `WITHSCORES` option, an with matching elements juxtaposed with as floating-point scores."
+          },
+          {
+            "type": "array",
+            "summary": "With the `WITHSCORES` and `WITHATTRIBS` options, an with matching elements, and two additional elements: (1) a as floating-point score and (2) a representing the JSON attribute associated with the element or for the elements missing an attribute."
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "simple_error",
+            "summary": "For unknown element."
+          },
+          {
+            "type": "array",
+            "summary": "(empty array) for unknown key."
+          },
+          {
+            "type": "array",
+            "summary": "With matching elements."
+          },
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "With the `WITHSCORES` option, a with matching elements (keys) and scores (values)."
+          },
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "With the `WITHSCORES` and `WITHATTRIBS` options, a with matching elements (keys), and an additional array (values) with the following elements: (1) a for the score and (2) a representing the JSON attribute associated with the element or for the elements missing an attribute."
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "WAIT": {
+    "returns": {
+      "summary": "The command returns the number of replicas reached by all the writes performed in the context of the current connection.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The command returns the number of replicas reached by all the writes performed in the context of the current connection."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "The number of replicas reached by all the writes performed in the context of the current connection."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "WAITAOF": {
+    "returns": {
+      "summary": "The command returns an array of two integers: 1. The first is the number of local Redises (0 or 1) that have fsynced to AOF all writes performed in the context of the current connection 2. The second is the number of replicas that have acknowledged doing the same.",
+      "resp2": {
+        "type": "array",
+        "summary": "The command returns an array of two integers: 1. The first is the number of local Redises (0 or 1) that have fsynced to AOF all writes performed in the context of the current connection 2. The second is the number of replicas that have acknowledged doing the same.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "WATCH": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XACK": {
+    "returns": {
+      "summary": "The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XACKDEL": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "1 for each requested ID when the given key does not exist.",
+            "when": "the given key does not exist"
+          },
+          {
+            "type": "array",
+            "summary": "For each ID: * : 1 if the entry was acknowledged and deleted from the stream. * : -1 if no such ID exists in the provided stream key. * : 2 if the entry was acknowledged but not deleted, as there are still dangling references (ACKED option).",
+            "when": "the entry was acknowledged and deleted from the stream"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The ID of the added entry. The ID is the one automatically generated if an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion. When using IDMP and a duplicate is detected, returns the ID of the original entry.",
+            "when": "an asterisk (`*`) is passed as the _id_ argument, otherwise the command just returns the same ID specified by the user during insertion"
+          },
+          {
+            "type": "null",
+            "when": "the NOMKSTREAM option is given and the key doesn't exist"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XAUTOCLAIM": {
+    "returns": {
+      "summary": ", specifically, an array with three elements: 1. A stream ID to be used as the _start_ argument for the next call to XAUTOCLAIM. 2. An containing all the successfully claimed messages in the same format as `XRANGE`. 3. An containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found.",
+      "resp2": {
+        "type": "array",
+        "summary": ", specifically, an array with three elements: 1. A stream ID to be used as the _start_ argument for the next call to XAUTOCLAIM. 2. An containing all the successfully claimed messages in the same format as `XRANGE`. 3. An containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XCFGSET": {
+    "returns": {
+      "summary": "`OK` if the configuration was set successfully.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK` if the configuration was set successfully.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XCLAIM": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "When the _JUSTID_ option is specified, an array of IDs of messages successfully claimed.",
+            "when": "the _JUSTID_ option is specified, an array of IDs of messages successfully claimed"
+          },
+          {
+            "type": "array",
+            "summary": "An array of stream entries, each of which contains an array of two elements, the entry ID and the entry data itself."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XDEL": {
+    "returns": {
+      "summary": "The number of entries that were deleted.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of entries that were deleted."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XDELEX": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "1 for each requested ID when the given key does not exist.",
+            "when": "the given key does not exist"
+          },
+          {
+            "type": "array",
+            "summary": "For each ID: * : -1 if no such ID exists in the provided stream key. * : 1 if the entry was deleted from the stream. * : 2 if the entry was not deleted and there are still existing references (`ACKED` option); also, if there are no consumer groups.",
+            "when": "no such ID exists in the provided stream key"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XGROUP CREATE": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XGROUP CREATECONSUMER": {
+    "returns": {
+      "summary": "The number of created consumers, either 0 or 1.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of created consumers, either 0 or 1."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XGROUP DELCONSUMER": {
+    "returns": {
+      "summary": "The number of pending messages the consumer had before it was deleted.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of pending messages the consumer had before it was deleted."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XGROUP DESTROY": {
+    "returns": {
+      "summary": "The number of destroyed consumer groups, either 0 or 1.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of destroyed consumer groups, either 0 or 1."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XGROUP HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XGROUP SETID": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XIDMPRECORD": {
+    "returns": {
+      "summary": "One of the following: - A - `OK` when the provided pid/iid pair already maps to the same stream ID (that is, the command is idempotent). - A in one of the following cases: - the key does not exist - the key does not refer to a stream - the stream ID refers to an non-existent or deleted entry - pid and/or iid are empty - the pid/iid pair already maps to a different stream ID.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "One of the following: - A - `OK` when the provided pid/iid pair already maps to the same stream ID (that is, the command is idempotent). - A in one of the following cases: - the key does not exist - the key does not refer to a stream - the stream ID refers to an non-existent or deleted entry - pid and/or iid are empty - the pid/iid pair already maps to a different stream ID."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XINFO CONSUMERS": {
+    "returns": {
+      "summary": "A list of consumers and their attributes.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of consumers and their attributes.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XINFO GROUPS": {
+    "returns": {
+      "summary": "A list of consumer groups.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of consumer groups.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XINFO HELP": {
+    "returns": {
+      "summary": "A list of sub-commands and their descriptions.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of sub-commands and their descriptions.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XINFO STREAM": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "When the _FULL_ argument is used, a list of information about a stream in summary form.",
+            "when": "the _FULL_ argument is used, a list of information about a stream in summary form"
+          },
+          {
+            "type": "array",
+            "summary": "When the _FULL_ argument is used, a list of information about a stream in extended form.",
+            "when": "the _FULL_ argument is used, a list of information about a stream in extended form"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "When the _FULL_ argument was not given, a list of information about a stream in summary form.",
+            "when": "the _FULL_ argument was not given, a list of information about a stream in summary form"
+          },
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "When the _FULL_ argument was given, a list of information about a stream in extended form.",
+            "when": "the _FULL_ argument was given, a list of information about a stream in extended form"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "XLEN": {
+    "returns": {
+      "summary": "The number of entries of the stream at _key_.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of entries of the stream at _key_."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XNACK": {
+    "returns": {
+      "summary": "The number of messages successfully released back to the group PEL. Messages that are not in the consumer group PEL will not be counted.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of messages successfully released back to the group PEL. Messages that are not in the consumer group PEL will not be counted."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "The number of messages successfully released back to the consumer group PEL. Messages that are not in the consumer group PEL will not be counted."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "XPENDING": {
+    "returns": {
+      "summary": "* : different data depending on the way XPENDING is called, as explained on this page.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : different data depending on the way XPENDING is called, as explained on this page.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XRANGE": {
+    "returns": {
+      "summary": "A list of stream entries with IDs matching the specified range.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of stream entries with IDs matching the specified range.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XREAD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "An array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`."
+          },
+          {
+            "type": "null",
+            "when": "the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`."
+          },
+          {
+            "type": "null",
+            "when": "the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "XREADGROUP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "array",
+            "summary": "An array where each element is an array composed of a two elements containing the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`."
+          },
+          {
+            "type": "null",
+            "when": "the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "map",
+            "key_type": "bulk_string",
+            "value_type": {
+              "type": "bulk_string"
+            },
+            "note": "Field set not enumerated; verify.",
+            "summary": "A map of key-value elements where each element is composed of the key name and the entries reported for that key. The entries reported are full stream entries, having IDs and the list of all the fields and values. Field and values are guaranteed to be reported in the same order they were added by `XADD`."
+          },
+          {
+            "type": "null",
+            "when": "the _BLOCK_ option is given and a timeout occurs, or if there is no stream that can be served"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "XREVRANGE": {
+    "returns": {
+      "summary": "The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them.",
+      "resp2": {
+        "type": "array",
+        "summary": "The command returns the entries with IDs matching the specified range. The returned entries are complete, which means that the ID and all the fields they are composed of are returned. Moreover, the entries are returned with their fields and values in the same order as `XADD` added them.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "XSETID": {
+    "returns": {
+      "summary": "`OK`.",
+      "resp2": {
+        "type": "simple_string",
+        "summary": "`OK`.",
+        "value": "OK"
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "XTRIM": {
+    "returns": {
+      "summary": "The number of entries deleted from the stream.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of entries deleted from the stream."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZADD": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options"
+          },
+          {
+            "type": "integer",
+            "summary": "The number of new members when the _CH_ option is not used.",
+            "when": "the _CH_ option is not used"
+          },
+          {
+            "type": "integer",
+            "summary": "The number of new or updated members when the _CH_ option is used.",
+            "when": "the _CH_ option is used"
+          },
+          {
+            "type": "bulk_string",
+            "summary": "The updated score of the member when the _INCR_ option is used.",
+            "when": "the _INCR_ option is used"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the operation was aborted because of a conflict with one of the _XX/NX/LT/GT_ options"
+          },
+          {
+            "type": "integer",
+            "summary": "The number of new members when the _CH_ option is not used.",
+            "when": "the _CH_ option is not used"
+          },
+          {
+            "type": "integer",
+            "summary": "The number of new or updated members when the _CH_ option is used.",
+            "when": "the _CH_ option is used"
+          },
+          {
+            "type": "double",
+            "summary": "The updated score of the member when the _INCR_ option is used.",
+            "when": "the _INCR_ option is used"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "ZCARD": {
+    "returns": {
+      "summary": "The cardinality (number of members) of the sorted set, or 0 if the key doesn't exist.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The cardinality (number of members) of the sorted set, or 0 if the key doesn't exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZCOUNT": {
+    "returns": {
+      "summary": "The number of members in the specified score range.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members in the specified score range."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZDIFF": {
+    "returns": {
+      "summary": "* : the result of the difference including, optionally, scores when the _WITHSCORES_ option is used.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : the result of the difference including, optionally, scores when the _WITHSCORES_ option is used.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZDIFFSTORE": {
+    "returns": {
+      "summary": "The number of members in the resulting sorted set at _destination_.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members in the resulting sorted set at _destination_."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZINCRBY": {
+    "returns": {
+      "summary": "The new score of _member_ as a double precision floating point number.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "The new score of _member_ as a double precision floating point number."
+      },
+      "resp3": {
+        "type": "double",
+        "summary": "The new score of _member_."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "ZINTER": {
+    "returns": {
+      "summary": "* : the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : the result of the intersection including, optionally, scores when the _WITHSCORES_ option is used.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZINTERCARD": {
+    "returns": {
+      "summary": "The number of members in the resulting intersection.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members in the resulting intersection."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZINTERSTORE": {
+    "returns": {
+      "summary": "The number of members in the resulting sorted set at the _destination_.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members in the resulting sorted set at the _destination_."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZLEXCOUNT": {
+    "returns": {
+      "summary": "The number of members in the specified score range.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members in the specified score range."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZMPOP": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "no element could be popped"
+          },
+          {
+            "type": "array",
+            "summary": "A two-element array with the first element being the name of the key from which elements were popped, and the second element is an array of the popped elements. Every entry in the elements array is also an array that contains the member and its score."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZMSCORE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the member does not exist in the sorted set"
+          },
+          {
+            "type": "array",
+            "summary": "A list of _member_ scores as double-precision floating point numbers."
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZPOPMAX": {
+    "returns": {
+      "summary": "* : a list of popped elements and scores.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : a list of popped elements and scores.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZPOPMIN": {
+    "returns": {
+      "summary": "* : a list of popped elements and scores.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : a list of popped elements and scores.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZRANDMEMBER": {
+    "returns": {
+      "summary": "Without the additional _count_ argument, the command returns a randomly selected member, or when _key_ doesn't exist. : when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "Without the additional _count_ argument, the command returns a randomly selected member, or when _key_ doesn't exist. : when the additional _count_ argument is passed, the command returns an array of members, or an empty array when _key_ doesn't exist. If the _WITHSCORES_ modifier is used, the reply is a list of members and their scores from the sorted set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZRANGE": {
+    "returns": {
+      "summary": "A list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of members in the specified range with, optionally, their scores when the _WITHSCORES_ option is given.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Member."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZRANGEBYLEX": {
+    "returns": {
+      "summary": "A list of elements in the specified score range.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of elements in the specified score range.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZRANGEBYSCORE": {
+    "returns": {
+      "summary": "* : a list of the members with, optionally, their scores in the specified score range.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : a list of the members with, optionally, their scores in the specified score range.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZRANGESTORE": {
+    "returns": {
+      "summary": "The number of elements in the resulting sorted set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements in the resulting sorted set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZRANK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the key does not exist or the member does not exist in the sorted set"
+          },
+          {
+            "type": "integer",
+            "summary": "The rank of the member when _WITHSCORE_ is not used.",
+            "when": "_WITHSCORE_ is not used"
+          },
+          {
+            "type": "array",
+            "summary": "The rank and score of the member when _WITHSCORE_ is used.",
+            "when": "_WITHSCORE_ is used"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZREM": {
+    "returns": {
+      "summary": "The number of members removed from the sorted set, not including non-existing members.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members removed from the sorted set, not including non-existing members."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZREMRANGEBYLEX": {
+    "returns": {
+      "summary": "The number of members removed.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members removed."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "Number of members removed."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "ZREMRANGEBYRANK": {
+    "returns": {
+      "summary": "The number of members removed.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members removed."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "Number of members removed."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "ZREMRANGEBYSCORE": {
+    "returns": {
+      "summary": "The number of members removed.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of members removed."
+      },
+      "resp3": {
+        "type": "integer",
+        "summary": "Number of members removed."
+      }
+    },
+    "returns_status": "auto"
+  },
+  "ZREVRANGE": {
+    "returns": {
+      "summary": "* : a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : a list of members in the specified range, optionally with their scores if _WITHSCORE_ was used.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Member."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZREVRANGEBYLEX": {
+    "returns": {
+      "summary": "A list of members in the specified score range.",
+      "resp2": {
+        "type": "array",
+        "summary": "A list of members in the specified score range.",
+        "items": {
+          "type": "bulk_string",
+          "summary": "Member."
+        }
+      },
+      "resp3": {
+        "type": "array",
+        "summary": "List of the elements in the specified score range.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      }
+    },
+    "returns_status": "stub"
+  },
+  "ZREVRANGEBYSCORE": {
+    "returns": {
+      "summary": "* : a list of the members and, optionally, their scores in the specified score range.",
+      "resp2": {
+        "type": "array",
+        "summary": "* : a list of the members and, optionally, their scores in the specified score range.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZREVRANK": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "null",
+            "when": "the key does not exist or the member does not exist in the sorted set"
+          },
+          {
+            "type": "integer",
+            "summary": "The rank of the member when _WITHSCORE_ is not used.",
+            "when": "_WITHSCORE_ is not used"
+          },
+          {
+            "type": "array",
+            "summary": "The rank and score of the member when _WITHSCORE_ is used.",
+            "when": "_WITHSCORE_ is used"
+          }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+  "ZSCAN": {
+    "returns": {
+      "summary": "Cursor and scan response in array form.",
+      "resp2": {
+        "type": "array",
+        "summary": "Cursor and scan response in array form.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZSCORE": {
+    "returns": {
+      "resp2": {
+        "oneof": [
+          {
+            "type": "bulk_string",
+            "summary": "The score of the member (a double-precision floating point number), represented as a string."
+          },
+          {
+            "type": "null",
+            "when": "_member_ does not exist in the sorted set, or the key does not exist"
+          }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          {
+            "type": "double",
+            "summary": "The score of the member (a double-precision floating point number)."
+          },
+          {
+            "type": "null",
+            "when": "_member_ does not exist in the sorted set, or the key does not exist"
+          }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+  "ZUNION": {
+    "returns": {
+      "summary": "The result of the union with, optionally, their scores when _WITHSCORES_ is used.",
+      "resp2": {
+        "type": "array",
+        "summary": "The result of the union with, optionally, their scores when _WITHSCORES_ is used.",
+        "items": {
+          "type": "bulk_string",
+          "note": "Item shape not described in prose; verify."
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+  "ZUNIONSTORE": {
+    "returns": {
+      "summary": "The number of elements in the resulting sorted set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "The number of elements in the resulting sorted set."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  }
+}

--- a/tools/extract_returns_from_prose.py
+++ b/tools/extract_returns_from_prose.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""Extract `returns` specs from the prose `## Return information` section
+of each command page.
+
+Usage:
+    python3 extract_returns_from_prose.py [--cmd <name>] [--out <path>]
+
+Without --cmd, walks every `public/commands/*/index.html.md` and emits a
+single JSON document keyed by uppercased command name. With --cmd, emits
+just that command's entry to stdout for inspection.
+
+The extractor is heuristic. It produces `returns_status: "auto"` when it
+believes it captured the shape, and `"stub"` when it knows it didn't.
+The `note` field flags inferences the heuristic isn't fully confident
+about. See returns-metadata-spec.md §15.1 for the downgrade and `note`
+rules this implements.
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMMANDS_DIR = REPO_ROOT / "public" / "commands"
+
+
+# ---- type detection from a prose link "[X reply](...)" ---------------------
+
+RESP_TYPE_MAP = [
+    # Order matters — longer phrases first to avoid premature matches.
+    ("Null bulk string reply",   "null"),
+    ("Null reply",               "null"),
+    ("Nil reply",                "null"),
+    ("Simple string reply",      "simple_string"),
+    ("Bulk string reply",        "bulk_string"),
+    ("Verbatim string reply",    "verbatim_string"),
+    ("Integer reply",            "integer"),
+    ("Double reply",             "double"),
+    ("Boolean reply",            "boolean"),
+    ("Big number reply",         "big_number"),
+    ("Map reply",                "map"),
+    ("Array reply",              "array"),
+    ("Set reply",                "set"),
+    ("Simple error reply",       "simple_error"),
+    ("Bulk error reply",         "bulk_error"),
+    # Bare forms used by some module pages
+    ("Array",                    "array"),
+    ("Map",                      "map"),
+    ("Set",                      "set"),
+    ("Simple string",            "simple_string"),
+    ("Integer",                  "integer"),
+    ("Bulk string",              "bulk_string"),
+    ("Boolean",                  "boolean"),
+    ("Double",                   "double"),
+]
+
+LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+
+
+def detect_type(text):
+    """Return RESP type-tag for the first protocol-spec link in `text`,
+    or None if none found. Matches case-insensitively (prose sometimes
+    drops a leading capital, e.g. `[maps](...)`)."""
+    for m in LINK_RE.finditer(text):
+        label = m.group(1).strip().lower()
+        for prose_name, tag in RESP_TYPE_MAP:
+            if label.startswith(prose_name.lower()):
+                return tag, label
+    return None, None
+
+
+# ---- section extraction ----------------------------------------------------
+
+def split_protocols(section):
+    """Return (resp2_text, resp3_text) from the Return information body."""
+    parts = re.split(r"\*\*RESP3:?\*\*\s*", section, maxsplit=1)
+    if len(parts) != 2:
+        return section, None
+    resp2_part = re.sub(r"\*\*RESP2:?\*\*\s*", "", parts[0]).strip()
+    resp3_part = parts[1].strip()
+    return resp2_part, resp3_part
+
+
+def get_return_section(md_path):
+    """Return the prose of the `## Return information` section as a single
+    string, or None if absent."""
+    text = md_path.read_text(encoding="utf-8")
+    m = re.search(r"^## Return information\s*\n(.*?)(?=^## |\Z)",
+                  text, flags=re.MULTILINE | re.DOTALL)
+    if not m:
+        return None
+    return m.group(1).strip()
+
+
+# ---- top-level pattern matching -------------------------------------------
+
+PROSE_VALUE_RE = re.compile(r"`([^`]+)`")
+SENTINEL_VALUE_RE = re.compile(r":\s*`([^`]+)`")  # ": `OK`"
+
+# Recognise "One of the following:" / "Any of the following:" preambles
+ONEOF_PREAMBLE_RE = re.compile(
+    r"^(?:One|Any) of the following:?\s*$",
+    flags=re.MULTILINE | re.IGNORECASE,
+)
+
+# Top-level bullet at column 0
+TOP_BULLET_RE = re.compile(r"^\*\s+(.*?)(?=^\*\s|\Z)",
+                           flags=re.MULTILINE | re.DOTALL)
+
+# Indented `- \`name\`: [Type](...) - description` for map-fields blocks
+FIELD_BULLET_RE = re.compile(
+    r"^\s*-\s+`([^`]+)`\s*:\s*(\[[^\]]+\]\([^)]+\))(?:\s+of\s+(\[[^\]]+\]\([^)]+\)))?([^\n]*)",
+    flags=re.MULTILINE,
+)
+
+
+def extract_when(text):
+    """Pull a `when X` predicate out of a bullet's trailing prose.
+
+    Does not match "in these cases:" — that's the error-list marker,
+    handled separately by extract_error_messages.
+    """
+    text = text.strip()
+    text = re.sub(r"\s+", " ", text)
+    # "when X" / "if X" / "in case X"
+    m = re.search(r"(?:^|[:\s])(?:when|if|in case)\s+([^.]+?)(?:[.]|$)",
+                  text, flags=re.IGNORECASE)
+    if m:
+        return m.group(1).strip().rstrip(".,")
+    return None
+
+
+def extract_sentinel(text):
+    """Pull a backticked sentinel value out of a bullet, e.g. `OK`."""
+    m = SENTINEL_VALUE_RE.search(text)
+    if m:
+        return m.group(1)
+    return None
+
+
+def clean_summary(text):
+    """Strip leading colon/whitespace and trailing whitespace; convert to
+    period-terminated sentence."""
+    text = text.strip()
+    text = re.sub(r"^[:\s\-]+", "", text)
+    text = re.sub(r"\s+", " ", text)
+    if text and not text.endswith("."):
+        text = text + "."
+    # Capitalise first letter
+    if text:
+        text = text[0].upper() + text[1:]
+    return text
+
+
+def extract_error_messages(text):
+    """Pull enumerated error sentinel messages out of an error bullet's
+    prose."""
+    # "in these cases: X, Y, Z." — comma-separated
+    m = re.search(r"in these cases?:\s*(.+?)\.?\s*$",
+                  text, flags=re.IGNORECASE | re.DOTALL)
+    if not m:
+        return None
+    rest = m.group(1)
+    parts = [p.strip() for p in re.split(r",|\bor\b", rest) if p.strip()]
+    return [{"value": p.rstrip(".")} for p in parts]
+
+
+# ---- per-bullet → spec ----------------------------------------------------
+
+def bullet_to_spec(bullet_text):
+    """Translate a single top-level bullet into a ReplySpec node."""
+    tag, _ = detect_type(bullet_text)
+    if tag is None:
+        return {"type": "bulk_string",
+                "note": "Type could not be detected from prose."}
+
+    when = extract_when(bullet_text)
+    summary = bullet_text
+    summary = LINK_RE.sub("", summary)        # strip the [X reply](...)
+    # Strip "in these cases: ..." trail from the summary if we'll capture
+    # messages from it below.
+    if tag in ("simple_error", "bulk_error"):
+        summary = re.sub(r"in these cases?:.*$", "",
+                         summary, flags=re.IGNORECASE | re.DOTALL)
+    summary = clean_summary(summary)
+
+    node = {}
+    if tag == "null":
+        node["type"] = "null"
+    elif tag in ("simple_error", "bulk_error"):
+        node["type"] = tag
+        msgs = extract_error_messages(bullet_text)
+        if msgs:
+            node["messages"] = msgs
+        # Error bullets don't take a `when` from "in these cases:"
+        when = None
+    elif tag == "simple_string":
+        node["type"] = "simple_string"
+        sentinel = extract_sentinel(bullet_text)
+        if sentinel:
+            node["value"] = sentinel
+    elif tag == "map":
+        node["type"] = "map"
+        fields = parse_map_fields(bullet_text)
+        if fields:
+            node["fields"] = fields
+            # Once we've decomposed into fields, drop the catch-all summary —
+            # the prose summary is "with the following fields: ..." which is
+            # noise once fields are extracted.
+            summary = None
+        else:
+            node["key_type"] = "bulk_string"
+            node["value_type"] = {"type": "bulk_string"}
+            node["note"] = "Field set not enumerated; verify."
+    else:
+        node["type"] = tag
+
+    if summary and tag not in ("null",):
+        node["summary"] = summary
+    if when:
+        node["when"] = when
+    return node
+
+
+def parse_oneof(text):
+    """Match a `One of the following:` preamble followed by top-level
+    bullets. Return list of ReplySpec branches, or None."""
+    if not ONEOF_PREAMBLE_RE.search(text):
+        return None
+    bullets = TOP_BULLET_RE.findall(text)
+    bullets = [b for b in bullets if b.strip()]
+    if not bullets:
+        return None
+    return [bullet_to_spec(b) for b in bullets]
+
+
+def parse_map_fields(text):
+    """For RESP3 'Map with the following fields:' patterns, extract the
+    enumerated fields."""
+    if "with the following fields" not in text.lower():
+        return None
+    fields = []
+    for m in FIELD_BULLET_RE.finditer(text):
+        name = m.group(1)
+        type_link = m.group(2)
+        item_link = m.group(3)   # Optional inner type for "Array of Maps"
+        tail = m.group(4) or ""
+        # Get the type tag from the link
+        tag, _ = detect_type(type_link)
+        if tag is None:
+            tag = "bulk_string"
+        # Description after the link
+        tail_line = re.sub(r"\s+", " ", tail).strip()
+        tail_line = re.sub(r"^[-:]\s*", "", tail_line)
+        # Strip the "of X" prefix where X is conceptually the items type.
+        # This applies whether or not item_link captured anything.
+        tail_line = re.sub(r"^(?:of|containing)\s+", "", tail_line,
+                           flags=re.IGNORECASE)
+        field = {"name": name, "type": tag}
+        if tail_line:
+            field["summary"] = clean_summary(tail_line)
+        if tag == "array":
+            inner_tag = None
+            if item_link:
+                inner_tag, _ = detect_type(item_link)
+            field["items"] = {"type": inner_tag or "bulk_string"}
+            if inner_tag == "map":
+                field["items"]["key_type"] = "bulk_string"
+                field["items"]["value_type"] = {"type": "bulk_string"}
+                field["items"]["note"] = "Field set within nested maps not enumerated; verify."
+            elif not inner_tag:
+                field["note"] = "Items inferred as bulk_string; verify."
+        elif tag == "map":
+            field["key_type"] = "bulk_string"
+            field["value_type"] = {"type": "bulk_string"}
+            field["note"] = "Field set within this nested map not enumerated by prose; verify."
+        fields.append(field)
+    if not fields:
+        return None
+    return fields
+
+
+def has_nested_conditional_structure(text):
+    """Detect prose that the flat heuristic cannot faithfully encode.
+
+    True when:
+    - "If X was/is specified" appears more than once (SET-style branching)
+    - Sub-bulleted lists appear under top-level bullets (deep nesting)
+    - "In the following two cases" / "in the following N cases" appears
+    """
+    if len(re.findall(r"If\s+`?[A-Z]+`?\s+was\s+(?:not\s+)?specified",
+                      text, flags=re.IGNORECASE)) >= 2:
+        return True
+    if re.search(r"in the following (?:two|three|four|\d+) cases?",
+                 text, flags=re.IGNORECASE):
+        return True
+    return False
+
+
+def parse_protocol_section(text):
+    """Translate the prose for one protocol into a ReplySpec.
+
+    Returns (spec, downgrade_to_stub) — boolean indicates whether the
+    extractor judges this entry shape-incomplete.
+    """
+    if text is None:
+        return None, False
+    text = text.strip()
+
+    nested = has_nested_conditional_structure(text)
+
+    # 1. Try `oneof` form (multiple top-level bullets after "One of the following:")
+    branches = parse_oneof(text)
+    if branches is not None:
+        return ({"oneof": branches}, nested)
+
+    # 2. Map fields enumerated explicitly
+    fields = parse_map_fields(text)
+    if fields:
+        return ({"type": "map", "fields": fields}, False)
+
+    # 3. Single declarative line "[X reply](...): summary"
+    tag, _ = detect_type(text)
+    if tag is None:
+        return ({"type": "bulk_string",
+                 "note": "Could not detect type from prose."}, True)
+
+    # If the prose has nested-conditional structure that didn't trigger
+    # the oneof path (no "One of the following:" preamble), the flat
+    # single-leaf result is misleading. Downgrade to stub.
+    if nested:
+        return ({"type": tag,
+                 "note": "Prose has nested-conditional structure (e.g. `If X was specified`) that the flat heuristic cannot encode. Full shape requires hand-authoring."},
+                True)
+
+    summary_text = LINK_RE.sub("", text)
+    summary_text = clean_summary(summary_text)
+
+    spec = {"type": tag}
+    if summary_text:
+        spec["summary"] = summary_text
+
+    # Container types need items / fields — flag if missing
+    downgrade = False
+    if tag == "array":
+        # Try to infer items from prose patterns
+        lower = text.lower()
+        if "list of fields" in lower or "list of field names" in lower:
+            spec["items"] = {"type": "bulk_string", "summary": "Field name."}
+        elif "list of values" in lower:
+            spec["items"] = {"type": "bulk_string", "summary": "Field value."}
+        elif "list of members" in lower:
+            spec["items"] = {"type": "bulk_string", "summary": "Member."}
+        elif "two-element array" in lower:
+            spec["type"] = "tuple"
+            spec["prefixItems"] = [
+                {"type": "bulk_string"}, {"type": "bulk_string"}
+            ]
+            spec["note"] = "Two-element tuple inferred from prose; element types/names not enumerated."
+        elif "pairs" in lower and "(" in text and ")" in text:
+            # "Array reply of (Integer, Double) pairs" pattern
+            tup_m = re.search(r"\(([^)]+)\)\s*pairs", text)
+            if tup_m:
+                inner_types = []
+                for raw in tup_m.group(1).split(","):
+                    sub_tag, _ = detect_type(raw)
+                    inner_types.append({"type": sub_tag or "bulk_string"})
+                spec["items"] = {
+                    "type": "tuple",
+                    "prefixItems": inner_types,
+                    "note": "Tuple shape inferred from `(Type1, Type2) pairs` pattern.",
+                }
+            else:
+                spec["items"] = {"type": "bulk_string",
+                                 "note": "Item shape not described in prose; verify."}
+                downgrade = True
+        else:
+            spec["items"] = {"type": "bulk_string",
+                             "note": "Item shape not described in prose; verify."}
+            downgrade = True
+    elif tag == "map":
+        # No fields enumerated — try the kv-array/map duality hint
+        lower = text.lower()
+        if "fields and their values" in lower or "field-value pairs" in lower \
+                or "key-value pairs" in lower:
+            spec["key_type"] = "bulk_string"
+            spec["value_type"] = {"type": "bulk_string"}
+        else:
+            spec["key_type"] = "bulk_string"
+            spec["value_type"] = {"type": "bulk_string"}
+            spec["note"] = "Field set not enumerated by prose; verify."
+            downgrade = True
+    elif tag == "simple_string":
+        sentinel = extract_sentinel(text)
+        if sentinel:
+            spec["value"] = sentinel
+
+    return spec, downgrade
+
+
+# ---- RESP2/RESP3 pairing rule (kv_array <-> map) --------------------------
+
+def apply_kvarray_pairing(resp2_spec, resp3_spec):
+    """If RESP2 says 'array of fields and their values' and RESP3 says
+    'map of fields and their values', rewrite RESP2 to use kv_array."""
+    if not isinstance(resp2_spec, dict) or not isinstance(resp3_spec, dict):
+        return resp2_spec, resp3_spec
+    if resp2_spec.get("type") == "array" and resp3_spec.get("type") == "map":
+        s2 = (resp2_spec.get("summary") or "").lower()
+        s3 = (resp3_spec.get("summary") or "").lower()
+        if any(k in s2 + " " + s3 for k in
+               ("fields and their values", "field-value pairs",
+                "key-value pairs", "parameters matching")):
+            resp2_spec = {
+                "type": "kv_array",
+                "summary": resp2_spec.get("summary"),
+                "key_type": resp3_spec.get("key_type", "bulk_string"),
+                "value_type": resp3_spec.get("value_type", {"type": "bulk_string"}),
+            }
+    return resp2_spec, resp3_spec
+
+
+def merge_protocols(resp2_spec, resp3_spec):
+    """Return a `returns` block with same_as_resp2 collapsing where appropriate."""
+    if resp3_spec is None:
+        return {"resp2": resp2_spec, "resp3": "same_as_resp2"}
+    if json.dumps(resp2_spec, sort_keys=True) == json.dumps(resp3_spec, sort_keys=True):
+        return {"resp2": resp2_spec, "resp3": "same_as_resp2"}
+    return {"resp2": resp2_spec, "resp3": resp3_spec}
+
+
+# ---- per-command pipeline -------------------------------------------------
+
+def extract_for_command(md_path):
+    """Return (returns_block, returns_status) for one command page, or
+    (None, "missing") if the page has no Return information section."""
+    section = get_return_section(md_path)
+    if section is None:
+        return None, "missing"
+
+    resp2_text, resp3_text = split_protocols(section)
+    resp2_spec, downgrade2 = parse_protocol_section(resp2_text)
+    if resp3_text:
+        resp3_spec, downgrade3 = parse_protocol_section(resp3_text)
+    else:
+        resp3_spec, downgrade3 = None, False
+
+    if resp2_spec and resp3_spec:
+        resp2_spec, resp3_spec = apply_kvarray_pairing(resp2_spec, resp3_spec)
+
+    block = merge_protocols(resp2_spec, resp3_spec)
+    block["summary"] = (resp2_spec.get("summary") if isinstance(resp2_spec, dict) else None) or ""
+    # Move summary first key by reconstructing
+    ordered = {"summary": block["summary"], "resp2": block["resp2"], "resp3": block["resp3"]}
+    if not ordered["summary"]:
+        del ordered["summary"]
+
+    status = "stub" if (downgrade2 or downgrade3) else "auto"
+    return ordered, status
+
+
+def slug_to_command_name(slug):
+    """Map directory slug to canonical uppercase command name."""
+    # e.g. "client-list" -> "CLIENT LIST", "ft.search" -> "FT.SEARCH"
+    if "." in slug:
+        return slug.upper()
+    return slug.replace("-", " ").upper()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--cmd", help="Single command slug to extract (e.g. 'get').")
+    p.add_argument("--out", help="Write JSON output to this path (default: stdout).")
+    args = p.parse_args()
+
+    if args.cmd:
+        md = COMMANDS_DIR / args.cmd / "index.html.md"
+        if not md.exists():
+            print(f"No page at {md}", file=sys.stderr)
+            return 1
+        block, status = extract_for_command(md)
+        out = {slug_to_command_name(args.cmd): {"returns": block, "returns_status": status}}
+        print(json.dumps(out, indent=2))
+        return 0
+
+    out = {}
+    stats = {"auto": 0, "stub": 0, "missing": 0}
+    for sub in sorted(COMMANDS_DIR.iterdir()):
+        if not sub.is_dir():
+            continue
+        md = sub / "index.html.md"
+        if not md.exists():
+            continue
+        block, status = extract_for_command(md)
+        stats[status] += 1
+        if block is None:
+            continue
+        out[slug_to_command_name(sub.name)] = {
+            "returns": block, "returns_status": status,
+        }
+    payload = {
+        "_meta": {
+            "command_count": sum(stats.values()),
+            "extracted_count": stats["auto"] + stats["stub"],
+            "tier_distribution": stats,
+        },
+        **out,
+    }
+    text = json.dumps(payload, indent=2)
+    if args.out:
+        Path(args.out).write_text(text + "\n")
+        print(f"Wrote {len(out)} commands to {args.out}", file=sys.stderr)
+        print(f"Distribution: {stats}", file=sys.stderr)
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/render_returns_to_prose.py
+++ b/tools/render_returns_to_prose.py
@@ -334,39 +334,74 @@ def render_examples(examples, cmd_name):
 
 
 def render_returns(returns, cmd_name=""):
-    """Render a full `returns` block to a markdown string with two
-    per-protocol sections, plus examples if present."""
-    out = []
+    """Render a full `returns` block to a markdown string with the two
+    per-protocol sections wrapped in a multitabs shortcode for human
+    rendering, plus an Examples section appended verbatim."""
+    proto_sections = {}
     for proto in (2, 3):
         key = f"resp{proto}"
         spec = returns.get(key)
         if isinstance(spec, str) and spec.startswith("same_as_"):
             other = "resp2" if "resp2" in spec else "resp3"
             spec = returns.get(other)
-        out.append(f"**RESP{proto}:**")
-        out.append("")
-        lines = render_spec(spec, proto)
-        out.extend(lines)
-        out.append("")
+        proto_sections[proto] = "\n".join(render_spec(spec, proto))
+
+    slug = cmd_name.lower().replace(" ", "-").replace(".", "-")
+    out = []
+    out.append(f'{{{{< multitabs id="{slug}-return-info"')
+    out.append('    tab1="RESP2"')
+    out.append('    tab2="RESP3" >}}')
+    out.append("")
+    out.append(proto_sections[2])
+    out.append("")
+    out.append("-tab-sep-")
+    out.append("")
+    out.append(proto_sections[3])
+    out.append("")
+    out.append("{{< /multitabs >}}")
+    out.append("")
     out.extend(render_examples(returns.get("examples", []), cmd_name))
     return "\n".join(out)
 
 
+def slug_for(cmd):
+    """Convert a command name to a filename slug (matches Hugo's URL-style)."""
+    return cmd.lower().replace(" ", "-").replace(".", ".")
+
+
 def main():
     p = argparse.ArgumentParser()
-    p.add_argument("specs", help="Path to a commands_returns_<module>.json file.")
+    p.add_argument("specs", nargs="+", help="Paths to commands_returns_*.json files.")
     p.add_argument("--cmd", help="Render only this command (uppercased).")
+    p.add_argument("--out-dir",
+                   help="Write one .md file per command to this directory "
+                        "(slug-based filename, no `## Return information` header).")
     args = p.parse_args()
 
-    data = json.loads(Path(args.specs).read_text())
-    for cmd, entry in data.items():
-        if cmd.startswith("_"):
-            continue
-        if args.cmd and cmd != args.cmd:
-            continue
-        print(f"\n## {cmd}\n")
-        print("## Return information\n")
-        print(render_returns(entry["returns"], cmd_name=cmd))
+    out_dir = Path(args.out_dir) if args.out_dir else None
+    if out_dir:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    for spec_path in args.specs:
+        data = json.loads(Path(spec_path).read_text())
+        for cmd, entry in data.items():
+            if cmd.startswith("_"):
+                continue
+            if args.cmd and cmd != args.cmd:
+                continue
+            body = render_returns(entry["returns"], cmd_name=cmd)
+            if out_dir:
+                f = out_dir / f"{slug_for(cmd)}.md"
+                f.write_text(body)
+                written += 1
+            else:
+                print(f"\n## {cmd}\n")
+                print("## Return information\n")
+                print(body)
+
+    if out_dir:
+        print(f"Wrote {written} files to {out_dir}", file=sys.stderr)
     return 0
 
 

--- a/tools/render_returns_to_prose.py
+++ b/tools/render_returns_to_prose.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Render `returns` JSON specs to the markdown `## Return information`
+section format used by the docs site.
+
+Demonstrates spec §12.1 in working form. Output should be at least as
+clear as the hand-written prose currently in `public/commands/*/index.html.md`,
+and follows the same protocol-spec link conventions.
+
+Usage:
+    python3 render_returns_to_prose.py data/commands_returns_core.json [--cmd HSET]
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+# Per-protocol link metadata. The link text and URL anchor differ between
+# RESP2 and RESP3 for nulls (RESP2 carries them as "Nil bulk string", RESP3
+# has a dedicated null type).
+TYPE_LINKS = {
+    "simple_string":   ("Simple string reply", "simple-strings"),
+    "bulk_string":     ("Bulk string reply",   "bulk-strings"),
+    "verbatim_string": ("Verbatim string reply", "verbatim-strings"),
+    "integer":         ("Integer reply",       "integers"),
+    "double":          ("Double reply",        "doubles"),
+    "boolean":         ("Boolean reply",       "booleans"),
+    "big_number":      ("Big number reply",    "big-numbers"),
+    "array":           ("Array reply",         "arrays"),
+    "map":             ("Map reply",           "maps"),
+    "set":             ("Set reply",           "sets"),
+    "push":            ("Push reply",          "pushes"),
+    "simple_error":    ("Simple error reply",  "simple-errors"),
+    "bulk_error":      ("Bulk error reply",    "bulk-errors"),
+    "kv_array":        ("Array reply",         "arrays"),    # wire-type: array of alternating k,v
+    "tuple":           ("Array reply",         "arrays"),    # wire-type: array with positional shape
+}
+
+# Null gets per-protocol link text.
+NULL_LINKS = {
+    2: ("Nil reply",  "bulk-strings"),
+    3: ("Null reply", "nulls"),
+}
+
+LINK_BASE = "../../develop/reference/protocol-spec"
+
+
+def type_link(t, proto):
+    if t == "null":
+        text, anchor = NULL_LINKS[proto]
+    else:
+        text, anchor = TYPE_LINKS.get(t, (t, ""))
+    return f"[{text}]({LINK_BASE}#{anchor})"
+
+
+def render_summary(node):
+    s = node.get("summary")
+    if not s:
+        return ""
+    return s if s.endswith(".") else s + "."
+
+
+def render_when(node):
+    when = node.get("when")
+    if not when:
+        return ""
+    return f"_{when}_ — "
+
+
+def render_spec(spec, proto, depth=0):
+    """Return the rendered markdown lines for a ReplySpec at the given depth."""
+    if spec is None:
+        return [""]
+
+    # oneof — render as a bulleted list of branches
+    if "oneof" in spec:
+        lines = ["One of the following:"]
+        for branch in spec["oneof"]:
+            lines.extend(render_branch(branch, proto))
+        return lines
+
+    return render_typed_node(spec, proto, depth=depth)
+
+
+def render_branch(branch, proto):
+    """Render one branch of a oneof — a bulleted list item, with
+    nested structure expanded as sub-bullets when present.
+
+    Style: type link first, then summary, then `when` as a trailing
+    parenthetical in italics. Container types (array, tuple, map)
+    expand their inner shape as indented sub-content.
+    """
+    t = branch.get("type")
+    when_text = branch.get("when")
+    suffix = f" _(when {when_text})_" if when_text and when_text not in ("default", "success") else ""
+    summary = render_summary(branch)
+    link = type_link(t, proto)
+
+    if t == "simple_error":
+        messages = branch.get("messages", [])
+        msg_str = "; ".join(m["value"] if isinstance(m, dict) else m for m in messages)
+        return [f"* {link} in these cases: {msg_str}."]
+    if t == "simple_string" and "value" in branch:
+        body = f"{link}: `{branch['value']}`."
+        if summary:
+            body += f" {summary}"
+        return [f"* {body}{suffix}"]
+    if t == "null":
+        return [f"* {link}{suffix}."]
+
+    # Header line
+    if summary:
+        out = [f"* {link}: {summary}{suffix}"]
+    else:
+        out = [f"* {link}{suffix}"]
+
+    # Expand nested structure for containers
+    if t == "array" and branch.get("items"):
+        out.extend(_render_items_sub(branch["items"], proto, indent="  "))
+    elif t == "tuple" and branch.get("prefixItems"):
+        out.extend(_render_tuple_sub(branch, proto, indent="  "))
+    elif t == "map" and branch.get("fields"):
+        out.extend(_render_map_sub(branch, proto, indent="  "))
+    elif t == "kv_array" and branch.get("fields"):
+        out.extend(_render_map_sub(branch, proto, indent="  "))
+
+    return out
+
+
+def _render_items_sub(items_spec, proto, indent):
+    """Render an array's `items` spec as a sub-bullet."""
+    it = items_spec.get("type")
+    isum = render_summary(items_spec)
+    ilink = type_link(it, proto)
+    head = f"{indent}- Each item: {ilink}"
+    if isum:
+        head += f" — {isum}"
+    out = [head]
+    if it == "tuple" and items_spec.get("prefixItems"):
+        out.extend(_render_tuple_sub(items_spec, proto, indent + "  "))
+    elif it == "array" and items_spec.get("items"):
+        out.extend(_render_items_sub(items_spec["items"], proto, indent + "  "))
+    elif it == "map" and items_spec.get("fields"):
+        out.extend(_render_map_sub(items_spec, proto, indent + "  "))
+    return out
+
+
+def _render_tuple_sub(tup_spec, proto, indent):
+    """Render tuple `prefixItems` and `rest` as sub-bullets."""
+    out = []
+    for i, item in enumerate(tup_spec.get("prefixItems", [])):
+        iname = item.get("name") or f"[{i}]"
+        iwhen = f" _(when {item['when']})_" if item.get("when") else ""
+        ioptional = " _(optional)_" if item.get("optional") and not item.get("when") else ""
+        if "oneof" in item:
+            out.append(f"{indent}- `{iname}`{iwhen}{ioptional}: one of —")
+            for branch in item["oneof"]:
+                for line in render_branch(branch, proto):
+                    out.append(f"{indent}  {line}")
+            continue
+        if "type" not in item:
+            continue
+        ilink = type_link(item["type"], proto)
+        isum = render_summary(item)
+        line = f"{indent}- `{iname}`: {ilink}{iwhen}{ioptional}"
+        if isum:
+            line += f" — {isum}"
+        out.append(line)
+        if item["type"] == "tuple" and item.get("prefixItems"):
+            out.extend(_render_tuple_sub(item, proto, indent + "  "))
+        elif item["type"] == "array" and item.get("items"):
+            out.extend(_render_items_sub(item["items"], proto, indent + "  "))
+        elif item["type"] == "map" and item.get("fields"):
+            out.extend(_render_map_sub(item, proto, indent + "  "))
+    if tup_spec.get("rest"):
+        out.append(f"{indent}- Followed by repeating elements:")
+        out.extend(_render_items_sub(tup_spec["rest"], proto, indent + "  "))
+    return out
+
+
+def _render_map_sub(map_spec, proto, indent):
+    """Render map `fields` as sub-bullets."""
+    out = []
+    for f in map_spec.get("fields", []):
+        fname = f["name"]
+        fwhen = f" _(when {f['when']})_" if f.get("when") else ""
+        foptional = " _(optional)_" if f.get("optional") and not f.get("when") else ""
+        if "oneof" in f:
+            out.append(f"{indent}- `{fname}`{fwhen}{foptional}: one of —")
+            for branch in f["oneof"]:
+                for line in render_branch(branch, proto):
+                    out.append(f"{indent}  {line}")
+            continue
+        if "type" not in f:
+            continue
+        flink = type_link(f["type"], proto)
+        fsum = render_summary(f)
+        line = f"{indent}- `{fname}`: {flink}{fwhen}{foptional}"
+        if fsum:
+            line += f" — {fsum}"
+        out.append(line)
+        if f["type"] == "tuple" and f.get("prefixItems"):
+            out.extend(_render_tuple_sub(f, proto, indent + "  "))
+        elif f["type"] == "array" and f.get("items"):
+            out.extend(_render_items_sub(f["items"], proto, indent + "  "))
+        elif f["type"] == "map" and f.get("fields"):
+            out.extend(_render_map_sub(f, proto, indent + "  "))
+    return out
+
+
+def render_typed_node(spec, proto, depth):
+    """Render a non-oneof spec: a single typed leaf or container."""
+    t = spec.get("type")
+    if t is None:
+        return [""]
+    link = type_link(t, proto)
+    summary = render_summary(spec)
+    indent = "  " * depth
+
+    # Scalar types
+    if t in ("integer", "double", "boolean", "bulk_string", "simple_string",
+            "verbatim_string", "big_number"):
+        if t == "simple_string" and "value" in spec:
+            line = f"{link}: `{spec['value']}`."
+            if summary:
+                line += f" {summary}"
+        else:
+            line = f"{link}: {summary}" if summary else link
+        return [f"{indent}{line}".rstrip()]
+
+    if t == "null":
+        return [f"{indent}{link}."]
+
+    # Array — emit summary, then describe items
+    if t == "array":
+        head = f"{link}: {summary}" if summary else f"{link}."
+        out = [f"{indent}{head}".rstrip()]
+        items = spec.get("items")
+        if items:
+            out.append(f"{indent}Each item is:")
+            out.extend(render_typed_node(items, proto, depth + 1))
+        return out
+
+    # kv_array — flat alternating array of key/value; same field rendering as map
+    if t == "kv_array":
+        head = f"{link}: {summary}" if summary else f"{link}."
+        out = [f"{indent}{head}".rstrip()]
+        fields = spec.get("fields")
+        if fields:
+            out.append(f"{indent}Fields:")
+            for f in fields:
+                field_link = type_link(f["type"], proto)
+                fwhen = f" _(when {f['when']})_" if f.get("when") else ""
+                foptional = " _(optional)_" if f.get("optional") and not f.get("when") else ""
+                fsum = render_summary(f)
+                out.append(f"{indent}  - `{f['name']}`: {field_link}{fwhen}{foptional}"
+                           + (f" — {fsum}" if fsum else ""))
+        return out
+
+    # Map — list named fields if any
+    if t == "map":
+        head = f"{link}: {summary}" if summary else f"{link}."
+        out = [f"{indent}{head}".rstrip()]
+        fields = spec.get("fields")
+        if fields:
+            out.append(f"{indent}Fields:")
+            for f in fields:
+                field_link = type_link(f["type"], proto)
+                fwhen = f" _(when {f['when']})_" if f.get("when") else ""
+                foptional = " _(optional)_" if f.get("optional") and not f.get("when") else ""
+                fsum = render_summary(f)
+                out.append(f"{indent}  - `{f['name']}`: {field_link}{fwhen}{foptional}"
+                           + (f" — {fsum}" if fsum else ""))
+        return out
+
+    # Set
+    if t == "set":
+        head = f"{link}: {summary}" if summary else f"{link}."
+        out = [f"{indent}{head}".rstrip()]
+        items = spec.get("items")
+        if items:
+            out.append(f"{indent}Each item is:")
+            out.extend(render_typed_node(items, proto, depth + 1))
+        return out
+
+    # Tuple — describe positional shape
+    if t == "tuple":
+        head = f"{link}: {summary}" if summary else f"{link}."
+        out = [f"{indent}{head}".rstrip()]
+        prefix = spec.get("prefixItems", [])
+        for i, item in enumerate(prefix):
+            iname = item.get("name") or f"[{i}]"
+            iwhen = f" _(when {item['when']})_" if item.get("when") else ""
+            ioptional = " _(optional)_" if item.get("optional") and not item.get("when") else ""
+            ilink = type_link(item["type"], proto) if "type" in item else "_(varies)_"
+            isum = render_summary(item)
+            out.append(f"{indent}  - `{iname}`: {ilink}{iwhen}{ioptional}"
+                       + (f" — {isum}" if isum else ""))
+        if spec.get("rest"):
+            out.append(f"{indent}Followed by repeating elements:")
+            out.extend(render_typed_node(spec["rest"], proto, depth + 1))
+        return out
+
+    return [f"{indent}{link}"]
+
+
+def render_examples(examples, cmd_name):
+    """Render the `examples` block as a markdown sub-section."""
+    if not examples:
+        return []
+    out = ["**Examples:**", ""]
+    for ex in examples:
+        args = " ".join(ex.get("args", []))
+        label = ex.get("label", "")
+        head = f"`{cmd_name} {args}`".rstrip()
+        if label:
+            head = f"{head} _({label})_"
+        out.append(f"- {head}")
+        # Compare via JSON serialisation: Python's `0 == False` and `1 == True`
+        # would otherwise collapse genuine protocol divergence (the canonical
+        # int-vs-bool case in modules like RedisBloom).
+        resp2_json = json.dumps(ex.get("resp2"))
+        resp3_json = json.dumps(ex.get("resp3")) if "resp3" in ex else None
+        if resp3_json is not None and resp3_json != resp2_json:
+            out.append(f"  - RESP2: `{resp2_json}`")
+            out.append(f"  - RESP3: `{resp3_json}`")
+        else:
+            out.append(f"  - Reply: `{resp2_json}`")
+        if ex.get("note"):
+            out.append(f"  - Note: {ex['note']}")
+    out.append("")
+    return out
+
+
+def render_returns(returns, cmd_name=""):
+    """Render a full `returns` block to a markdown string with two
+    per-protocol sections, plus examples if present."""
+    out = []
+    for proto in (2, 3):
+        key = f"resp{proto}"
+        spec = returns.get(key)
+        if isinstance(spec, str) and spec.startswith("same_as_"):
+            other = "resp2" if "resp2" in spec else "resp3"
+            spec = returns.get(other)
+        out.append(f"**RESP{proto}:**")
+        out.append("")
+        lines = render_spec(spec, proto)
+        out.extend(lines)
+        out.append("")
+    out.extend(render_examples(returns.get("examples", []), cmd_name))
+    return "\n".join(out)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("specs", help="Path to a commands_returns_<module>.json file.")
+    p.add_argument("--cmd", help="Render only this command (uppercased).")
+    args = p.parse_args()
+
+    data = json.loads(Path(args.specs).read_text())
+    for cmd, entry in data.items():
+        if cmd.startswith("_"):
+            continue
+        if args.cmd and cmd != args.cmd:
+            continue
+        print(f"\n## {cmd}\n")
+        print("## Return information\n")
+        print(render_returns(entry["returns"], cmd_name=cmd))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/resp_inspect.py
+++ b/tools/resp_inspect.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Inspect raw RESP2/RESP3 replies for a Redis command.
+
+Usage:
+    python3 resp_inspect.py FT.AGGREGATE idx '*' GROUPBY 1 @country REDUCE COUNT 0 AS num
+    python3 resp_inspect.py --no-resp2 HGETALL myhash
+
+Runs the command in both protocols by default and prints the reply with
+each node tagged by its RESP type. Used to verify `returns` specs against
+real server behaviour and to inspect commands whose prose documentation
+is too thin to bootstrap a spec from.
+
+Caveat: redis-py with `disable_decoding=True` returns bytes for both
+simple_string and bulk_string replies, so this inspector labels both
+as `<string>`. The structural shape (array vs map vs integer vs null
+vs string) is faithful; the simple/bulk distinction is not. For most
+documentation purposes the structural shape is the important part.
+"""
+
+import argparse
+import sys
+
+from redis.connection import Connection
+
+
+def inspect(host, port, protocol, command_args):
+    conn = Connection(host=host, port=port, protocol=protocol)
+    conn.connect()
+    conn.send_command(*command_args)
+    return conn.read_response(disable_decoding=True)
+
+
+def pretty(obj, indent=0):
+    pad = "  " * indent
+    if isinstance(obj, bool):
+        return f"<boolean> {obj}"
+    if isinstance(obj, int):
+        return f"<integer> {obj}"
+    if isinstance(obj, float):
+        return f"<double> {obj}"
+    if obj is None:
+        return "<null>"
+    if isinstance(obj, bytes):
+        try:
+            return f"<string len={len(obj)}> {obj.decode('utf-8')!r}"
+        except UnicodeDecodeError:
+            return f"<string len={len(obj)} binary> {obj!r}"
+    if isinstance(obj, str):
+        return f"<string> {obj!r}"
+    if isinstance(obj, list):
+        if not obj:
+            return "<array len=0> []"
+        lines = [f"<array len={len(obj)}>"]
+        for i, item in enumerate(obj):
+            lines.append(f"{pad}  [{i}] {pretty(item, indent + 1)}")
+        return "\n".join(lines)
+    if isinstance(obj, dict):
+        if not obj:
+            return "<map size=0> {}"
+        lines = [f"<map size={len(obj)}>"]
+        for k, v in obj.items():
+            lines.append(f"{pad}  {pretty(k, indent + 1)}:")
+            lines.append(f"{pad}    {pretty(v, indent + 2)}")
+        return "\n".join(lines)
+    if isinstance(obj, set):
+        if not obj:
+            return "<set size=0> {}"
+        lines = [f"<set size={len(obj)}>"]
+        for i, item in enumerate(sorted(obj, key=repr)):
+            lines.append(f"{pad}  [{i}] {pretty(item, indent + 1)}")
+        return "\n".join(lines)
+    return f"<{type(obj).__name__}> {obj!r}"
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--host", default="localhost")
+    p.add_argument("--port", type=int, default=6379)
+    p.add_argument("--no-resp2", action="store_true")
+    p.add_argument("--no-resp3", action="store_true")
+    p.add_argument("command", nargs="+")
+    args = p.parse_args()
+
+    rc = 0
+    for proto in (2, 3):
+        if (proto == 2 and args.no_resp2) or (proto == 3 and args.no_resp3):
+            continue
+        print(f"\n===== RESP{proto} =====")
+        try:
+            reply = inspect(args.host, args.port, proto, args.command)
+            print(pretty(reply))
+        except Exception as e:
+            print(f"<error> {type(e).__name__}: {e}")
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sample_returns_extracted.json
+++ b/tools/sample_returns_extracted.json
@@ -1,0 +1,704 @@
+{
+  "_meta": {
+    "note": "Sample output of the prose-extraction heuristic, applied by hand to 46 commands across core and modules. Demonstrates the auto/stub distribution and the kinds of structural detail that auto-extraction captures vs misses. All entries need a human pass before promoting to `verified`.",
+    "extracted_at": "2026-06-05",
+    "command_count": 46,
+    "tier_distribution": {
+      "auto_ship_ready": 23,
+      "auto_minor_review": 14,
+      "auto_with_notes": 7,
+      "stub": 2
+    }
+  },
+
+  "SET": {
+    "returns": {
+      "summary": "Whether the key was set, optionally returning the previous value with GET.",
+      "resp2": {
+        "oneof": [
+          { "when": "GET not specified, key was set",
+            "type": "simple_string", "value": "OK" },
+          { "when": "GET not specified, condition (NX/XX/IFEQ/IFNE/IFDEQ/IFDNE) failed",
+            "type": "null",
+            "summary": "Key was not set or not created." },
+          { "when": "GET specified",
+            "type": "bulk_string", "nullable": true,
+            "summary": "Previous value of the key, or null if the key did not exist before SET.",
+            "note": "Prose enumerates further sub-conditions per branch. Heuristic flattens them; verify if needed." }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+
+  "GET": {
+    "returns": {
+      "summary": "Value of the key, or null if it does not exist.",
+      "resp2": {
+        "oneof": [
+          { "when": "key exists",          "type": "bulk_string", "summary": "Value of the key." },
+          { "when": "key does not exist",  "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "DEL": {
+    "returns": {
+      "summary": "Number of keys that were removed.",
+      "resp2": { "type": "integer", "summary": "Number of keys that were removed." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "EXISTS": {
+    "returns": {
+      "summary": "Number of keys that exist from those specified as arguments.",
+      "resp2": { "type": "integer", "summary": "Number of keys that exist from those specified as arguments." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "INCR": {
+    "returns": {
+      "summary": "Value of the key after the increment.",
+      "resp2": { "type": "integer", "summary": "Value of the key after the increment." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "DECR": {
+    "returns": {
+      "summary": "Value of the key after decrementing it.",
+      "resp2": { "type": "integer", "summary": "Value of the key after decrementing it." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "STRLEN": {
+    "returns": {
+      "summary": "Length of the string stored at key, or 0 when the key does not exist.",
+      "resp2": { "type": "integer", "summary": "Length of the string stored at key, or 0 when the key does not exist." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "APPEND": {
+    "returns": {
+      "summary": "Length of the string after the append operation.",
+      "resp2": { "type": "integer", "summary": "Length of the string after the append operation." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "TYPE": {
+    "returns": {
+      "summary": "Type of the key, or `none` when the key does not exist.",
+      "resp2": { "type": "simple_string", "summary": "Type of the key, or `none` when the key does not exist.",
+                 "note": "Possible values include string, list, hash, set, zset, stream, none. Not enumerated by extractor." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "RENAME": {
+    "returns": {
+      "summary": "Confirms the rename succeeded.",
+      "resp2": { "type": "simple_string", "value": "OK" },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "COPY": {
+    "returns": {
+      "summary": "Whether the source key was copied.",
+      "resp2": {
+        "type": "integer",
+        "summary": "1 if source was copied, 0 if not."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "EXPIRE": {
+    "returns": {
+      "summary": "Whether the expiry was set.",
+      "resp2": {
+        "type": "integer",
+        "summary": "1 if the timeout was set; 0 if the key doesn't exist or the operation was skipped."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "FLUSHDB": {
+    "returns": {
+      "summary": "Confirms the database was flushed.",
+      "resp2": { "type": "simple_string", "value": "OK" },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "BGSAVE": {
+    "returns": {
+      "summary": "Confirms the background save was started or scheduled.",
+      "resp2": {
+        "oneof": [
+          { "when": "save started immediately",   "type": "simple_string", "value": "Background saving started" },
+          { "when": "save scheduled for later",   "type": "simple_string", "value": "Background saving scheduled" }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "HSET": {
+    "returns": {
+      "summary": "Number of fields that were added.",
+      "resp2": { "type": "integer", "summary": "Number of fields that were added." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "HGET": {
+    "returns": {
+      "summary": "Value associated with the field, or null if missing.",
+      "resp2": {
+        "oneof": [
+          { "when": "field present",          "type": "bulk_string", "summary": "Value associated with the field." },
+          { "when": "field or key missing",   "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "HDEL": {
+    "returns": {
+      "summary": "Number of fields that were removed, excluding non-existing fields.",
+      "resp2": { "type": "integer", "summary": "Number of fields that were removed, excluding non-existing fields." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "HKEYS": {
+    "returns": {
+      "summary": "Field names of the hash, or empty if the key does not exist.",
+      "resp2": {
+        "type": "array",
+        "items": { "type": "bulk_string", "summary": "Field name." },
+        "summary": "Field names of the hash, or empty if the key does not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "HVALS": {
+    "returns": {
+      "summary": "Values of the hash, or empty if the key does not exist.",
+      "resp2": {
+        "type": "array",
+        "items": { "type": "bulk_string", "summary": "Field value." },
+        "summary": "Values of the hash, or empty if the key does not exist."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "HMGET": {
+    "returns": {
+      "summary": "Values associated with the requested fields, in order. Missing fields are null.",
+      "resp2": {
+        "type": "array",
+        "items": { "type": "bulk_string", "nullable": true,
+                   "summary": "Field value, or null if the field is not in the hash.",
+                   "note": "Per-field nullability inferred — prose says 'in the same order as requested' but does not explicitly call out null for missing fields. Verify." },
+        "summary": "Values associated with the requested fields, in order."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "ZCARD": {
+    "returns": {
+      "summary": "Cardinality of the sorted set, or 0 if the key doesn't exist.",
+      "resp2": { "type": "integer", "summary": "Cardinality of the sorted set, or 0 if the key doesn't exist." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "ZSCORE": {
+    "returns": {
+      "summary": "Score of the member, or null if the member or key is missing.",
+      "resp2": {
+        "oneof": [
+          { "when": "member exists", "type": "bulk_string",
+            "summary": "Score of the member (double-precision floating point) as a string." },
+          { "when": "member or key missing", "type": "null" }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "member exists", "type": "double",
+            "summary": "Score of the member (double-precision floating point)." },
+          { "when": "member or key missing", "type": "null" }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "SISMEMBER": {
+    "returns": {
+      "summary": "Whether the element is a member of the set.",
+      "resp2": { "type": "integer", "summary": "1 if the element is a member of the set, 0 otherwise (including when the key does not exist)." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "SCARD": {
+    "returns": {
+      "summary": "Cardinality of the set, or 0 if the key does not exist.",
+      "resp2": { "type": "integer", "summary": "Cardinality of the set, or 0 if the key does not exist." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "LPUSH": {
+    "returns": {
+      "summary": "Length of the list after the push operation.",
+      "resp2": { "type": "integer", "summary": "Length of the list after the push operation." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "LINDEX": {
+    "returns": {
+      "summary": "Element at the index, or null if the index is out of range.",
+      "resp2": {
+        "oneof": [
+          { "when": "index in range",      "type": "bulk_string", "summary": "Requested element." },
+          { "when": "index out of range",  "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "LPOP": {
+    "returns": {
+      "summary": "Popped element(s), or null if the key does not exist.",
+      "resp2": {
+        "oneof": [
+          { "when": "key does not exist",  "type": "null" },
+          { "when": "count argument omitted", "type": "bulk_string",
+            "summary": "Value of the first element." },
+          { "when": "count argument given", "type": "array",
+            "items": { "type": "bulk_string", "summary": "A popped element." },
+            "summary": "List of popped elements." }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "XADD": {
+    "returns": {
+      "summary": "ID of the added entry, or null when NOMKSTREAM is set and the key does not exist.",
+      "resp2": {
+        "oneof": [
+          { "when": "entry added",         "type": "bulk_string",
+            "summary": "ID of the added entry (auto-generated or supplied)." },
+          { "when": "NOMKSTREAM and key missing", "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "XLEN": {
+    "returns": {
+      "summary": "Number of entries in the stream at the key.",
+      "resp2": { "type": "integer", "summary": "Number of entries in the stream at the key." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "XRANGE": {
+    "returns": {
+      "summary": "Stream entries with IDs matching the specified range.",
+      "resp2": {
+        "type": "array",
+        "summary": "Stream entries with IDs matching the specified range.",
+        "items": {
+          "type": "tuple",
+          "note": "Stream entry shape not described in source prose. Expected: [id, kv_array of fields]. Candidate for $ref to a shared `stream_entry` schema.",
+          "prefixItems": []
+        }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+
+  "OBJECT ENCODING": {
+    "returns": {
+      "summary": "Encoding of the object, or null if the key doesn't exist.",
+      "resp2": {
+        "oneof": [
+          { "when": "key exists",          "type": "bulk_string", "summary": "Encoding of the object." },
+          { "when": "key does not exist",  "type": "null" }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "ROLE": {
+    "returns": {
+      "summary": "Replication role and role-specific details.",
+      "resp2": {
+        "type": "tuple",
+        "summary": "First element is the role name; remaining elements depend on role.",
+        "prefixItems": [
+          { "name": "role", "type": "bulk_string",
+            "summary": "One of `master`, `slave`, `sentinel`." }
+        ],
+        "rest": { "type": "bulk_string",
+                  "note": "Role-specific tail not enumerated in source prose. Expected: per-role shape — master returns [replication_offset, [replica_descriptor...]]; slave returns [master_ip, master_port, link_status, replication_offset]; sentinel returns [[monitored_master_name...]]. Use the verification script to capture each." }
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+
+  "TIME": {
+    "returns": {
+      "summary": "Server's current Unix time as seconds and microseconds.",
+      "resp2": {
+        "type": "tuple",
+        "prefixItems": [
+          { "name": "seconds",      "type": "bulk_string",
+            "summary": "Unix timestamp in seconds.",
+            "note": "Prose says 'Unix timestamp in seconds' — element type inferred as bulk_string (RESP2 array elements). Verify whether server emits as integer or string." },
+          { "name": "microseconds", "type": "bulk_string",
+            "summary": "Microseconds component of the current second." }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "PING": {
+    "returns": {
+      "summary": "PONG or the supplied message.",
+      "resp2": {
+        "oneof": [
+          { "when": "no argument", "type": "simple_string", "value": "PONG" },
+          { "when": "argument provided", "type": "bulk_string", "summary": "The provided argument echoed back." }
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "ECHO": {
+    "returns": {
+      "summary": "The given string echoed back.",
+      "resp2": { "type": "bulk_string", "summary": "The given string." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "DBSIZE": {
+    "returns": {
+      "summary": "Number of keys in the currently-selected database.",
+      "resp2": { "type": "integer", "summary": "Number of keys in the currently-selected database." },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "INFO": {
+    "returns": {
+      "summary": "Server statistics and configuration as a CRLF-delimited key/value text document.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "Map of info fields, one field per line as `<field>:<value>`, with `#`-prefixed section headers and blank lines."
+      },
+      "resp3": {
+        "type": "verbatim_string",
+        "encoding": "txt",
+        "summary": "Map of info fields, one field per line as `<field>:<value>`, with `#`-prefixed section headers and blank lines."
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "CLIENT LIST": {
+    "returns": {
+      "summary": "Information and statistics about client connections.",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "One line per client, space-separated `key=value` pairs.",
+        "note": "Internal record format described informally in the CLIENT LIST page. Heuristic captures the wire-type but not the structured record schema."
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "auto"
+  },
+
+  "FT.SEARCH": {
+    "returns": {
+      "summary": "Search results matching the query.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "array",
+            "summary": "First element is total results, followed by document IDs and their field-value pairs as arrays.",
+            "note": "Item shape not explicitly enumerated — implicitly a tuple of [total_results, ...(id, fields)] with conditional WITHSCORES/WITHPAYLOADS/NOCONTENT modifiers not captured here." },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "no such index" },
+            { "value": "syntax error in query" }
+          ]}
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "map", "fields": [
+            { "name": "total_results", "type": "integer", "summary": "Total number of results." },
+            { "name": "results", "type": "array",
+              "items": { "type": "map",
+                         "note": "Per-document map fields not enumerated by prose. Verify with resp_inspect.py." },
+              "summary": "Documents matching the query." },
+            { "name": "attributes", "type": "array",
+              "items": { "type": "bulk_string", "summary": "Attribute name." } },
+            { "name": "format", "type": "simple_string", "summary": "Result format." },
+            { "name": "warning", "type": "array",
+              "items": { "type": "bulk_string", "summary": "Warning message." } }
+          ]},
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "no such index" },
+            { "value": "syntax error in query" }
+          ]}
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "FT.INFO": {
+    "returns": {
+      "summary": "Index information and statistics.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "kv_array",
+            "key_type": "bulk_string", "value_type": { "type": "bulk_string" },
+            "summary": "Index information and statistics as field-value pairs.",
+            "note": "Field set not enumerated by prose. Use resp_inspect.py to capture the actual keys." },
+          { "when": "error", "type": "simple_error", "messages": [{ "value": "no such index" }] }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "map",
+            "key_type": "bulk_string", "value_type": { "type": "bulk_string" },
+            "summary": "Index information and statistics as a map.",
+            "note": "Field set not enumerated by prose. Use resp_inspect.py to capture the actual keys." },
+          { "when": "error", "type": "simple_error", "messages": [{ "value": "no such index" }] }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "FT.TAGVALS": {
+    "returns": {
+      "summary": "Distinct tag values for the named field.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "array",
+            "items": { "type": "bulk_string", "summary": "Tag value." },
+            "summary": "Distinct tag values as bulk strings." },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "no such index" }, { "value": "not a tag field" }
+          ]}
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "set",
+            "items": { "type": "bulk_string", "summary": "Tag value." },
+            "summary": "Distinct tag values as a set of bulk strings." },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "no such index" }, { "value": "not a tag field" }
+          ]}
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "JSON.GET": {
+    "returns": {
+      "summary": "JSON-encoded value at the path(s).",
+      "resp2": {
+        "type": "bulk_string",
+        "summary": "Serialised JSON. Single path → the value's serialisation. Multiple paths → a JSON object mapping each path to an array of serialisations.",
+        "note": "Content is a JSON document; structure inside the string varies per query and is not captured at the RESP level."
+      },
+      "resp3": {
+        "type": "bulk_string",
+        "summary": "Serialised JSON. Single path with `$` → array containing the value. Multiple paths → object mapping each path to an array of serialisations.",
+        "note": "RESP3 differs from RESP2 in that a single `$` path returns an array wrapper, not the raw value."
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "JSON.SET": {
+    "returns": {
+      "summary": "Confirms the path was set, or null/error when conditions are unmet.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "simple_string", "value": "OK" },
+          { "when": "path missing and uncreatable, or NX/XX condition unmet", "type": "null" },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "expected ...", "summary": "Value is invalid." },
+            { "value": "Error occurred on position ... expected ...", "summary": "Path is invalid." },
+            { "value": "ERR new objects must be created at the root",
+              "summary": "Key does not exist and path is not root." },
+            { "value": "ERR wrong static path",
+              "summary": "Dynamic path expression has no matching locations." },
+            { "value": "ERR index out of bounds",
+              "summary": "Path refers to an array index outside the array bounds." },
+            { "value": "value out of range for ...",
+              "summary": "One or more values of a FP array are out of range for the given type." }
+          ]}
+        ]
+      },
+      "resp3": "same_as_resp2"
+    },
+    "returns_status": "stub"
+  },
+
+  "TS.RANGE": {
+    "returns": {
+      "summary": "Time-series samples in the requested range.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "array",
+            "items": { "type": "tuple",
+                       "prefixItems": [
+                         { "name": "timestamp", "type": "integer", "summary": "Sample timestamp in ms." },
+                         { "name": "value",     "type": "bulk_string", "summary": "Sample value as a string." }
+                       ]},
+            "summary": "List of (timestamp, value) pairs." },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "invalid filter value" },
+            { "value": "wrong key type" },
+            { "value": "key does not exist" }
+          ]}
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "array",
+            "items": { "type": "tuple",
+                       "prefixItems": [
+                         { "name": "timestamp", "type": "integer", "summary": "Sample timestamp in ms." },
+                         { "name": "value",     "type": "double", "summary": "Sample value." }
+                       ]},
+            "summary": "List of (timestamp, value) pairs." },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "invalid filter value" },
+            { "value": "wrong key type" },
+            { "value": "key does not exist" }
+          ]}
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "BF.ADD": {
+    "returns": {
+      "summary": "Whether the item was added to the Bloom filter.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "integer",
+            "summary": "1 if added, 0 if probably already present." },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "invalid arguments" }, { "value": "wrong key type" },
+            { "value": "filter is full" }
+          ]}
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "boolean",
+            "summary": "true if added, false if probably already present." },
+          { "when": "error", "type": "simple_error", "messages": [
+            { "value": "invalid arguments" }, { "value": "wrong key type" },
+            { "value": "filter is full" }
+          ]}
+        ]
+      }
+    },
+    "returns_status": "auto"
+  },
+
+  "BF.EXISTS": {
+    "returns": {
+      "summary": "Whether the item probably exists in the Bloom filter.",
+      "resp2": {
+        "oneof": [
+          { "when": "success", "type": "integer",
+            "summary": "1 if probably in the filter, 0 if definitely not (or key missing)." },
+          { "when": "error", "type": "simple_error",
+            "messages": [{ "value": "invalid arguments" }] }
+        ]
+      },
+      "resp3": {
+        "oneof": [
+          { "when": "success", "type": "boolean",
+            "summary": "true if probably in the filter, false if definitely not (or key missing)." },
+          { "when": "error", "type": "simple_error",
+            "messages": [{ "value": "invalid arguments" }, { "value": "wrong key type" }] }
+        ]
+      }
+    },
+    "returns_status": "auto"
+  }
+}

--- a/tools/validate_returns.py
+++ b/tools/validate_returns.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Validate a `commands_returns_<module>.json` file against the format spec.
+
+Checks the structural rules in spec §14, plus the new `examples` rules from
+§3.1. Reports issues with file paths and JSON paths so authors can locate
+problems quickly.
+
+Usage:
+    python3 validate_returns.py data/commands_returns_core.json
+    python3 validate_returns.py data/commands_returns_*.json
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+VALID_PRIMITIVES = {
+    "simple_string", "bulk_string", "verbatim_string",
+    "integer", "double", "boolean", "big_number", "null",
+    "simple_error", "bulk_error",
+}
+VALID_CONTAINERS = {"array", "tuple", "map", "kv_array", "set", "push"}
+VALID_TYPES = VALID_PRIMITIVES | VALID_CONTAINERS
+
+VALID_STATUS = {"verified", "auto", "stub"}
+
+# Common keys permitted on any ReplySpec node.
+COMMON_KEYS = {
+    "summary", "name", "when", "optional", "since", "nullable", "note",
+    "type", "oneof", "$ref",
+}
+PER_TYPE_KEYS = {
+    "simple_string":   {"value"},
+    "verbatim_string": {"encoding"},
+    "array":           {"items", "length", "length_expr"},
+    "tuple":           {"prefixItems", "rest"},
+    "map":             {"fields", "key_type", "value_type"},
+    "kv_array":        {"fields", "key_type", "value_type"},
+    "set":             {"items"},
+    "push":            {"items"},
+    "simple_error":    {"messages"},
+    "bulk_error":      {"messages"},
+}
+
+VALID_META_KEYS = {
+    "module", "returns_format_version", "scope_note", "universal_errors",
+    "note", "extracted_at", "command_count", "tier_distribution",
+    "schema", "naming",  # used by fixtures-style files; benign on data files
+}
+
+
+class Validator:
+    def __init__(self, filename, data):
+        self.filename = filename
+        self.data = data
+        self.findings = []
+        # Collect refs for ref-resolution check
+        self.schemas = data.get("_schemas", {})
+        self.refs_used = set()
+
+    def err(self, path, msg):
+        self.findings.append({"severity": "error", "path": path, "message": msg})
+
+    def warn(self, path, msg):
+        self.findings.append({"severity": "warn", "path": path, "message": msg})
+
+    # ---- top-level ----------------------------------------------------
+
+    def validate(self):
+        if not isinstance(self.data, dict):
+            self.err("$", "top-level must be a JSON object")
+            return self.findings
+
+        # _meta validation
+        meta = self.data.get("_meta")
+        if meta is not None:
+            self._validate_meta(meta)
+
+        # Validate each command entry
+        for key, entry in self.data.items():
+            if key.startswith("_"):
+                continue
+            self._validate_command(key, entry)
+
+        # Check ref resolution
+        for ref_path, ref_target in self.refs_used:
+            if ref_target.startswith("#/_schemas/"):
+                name = ref_target[len("#/_schemas/"):]
+                if name not in self.schemas:
+                    self.err(ref_path, f"$ref `{ref_target}` does not resolve in this file")
+            elif ".json#/" in ref_target:
+                pass    # cross-file refs not validated here
+            else:
+                self.warn(ref_path, f"$ref `{ref_target}` has unrecognised syntax")
+
+        # Orphan schemas
+        for schema_name in self.schemas:
+            qualified = f"#/_schemas/{schema_name}"
+            if not any(t == qualified for _, t in self.refs_used):
+                self.warn(f"$._schemas.{schema_name}",
+                          "schema is not referenced by any command")
+
+        return self.findings
+
+    def _validate_meta(self, meta):
+        if not isinstance(meta, dict):
+            self.err("$._meta", "_meta must be an object")
+            return
+        for k in meta:
+            if k not in VALID_META_KEYS:
+                self.warn(f"$._meta.{k}", f"unrecognised _meta key `{k}`")
+        ver = meta.get("returns_format_version", "1")
+        if ver not in ("1",):
+            self.err("$._meta.returns_format_version",
+                     f"unsupported format version `{ver}`")
+
+    # ---- command entry -----------------------------------------------
+
+    def _validate_command(self, name, entry):
+        path = f"$.{name}"
+        if not isinstance(entry, dict):
+            self.err(path, "command entry must be an object")
+            return
+        # Required: returns, returns_status
+        if "returns" not in entry:
+            self.err(path, "missing `returns`")
+        if "returns_status" not in entry:
+            self.err(path, "missing `returns_status`")
+        else:
+            status = entry["returns_status"]
+            if status not in VALID_STATUS:
+                self.err(f"{path}.returns_status",
+                         f"must be one of {sorted(VALID_STATUS)}, got `{status}`")
+        # No `description` allowed
+        if "description" in entry:
+            self.err(path, "use `summary` (inside `returns`), not `description`")
+        # Permitted extra keys
+        for k in entry:
+            if k not in {"returns", "returns_status"}:
+                self.warn(f"{path}.{k}", f"unrecognised command-level key `{k}`")
+        # Recurse into returns
+        if "returns" in entry:
+            self._validate_returns(f"{path}.returns", entry["returns"])
+
+    def _validate_returns(self, path, returns):
+        if not isinstance(returns, dict):
+            self.err(path, "`returns` must be an object")
+            return
+        # Required protocols
+        for proto in ("resp2", "resp3"):
+            if proto not in returns:
+                self.err(f"{path}.{proto}", f"missing `{proto}`")
+
+        # Validate per-protocol
+        for proto in ("resp2", "resp3"):
+            spec = returns.get(proto)
+            if spec is None:
+                continue
+            if isinstance(spec, str):
+                if spec not in ("same_as_resp2", "same_as_resp3"):
+                    self.err(f"{path}.{proto}",
+                             f"string value must be `same_as_resp2` or `same_as_resp3`, got `{spec}`")
+            else:
+                self._validate_spec(f"{path}.{proto}", spec)
+
+        # Validate examples
+        examples = returns.get("examples")
+        if examples is not None:
+            self._validate_examples(f"{path}.examples", examples, returns)
+
+        # Permitted keys
+        allowed = {"summary", "resp2", "resp3", "examples"}
+        for k in returns:
+            if k not in allowed:
+                self.warn(f"{path}.{k}", f"unrecognised key in `returns`: `{k}`")
+
+    # ---- ReplySpec -----------------------------------------------------
+
+    def _validate_spec(self, path, spec):
+        if not isinstance(spec, dict):
+            self.err(path, "ReplySpec must be an object")
+            return
+
+        # $ref
+        if "$ref" in spec:
+            self.refs_used.add((path, spec["$ref"]))
+            return
+
+        # oneof
+        if "oneof" in spec:
+            if not isinstance(spec["oneof"], list) or not spec["oneof"]:
+                self.err(path, "`oneof` must be a non-empty array")
+                return
+            for i, branch in enumerate(spec["oneof"]):
+                bpath = f"{path}.oneof[{i}]"
+                if not isinstance(branch, dict):
+                    self.err(bpath, "branch must be an object")
+                    continue
+                if "when" not in branch:
+                    self.err(bpath, "every `oneof` branch must carry `when`")
+                self._validate_spec(bpath, branch)
+            return
+
+        # Typed node
+        t = spec.get("type")
+        if t is None:
+            self.err(path, "ReplySpec must have `type`, `oneof`, or `$ref`")
+            return
+        if t not in VALID_TYPES:
+            self.err(f"{path}.type", f"unknown type `{t}`")
+            return
+
+        # Permitted keys = common + per-type
+        permitted = COMMON_KEYS | PER_TYPE_KEYS.get(t, set())
+        for k in spec:
+            if k not in permitted:
+                self.warn(f"{path}.{k}",
+                          f"unrecognised key `{k}` for type `{t}`")
+
+        # Per-type checks
+        if t in ("array", "set", "push"):
+            self._check_items(path, spec)
+        elif t == "tuple":
+            self._check_tuple(path, spec)
+        elif t in ("map", "kv_array"):
+            self._check_map(path, spec)
+        elif t in ("simple_error", "bulk_error"):
+            self._check_error(path, spec)
+        elif t == "simple_string" and "value" in spec:
+            if not isinstance(spec["value"], str):
+                self.err(f"{path}.value", "simple_string.value must be a string")
+
+    def _check_items(self, path, spec):
+        items = spec.get("items")
+        if items is None:
+            self.warn(f"{path}.items",
+                      "container type emitted without `items` — verifier cannot check item shape")
+        else:
+            self._validate_spec(f"{path}.items", items)
+
+    def _check_tuple(self, path, spec):
+        prefix = spec.get("prefixItems")
+        if not prefix:
+            self.warn(f"{path}.prefixItems",
+                      "tuple without `prefixItems` — collapses to an unstructured array")
+        else:
+            for i, sub in enumerate(prefix):
+                self._validate_spec(f"{path}.prefixItems[{i}]", sub)
+        if spec.get("rest"):
+            self._validate_spec(f"{path}.rest", spec["rest"])
+
+    def _check_map(self, path, spec):
+        fields = spec.get("fields")
+        if fields:
+            for i, f in enumerate(fields):
+                fp = f"{path}.fields[{i}]"
+                if not isinstance(f, dict):
+                    self.err(fp, "field must be an object")
+                    continue
+                if "name" not in f:
+                    self.err(fp, "map/kv_array field must have `name`")
+                if "summary" not in f and "oneof" not in f and not f.get("note"):
+                    self.warn(fp, "map/kv_array field should have `summary` "
+                                  "(or `note` if shape is uncertain)")
+                self._validate_spec(fp, f)
+        # value_type validation
+        vt = spec.get("value_type")
+        if vt is not None and isinstance(vt, dict):
+            self._validate_spec(f"{path}.value_type", vt)
+
+    def _check_error(self, path, spec):
+        messages = spec.get("messages", [])
+        for i, m in enumerate(messages):
+            mp = f"{path}.messages[{i}]"
+            if isinstance(m, str):
+                if not m.strip():
+                    self.err(mp, "error message must be non-empty")
+            elif isinstance(m, dict):
+                if not m.get("value"):
+                    self.err(mp + ".value", "error message must have non-empty `value`")
+            else:
+                self.err(mp, "error message must be a string or object")
+
+    # ---- examples ------------------------------------------------------
+
+    def _validate_examples(self, path, examples, returns):
+        if not isinstance(examples, list):
+            self.err(path, "`examples` must be an array")
+            return
+        for i, ex in enumerate(examples):
+            ep = f"{path}[{i}]"
+            if not isinstance(ex, dict):
+                self.err(ep, "example must be an object")
+                continue
+            if not ex.get("label"):
+                self.err(f"{ep}.label", "example must have non-empty `label`")
+            args = ex.get("args")
+            if not isinstance(args, list):
+                self.err(f"{ep}.args", "example must have `args` array")
+            elif not all(isinstance(a, str) for a in args):
+                self.err(f"{ep}.args", "every arg must be a string")
+            if "resp2" not in ex:
+                self.err(f"{ep}.resp2", "example must include `resp2` value")
+            # Permitted keys
+            for k in ex:
+                if k not in {"label", "args", "resp2", "resp3", "note"}:
+                    self.warn(f"{ep}.{k}", f"unrecognised key in example: `{k}`")
+            # Type-compat check against the spec
+            for proto_key in ("resp2", "resp3"):
+                if proto_key not in ex:
+                    continue
+                spec_for_proto = returns.get(proto_key)
+                if isinstance(spec_for_proto, str) and spec_for_proto.startswith("same_as_"):
+                    other = "resp3" if "resp3" in spec_for_proto else "resp2"
+                    spec_for_proto = returns.get(other)
+                self._check_example_value(f"{ep}.{proto_key}",
+                                          spec_for_proto, ex[proto_key])
+
+    def _check_example_value(self, path, spec, value):
+        """Confirm an example value is structurally compatible with the spec."""
+        if spec is None or not isinstance(spec, dict):
+            return
+        if "oneof" in spec:
+            # If any branch is compatible, OK
+            for branch in spec["oneof"]:
+                if self._json_compatible(branch, value):
+                    return
+            self.err(path, f"example value `{json.dumps(value)[:60]}` "
+                           f"does not match any `oneof` branch")
+            return
+        if not self._json_compatible(spec, value):
+            t = spec.get("type", "?")
+            shown = json.dumps(value)[:80]
+            self.err(path, f"example value {shown} not compatible with `type: {t}`")
+
+    def _json_compatible(self, spec, value):
+        """Approximate the verifier's compatibility check, but against
+        JSON-typed values (strings vs bytes, ints, etc.)."""
+        if "oneof" in spec:
+            return any(self._json_compatible(b, value) for b in spec["oneof"])
+        t = spec.get("type")
+        if t is None:
+            return True   # $ref or empty — accept
+        v = value
+        if t == "null":               return v is None
+        if t in ("integer",):         return isinstance(v, int) and not isinstance(v, bool)
+        if t in ("double", "big_number"):
+            return isinstance(v, (int, float)) and not isinstance(v, bool)
+        if t == "boolean":            return isinstance(v, bool)
+        if t in ("simple_string", "bulk_string", "verbatim_string"):
+            return v is None or isinstance(v, str)
+        if t in ("array", "tuple", "kv_array", "set", "push"):
+            return isinstance(v, list)
+        if t == "map":
+            return isinstance(v, dict)
+        if t in ("simple_error", "bulk_error"):
+            return isinstance(v, str)
+        return True
+
+
+def validate_file(path):
+    text = Path(path).read_text()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        return [{"severity": "error", "path": "$",
+                 "message": f"invalid JSON: {e}"}]
+    v = Validator(path, data)
+    return v.validate()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("files", nargs="+", help="commands_returns_<module>.json paths")
+    args = p.parse_args()
+
+    total_err = 0
+    total_warn = 0
+    for f in args.files:
+        findings = validate_file(f)
+        errs = [x for x in findings if x["severity"] == "error"]
+        warns = [x for x in findings if x["severity"] == "warn"]
+        total_err += len(errs)
+        total_warn += len(warns)
+        print(f"\n=== {f} ===")
+        if not findings:
+            print("  no issues")
+            continue
+        for x in findings:
+            marker = "✗" if x["severity"] == "error" else "?"
+            print(f"  {marker} {x['path']}: {x['message']}")
+
+    print(f"\nTotal: {total_err} error(s), {total_warn} warn(s)")
+    return 1 if total_err > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verification_fixtures.json
+++ b/tools/verification_fixtures.json
@@ -1,0 +1,679 @@
+{
+  "_meta": {
+    "note": "Per-command verification fixtures. Each entry describes setup state, argument permutations to execute, and cleanup. The verifier runs setup once per command, executes each permutation against the live server in both RESP2 and RESP3, and compares the captured reply to the stored spec.",
+    "naming": "All scratch keys are prefixed `vfy:` to make cleanup obvious and avoid clashing with real data.",
+    "schema": {
+      "setup":        "list of [cmd, args...] tuples run before any permutations",
+      "permutations": "list of { label, args } pairs — `label` matches a `when` predicate in the spec",
+      "cleanup":      "list of [cmd, args...] tuples run after all permutations"
+    }
+  },
+
+  "_comment_strings": "String / scalar commands ----------------------------------",
+
+  "SET": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default",       "args": ["vfy:str", "hello"] },
+      { "label": "NX on missing", "args": ["vfy:str:nx", "first", "NX"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:str", "vfy:str:nx"] ]
+  },
+  "GET": {
+    "setup":        [ ["SET", "vfy:get", "hello"] ],
+    "permutations": [
+      { "label": "key exists",         "args": ["vfy:get"] },
+      { "label": "key does not exist", "args": ["vfy:get:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:get"] ]
+  },
+  "STRLEN": {
+    "setup":        [ ["SET", "vfy:strlen", "hello"] ],
+    "permutations": [
+      { "label": "key exists",  "args": ["vfy:strlen"] },
+      { "label": "key missing", "args": ["vfy:strlen:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:strlen"] ]
+  },
+  "APPEND": {
+    "setup":        [ ["SET", "vfy:append", "abc"] ],
+    "permutations": [
+      { "label": "existing key", "args": ["vfy:append", "def"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:append"] ]
+  },
+  "GETRANGE": {
+    "setup":        [ ["SET", "vfy:getrange", "abcdefghij"] ],
+    "permutations": [
+      { "label": "in range",     "args": ["vfy:getrange", "0", "4"] },
+      { "label": "out of range", "args": ["vfy:getrange", "20", "30"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:getrange"] ]
+  },
+  "MSET": {
+    "setup":        [],
+    "permutations": [
+      { "label": "two pairs", "args": ["vfy:mset:a", "1", "vfy:mset:b", "2"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:mset:a", "vfy:mset:b"] ]
+  },
+  "MGET": {
+    "setup":        [ ["SET", "vfy:mget:a", "1"], ["SET", "vfy:mget:b", "2"] ],
+    "permutations": [
+      { "label": "mixed existing/missing", "args": ["vfy:mget:a", "vfy:mget:missing", "vfy:mget:b"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:mget:a", "vfy:mget:b"] ]
+  },
+  "INCR": {
+    "setup":        [ ["SET", "vfy:incr", "0"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:incr"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:incr"] ]
+  },
+  "DECR": {
+    "setup":        [ ["SET", "vfy:decr", "10"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:decr"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:decr"] ]
+  },
+  "INCRBY": {
+    "setup":        [ ["SET", "vfy:incrby", "0"] ],
+    "permutations": [
+      { "label": "positive", "args": ["vfy:incrby", "5"] },
+      { "label": "negative", "args": ["vfy:incrby", "-3"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:incrby"] ]
+  },
+  "INCRBYFLOAT": {
+    "setup":        [ ["SET", "vfy:incrf", "1.5"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:incrf", "0.5"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:incrf"] ]
+  },
+
+  "_comment_generic": "Generic / key-lifecycle commands -------------------------",
+
+  "DEL": {
+    "setup":        [ ["SET", "vfy:del:a", "1"], ["SET", "vfy:del:b", "2"] ],
+    "permutations": [
+      { "label": "two existing",       "args": ["vfy:del:a", "vfy:del:b"] },
+      { "label": "no matching",        "args": ["vfy:del:missing"] }
+    ],
+    "cleanup":      []
+  },
+  "EXISTS": {
+    "setup":        [ ["SET", "vfy:exists:a", "1"] ],
+    "permutations": [
+      { "label": "one existing", "args": ["vfy:exists:a"] },
+      { "label": "missing",      "args": ["vfy:exists:missing"] },
+      { "label": "duplicates",   "args": ["vfy:exists:a", "vfy:exists:a"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:exists:a"] ]
+  },
+  "EXPIRE": {
+    "setup":        [ ["SET", "vfy:expire:a", "1"] ],
+    "permutations": [
+      { "label": "existing key", "args": ["vfy:expire:a", "60"] },
+      { "label": "missing key",  "args": ["vfy:expire:missing", "60"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:expire:a"] ]
+  },
+  "TTL": {
+    "setup":        [ ["SET", "vfy:ttl:a", "1", "EX", "60"], ["SET", "vfy:ttl:b", "1"] ],
+    "permutations": [
+      { "label": "with TTL",     "args": ["vfy:ttl:a"] },
+      { "label": "no TTL",       "args": ["vfy:ttl:b"] },
+      { "label": "missing",      "args": ["vfy:ttl:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:ttl:a", "vfy:ttl:b"] ]
+  },
+  "TYPE": {
+    "setup":        [ ["SET", "vfy:type:str", "x"], ["HSET", "vfy:type:hash", "f", "v"] ],
+    "permutations": [
+      { "label": "string",  "args": ["vfy:type:str"] },
+      { "label": "hash",    "args": ["vfy:type:hash"] },
+      { "label": "missing", "args": ["vfy:type:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:type:str", "vfy:type:hash"] ]
+  },
+  "RENAME": {
+    "setup":        [ ["SET", "vfy:rn:src", "1"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:rn:src", "vfy:rn:dst"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:rn:dst"] ]
+  },
+  "COPY": {
+    "setup":        [ ["SET", "vfy:cp:src", "1"] ],
+    "permutations": [
+      { "label": "copied",        "args": ["vfy:cp:src", "vfy:cp:dst"] },
+      { "label": "dst exists",    "args": ["vfy:cp:src", "vfy:cp:dst"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:cp:src", "vfy:cp:dst"] ]
+  },
+  "UNLINK": {
+    "setup":        [ ["SET", "vfy:unlink:a", "1"] ],
+    "permutations": [
+      { "label": "one existing", "args": ["vfy:unlink:a"] }
+    ],
+    "cleanup":      []
+  },
+  "OBJECT ENCODING": {
+    "setup":        [ ["SET", "vfy:oe:str", "hello"] ],
+    "permutations": [
+      { "label": "string", "args": ["vfy:oe:str"] },
+      { "label": "missing","args": ["vfy:oe:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:oe:str"] ]
+  },
+  "DBSIZE": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+
+  "_comment_hashes": "Hash commands -------------------------------------------",
+
+  "HSET": {
+    "setup":        [],
+    "permutations": [
+      { "label": "new fields",  "args": ["vfy:hset", "a", "1", "b", "2"] },
+      { "label": "update field","args": ["vfy:hset", "a", "9"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hset"] ]
+  },
+  "HGET": {
+    "setup":        [ ["HSET", "vfy:hget", "f1", "v1"] ],
+    "permutations": [
+      { "label": "field present", "args": ["vfy:hget", "f1"] },
+      { "label": "field missing", "args": ["vfy:hget", "fx"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hget"] ]
+  },
+  "HMGET": {
+    "setup":        [ ["HSET", "vfy:hmget", "f1", "v1", "f2", "v2"] ],
+    "permutations": [
+      { "label": "mix present/missing", "args": ["vfy:hmget", "f1", "fx", "f2"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hmget"] ]
+  },
+  "HEXISTS": {
+    "setup":        [ ["HSET", "vfy:hexists", "f1", "v1"] ],
+    "permutations": [
+      { "label": "field exists",  "args": ["vfy:hexists", "f1"] },
+      { "label": "field missing", "args": ["vfy:hexists", "fx"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hexists"] ]
+  },
+  "HKEYS": {
+    "setup":        [ ["HSET", "vfy:hkeys", "f1", "v1", "f2", "v2"] ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:hkeys"] },
+      { "label": "missing",  "args": ["vfy:hkeys:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hkeys"] ]
+  },
+  "HVALS": {
+    "setup":        [ ["HSET", "vfy:hvals", "f1", "v1", "f2", "v2"] ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:hvals"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hvals"] ]
+  },
+  "HLEN": {
+    "setup":        [ ["HSET", "vfy:hlen", "f1", "v1", "f2", "v2"] ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:hlen"] },
+      { "label": "missing",  "args": ["vfy:hlen:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hlen"] ]
+  },
+  "HGETALL": {
+    "setup":        [ ["HSET", "vfy:hgetall", "f1", "v1", "f2", "v2"] ],
+    "permutations": [
+      { "label": "key exists",         "args": ["vfy:hgetall"] },
+      { "label": "key does not exist", "args": ["vfy:hgetall:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hgetall"] ]
+  },
+  "HDEL": {
+    "setup":        [ ["HSET", "vfy:hdel", "f1", "v1", "f2", "v2"] ],
+    "permutations": [
+      { "label": "delete existing", "args": ["vfy:hdel", "f1"] },
+      { "label": "delete missing",  "args": ["vfy:hdel", "fx"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:hdel"] ]
+  },
+
+  "_comment_lists": "List commands -------------------------------------------",
+
+  "LPUSH": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": ["vfy:lpush", "a", "b", "c"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:lpush"] ]
+  },
+  "RPUSH": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": ["vfy:rpush", "a", "b", "c"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:rpush"] ]
+  },
+  "LLEN": {
+    "setup":        [ ["RPUSH", "vfy:llen", "a", "b", "c"] ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:llen"] },
+      { "label": "missing",  "args": ["vfy:llen:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:llen"] ]
+  },
+  "LINDEX": {
+    "setup":        [ ["RPUSH", "vfy:lindex", "a", "b", "c"] ],
+    "permutations": [
+      { "label": "in range",     "args": ["vfy:lindex", "1"] },
+      { "label": "out of range", "args": ["vfy:lindex", "99"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:lindex"] ]
+  },
+  "LRANGE": {
+    "setup":        [ ["RPUSH", "vfy:lrange", "a", "b", "c", "d"] ],
+    "permutations": [
+      { "label": "all",     "args": ["vfy:lrange", "0", "-1"] },
+      { "label": "subset",  "args": ["vfy:lrange", "1", "2"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:lrange"] ]
+  },
+  "LPOP": {
+    "setup":        [ ["RPUSH", "vfy:lpop", "a", "b", "c"] ],
+    "permutations": [
+      { "label": "no count",     "args": ["vfy:lpop"] },
+      { "label": "with count",   "args": ["vfy:lpop", "2"] },
+      { "label": "missing key",  "args": ["vfy:lpop:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:lpop"] ]
+  },
+
+  "_comment_sets": "Set commands --------------------------------------------",
+
+  "SADD": {
+    "setup":        [],
+    "permutations": [
+      { "label": "new members", "args": ["vfy:sadd", "a", "b", "c"] },
+      { "label": "duplicates",  "args": ["vfy:sadd", "a", "b"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:sadd"] ]
+  },
+  "SCARD": {
+    "setup":        [ ["SADD", "vfy:scard", "a", "b", "c"] ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:scard"] },
+      { "label": "missing",  "args": ["vfy:scard:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:scard"] ]
+  },
+  "SISMEMBER": {
+    "setup":        [ ["SADD", "vfy:sismember", "a"] ],
+    "permutations": [
+      { "label": "member exists",  "args": ["vfy:sismember", "a"] },
+      { "label": "member missing", "args": ["vfy:sismember", "b"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:sismember"] ]
+  },
+  "SMEMBERS": {
+    "setup":        [ ["SADD", "vfy:smembers", "a", "b", "c"] ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:smembers"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:smembers"] ]
+  },
+  "SREM": {
+    "setup":        [ ["SADD", "vfy:srem", "a", "b", "c"] ],
+    "permutations": [
+      { "label": "remove existing", "args": ["vfy:srem", "a"] },
+      { "label": "remove missing",  "args": ["vfy:srem", "x"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:srem"] ]
+  },
+
+  "_comment_zsets": "Sorted set commands ------------------------------------",
+
+  "ZADD": {
+    "setup":        [],
+    "permutations": [
+      { "label": "new members",       "args": ["vfy:zadd", "1.0", "a", "2.0", "b"] },
+      { "label": "INCR existing",     "args": ["vfy:zadd", "INCR", "0.5", "a"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:zadd"] ]
+  },
+  "ZCARD": {
+    "setup":        [ ["ZADD", "vfy:zcard", "1", "a", "2", "b"] ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:zcard"] },
+      { "label": "missing",  "args": ["vfy:zcard:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:zcard"] ]
+  },
+  "ZSCORE": {
+    "setup":        [ ["ZADD", "vfy:zscore", "3.14", "member_a"] ],
+    "permutations": [
+      { "label": "member exists",     "args": ["vfy:zscore", "member_a"] },
+      { "label": "member missing",    "args": ["vfy:zscore", "member_b"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:zscore"] ]
+  },
+  "ZRANGE": {
+    "setup":        [ ["ZADD", "vfy:zrange", "1", "a", "2", "b", "3", "c"] ],
+    "permutations": [
+      { "label": "default",     "args": ["vfy:zrange", "0", "-1"] },
+      { "label": "WITHSCORES",  "args": ["vfy:zrange", "0", "-1", "WITHSCORES"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:zrange"] ]
+  },
+  "ZRANK": {
+    "setup":        [ ["ZADD", "vfy:zrank", "1", "a", "2", "b"] ],
+    "permutations": [
+      { "label": "member exists",  "args": ["vfy:zrank", "a"] },
+      { "label": "member missing", "args": ["vfy:zrank", "x"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:zrank"] ]
+  },
+
+  "_comment_streams": "Stream commands ----------------------------------------",
+
+  "XADD": {
+    "setup":        [],
+    "permutations": [
+      { "label": "auto id",      "args": ["vfy:xadd", "*", "f", "v"] },
+      { "label": "NOMKSTREAM",   "args": ["NOMKSTREAM", "vfy:xadd:noexist", "*", "f", "v"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:xadd"] ]
+  },
+  "XLEN": {
+    "setup":        [
+      ["XADD", "vfy:xlen", "*", "f", "v"],
+      ["XADD", "vfy:xlen", "*", "f", "w"]
+    ],
+    "permutations": [
+      { "label": "existing", "args": ["vfy:xlen"] },
+      { "label": "missing",  "args": ["vfy:xlen:missing"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:xlen"] ]
+  },
+  "XRANGE": {
+    "setup":        [
+      ["XADD", "vfy:xrange", "*", "f1", "v1"],
+      ["XADD", "vfy:xrange", "*", "f2", "v2"]
+    ],
+    "permutations": [
+      { "label": "all",      "args": ["vfy:xrange", "-", "+"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:xrange"] ]
+  },
+
+  "_comment_server": "Server-info commands ------------------------------------",
+
+  "PING": {
+    "setup":        [],
+    "permutations": [
+      { "label": "no argument",     "args": [] },
+      { "label": "with argument",   "args": ["hello"] }
+    ],
+    "cleanup":      []
+  },
+  "ECHO": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": ["hello"] }
+    ],
+    "cleanup":      []
+  },
+  "TIME": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+  "ROLE": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+  "INFO": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default",         "args": [] },
+      { "label": "specific section","args": ["server"] }
+    ],
+    "cleanup":      []
+  },
+  "CONFIG GET": {
+    "setup":        [],
+    "permutations": [
+      { "label": "single parameter", "args": ["maxmemory"] },
+      { "label": "glob match",       "args": ["max*"] }
+    ],
+    "cleanup":      []
+  },
+  "CLIENT INFO": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+  "CLIENT LIST": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+  "CLUSTER INFO": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+  "CLUSTER NODES": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+  "CLUSTER SHARDS": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": [] }
+    ],
+    "cleanup":      []
+  },
+
+  "_comment_search": "RediSearch commands -------------------------------------",
+
+  "FT.SEARCH": {
+    "setup": [
+      ["FT.CREATE", "vfy:search_idx", "ON", "HASH", "PREFIX", "1", "vfy:doc:", "SCHEMA", "title", "TEXT", "country", "TAG"],
+      ["HSET", "vfy:doc:1", "title", "alpha",  "country", "UK"],
+      ["HSET", "vfy:doc:2", "title", "beta",   "country", "US"]
+    ],
+    "permutations": [
+      { "label": "default",      "args": ["vfy:search_idx", "*", "LIMIT", "0", "2"] },
+      { "label": "NOCONTENT",    "args": ["vfy:search_idx", "*", "NOCONTENT", "LIMIT", "0", "2"] },
+      { "label": "WITHSCORES",   "args": ["vfy:search_idx", "alpha", "WITHSCORES"] },
+      { "label": "WITHSORTKEYS", "args": ["vfy:search_idx", "*", "SORTBY", "country", "WITHSORTKEYS", "LIMIT", "0", "2"] }
+    ],
+    "cleanup": [
+      ["FT.DROPINDEX", "vfy:search_idx"],
+      ["DEL", "vfy:doc:1", "vfy:doc:2"]
+    ]
+  },
+  "FT.AGGREGATE": {
+    "setup": [
+      ["FT.CREATE", "vfy:agg_idx", "ON", "HASH", "PREFIX", "1", "vfy:agg:", "SCHEMA", "country", "TAG", "price", "NUMERIC", "SORTABLE"],
+      ["HSET", "vfy:agg:1", "country", "UK", "price", "10.0"],
+      ["HSET", "vfy:agg:2", "country", "UK", "price", "15.0"],
+      ["HSET", "vfy:agg:3", "country", "US", "price", "20.0"]
+    ],
+    "permutations": [
+      { "label": "GROUPBY + REDUCE", "args": ["vfy:agg_idx", "*", "GROUPBY", "1", "@country", "REDUCE", "COUNT", "0", "AS", "num"] },
+      { "label": "WITHCURSOR",       "args": ["vfy:agg_idx", "*", "GROUPBY", "1", "@country", "REDUCE", "COUNT", "0", "AS", "num", "WITHCURSOR", "COUNT", "1"] }
+    ],
+    "cleanup": [
+      ["FT.DROPINDEX", "vfy:agg_idx"],
+      ["DEL", "vfy:agg:1", "vfy:agg:2", "vfy:agg:3"]
+    ]
+  },
+  "FT.INFO": {
+    "setup": [
+      ["FT.CREATE", "vfy:info_idx", "ON", "HASH", "PREFIX", "1", "vfy:ifd:", "SCHEMA", "title", "TEXT"]
+    ],
+    "permutations": [
+      { "label": "existing index", "args": ["vfy:info_idx"] }
+    ],
+    "cleanup": [
+      ["FT.DROPINDEX", "vfy:info_idx"]
+    ]
+  },
+  "FT.TAGVALS": {
+    "setup": [
+      ["FT.CREATE", "vfy:tag_idx", "ON", "HASH", "PREFIX", "1", "vfy:tdoc:", "SCHEMA", "country", "TAG"],
+      ["HSET", "vfy:tdoc:1", "country", "UK"],
+      ["HSET", "vfy:tdoc:2", "country", "US"]
+    ],
+    "permutations": [
+      { "label": "existing tag field", "args": ["vfy:tag_idx", "country"] }
+    ],
+    "cleanup": [
+      ["FT.DROPINDEX", "vfy:tag_idx"],
+      ["DEL", "vfy:tdoc:1", "vfy:tdoc:2"]
+    ]
+  },
+
+  "_comment_json": "RedisJSON commands --------------------------------------",
+
+  "JSON.SET": {
+    "setup":        [],
+    "permutations": [
+      { "label": "default", "args": ["vfy:json", "$", "{\"a\":1,\"b\":\"hello\"}"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:json"] ]
+  },
+  "JSON.GET": {
+    "setup":        [ ["JSON.SET", "vfy:jget", "$", "{\"a\":1,\"b\":\"hello\"}"] ],
+    "permutations": [
+      { "label": "single path",     "args": ["vfy:jget", "$.a"] },
+      { "label": "root",            "args": ["vfy:jget", "$"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:jget"] ]
+  },
+  "JSON.TYPE": {
+    "setup":        [ ["JSON.SET", "vfy:jtype", "$", "{\"a\":1}"] ],
+    "permutations": [
+      { "label": "object root",     "args": ["vfy:jtype", "$"] },
+      { "label": "leaf path",       "args": ["vfy:jtype", "$.a"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:jtype"] ]
+  },
+  "JSON.OBJKEYS": {
+    "setup":        [ ["JSON.SET", "vfy:jok", "$", "{\"a\":1,\"b\":2}"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:jok", "$"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:jok"] ]
+  },
+
+  "_comment_ts": "RedisTimeSeries commands --------------------------------",
+
+  "TS.ADD": {
+    "setup":        [],
+    "permutations": [
+      { "label": "auto timestamp",  "args": ["vfy:ts", "*", "1.0"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:ts"] ]
+  },
+  "TS.GET": {
+    "setup":        [ ["TS.ADD", "vfy:tsget", "1000", "1.0"], ["TS.ADD", "vfy:tsget", "2000", "2.0"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:tsget"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:tsget"] ]
+  },
+  "TS.RANGE": {
+    "setup":        [
+      ["TS.ADD", "vfy:tsr", "1000", "1.0"],
+      ["TS.ADD", "vfy:tsr", "2000", "2.0"],
+      ["TS.ADD", "vfy:tsr", "3000", "3.0"]
+    ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:tsr", "-", "+"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:tsr"] ]
+  },
+  "TS.INFO": {
+    "setup":        [ ["TS.ADD", "vfy:tsi", "*", "1.0"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:tsi"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:tsi"] ]
+  },
+
+  "_comment_bloom": "RedisBloom commands -------------------------------------",
+
+  "BF.ADD": {
+    "setup":        [],
+    "permutations": [
+      { "label": "first add",      "args": ["vfy:bf", "item_a"] },
+      { "label": "duplicate add",  "args": ["vfy:bf", "item_a"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:bf"] ]
+  },
+  "BF.EXISTS": {
+    "setup":        [ ["BF.ADD", "vfy:bfe", "item_a"] ],
+    "permutations": [
+      { "label": "exists",       "args": ["vfy:bfe", "item_a"] },
+      { "label": "not present",  "args": ["vfy:bfe", "item_b"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:bfe"] ]
+  },
+  "BF.MEXISTS": {
+    "setup":        [ ["BF.ADD", "vfy:bfm", "item_a"] ],
+    "permutations": [
+      { "label": "mix", "args": ["vfy:bfm", "item_a", "item_b"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:bfm"] ]
+  },
+  "BF.INFO": {
+    "setup":        [ ["BF.RESERVE", "vfy:bfi", "0.01", "1000"] ],
+    "permutations": [
+      { "label": "default", "args": ["vfy:bfi"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:bfi"] ]
+  },
+  "CF.ADD": {
+    "setup":        [],
+    "permutations": [
+      { "label": "first add", "args": ["vfy:cf", "item_a"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:cf"] ]
+  },
+  "CF.EXISTS": {
+    "setup":        [ ["CF.ADD", "vfy:cfe", "item_a"] ],
+    "permutations": [
+      { "label": "exists",     "args": ["vfy:cfe", "item_a"] },
+      { "label": "missing",    "args": ["vfy:cfe", "item_b"] }
+    ],
+    "cleanup":      [ ["DEL", "vfy:cfe"] ]
+  }
+}

--- a/tools/verification_report.json
+++ b/tools/verification_report.json
@@ -1,0 +1,3023 @@
+[
+  {
+    "command": "SET",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:str",
+          "hello"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": [
+              {
+                "path": "$",
+                "severity": "info",
+                "message": "spec type `null` not compatible with reply shape `string`"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": [
+              {
+                "path": "$",
+                "severity": "info",
+                "message": "spec type `null` not compatible with reply shape `string`"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "label": "NX on missing",
+        "args": [
+          "vfy:str:nx",
+          "first",
+          "NX"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": [
+              {
+                "path": "$",
+                "severity": "info",
+                "message": "spec type `null` not compatible with reply shape `string`"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": [
+              {
+                "path": "$",
+                "severity": "info",
+                "message": "spec type `null` not compatible with reply shape `string`"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "GET",
+    "permutations": [
+      {
+        "label": "key exists",
+        "args": [
+          "vfy:get"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "key does not exist",
+        "args": [
+          "vfy:get:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "null",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "null",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "STRLEN",
+    "permutations": [
+      {
+        "label": "key exists",
+        "args": [
+          "vfy:strlen"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "key missing",
+        "args": [
+          "vfy:strlen:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "APPEND",
+    "permutations": [
+      {
+        "label": "existing key",
+        "args": [
+          "vfy:append",
+          "def"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "GETRANGE",
+    "permutations": [
+      {
+        "label": "in range",
+        "args": [
+          "vfy:getrange",
+          "0",
+          "4"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "out of range",
+        "args": [
+          "vfy:getrange",
+          "20",
+          "30"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "MSET",
+    "permutations": [
+      {
+        "label": "two pairs",
+        "args": [
+          "vfy:mset:a",
+          "1",
+          "vfy:mset:b",
+          "2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "MGET",
+    "permutations": [
+      {
+        "label": "mixed existing/missing",
+        "args": [
+          "vfy:mget:a",
+          "vfy:mget:missing",
+          "vfy:mget:b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "INCR",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:incr"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "DECR",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:decr"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "INCRBY",
+    "permutations": [
+      {
+        "label": "positive",
+        "args": [
+          "vfy:incrby",
+          "5"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "negative",
+        "args": [
+          "vfy:incrby",
+          "-3"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "INCRBYFLOAT",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:incrf",
+          "0.5"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "DEL",
+    "permutations": [
+      {
+        "label": "two existing",
+        "args": [
+          "vfy:del:a",
+          "vfy:del:b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "no matching",
+        "args": [
+          "vfy:del:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "EXISTS",
+    "permutations": [
+      {
+        "label": "one existing",
+        "args": [
+          "vfy:exists:a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:exists:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "duplicates",
+        "args": [
+          "vfy:exists:a",
+          "vfy:exists:a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "EXPIRE",
+    "permutations": [
+      {
+        "label": "existing key",
+        "args": [
+          "vfy:expire:a",
+          "60"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing key",
+        "args": [
+          "vfy:expire:missing",
+          "60"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "TTL",
+    "permutations": [
+      {
+        "label": "with TTL",
+        "args": [
+          "vfy:ttl:a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "no TTL",
+        "args": [
+          "vfy:ttl:b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:ttl:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "TYPE",
+    "permutations": [
+      {
+        "label": "string",
+        "args": [
+          "vfy:type:str"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "hash",
+        "args": [
+          "vfy:type:hash"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:type:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "RENAME",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:rn:src",
+          "vfy:rn:dst"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "COPY",
+    "permutations": [
+      {
+        "label": "copied",
+        "args": [
+          "vfy:cp:src",
+          "vfy:cp:dst"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "dst exists",
+        "args": [
+          "vfy:cp:src",
+          "vfy:cp:dst"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "UNLINK",
+    "permutations": [
+      {
+        "label": "one existing",
+        "args": [
+          "vfy:unlink:a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "OBJECT ENCODING",
+    "permutations": [
+      {
+        "label": "string",
+        "args": [
+          "vfy:oe:str"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:oe:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "null",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "null",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "DBSIZE",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HSET",
+    "permutations": [
+      {
+        "label": "new fields",
+        "args": [
+          "vfy:hset",
+          "a",
+          "1",
+          "b",
+          "2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "update field",
+        "args": [
+          "vfy:hset",
+          "a",
+          "9"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HGET",
+    "permutations": [
+      {
+        "label": "field present",
+        "args": [
+          "vfy:hget",
+          "f1"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "field missing",
+        "args": [
+          "vfy:hget",
+          "fx"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "null",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "null",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HMGET",
+    "permutations": [
+      {
+        "label": "mix present/missing",
+        "args": [
+          "vfy:hmget",
+          "f1",
+          "fx",
+          "f2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HEXISTS",
+    "permutations": [
+      {
+        "label": "field exists",
+        "args": [
+          "vfy:hexists",
+          "f1"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "field missing",
+        "args": [
+          "vfy:hexists",
+          "fx"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HKEYS",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:hkeys"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:hkeys:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HVALS",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:hvals"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HLEN",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:hlen"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:hlen:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HGETALL",
+    "permutations": [
+      {
+        "label": "key exists",
+        "args": [
+          "vfy:hgetall"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "key does not exist",
+        "args": [
+          "vfy:hgetall:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "HDEL",
+    "permutations": [
+      {
+        "label": "delete existing",
+        "args": [
+          "vfy:hdel",
+          "f1"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "delete missing",
+        "args": [
+          "vfy:hdel",
+          "fx"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "LPUSH",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:lpush",
+          "a",
+          "b",
+          "c"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "RPUSH",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:rpush",
+          "a",
+          "b",
+          "c"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "LLEN",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:llen"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:llen:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "LINDEX",
+    "permutations": [
+      {
+        "label": "in range",
+        "args": [
+          "vfy:lindex",
+          "1"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "out of range",
+        "args": [
+          "vfy:lindex",
+          "99"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "null",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "null",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "LRANGE",
+    "permutations": [
+      {
+        "label": "all",
+        "args": [
+          "vfy:lrange",
+          "0",
+          "-1"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "subset",
+        "args": [
+          "vfy:lrange",
+          "1",
+          "2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "LPOP",
+    "permutations": [
+      {
+        "label": "no count",
+        "args": [
+          "vfy:lpop"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "with count",
+        "args": [
+          "vfy:lpop",
+          "2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[2]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[2]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "label": "missing key",
+        "args": [
+          "vfy:lpop:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "null",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "null",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "SADD",
+    "permutations": [
+      {
+        "label": "new members",
+        "args": [
+          "vfy:sadd",
+          "a",
+          "b",
+          "c"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "duplicates",
+        "args": [
+          "vfy:sadd",
+          "a",
+          "b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "SCARD",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:scard"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:scard:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "SISMEMBER",
+    "permutations": [
+      {
+        "label": "member exists",
+        "args": [
+          "vfy:sismember",
+          "a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "member missing",
+        "args": [
+          "vfy:sismember",
+          "b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "SMEMBERS",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:smembers"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "SREM",
+    "permutations": [
+      {
+        "label": "remove existing",
+        "args": [
+          "vfy:srem",
+          "a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "remove missing",
+        "args": [
+          "vfy:srem",
+          "x"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "ZADD",
+    "permutations": [
+      {
+        "label": "new members",
+        "args": [
+          "vfy:zadd",
+          "1.0",
+          "a",
+          "2.0",
+          "b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "INCR existing",
+        "args": [
+          "vfy:zadd",
+          "INCR",
+          "0.5",
+          "a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "double",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "ZCARD",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:zcard"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:zcard:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "ZSCORE",
+    "permutations": [
+      {
+        "label": "member exists",
+        "args": [
+          "vfy:zscore",
+          "member_a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "double",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "member missing",
+        "args": [
+          "vfy:zscore",
+          "member_b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "null",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "null",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "ZRANGE",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:zrange",
+          "0",
+          "-1"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "WITHSCORES",
+        "args": [
+          "vfy:zrange",
+          "0",
+          "-1",
+          "WITHSCORES"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[0]",
+                "severity": "error",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              },
+              {
+                "path": "$[1]",
+                "severity": "error",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              },
+              {
+                "path": "$[2]",
+                "severity": "error",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "ZRANK",
+    "permutations": [
+      {
+        "label": "member exists",
+        "args": [
+          "vfy:zrank",
+          "a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "member missing",
+        "args": [
+          "vfy:zrank",
+          "x"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "null",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "null",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "XADD",
+    "permutations": [
+      {
+        "label": "auto id",
+        "args": [
+          "vfy:xadd",
+          "*",
+          "f",
+          "v"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "NOMKSTREAM",
+        "args": [
+          "NOMKSTREAM",
+          "vfy:xadd:noexist",
+          "*",
+          "f",
+          "v"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: Invalid stream ID specified as stream command argument"
+          },
+          "resp3": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: Invalid stream ID specified as stream command argument"
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "XLEN",
+    "permutations": [
+      {
+        "label": "existing",
+        "args": [
+          "vfy:xlen"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:xlen:missing"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "XRANGE",
+    "permutations": [
+      {
+        "label": "all",
+        "args": [
+          "vfy:xrange",
+          "-",
+          "+"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[0]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              },
+              {
+                "path": "$[1]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[0]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              },
+              {
+                "path": "$[1]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "PING",
+    "permutations": [
+      {
+        "label": "no argument",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "with argument",
+        "args": [
+          "hello"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "ECHO",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "hello"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "TIME",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "ROLE",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[1]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `integer`"
+              },
+              {
+                "path": "$[2]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[1]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `integer`"
+              },
+              {
+                "path": "$[2]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "INFO",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "specific section",
+        "args": [
+          "server"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "CONFIG GET",
+    "permutations": [
+      {
+        "label": "single parameter",
+        "args": [
+          "maxmemory"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "glob match",
+        "args": [
+          "max*"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "CLIENT INFO",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "CLIENT LIST",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "CLUSTER INFO",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: This instance has cluster support disabled"
+          },
+          "resp3": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: This instance has cluster support disabled"
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "CLUSTER NODES",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: This instance has cluster support disabled"
+          },
+          "resp3": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: This instance has cluster support disabled"
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "CLUSTER SHARDS",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [],
+        "protocols": {
+          "resp2": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: This instance has cluster support disabled"
+          },
+          "resp3": {
+            "reply_shape": null,
+            "findings": [],
+            "server_error": "ResponseError: This instance has cluster support disabled"
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "FT.SEARCH",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:search_idx",
+          "*",
+          "LIMIT",
+          "0",
+          "2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "NOCONTENT",
+        "args": [
+          "vfy:search_idx",
+          "*",
+          "NOCONTENT",
+          "LIMIT",
+          "0",
+          "2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "WITHSCORES",
+        "args": [
+          "vfy:search_idx",
+          "alpha",
+          "WITHSCORES"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "WITHSORTKEYS",
+        "args": [
+          "vfy:search_idx",
+          "*",
+          "SORTBY",
+          "country",
+          "WITHSORTKEYS",
+          "LIMIT",
+          "0",
+          "2"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "FT.AGGREGATE",
+    "permutations": [
+      {
+        "label": "GROUPBY + REDUCE",
+        "args": [
+          "vfy:agg_idx",
+          "*",
+          "GROUPBY",
+          "1",
+          "@country",
+          "REDUCE",
+          "COUNT",
+          "0",
+          "AS",
+          "num"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "WITHCURSOR",
+        "args": [
+          "vfy:agg_idx",
+          "*",
+          "GROUPBY",
+          "1",
+          "@country",
+          "REDUCE",
+          "COUNT",
+          "0",
+          "AS",
+          "num",
+          "WITHCURSOR",
+          "COUNT",
+          "1"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "info",
+                "message": "spec is map; got array (likely RESP2 flattening \u2014 verify the RESP3 reply)"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "FT.INFO",
+    "permutations": [
+      {
+        "label": "existing index",
+        "args": [
+          "vfy:info_idx"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "FT.TAGVALS",
+    "permutations": [
+      {
+        "label": "existing tag field",
+        "args": [
+          "vfy:tag_idx",
+          "country"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "JSON.SET",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:json",
+          "$",
+          "{\"a\":1,\"b\":\"hello\"}"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "JSON.GET",
+    "permutations": [
+      {
+        "label": "single path",
+        "args": [
+          "vfy:jget",
+          "$.a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "root",
+        "args": [
+          "vfy:jget",
+          "$"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "string",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "string",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "JSON.TYPE",
+    "permutations": [
+      {
+        "label": "object root",
+        "args": [
+          "vfy:jtype",
+          "$"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[0]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "label": "leaf path",
+        "args": [
+          "vfy:jtype",
+          "$.a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[0]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "JSON.OBJKEYS",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:jok",
+          "$"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[0]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$[0]",
+                "severity": "info",
+                "message": "spec type `bulk_string` not compatible with reply shape `array`"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "TS.ADD",
+    "permutations": [
+      {
+        "label": "auto timestamp",
+        "args": [
+          "vfy:ts",
+          "*",
+          "1.0"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "integer",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "TS.GET",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:tsget"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "TS.RANGE",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:tsr",
+          "-",
+          "+"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "TS.INFO",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:tsi"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": true
+  },
+  {
+    "command": "BF.ADD",
+    "permutations": [
+      {
+        "label": "first add",
+        "args": [
+          "vfy:bf",
+          "item_a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "boolean",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "duplicate add",
+        "args": [
+          "vfy:bf",
+          "item_a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "boolean",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "BF.EXISTS",
+    "permutations": [
+      {
+        "label": "exists",
+        "args": [
+          "vfy:bfe",
+          "item_a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "boolean",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "not present",
+        "args": [
+          "vfy:bfe",
+          "item_b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "boolean",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "BF.MEXISTS",
+    "permutations": [
+      {
+        "label": "mix",
+        "args": [
+          "vfy:bfm",
+          "item_a",
+          "item_b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "BF.INFO",
+    "permutations": [
+      {
+        "label": "default",
+        "args": [
+          "vfy:bfi"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "array",
+            "findings": [
+              {
+                "path": "$|oneof[0]",
+                "severity": "warn",
+                "message": "spec has no `items` for array \u2014 cannot verify item shape"
+              }
+            ]
+          },
+          "resp3": {
+            "reply_shape": "map",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "CF.ADD",
+    "permutations": [
+      {
+        "label": "first add",
+        "args": [
+          "vfy:cf",
+          "item_a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "boolean",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  },
+  {
+    "command": "CF.EXISTS",
+    "permutations": [
+      {
+        "label": "exists",
+        "args": [
+          "vfy:cfe",
+          "item_a"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "boolean",
+            "findings": []
+          }
+        }
+      },
+      {
+        "label": "missing",
+        "args": [
+          "vfy:cfe",
+          "item_b"
+        ],
+        "protocols": {
+          "resp2": {
+            "reply_shape": "integer",
+            "findings": []
+          },
+          "resp3": {
+            "reply_shape": "boolean",
+            "findings": []
+          }
+        }
+      }
+    ],
+    "setup_errors": [],
+    "cleanup_errors": [],
+    "stub": false
+  }
+]

--- a/tools/verify_returns_from_server.py
+++ b/tools/verify_returns_from_server.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Batch-verify `returns` specs against a live Redis server.
+
+For each command in the fixtures file:
+  1. Run setup commands.
+  2. For each permutation, execute the command in RESP2 and RESP3,
+     capture the raw reply, and compare its structural shape to the
+     stored spec.
+  3. Run cleanup commands.
+  4. Emit a diff report.
+
+Usage:
+    python3 verify_returns_from_server.py \
+        --specs   tools/corpus_returns_extracted.json \
+        --fixtures tools/verification_fixtures.json \
+        [--cmd FT.SEARCH] \
+        [--report tools/verification_report.json]
+
+By design the verifier is conservative: it flags definite mismatches
+(e.g. spec says `integer` but got bytes), and it warns on structural
+gaps (e.g. spec is a `map` with enumerated fields but the reply has
+keys not in the spec). It does not attempt to verify `when` predicates
+or conditional shapes — those remain prose-level.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from redis.connection import Connection
+from redis.exceptions import RedisError
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---- raw RESP execution ---------------------------------------------------
+
+def execute(host, port, protocol, command_args):
+    """Connect, run a single command, return raw reply (no decoding)."""
+    conn = Connection(host=host, port=port, protocol=protocol)
+    conn.connect()
+    try:
+        conn.send_command(*command_args)
+        return conn.read_response(disable_decoding=True)
+    finally:
+        conn.disconnect()
+
+
+# ---- structural comparison ------------------------------------------------
+
+# Map a Python value to a coarse RESP-style shape category.
+def value_shape(v):
+    if isinstance(v, bool):     return "boolean"
+    if isinstance(v, int):      return "integer"
+    if isinstance(v, float):    return "double"
+    if v is None:               return "null"
+    if isinstance(v, (bytes, str)):
+        return "string"
+    if isinstance(v, dict):     return "map"
+    if isinstance(v, set):      return "set"
+    if isinstance(v, list):     return "array"
+    return "unknown"
+
+
+# Which spec types are compatible with which value shapes.
+COMPATIBLE = {
+    "simple_string":   {"string"},
+    "bulk_string":     {"string", "null"},   # nullable bulk string is common
+    "verbatim_string": {"string"},
+    "integer":         {"integer"},
+    "double":          {"double", "string"}, # RESP2 encodes doubles as strings
+    "boolean":         {"boolean", "integer"}, # RESP2 encodes booleans as 0/1
+    "null":            {"null"},
+    "big_number":      {"integer", "string"},
+    "array":           {"array"},
+    "tuple":           {"array"},
+    "kv_array":        {"array"},
+    "map":             {"map", "array"},     # RESP2 may flatten a map to an array
+    "set":             {"set", "array"},     # RESP2 lacks set type
+    "push":            {"array"},
+}
+
+
+def compatible(spec_type, value):
+    shape = value_shape(value)
+    return shape in COMPATIBLE.get(spec_type, set())
+
+
+def compare(spec, value, path="$"):
+    """Recursively compare a ReplySpec to a Python value (the captured
+    reply). Yields {path, severity, message} dicts for each finding."""
+    if spec is None:
+        return
+    if isinstance(spec, str):
+        # "same_as_resp2" / "same_as_resp3" — handled at the protocol
+        # level, not here. Shouldn't reach this with a string.
+        yield {"path": path, "severity": "warn",
+               "message": f"unresolved spec reference: {spec}"}
+        return
+    if "oneof" in spec:
+        # Try each branch; pass if any branch matches with no `error`-level
+        # findings. Warns are tolerated — they flag inferred-but-unverified
+        # shape detail, not a definite mismatch.
+        branch_findings = []
+        for i, branch in enumerate(spec["oneof"]):
+            findings = list(compare(branch, value, f"{path}|oneof[{i}]"))
+            errors = [f for f in findings if f["severity"] == "error"]
+            if not errors:
+                # Surface this branch's warns, then we're done.
+                for f in findings:
+                    yield f
+                return
+            branch_findings.append(findings)
+        # No branch matched — emit the shortest-conflict branch's findings
+        branch_findings.sort(key=len)
+        for f in branch_findings[0][:3]:
+            yield f
+        yield {"path": path, "severity": "error",
+               "message": f"value matches none of {len(spec['oneof'])} oneof branches"}
+        return
+    if "$ref" in spec:
+        # Cross-file refs not resolved here (would need the full schema
+        # registry). Skip with a note.
+        yield {"path": path, "severity": "info",
+               "message": f"$ref {spec['$ref']} not resolved by verifier"}
+        return
+
+    spec_type = spec.get("type")
+    if spec_type is None:
+        return
+
+    if not compatible(spec_type, value):
+        yield {"path": path, "severity": "error",
+               "message": f"spec type `{spec_type}` not compatible with reply shape `{value_shape(value)}`"}
+        return
+
+    if spec_type == "simple_string" and "value" in spec:
+        # Sentinel — should match exactly.
+        observed = value.decode("utf-8") if isinstance(value, bytes) else value
+        if observed != spec["value"]:
+            yield {"path": path, "severity": "error",
+                   "message": f"sentinel mismatch: spec says `{spec['value']}`, got `{observed}`"}
+
+    elif spec_type == "array":
+        items_spec = spec.get("items")
+        if items_spec is None:
+            yield {"path": path, "severity": "warn",
+                   "message": "spec has no `items` for array — cannot verify item shape"}
+        else:
+            for i, item in enumerate(value[:5]):    # cap at 5 to limit noise
+                yield from compare(items_spec, item, f"{path}[{i}]")
+
+    elif spec_type == "tuple":
+        prefix = spec.get("prefixItems", [])
+        for i, sub_spec in enumerate(prefix):
+            if i >= len(value):
+                if not sub_spec.get("optional"):
+                    yield {"path": path, "severity": "error",
+                           "message": f"missing required tuple element [{i}] ({sub_spec.get('name','?')})"}
+                continue
+            yield from compare(sub_spec, value[i], f"{path}[{i}]")
+        rest = spec.get("rest")
+        if rest is not None and len(value) > len(prefix):
+            for i, item in enumerate(value[len(prefix):len(prefix)+3]):
+                yield from compare(rest, item, f"{path}[{len(prefix)+i}/rest]")
+
+    elif spec_type == "map":
+        if not isinstance(value, dict):
+            yield {"path": path, "severity": "info",
+                   "message": f"spec is map; got array (likely RESP2 flattening — verify the RESP3 reply)"}
+            return
+        fields = spec.get("fields") or []
+        named = {f["name"]: f for f in fields}
+        observed_keys = set()
+        for k, v in value.items():
+            kname = k.decode("utf-8") if isinstance(k, bytes) else k
+            observed_keys.add(kname)
+            if kname in named:
+                yield from compare(named[kname], v, f"{path}.{kname}")
+        for fname, fspec in named.items():
+            if fname not in observed_keys and not fspec.get("optional"):
+                yield {"path": path, "severity": "warn",
+                       "message": f"required field `{fname}` not present in reply"}
+        if fields:
+            extras = observed_keys - set(named)
+            if extras:
+                yield {"path": path, "severity": "warn",
+                       "message": f"reply has keys not in spec: {sorted(extras)}"}
+
+    elif spec_type == "kv_array":
+        if len(value) % 2 != 0:
+            yield {"path": path, "severity": "error",
+                   "message": f"kv_array must have even length; got {len(value)}"}
+
+
+# ---- per-command pipeline -------------------------------------------------
+
+def verify_command(host, port, cmd_name, spec_entry, fixture):
+    """Run setup, execute each permutation in both protocols, compare to
+    spec, run cleanup. Return a per-command report dict."""
+    report = {"command": cmd_name, "permutations": [],
+              "setup_errors": [], "cleanup_errors": []}
+
+    spec = spec_entry.get("returns")
+    if spec is None:
+        report["error"] = "no `returns` in spec entry"
+        return report
+
+    # Skip strict verification of stubs — by definition they don't claim
+    # to be shape-complete. We still execute the command to confirm it
+    # doesn't error, but report any spec/reply gaps as `info` not `error`.
+    is_stub = spec_entry.get("returns_status") == "stub"
+    report["stub"] = is_stub
+
+    def run_setup():
+        for setup_cmd in fixture.get("setup", []):
+            try:
+                execute(host, port, 2, setup_cmd)
+            except RedisError as e:
+                report["setup_errors"].append(f"{setup_cmd[0]}: {e}")
+
+    def run_cleanup():
+        for cleanup_cmd in fixture.get("cleanup", []):
+            try:
+                execute(host, port, 2, cleanup_cmd)
+            except RedisError:
+                pass    # cleanup errors are non-fatal; common when keys were already removed
+
+    for perm in fixture.get("permutations", []):
+        perm_report = {"label": perm["label"], "args": perm["args"], "protocols": {}}
+        full_cmd = cmd_name.split() + perm["args"]
+
+        for proto in (2, 3):
+            # Re-run setup before each protocol invocation. Some commands
+            # mutate state (RENAME, DEL) and would otherwise see different
+            # preconditions in their second protocol run.
+            run_cleanup()
+            run_setup()
+
+            proto_report = {"reply_shape": None, "findings": []}
+            try:
+                reply = execute(host, port, proto, full_cmd)
+                proto_report["reply_shape"] = value_shape(reply)
+                proto_spec = spec.get(f"resp{proto}")
+                # Resolve same_as
+                if proto_spec == "same_as_resp2":
+                    proto_spec = spec.get("resp2")
+                elif proto_spec == "same_as_resp3":
+                    proto_spec = spec.get("resp3")
+                findings = list(compare(proto_spec, reply))
+                # Demote findings to info for stub specs.
+                if is_stub:
+                    findings = [{**f, "severity": "info"} for f in findings]
+                proto_report["findings"] = findings
+            except RedisError as e:
+                # Server-side errors aren't spec mismatches — they're
+                # environmental (CLUSTER on non-cluster, missing module, etc.).
+                proto_report["server_error"] = f"{type(e).__name__}: {e}"
+            except Exception as e:
+                proto_report["error"] = f"{type(e).__name__}: {e}"
+            perm_report["protocols"][f"resp{proto}"] = proto_report
+
+        report["permutations"].append(perm_report)
+
+    run_cleanup()
+
+    return report
+
+
+# ---- summary -------------------------------------------------------------
+
+def summarise(reports):
+    """Produce a human-readable summary from a list of per-command reports."""
+    lines = []
+    error_count = 0
+    warn_count = 0
+    clean_count = 0
+    skipped_count = 0
+    for r in reports:
+        cmd = r["command"]
+        lines.append(f"\n===== {cmd} ====={' (stub)' if r.get('stub') else ''}")
+        if r.get("setup_errors"):
+            for se in r["setup_errors"]:
+                lines.append(f"  ! setup error: {se}")
+        for perm in r["permutations"]:
+            lines.append(f"  [{perm['label']}]  args={perm['args']}")
+            for proto, pr in perm["protocols"].items():
+                if pr.get("server_error"):
+                    lines.append(f"    {proto}: SKIP (server: {pr['server_error']})")
+                    skipped_count += 1
+                    continue
+                if pr.get("error"):
+                    lines.append(f"    {proto}: ERROR {pr['error']}")
+                    error_count += 1
+                    continue
+                findings = pr.get("findings", [])
+                shape = pr.get("reply_shape")
+                if not findings:
+                    lines.append(f"    {proto}: ok (reply is {shape})")
+                    clean_count += 1
+                else:
+                    severities = {f["severity"] for f in findings}
+                    if "error" in severities:
+                        error_count += 1
+                    elif "warn" in severities:
+                        warn_count += 1
+                    else:
+                        clean_count += 1
+                    for f in findings:
+                        marker = {"error": "✗", "warn": "?", "info": "·"}.get(
+                            f["severity"], "·")
+                        lines.append(f"    {proto}: {marker} {f['path']}: {f['message']}")
+    total = clean_count + warn_count + error_count + skipped_count
+    lines.append(f"\nTotals: {total} checks — clean={clean_count} warn={warn_count} error={error_count} skipped={skipped_count}")
+    return "\n".join(lines)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--specs", required=True)
+    p.add_argument("--fixtures", required=True)
+    p.add_argument("--host", default="localhost")
+    p.add_argument("--port", type=int, default=6379)
+    p.add_argument("--cmd", help="Verify only this command (uppercased name).")
+    p.add_argument("--report", help="Write JSON report to this path.")
+    args = p.parse_args()
+
+    specs = json.loads(Path(args.specs).read_text())
+    fixtures = json.loads(Path(args.fixtures).read_text())
+
+    cmd_filter = args.cmd
+    reports = []
+    for cmd_name, fixture in fixtures.items():
+        if cmd_name.startswith("_"):
+            continue
+        if cmd_filter and cmd_name != cmd_filter:
+            continue
+        spec_entry = specs.get(cmd_name)
+        if spec_entry is None:
+            reports.append({"command": cmd_name,
+                            "permutations": [], "setup_errors": [],
+                            "cleanup_errors": [],
+                            "error": "no spec entry"})
+            continue
+        reports.append(verify_command(args.host, args.port,
+                                      cmd_name, spec_entry, fixture))
+
+    print(summarise(reports))
+
+    if args.report:
+        Path(args.report).write_text(json.dumps(reports, indent=2) + "\n")
+        print(f"\nWrote JSON report to {args.report}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Note: WIP - don't merge yet.

This is a draft of a new approach to adding return value info to the command pages. It introduces a structured definition for the returned RESP2/3 (a bit like the one used for the argument syntax), and then uses that to generate the human-facing Return Information section at the end of the command page via a shortcode. The original JSON structured form of the return info is also added to the AI-facing metadata.

At the moment the new return info is only added to a few test pages. All feedback is welcome, but there are a couple of things worth drawing attention to:

- Claude has added a bit more detail with the structure of the return values than we currently have. I don't mind this but I'm not sure if it is helpful or not. Maybe the more concise existing descriptions are better?
- Without being asked, Claude also ventured to add examples of the return values. It seems like a reasonable idea but the main issue is that it introduces a notation for the RESP2/3 types. I'm wondering if it might be quite useful to establish this notation generally and document it (we could maybe use it to add testing to the CLI examples, say). At the very least, we should have a brief description of this notation somewhere if we decide to go ahead with the return examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how documented reply types are authored and rendered; incorrect JSON could mislead readers and AI consumers, though scope is limited to pilot pages and new data files.
> 
> **Overview**
> Introduces **structured RESP return-value specs** in `data/commands_returns_*.json` and a Hugo pipeline (`returns-data`, `returns/render-*`, `{{< return-info >}}`) that generates **Return information** from that single source instead of hand-maintained RESP2/RESP3 `multitabs` blocks.
> 
> Eight pilot command pages (`HGET`, `HGETALL`, `HINCRBY`, `XADD`, `XRANGE`, `ZADD`, `ZRANGE`, `BF.ADD`) now use `{{< return-info >}}`. The specs cover richer shapes (`oneof`, maps vs `kv_array`, tuples, errors) and optional **JSON-serialized reply examples** with RESP2/RESP3 differences (e.g. integers vs booleans, `HGETALL` map vs flat array).
> 
> **AI-facing outputs** (`single.json`, `single.md` metadata) gain `returns` and `returns_status` when a data entry exists; `process-markdown-content` inlines the same rendered prose for `.md`/`.json` content paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7601839819fc188add6bb5a451acb79b790d82a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->