### PR TITLE
K8s: add let's encrypt limitation to cert-manager page

### DIFF
--- a/content/operate/kubernetes/8.0.18/security/cert-manager.md
+++ b/content/operate/kubernetes/8.0.18/security/cert-manager.md
@@ -22,7 +22,7 @@ Benefits of using cert-manager include:
 
 - **Automatic certificate renewal**: cert-manager handles certificate rotation before expiration.
 - **Standardized management**: Use the same certificate management approach across your Kubernetes infrastructure.
-- **Multiple certificate authorities**: Support for Let's Encrypt, private CAs, Vault, and more.
+- **Multiple certificate authorities**: Support for private CAs, Vault, and other issuers that provide the root CA certificate.
 - **Automatic propagation**: For Active-Active databases, certificate changes automatically sync across all participating clusters.
 
 {{<warning>}}The cert-manager integration uses Kubernetes secrets. It is not compatible with Vault-based secret management (when `clusterCredentialSecretType: vault`). See [HashiCorp Vault integration]({{< relref "/operate/kubernetes/8.0.18/security/vault" >}}) for details.{{</warning>}}
@@ -203,42 +203,15 @@ No manual intervention is required.
 
 ## Use production certificate authorities
 
-### Let's Encrypt
+### Let's Encrypt and ACME issuers
 
-For production environments, you can use Let's Encrypt:
+{{<warning>}}
+Don't use Let's Encrypt or other ACME issuers with this integration. ACME issuers don't populate the `ca.crt` field in the generated TLS secret, so the secret doesn't include the root CA certificate.
 
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: letsencrypt-prod
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: admin@example.com
-    privateKeySecretRef:
-      name: letsencrypt-prod-account-key
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
-```
+Redis Software requires the root CA certificate to build a complete certificate chain. Without it, the cluster can't establish trust for the certificate and rejects it. This is a limitation in how Redis Software handles certificates, not specific to Kubernetes.
+{{</warning>}}
 
-Then reference this issuer in your `Certificate` resources:
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: redis-api-cert
-spec:
-  secretName: redis-api-tls
-  issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
-  dnsNames:
-    - redis-api.example.com
-```
+For production environments, use an issuer that provides the full certificate chain, such as a private CA or HashiCorp Vault.
 
 ### Private CA
 
@@ -336,8 +309,6 @@ kubectl logs -n cert-manager deployment/cert-manager
 Common issues:
 
 - **Issuer not ready**: Verify your `Issuer` or `ClusterIssuer` is configured correctly.
-- **DNS validation failure**: For ACME issuers, ensure DNS records are correctly configured.
-- **Rate limits**: Let's Encrypt has rate limits. Use the staging environment for testing.
 
 ### Operator not detecting certificate changes
 

--- a/content/operate/kubernetes/8.0.18/security/cert-manager.md
+++ b/content/operate/kubernetes/8.0.18/security/cert-manager.md
@@ -22,7 +22,7 @@ Benefits of using cert-manager include:
 
 - **Automatic certificate renewal**: cert-manager handles certificate rotation before expiration.
 - **Standardized management**: Use the same certificate management approach across your Kubernetes infrastructure.
-- **Multiple certificate authorities**: Support for private CAs, Vault, and other issuers that provide the root CA certificate.
+- **Multiple certificate authorities**: Support for Let's Encrypt, private CAs, Vault, and more.
 - **Automatic propagation**: For Active-Active databases, certificate changes automatically sync across all participating clusters.
 
 {{<warning>}}The cert-manager integration uses Kubernetes secrets. It is not compatible with Vault-based secret management (when `clusterCredentialSecretType: vault`). See [HashiCorp Vault integration]({{< relref "/operate/kubernetes/8.0.18/security/vault" >}}) for details.{{</warning>}}
@@ -205,13 +205,17 @@ No manual intervention is required.
 
 ### Let's Encrypt and ACME issuers
 
-{{<warning>}}
-Don't use Let's Encrypt or other ACME issuers with this integration. ACME issuers don't populate the `ca.crt` field in the generated TLS secret, so the secret doesn't include the root CA certificate.
+You can use Let's Encrypt and other ACME issuers, but not as an out-of-the-box integration. ACME issuers don't populate the `ca.crt` field of the generated TLS secret with the root certificate, so the secret that cert-manager creates doesn't include the full certificate chain.
 
