### PR TITLE
K8s: add helm pull option

### DIFF
--- a/content/operate/kubernetes/7.22/deployment/helm.md
+++ b/content/operate/kubernetes/7.22/deployment/helm.md
@@ -55,15 +55,41 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Install from local directory
 
+If you need a local copy of the chart, for example to inspect it or customize values, use one of the following methods.
+
+**Pull the packaged chart (recommended).** `helm pull` fetches the exact packaged chart the Helm repository serves for the version you specify, matching what `helm install` from the repository would deploy.
+
+1. Add the Redis repository, if you haven't already.
+
+   ```sh
+   helm repo add <repo-name> https://helm.redis.io
+   ```
+
+2. Pull and unpack the chart. This creates a `redis-enterprise-operator` directory in your current location.
+
+   ```sh
+   helm pull <repo-name>/redis-enterprise-operator --version <chart-version> --untar
+   ```
+
+3. Install the Helm chart from the local directory.
+
+   ```sh
+   helm install <release-name> ./redis-enterprise-operator \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
+
+**Download the source code.** Alternatively, download the chart source from GitHub.
+
 1. Find the latest release on the [redis-enterprise-k8s-docs](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases) repo and download the `tar.gz` source code into a local directory.
 
 2. Install the Helm chart from your local directory.
 
-```sh
-helm install <release-name> <path-to-chart> \
-    --namespace <namespace-name> \
-    --create-namespace
-```
+   ```sh
+   helm install <release-name> <path-to-chart> \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
 
 To install with Openshift, add `--set openshift.mode=true`.
 

--- a/content/operate/kubernetes/7.8.6/deployment/helm.md
+++ b/content/operate/kubernetes/7.8.6/deployment/helm.md
@@ -55,15 +55,41 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Install from local directory
 
+If you need a local copy of the chart, for example to inspect it or customize values, use one of the following methods.
+
+**Pull the packaged chart (recommended).** `helm pull` fetches the exact packaged chart the Helm repository serves for the version you specify, matching what `helm install` from the repository would deploy.
+
+1. Add the Redis repository, if you haven't already.
+
+   ```sh
+   helm repo add <repo-name> https://helm.redis.io
+   ```
+
+2. Pull and unpack the chart. This creates a `redis-enterprise-operator` directory in your current location.
+
+   ```sh
+   helm pull <repo-name>/redis-enterprise-operator --version <chart-version> --untar
+   ```
+
+3. Install the Helm chart from the local directory.
+
+   ```sh
+   helm install <release-name> ./redis-enterprise-operator \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
+
+**Download the source code.** Alternatively, download the chart source from GitHub.
+
 1. Find the latest release on the [redis-enterprise-k8s-docs](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases) repo and download the `tar.gz` source code into a local directory.
 
 2. Install the Helm chart from your local directory.
 
-```sh
-helm install <release-name> <path-to-chart> \
-    --namespace <namespace-name> \
-    --create-namespace
-```
+   ```sh
+   helm install <release-name> <path-to-chart> \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
 
 To install with Openshift, add `--set openshift.mode=true`.
 

--- a/content/operate/kubernetes/8.0.18/deployment/helm.md
+++ b/content/operate/kubernetes/8.0.18/deployment/helm.md
@@ -64,15 +64,41 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Install from local directory
 
+If you need a local copy of the chart, for example to inspect it or customize values, use one of the following methods.
+
+**Pull the packaged chart (recommended).** `helm pull` fetches the exact packaged chart the Helm repository serves for the version you specify, matching what `helm install` from the repository would deploy.
+
+1. Add the Redis repository, if you haven't already.
+
+   ```sh
+   helm repo add <repo-name> https://helm.redis.io
+   ```
+
+2. Pull and unpack the chart. This creates a `redis-enterprise-operator` directory in your current location.
+
+   ```sh
+   helm pull <repo-name>/redis-enterprise-operator --version <chart-version> --untar
+   ```
+
+3. Install the Helm chart from the local directory.
+
+   ```sh
+   helm install <release-name> ./redis-enterprise-operator \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
+
+**Download the source code.** Alternatively, download the chart source from GitHub.
+
 1. Find the latest release on the [redis-enterprise-k8s-docs](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases) repo and download the `tar.gz` source code into a local directory.
 
 2. Install the Helm chart from your local directory.
 
-```sh
-helm install <release-name> <path-to-chart> \
-    --namespace <namespace-name> \
-    --create-namespace
-```
+   ```sh
+   helm install <release-name> <path-to-chart> \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
 
 To install with Openshift, add `--set openshift.mode=true`.
 

