### PR TITLE
DOC-6736 add aliases to NRedisStack pages

### DIFF
--- a/content/develop/clients/dotnet/nredisstack/prob.md
+++ b/content/develop/clients/dotnet/nredisstack/prob.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/clients/dotnet/prob
 categories:
 - docs
 - develop

--- a/content/develop/clients/dotnet/nredisstack/queryjson.md
+++ b/content/develop/clients/dotnet/nredisstack/queryjson.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/clients/dotnet/queryjson
 categories:
 - docs
 - develop

--- a/content/develop/clients/dotnet/nredisstack/vecsearch.md
+++ b/content/develop/clients/dotnet/nredisstack/vecsearch.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/clients/dotnet/vecsearch
 categories:
 - docs
 - develop


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only Hugo alias changes with no runtime or application impact.
> 
> **Overview**
> Adds **Hugo `aliases`** in the front matter of three NRedisStack docs so legacy URLs keep working after the pages moved under `content/develop/clients/dotnet/nredisstack/`.
> 
> - `prob.md` → `/develop/clients/dotnet/prob`
> - `queryjson.md` → `/develop/clients/dotnet/queryjson`
> - `vecsearch.md` → `/develop/clients/dotnet/vecsearch`
> 
> No body content or examples change—only redirect metadata for DOC-6736.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dfb6e7b2acd90b5c63b821319221eb18c43e0b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->