-Redis Software requires the root CA certificate to build a complete certificate chain. Without it, the cluster can't establish trust for the certificate and rejects it. This is a limitation in how Redis Software handles certificates, not specific to Kubernetes.
-{{</warning>}}
+Redis Software needs the full chain, including the root CA, to trust the certificate. Whenever cert-manager doesn't populate `ca.crt` with the root certificate, supply the full chain yourself:
 
-For production environments, use an issuer that provides the full certificate chain, such as a private CA or HashiCorp Vault.
+1. Assemble the full certificate chain, including the root CA certificate.
+1. Create a Kubernetes secret that contains the full chain.
+1. Reference that secret in your Redis custom resource instead of the secret that cert-manager generates.
+
+{{<note>}}This applies to any issuer that doesn't populate `ca.crt` with the root certificate, not only Let's Encrypt.{{</note>}}
+
+For production environments where the issuer supplies the full chain automatically, such as a private CA or HashiCorp Vault, no extra steps are required.
 
 ### Private CA
 
@@ -309,6 +313,8 @@ kubectl logs -n cert-manager deployment/cert-manager
 Common issues:
 
 - **Issuer not ready**: Verify your `Issuer` or `ClusterIssuer` is configured correctly.
+- **DNS validation failure**: For ACME issuers, ensure DNS records are correctly configured.
+- **Rate limits**: Let's Encrypt has rate limits. Use the staging environment for testing.
 
 ### Operator not detecting certificate changes
 

--- a/content/operate/kubernetes/security/cert-manager.md
+++ b/content/operate/kubernetes/security/cert-manager.md
@@ -21,7 +21,7 @@ Benefits of using cert-manager include:
 
 - **Automatic certificate renewal**: cert-manager handles certificate rotation before expiration.
 - **Standardized management**: Use the same certificate management approach across your Kubernetes infrastructure.
-- **Multiple certificate authorities**: Support for private CAs, Vault, and other issuers that provide the root CA certificate.
+- **Multiple certificate authorities**: Support for Let's Encrypt, private CAs, Vault, and more.
 - **Automatic propagation**: For Active-Active databases, certificate changes automatically sync across all participating clusters.
 
 {{<warning>}}The cert-manager integration uses Kubernetes secrets. It is not compatible with Vault-based secret management (when `clusterCredentialSecretType: vault`). See [HashiCorp Vault integration]({{< relref "/operate/kubernetes/security/vault" >}}) for details.{{</warning>}}
@@ -204,13 +204,17 @@ No manual intervention is required.
 
 ### Let's Encrypt and ACME issuers
 
-{{<warning>}}
-Don't use Let's Encrypt or other ACME issuers with this integration. ACME issuers don't populate the `ca.crt` field in the generated TLS secret, so the secret doesn't include the root CA certificate.
+You can use Let's Encrypt and other ACME issuers, but not as an out-of-the-box integration. ACME issuers don't populate the `ca.crt` field of the generated TLS secret with the root certificate, so the secret that cert-manager creates doesn't include the full certificate chain.
 
-Redis Software requires the root CA certificate to build a complete certificate chain. Without it, the cluster can't establish trust for the certificate and rejects it. This is a limitation in how Redis Software handles certificates, not specific to Kubernetes.
-{{</warning>}}
+Redis Software needs the full chain, including the root CA, to trust the certificate. Whenever cert-manager doesn't populate `ca.crt` with the root certificate, supply the full chain yourself:
 
-For production environments, use an issuer that provides the full certificate chain, such as a private CA or HashiCorp Vault.
+1. Assemble the full certificate chain, including the root CA certificate.
+1. Create a Kubernetes secret that contains the full chain.
+1. Reference that secret in your Redis custom resource instead of the secret that cert-manager generates.
+
+{{<note>}}This applies to any issuer that doesn't populate `ca.crt` with the root certificate, not only Let's Encrypt.{{</note>}}
+
+For production environments where the issuer supplies the full chain automatically, such as a private CA or HashiCorp Vault, no extra steps are required.
 
 ### Private CA
 
