### PR TITLE
DOC-6738 removed mention of Active-active as a source DB

### DIFF
--- a/content/embeds/rdi-when-to-use-dec-tree.md
+++ b/content/embeds/rdi-when-to-use-dec-tree.md
@@ -39,7 +39,7 @@ questions:
         text: |
             Are you transferring data from a single source database?
         whyAsk: |
-            RDI is designed to work with a single source database. Multiple sources or Active-Active replicas create conflicting change events.
+            RDI is designed to work with a single source database. Multiple sources create conflicting change events.
         answers:
             no:
                 value: "No"

--- a/content/embeds/rdi-when-to-use.md
+++ b/content/embeds/rdi-when-to-use.md
@@ -35,7 +35,6 @@ RDI is not a good fit when:
 - Your app needs *immediate* cache consistency (or a hard limit on latency) rather
   than *eventual* consistency.
 - You need *transactional* consistency between the source and target databases.
-- The data is ingested from two replicas of Active-Active at the same time.
 - The app must *write* data to the Redis cache, which then updates the source database
   (write-behind/write-through patterns).
 - Your data set will only ever be small.

--- a/content/operate/rc/rdi/_index.md
+++ b/content/operate/rc/rdi/_index.md
@@ -76,7 +76,6 @@ RDI is not a good fit when:
 - Your app needs *immediate* cache consistency (or a hard limit on latency) rather
   than *eventual* consistency.
 - You need *transactional* consistency between the source and target databases.
-- The data is ingested from two replicas of Active-Active at the same time.
 - The app must *write* data to the Redis cache, which then updates the source database
   (write-behind/write-through patterns).
 - Your data set will only ever be small.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no product or runtime behavior impact.
> 
> **Overview**
> Aligns RDI guidance with **DOC-6738** by dropping Active-Active as a called-out **source** limitation.
> 
> The interactive decision tree’s `singleSource` **whyAsk** now only warns that multiple sources create conflicting change events—it no longer mentions Active-Active replicas. The **When not to use RDI** bullet about ingesting from two Active-Active replicas at once is removed from `rdi-when-to-use.md` and the Redis Cloud RDI overview (`operate/rc/rdi/_index.md`). Other multi-target guidance still references Active Active only as a Redis replication option, not as an RDI source pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 942d53a857e8d62390518c5d3abff618a4ddb865. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->