--- a/content/operate/kubernetes/8.0/deployment/helm.md
+++ b/content/operate/kubernetes/8.0/deployment/helm.md
@@ -55,15 +55,41 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Install from local directory
 
+If you need a local copy of the chart, for example to inspect it or customize values, use one of the following methods.
+
+**Pull the packaged chart (recommended).** `helm pull` fetches the exact packaged chart the Helm repository serves for the version you specify, matching what `helm install` from the repository would deploy.
+
+1. Add the Redis repository, if you haven't already.
+
+   ```sh
+   helm repo add <repo-name> https://helm.redis.io
+   ```
+
+2. Pull and unpack the chart. This creates a `redis-enterprise-operator` directory in your current location.
+
+   ```sh
+   helm pull <repo-name>/redis-enterprise-operator --version <chart-version> --untar
+   ```
+
+3. Install the Helm chart from the local directory.
+
+   ```sh
+   helm install <release-name> ./redis-enterprise-operator \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
+
+**Download the source code.** Alternatively, download the chart source from GitHub.
+
 1. Find the latest release on the [redis-enterprise-k8s-docs](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases) repo and download the `tar.gz` source code into a local directory.
 
 2. Install the Helm chart from your local directory.
 
-```sh
-helm install <release-name> <path-to-chart> \
-    --namespace <namespace-name> \
-    --create-namespace
-```
+   ```sh
+   helm install <release-name> <path-to-chart> \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
 
 To install with Openshift, add `--set openshift.mode=true`.
 

--- a/content/operate/kubernetes/deployment/helm.md
+++ b/content/operate/kubernetes/deployment/helm.md
@@ -63,15 +63,41 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Install from local directory
 
+If you need a local copy of the chart, for example to inspect it or customize values, use one of the following methods.
+
+**Pull the packaged chart (recommended).** `helm pull` fetches the exact packaged chart the Helm repository serves for the version you specify, matching what `helm install` from the repository would deploy.
+
+1. Add the Redis repository, if you haven't already.
+
+   ```sh
+   helm repo add <repo-name> https://helm.redis.io
+   ```
+
+2. Pull and unpack the chart. This creates a `redis-enterprise-operator` directory in your current location.
+
+   ```sh
+   helm pull <repo-name>/redis-enterprise-operator --version <chart-version> --untar
+   ```
+
+3. Install the Helm chart from the local directory.
+
+   ```sh
+   helm install <release-name> ./redis-enterprise-operator \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
+
+**Download the source code.** Alternatively, download the chart source from GitHub.
+
 1. Find the latest release on the [redis-enterprise-k8s-docs](https://github.com/RedisLabs/redis-enterprise-k8s-docs/releases) repo and download the `tar.gz` source code into a local directory.
 
 2. Install the Helm chart from your local directory.
 
-```sh
-helm install <release-name> <path-to-chart> \
-    --namespace <namespace-name> \
-    --create-namespace
-```
+   ```sh
+   helm install <release-name> <path-to-chart> \
+       --namespace <namespace-name> \
+       --create-namespace
+   ```
 
 To install with Openshift, add `--set openshift.mode=true`.
 


### PR DESCRIPTION
DOC-6734

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to installation instructions; no application or infrastructure code is modified.
> 
> **Overview**
> Updates the **Install from local directory** section in Redis Enterprise Kubernetes Helm docs (multiple version paths) so readers have two clear options for a local chart.
> 
> Adds a **recommended** flow using `helm pull … --untar` from `https://helm.redis.io`, then `helm install` from `./redis-enterprise-operator`, with a short note that this matches the packaged chart from the repo. The existing GitHub `redis-enterprise-k8s-docs` tarball steps are kept as **Download the source code**, with minor code-block indentation fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48051ebebf82a6d0c748ded8ed48e0cebb0394ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->