### PR TITLE
K8s: fix helm repo name

### DIFF
--- a/content/operate/kubernetes/7.22/deployment/helm.md
+++ b/content/operate/kubernetes/7.22/deployment/helm.md
@@ -26,7 +26,6 @@ If you suspect your file descriptor limits are below 100,000, you must either ma
 
 The steps below use the following placeholders to indicate command line parameters you must provide:
 
-- `<repo-name>` is the name of the repo holding your Helm chart (example: `redis`).
 - `<release-name>` is the name you give a specific installation of the Helm chart (example: `my-redis-enterprise-operator`)
 - `<chart-version>` is the version of the Helm chart you are installing (example: `7.8.2-2`)
 - `<namespace-name>` is the name of the new namespace the Redis operator will run in (example: `ns1`)
@@ -37,13 +36,13 @@ The steps below use the following placeholders to indicate command line paramete
 1. Add the Redis repository.
 
    ```sh
-   helm repo add <repo-name> https://helm.redis.io
+   helm repo add redis https://helm.redis.io
    ```
 
 2. Install the Helm chart into a new namespace.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -71,12 +70,12 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Specify values during install
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Install the Helm chart, overriding specific value defaults using `--set`.
 
 ```sh
-helm install <operator-name> <repo-name>/redis-enterprise-operator \
+helm install <operator-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -86,14 +85,14 @@ helm install <operator-name> <repo-name>/redis-enterprise-operator \
 
 ### Install with values file
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Create a YAML file to specify the values you want to configure.
 
 3. Install the chart with the `--values` option.
 
 ```sh
