### PR TITLE
DOC-6709 Lettuce and redis-py pub/sub failover docs

### DIFF
--- a/content/develop/clients/lettuce/failover.md
+++ b/content/develop/clients/lettuce/failover.md
@@ -437,6 +437,69 @@ systems to trigger this method in your application. For example, if your applica
 exposes a REST API, you might consider creating a REST endpoint to call
 `switchTo()`.
 
+## Pub/Sub and re-subscription
+
+`MultiDbClient` supports [Pub/Sub]({{< relref "/develop/pubsub" >}})
+messaging with automatic re-subscription to channels during failover.
+This means you don't have to detect failovers and re-subscribe manually:
+
+- **Subscriber failover**: When the active database becomes unhealthy, the
+  subscriber automatically reconnects to the next available database and
+  re-subscribes to the same channels.
+- **Publisher failover**: The publisher switches to the next available
+  database and continues publishing to the same channels.
+
+For reliable Pub/Sub delivery during failover, use `MultiDbClient` instances
+for *both* publishers and subscribers.
+
+Unlike the standard commands, which use the connection returned by `connect()`,
+Pub/Sub uses a dedicated connection that you obtain with the `connectPubSub()`
+method. This returns a `StatefulRedisMultiDbPubSubConnection`, which implements
+the same interface as the standard `StatefulRedisPubSubConnection`. Register a
+`RedisPubSubListener` (or extend `RedisPubSubAdapter` to override only the
+callbacks you need) to receive messages, then subscribe to one or more channels:
+
+```java
+import io.lettuce.core.failover.api.StatefulRedisMultiDbPubSubConnection;
+import io.lettuce.core.pubsub.RedisPubSubAdapter;
+
+StatefulRedisMultiDbPubSubConnection<String, String> pubSubConnection =
+        client.connectPubSub();
+
+// Register a listener to handle incoming messages.
+pubSubConnection.addListener(new RedisPubSubAdapter<String, String>() {
+    @Override
+    public void message(String channel, String message) {
+        System.out.printf("Received \"%s\" on channel \"%s\"%n", message, channel);
+    }
+});
+
+// Subscribe to one or more channels. If a failover happens, the
+// subscriptions are automatically re-established on the new active database.
+pubSubConnection.sync().subscribe("news", "alerts");
+```
+
+Use a separate Pub/Sub connection to publish messages:
+
+```java
+StatefulRedisMultiDbPubSubConnection<String, String> publisher =
+        client.connectPubSub();
+
+publisher.sync().publish("news", "Hello World");
+```
+
+{{< note >}}The main difference from a non-failover client is that messages are
+delivered asynchronously to a `RedisPubSubListener` rather than being retrieved
+by polling. Apart from obtaining the connection with `connectPubSub()`, the
+subscription and publishing API is the same as for a standard Lettuce Pub/Sub
+connection.
+
+Message loss can still occur if the failover events happen in the reverse order,
+with the publisher failing over to the new database before the subscriber.
+Messages published during this window may not reach a subscriber that is still
+connected to the previous database.
+{{< /note >}}
+
 ## Behavior when all endpoints are unhealthy
 
 In the extreme case where no endpoint is healthy, Lettuce will keep trying

--- a/content/develop/clients/redis-py/failover.md
+++ b/content/develop/clients/redis-py/failover.md
@@ -389,6 +389,43 @@ Note that `set_active_database()` is thread-safe.
 
 If you decide to implement manual failback, you will need a way for external systems to trigger this method in your application. For example, if your application exposes a REST API, you might consider creating a REST endpoint to call `set_active_database()`.
 
+## Pub/Sub and re-subscription
+
+`MultiDBClient` supports [Pub/Sub]({{< relref "/develop/pubsub" >}})
+messaging with automatic re-subscription to channels during failover.
+This means you don't have to detect failovers and re-subscribe manually:
+
+- **Subscriber failover**: When the active database becomes unhealthy, the
+  subscriber automatically reconnects to the next available database and
+  re-subscribes to the same channels.
+- **Publisher failover**: The publisher switches to the next available
+  database and continues publishing to the same channels.
+
+For reliable Pub/Sub delivery during failover, use `MultiDBClient` instances
+for *both* publishers and subscribers. Create a Pub/Sub interface from the
+client in the usual way using the `pubsub()` method, then subscribe to one or
+more channels:
+
+```py
+pubsub = client.pubsub()
+pubsub.subscribe("news", "alerts")
+
+# If a failover happens here, the subscriptions are automatically
+# re-established on the new active database.
+msg = pubsub.get_message(timeout=1.0)
+if msg:
+    print(msg)
+```
+
+Re-subscription happens transparently and is independent of any custom
+event listeners you register (see [Failover callbacks](#failover-callbacks)).
+
+{{< note >}}Message loss can still occur if the failover events happen in
+the reverse order, with the publisher failing over to the new database
+before the subscriber. Messages published during this window may not reach
+a subscriber that is still connected to the previous database.
+{{< /note >}}
+
 ## Behavior when all endpoints are unhealthy
 
 In the extreme case where no endpoint is healthy, a command will throw a `TemporaryUnavailableException`.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to client failover guides with no runtime or configuration impact.
> 
> **Overview**
> Adds a **Pub/Sub and re-subscription** section to the geographic failover guides for **Lettuce** and **redis-py**, placed after manual failback and before the “all endpoints unhealthy” behavior.
> 
> Both pages document that multi-database failover clients automatically reconnect and **re-subscribe** on subscriber failover and switch active DB on publisher failover, and recommend using the failover client for **both** publishers and subscribers. **Lettuce** adds examples for `connectPubSub()`, `RedisPubSubAdapter` listeners, and a separate publish connection. **redis-py** documents the standard `pubsub()` / `subscribe()` / `get_message()` flow and notes that re-subscription is independent of failover event listeners.
> 
> Each guide includes a note warning that **message loss** is still possible if the publisher fails over before the subscriber.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e18eafeae51e81bc34256906de18fa55c14ac229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->