### PR TITLE
DOC-6709 update to Lettuce pub/sub failover info

### DIFF
--- a/content/develop/clients/lettuce/failover.md
+++ b/content/develop/clients/lettuce/failover.md
@@ -488,11 +488,11 @@ StatefulRedisMultiDbPubSubConnection<String, String> publisher =
 publisher.sync().publish("news", "Hello World");
 ```
 
-{{< note >}}The main difference from a non-failover client is that messages are
-delivered asynchronously to a `RedisPubSubListener` rather than being retrieved
-by polling. Apart from obtaining the connection with `connectPubSub()`, the
-subscription and publishing API is the same as for a standard Lettuce Pub/Sub
-connection.
+{{< note >}}The only addition over a standard Lettuce Pub/Sub connection is that
+you obtain the connection with `connectPubSub()` on the `MultiDbClient`. The
+subscription and publishing API is otherwise identical, but the active
+subscriptions and registered listeners are automatically migrated to the new
+database when a failover occurs.
 
 Message loss can still occur if the failover events happen in the reverse order,
 with the publisher failing over to the new database before the subscriber.


### PR DESCRIPTION
Info missing from the original version of this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change in failover.md with no code or configuration impact.
> 
> **Overview**
> Revises the **Pub/Sub and re-subscription** note in the Lettuce geographic failover guide so it matches the rest of the section.
> 
> The note no longer stresses listener-based delivery vs polling. It now states that the only difference from standard Lettuce Pub/Sub is obtaining the connection via `connectPubSub()` on `MultiDbClient`, and that **active subscriptions and registered listeners are automatically migrated** to the new database on failover. The existing warning about possible message loss when publisher and subscriber fail over in reverse order is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff35c1123b6221ae9179153c1204923a6af5a1da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->