-helm install <operator-name> <repo-name>/redis-enterprise-operator \
+helm install <operator-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace \
@@ -109,7 +108,7 @@ To migrate an existing non-Helm installation of the Redis Enterprise operator to
 2. [Install](#install) the Helm chart adding the `--take-ownership` flag:
 
    ```sh
-   helm install <release-name> <repo-name>/redis-enterprise-operator --take-ownership
+   helm install <release-name> redis/redis-enterprise-operator --take-ownership
    ```
 
    - The `--take-ownership` flag is available with Helm versions 3.18 or later.
@@ -129,7 +128,7 @@ To migrate an existing non-Helm installation of the Redis Enterprise operator to
 To upgrade an existing Helm chart installation:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version>
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version>
 ```
 
 You can also upgrade from a local directory:

--- a/content/operate/kubernetes/7.22/upgrade/openshift-cli.md
+++ b/content/operate/kubernetes/7.22/upgrade/openshift-cli.md
@@ -65,14 +65,14 @@ If you installed the Redis Enterprise operator using Helm charts on OpenShift, y
 To upgrade using Helm on OpenShift:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version> \
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version> \
     --set openshift.mode=true
 ```
 
 For example:
 
 ```sh
-helm upgrade my-redis-enterprise <repo-name>/redis-enterprise-operator --version 7.8.2-2 \
+helm upgrade my-redis-enterprise redis/redis-enterprise-operator --version 7.8.2-2 \
     --set openshift.mode=true
 ```
 

--- a/content/operate/kubernetes/7.8.6/deployment/helm.md
+++ b/content/operate/kubernetes/7.8.6/deployment/helm.md
@@ -26,7 +26,6 @@ Helm charts provide a simple way to install the Redis Enterprise for Kubernetes 
 
 The steps below use the following placeholders to indicate command line parameters you must provide:
 
-- `<repo-name>` is the name of the repo holding your Helm chart (example: `redis`).
 - `<release-name>` is the name you give a specific installation of the Helm chart (example: `my-redis-enterprise-operator`)
 - `<chart-version>` is the version of the Helm chart you are installing (example: `7.8.2-2`)
 - `<namespace-name>` is the name of the new namespace the Redis operator will run in (example: `ns1`)
@@ -37,7 +36,7 @@ The steps below use the following placeholders to indicate command line paramete
 1. Add the Redis repository.
 
 ```sh
-helm repo add <repo-name> https://helm.redis.io
+helm repo add redis https://helm.redis.io
 ```
 
 2. Install the Helm chart into a new namespace.
@@ -71,7 +70,7 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Specify values during install
 
-1. View configurable values with `helm show values <repo-name>/<chart-name>`.
+1. View configurable values with `helm show values redis/<chart-name>`.
 
 2. Install the Helm chart, overriding specific value defaults using `--set`.
 
@@ -86,7 +85,7 @@ helm install <operator-name> redis/redis-enterprise-operator \
 
 ### Install with values file
 
-1. View configurable values with `helm show values <repo-name>/<chart-name>`.
+1. View configurable values with `helm show values redis/<chart-name>`.
 
 2. Create a YAML file to specify the values you want to configure.
 

--- a/content/operate/kubernetes/8.0.18/deployment/helm.md
+++ b/content/operate/kubernetes/8.0.18/deployment/helm.md
@@ -26,7 +26,6 @@ If you suspect your file descriptor limits are below 100,000, you must either ma
 
 The steps below use the following placeholders to indicate command line parameters you must provide:
 
-- `<repo-name>` is the name of the repo holding your Helm chart (example: `redis`).
 - `<release-name>` is the name you give a specific installation of the Helm chart (example: `my-redis-enterprise-operator`)
 - `<chart-version>` is the version of the Helm chart you are installing (example: `7.8.6-2`). Verify that the version you specify is listed in the [Redis Helm repository](https://helm.redis.io/). Using an invalid version number causes installation failures.
 - `<namespace-name>` is the name of the new namespace the Redis operator will run in (example: `ns1`)
@@ -46,13 +45,13 @@ Below are several ways to install the operator using Helm. To create the REC in 
 1. Add the Redis repository.
 
    ```sh
-   helm repo add <repo-name> https://helm.redis.io
+   helm repo add redis https://helm.redis.io
    ```
 
 2. Install the Helm chart into a new namespace.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -80,12 +79,12 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Specify values during install
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Install the Helm chart, overriding specific value defaults using `--set`.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -95,14 +94,14 @@ helm install <release-name> <repo-name>/redis-enterprise-operator \
 
 ### Install with values file
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Create a YAML file to specify the values you want to configure.
 
 3. Install the chart with the `--values` option.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace \
@@ -135,7 +134,7 @@ The chart can create the `RedisEnterpriseCluster` (REC) custom resource at insta
 2. Install the chart with the values file.
 
     ```sh
-    helm install <release-name> <repo-name>/redis-enterprise-operator \
+    helm install <release-name> redis/redis-enterprise-operator \
         --version <chart-version> \
         --namespace <namespace-name> \
         --create-namespace \
@@ -163,7 +162,7 @@ To update or uninstall an REC created by the chart, see [Update an REC created b
 To upgrade an existing Helm chart installation:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version>
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version>
 ```
 
 You can also upgrade from a local directory:
@@ -214,7 +213,7 @@ If you used `cluster.create: true`, change REC settings by editing `cluster.spec
 2. Apply the changes.
 
     ```sh
-    helm upgrade <release-name> <repo-name>/redis-enterprise-operator \
+    helm upgrade <release-name> redis/redis-enterprise-operator \
         --namespace <namespace-name> \
         --values <path-to-values-file>
     ```
@@ -268,7 +267,7 @@ To migrate an existing non-Helm installation of the Redis Enterprise operator to
 2. [Install](#install-the-operator) the Helm chart adding the `--take-ownership` flag:
 
    ```sh
-   helm install <release-name> <repo-name>/redis-enterprise-operator --take-ownership
+   helm install <release-name> redis/redis-enterprise-operator --take-ownership
    ```
 
    - The `--take-ownership` flag is available with Helm versions 3.18 or later.

--- a/content/operate/kubernetes/8.0.18/upgrade/openshift-cli.md
+++ b/content/operate/kubernetes/8.0.18/upgrade/openshift-cli.md
@@ -75,14 +75,14 @@ If you installed the Redis Enterprise operator using Helm charts on OpenShift, y
 To upgrade using Helm on OpenShift:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version> \
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version> \
     --set openshift.mode=true
 ```
 
 For example:
 
 ```sh
-helm upgrade my-redis-enterprise <repo-name>/redis-enterprise-operator --version 7.8.2-2 \
+helm upgrade my-redis-enterprise redis/redis-enterprise-operator --version 7.8.2-2 \
     --set openshift.mode=true
 ```
 

--- a/content/operate/kubernetes/8.0/deployment/helm.md
+++ b/content/operate/kubernetes/8.0/deployment/helm.md
@@ -26,7 +26,6 @@ If you suspect your file descriptor limits are below 100,000, you must either ma
 
 The steps below use the following placeholders to indicate command line parameters you must provide:
 
-- `<repo-name>` is the name of the repo holding your Helm chart (example: `redis`).
 - `<release-name>` is the name you give a specific installation of the Helm chart (example: `my-redis-enterprise-operator`)
 - `<chart-version>` is the version of the Helm chart you are installing (example: `7.8.6-2`). Verify that the version you specify is listed in the [Redis Helm repository](https://helm.redis.io/). Using an invalid version number causes installation failures.
 - `<namespace-name>` is the name of the new namespace the Redis operator will run in (example: `ns1`)
@@ -37,13 +36,13 @@ The steps below use the following placeholders to indicate command line paramete
 1. Add the Redis repository.
 
    ```sh
-   helm repo add <repo-name> https://helm.redis.io
+   helm repo add redis https://helm.redis.io
    ```
 
 2. Install the Helm chart into a new namespace.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -71,12 +70,12 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Specify values during install
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Install the Helm chart, overriding specific value defaults using `--set`.
 
 ```sh
-helm install <operator-name> <repo-name>/redis-enterprise-operator \
+helm install <operator-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -86,14 +85,14 @@ helm install <operator-name> <repo-name>/redis-enterprise-operator \
 
 ### Install with values file
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Create a YAML file to specify the values you want to configure.
 
 3. Install the chart with the `--values` option.
 
 ```sh
-helm install <operator-name> <repo-name>/redis-enterprise-operator \
+helm install <operator-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace \
@@ -109,7 +108,7 @@ To migrate an existing non-Helm installation of the Redis Enterprise operator to
 2. [Install](#install) the Helm chart adding the `--take-ownership` flag:
 
    ```sh
-   helm install <release-name> <repo-name>/redis-enterprise-operator --take-ownership
+   helm install <release-name> redis/redis-enterprise-operator --take-ownership
    ```
 
    - The `--take-ownership` flag is available with Helm versions 3.18 or later.
@@ -129,7 +128,7 @@ To migrate an existing non-Helm installation of the Redis Enterprise operator to
 To upgrade an existing Helm chart installation:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version>
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version>
 ```
 
 You can also upgrade from a local directory:

--- a/content/operate/kubernetes/8.0/upgrade/openshift-cli.md
+++ b/content/operate/kubernetes/8.0/upgrade/openshift-cli.md
@@ -75,14 +75,14 @@ If you installed the Redis Enterprise operator using Helm charts on OpenShift, y
 To upgrade using Helm on OpenShift:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version> \
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version> \
     --set openshift.mode=true
 ```
 
 For example:
 
 ```sh
-helm upgrade my-redis-enterprise <repo-name>/redis-enterprise-operator --version 7.8.2-2 \
+helm upgrade my-redis-enterprise redis/redis-enterprise-operator --version 7.8.2-2 \
     --set openshift.mode=true
 ```
 

--- a/content/operate/kubernetes/deployment/helm.md
+++ b/content/operate/kubernetes/deployment/helm.md
@@ -25,7 +25,6 @@ If you suspect your file descriptor limits are below 100,000, you must either ma
 
 The steps below use the following placeholders to indicate command line parameters you must provide:
 
-- `<repo-name>` is the name of the repo holding your Helm chart (example: `redis`).
 - `<release-name>` is the name you give a specific installation of the Helm chart (example: `my-redis-enterprise-operator`)
 - `<chart-version>` is the version of the Helm chart you are installing (example: `7.8.6-2`). Verify that the version you specify is listed in the [Redis Helm repository](https://helm.redis.io/). Using an invalid version number causes installation failures.
 - `<namespace-name>` is the name of the new namespace the Redis operator will run in (example: `ns1`)
@@ -45,13 +44,13 @@ Below are several ways to install the operator using Helm. To create the REC in 
 1. Add the Redis repository.
 
    ```sh
-   helm repo add <repo-name> https://helm.redis.io
+   helm repo add redis https://helm.redis.io
    ```
 
 2. Install the Helm chart into a new namespace.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -79,12 +78,12 @@ To monitor the installation add the `--debug` flag. The installation runs severa
 
 ### Specify values during install
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Install the Helm chart, overriding specific value defaults using `--set`.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace
@@ -94,14 +93,14 @@ helm install <release-name> <repo-name>/redis-enterprise-operator \
 
 ### Install with values file
 
-1. View configurable values with `helm show values <repo-name>/redis-enterprise-operator`.
+1. View configurable values with `helm show values redis/redis-enterprise-operator`.
 
 2. Create a YAML file to specify the values you want to configure.
 
 3. Install the chart with the `--values` option.
 
 ```sh
-helm install <release-name> <repo-name>/redis-enterprise-operator \
+helm install <release-name> redis/redis-enterprise-operator \
     --version <chart-version> \
     --namespace <namespace-name> \
     --create-namespace \
@@ -134,7 +133,7 @@ The chart can create the `RedisEnterpriseCluster` (REC) custom resource at insta
 2. Install the chart with the values file.
 
     ```sh
-    helm install <release-name> <repo-name>/redis-enterprise-operator \
+    helm install <release-name> redis/redis-enterprise-operator \
         --version <chart-version> \
         --namespace <namespace-name> \
         --create-namespace \
@@ -162,7 +161,7 @@ To update or uninstall an REC created by the chart, see [Update an REC created b
 To upgrade an existing Helm chart installation:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version>
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version>
 ```
 
 You can also upgrade from a local directory:
@@ -213,7 +212,7 @@ If you used `cluster.create: true`, change REC settings by editing `cluster.spec
 2. Apply the changes.
 
     ```sh
-    helm upgrade <release-name> <repo-name>/redis-enterprise-operator \
+    helm upgrade <release-name> redis/redis-enterprise-operator \
         --namespace <namespace-name> \
         --values <path-to-values-file>
     ```
@@ -267,7 +266,7 @@ To migrate an existing non-Helm installation of the Redis Enterprise operator to
 2. [Install](#install-the-operator) the Helm chart adding the `--take-ownership` flag:
 
    ```sh
-   helm install <release-name> <repo-name>/redis-enterprise-operator --take-ownership
+   helm install <release-name> redis/redis-enterprise-operator --take-ownership
    ```
 
    - The `--take-ownership` flag is available with Helm versions 3.18 or later.

--- a/content/operate/kubernetes/upgrade/openshift-cli.md
+++ b/content/operate/kubernetes/upgrade/openshift-cli.md
@@ -74,14 +74,14 @@ If you installed the Redis Enterprise operator using Helm charts on OpenShift, y
 To upgrade using Helm on OpenShift:
 
 ```sh
-helm upgrade <release-name> <repo-name>/redis-enterprise-operator --version <chart-version> \
+helm upgrade <release-name> redis/redis-enterprise-operator --version <chart-version> \
     --set openshift.mode=true
 ```
 
 For example:
 
 ```sh
-helm upgrade my-redis-enterprise <repo-name>/redis-enterprise-operator --version 7.8.2-2 \
+helm upgrade my-redis-enterprise redis/redis-enterprise-operator --version 7.8.2-2 \
     --set openshift.mode=true
 ```
 


### PR DESCRIPTION
DOC-6729

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording in Helm command examples; no application or deployment logic changes.
> 
> **Overview**
> Updates Redis Enterprise for Kubernetes Helm and OpenShift upgrade docs so examples use the fixed Helm repo alias **`redis`** instead of the **`<repo-name>`** placeholder.
> 
> **`helm repo add`** examples now show `helm repo add redis https://helm.redis.io`, and install/upgrade/migrate commands use **`redis/redis-enterprise-operator`** (including `helm show values`). The **`<repo-name>`** bullet is removed from the “Example values” lists. The same edits are applied across versioned **`deployment/helm.md`** pages (7.22, 7.8.6, 8.0, 8.0.18, and the unversioned tree) and matching **`upgrade/openshift-cli.md`** Helm upgrade snippets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77e9c6a83612386201ef54176f4e03dae4f3af67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->