@@ -308,6 +312,8 @@ kubectl logs -n cert-manager deployment/cert-manager
 Common issues:
 
 - **Issuer not ready**: Verify your `Issuer` or `ClusterIssuer` is configured correctly.
+- **DNS validation failure**: For ACME issuers, ensure DNS records are correctly configured.
+- **Rate limits**: Let's Encrypt has rate limits. Use the staging environment for testing.
 
 ### Operator not detecting certificate changes
 

--- a/content/operate/kubernetes/security/cert-manager.md
+++ b/content/operate/kubernetes/security/cert-manager.md
@@ -21,7 +21,7 @@ Benefits of using cert-manager include:
 
 - **Automatic certificate renewal**: cert-manager handles certificate rotation before expiration.
 - **Standardized management**: Use the same certificate management approach across your Kubernetes infrastructure.
-- **Multiple certificate authorities**: Support for Let's Encrypt, private CAs, Vault, and more.
+- **Multiple certificate authorities**: Support for private CAs, Vault, and other issuers that provide the root CA certificate.
 - **Automatic propagation**: For Active-Active databases, certificate changes automatically sync across all participating clusters.
 
 {{<warning>}}The cert-manager integration uses Kubernetes secrets. It is not compatible with Vault-based secret management (when `clusterCredentialSecretType: vault`). See [HashiCorp Vault integration]({{< relref "/operate/kubernetes/security/vault" >}}) for details.{{</warning>}}
@@ -202,42 +202,15 @@ No manual intervention is required.
 
 ## Use production certificate authorities
 
-### Let's Encrypt
+### Let's Encrypt and ACME issuers
 
-For production environments, you can use Let's Encrypt:
+{{<warning>}}
+Don't use Let's Encrypt or other ACME issuers with this integration. ACME issuers don't populate the `ca.crt` field in the generated TLS secret, so the secret doesn't include the root CA certificate.
 
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: letsencrypt-prod
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: admin@example.com
-    privateKeySecretRef:
-      name: letsencrypt-prod-account-key
-    solvers:
-      - http01:
-          ingress:
-            class: nginx
-```
+Redis Software requires the root CA certificate to build a complete certificate chain. Without it, the cluster can't establish trust for the certificate and rejects it. This is a limitation in how Redis Software handles certificates, not specific to Kubernetes.
+{{</warning>}}
 
-Then reference this issuer in your `Certificate` resources:
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: redis-api-cert
-spec:
-  secretName: redis-api-tls
-  issuerRef:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
-  dnsNames:
-    - redis-api.example.com
-```
+For production environments, use an issuer that provides the full certificate chain, such as a private CA or HashiCorp Vault.
 
 ### Private CA
 
@@ -335,8 +308,6 @@ kubectl logs -n cert-manager deployment/cert-manager
 Common issues:
 
 - **Issuer not ready**: Verify your `Issuer` or `ClusterIssuer` is configured correctly.
-- **DNS validation failure**: For ACME issuers, ensure DNS records are correctly configured.
-- **Rate limits**: Let's Encrypt has rate limits. Use the staging environment for testing.
 
 ### Operator not detecting certificate changes
 


### PR DESCRIPTION
DOC-6737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, security, or application code changes.
> 
> **Overview**
> Updates the **Use production certificate authorities** section on the Kubernetes cert-manager docs (versioned and default paths) so ACME/Let’s Encrypt is no longer presented as a plug-and-play setup.
> 
> The **Let’s Encrypt** subsection is renamed to **Let’s Encrypt and ACME issuers** and the sample `ClusterIssuer` / `Certificate` YAML is removed. The text now states that ACME issuers typically leave `ca.crt` without the root CA, so cert-manager secrets may lack the full chain Redis Software needs, and documents a three-step workaround: build the full chain, store it in a Kubernetes secret, and point the Redis custom resource at that secret instead of the cert-manager-generated one. A note generalizes this to any issuer that omits the root in `ca.crt`, and a short contrast clarifies that private CA or Vault paths that supply the full chain need no extra steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57cfb93f87d5666a7c79399cf8d432a3dfe0310. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->