### PR TITLE
RS: Updated supported connection clients and discovery service clients

### DIFF
--- a/content/operate/rs/databases/connect/supported-clients-browsers.md
+++ b/content/operate/rs/databases/connect/supported-clients-browsers.md
@@ -26,15 +26,7 @@ Note: You cannot use client libraries to configure Redis Software.  Instead, use
 
 ### Discovery service
 
-We recommend the following clients when using a [discovery service]({{< relref "/operate/rs/databases/durability-ha/discovery-service.md" >}}) based on the Redis Sentinel API:
+All [recommended Redis client libraries]({{< relref "/develop/clients" >}}) support the Redis Sentinel API, so you can use any of them with the [discovery service]({{< relref "/operate/rs/databases/durability-ha/discovery-service.md" >}}).
 
-- [redis-py]({{< relref "/develop/clients/redis-py" >}}) (Python client)
-- [StackExchange.Redis]({{< relref "/develop/clients/dotnet" >}}) (.NET client)
-- [Jedis]({{< relref "/develop/clients/jedis" >}}) (synchronous Java client)
-- [Lettuce]({{< relref "/develop/clients/lettuce" >}}) (asynchronous Java client)
-- [go-redis]({{< relref "/develop/clients/go" >}}) (Go client)
-- [Hiredis](https://github.com/redis/hiredis) (C client)
-
-If you need to use another client, you can use [Sentinel Tunnel](https://github.com/RedisLabs/sentinel_tunnel)
-to discover the current Redis master with Sentinel and create a TCP tunnel between a local port on the client and the master.
+If you need to use a client that doesn't support Sentinel, you can use [Sentinel Tunnel](https://github.com/RedisLabs/sentinel_tunnel) to discover the current primary Redis endpoint with Sentinel and create a TCP tunnel between a local port on the client and the primary endpoint.
 

--- a/content/operate/rs/databases/durability-ha/discovery-service.md
+++ b/content/operate/rs/databases/durability-ha/discovery-service.md
@@ -93,13 +93,13 @@ To use Redis Sentinel, every database name must be unique across the cluster.
 
 ## Redis client support
 
-We recommend these clients that are tested for use with the [Discovery Service]({{< relref "/operate/rs/databases/durability-ha/discovery-service.md" >}}) that uses the Redis Sentinel API:
+All [recommended Redis client libraries]({{< relref "/develop/clients" >}}) support the Redis Sentinel API, so you can use any of them with the discovery service.
 
-{{< embed-md "discovery-clients.md" >}}
+If you need to use a client that doesn't support Sentinel, you can use [Sentinel Tunnel](https://github.com/RedisLabs/sentinel_tunnel) to discover the current primary Redis endpoint with Sentinel and create a TCP tunnel between a local port on the client and the primary endpoint.
 
 {{< note >}}
-Redis Sentinel API can return endpoints for both master and replica
+Redis Sentinel API can return endpoints for both primary and replica
 endpoints.
-Discovery Service only supports master endpoints and does not
+Discovery Service only supports primary endpoints and does not
 support returning replica endpoints for a database.
 {{< /note >}}


### PR DESCRIPTION
Fixes #3400

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or security impact.
> 
> **Overview**
> Updates Redis Software docs for **discovery service** and **supported connection clients** so Sentinel guidance is consistent and less fragmented.
> 
> The per-language client bullet list (and the `discovery-clients.md` embed on the discovery service page) is replaced with a single pointer to all [recommended Redis client libraries]({{< relref "/develop/clients" >}}) as Sentinel-capable. **Sentinel Tunnel** is documented on both pages for clients without native Sentinel support, with wording that refers to the **primary** endpoint instead of “master.”
> 
> Discovery service notes now use **primary/replica** terminology instead of **master/replica** when describing what the Sentinel API returns versus what Discovery Service supports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b75bdc990ca1c00358537de41e7afa6bb26a3ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->