### PR TITLE
DOC-6739 added note about Lettuce SCH relaxed timeouts

### DIFF
--- a/content/develop/clients/lettuce/connect.md
+++ b/content/develop/clients/lettuce/connect.md
@@ -345,7 +345,7 @@ that is relevant to SCH:
 
 | Method | Description |
 |--------|-------------|
-| `relaxedTimeoutsDuringMaintenance(Duration duration)` | Set the timeout to use while the server is performing maintenance. The default is 10 seconds. |
+| `relaxedTimeoutsDuringMaintenance(Duration duration)` | Set the *command* timeout to use while the server is performing maintenance (this doesn't change the connection timeout). The default is 10 seconds. Note that relaxed timeouts are only available for the asynchronous and reactive APIs. |
 |
 
 {{< note >}} Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or security impact.
> 
> **Overview**
> Clarifies the Lettuce SCH docs for **`relaxedTimeoutsDuringMaintenance`**: it applies to **command** timeouts during maintenance, not connection timeouts, and relaxed timeouts are **only** supported on the **async and reactive** APIs (default remains 10 seconds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b55b7f0421181a13dc22f1ad0cba476a96c335a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->