### PR TITLE
RS: Updated sharding descriptions in BDB REST API object reference

### DIFF
--- a/content/operate/rs/7.22/references/rest-api/objects/bdb/_index.md
+++ b/content/operate/rs/7.22/references/rest-api/objects/bdb/_index.md
@@ -120,7 +120,7 @@ An API object that represents a managed database in the cluster.
 | oss_cluster | boolean (default:&nbsp;false); OSS Cluster mode option. Cannot be enabled with `'hash_slots_policy': 'legacy'` |
 | <span class="break-all">oss_cluster_api_preferred_endpoint_type</span> | Endpoint type in the OSS cluster API<br />Values:<br />**‘ip’**<br />‘hostname’ |
 | <span class="break-all">oss_cluster_api_preferred_ip_type</span> | Internal/external IP type in OSS cluster API. Default value for new endpoints<br />Values:<br />**'internal'** <br />'external' |
-| oss_sharding | boolean (default:&nbsp;false); An alternative to `shard_key_regex` for using the common case of the OSS shard hashing policy |
+| oss_sharding | boolean (default: false); This flag is for future use and should not be changed |
 | port | integer; TCP port on which the database is available. Generated automatically if omitted and returned as 0 |
 | proxy_policy | The default policy used for proxy binding to endpoints<br />Values:<br />'single'<br />'all-master-shards'<br />'all-nodes' |
 | rack_aware | boolean (default:&nbsp;false); Require the database to always replicate across multiple racks |
@@ -140,7 +140,7 @@ An API object that represents a managed database in the cluster.
 | shard_block_foreign_keys | boolean (default:&nbsp;true); In Lua scripts, `foreign_keys` prevent use of keys which could reside in a different shard (foreign keys) |
 | shard_key_regex | Custom keyname-based sharding rules.<br />`[{"regex": string}, ...]`<br />To use the default rules you should set the value to: <br />`[{"regex": ".*\\{(?<tag>.*)\\}.*"}, {"regex": "(?<tag>.*)"}]` |
 | shard_list | array of integers; Cluster unique IDs of all database shards. |
-| sharding | boolean (default:&nbsp;false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by either `oss_sharding` or `shard_key_regex` |
+| sharding | boolean (default: false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by `shard_key_regex` |
 | shards_count | integer, <nobr>(range: 1-512)</nobr> (default:&nbsp;1); Number of database server-side shards |
 | shards_placement | Control the density of shards <br />Values:<br />**'dense'**: Shards reside on as few nodes as possible <br /> **'sparse'**: Shards reside on as many nodes as possible |
 | skip_import_analyze | Enable/disable skipping the analysis stage when importing an RDB file<br />Values:<br />'enabled'<br />'disabled' |

--- a/content/operate/rs/7.4/references/rest-api/objects/bdb/_index.md
+++ b/content/operate/rs/7.4/references/rest-api/objects/bdb/_index.md
@@ -109,7 +109,7 @@ An API object that represents a managed database in the cluster.
 | oss_cluster | boolean (default:&nbsp;false); OSS Cluster mode option. Cannot be enabled with `'hash_slots_policy': 'legacy'` |
 | <span class="break-all">oss_cluster_api_preferred_endpoint_type</span> | Endpoint type in the OSS cluster API<br />Values:<br />**‘ip’**<br />‘hostname’ |
 | <span class="break-all">oss_cluster_api_preferred_ip_type</span> | Internal/external IP type in OSS cluster API. Default value for new endpoints<br />Values:<br />**'internal'** <br />'external' |
-| oss_sharding | boolean (default:&nbsp;false); An alternative to `shard_key_regex` for using the common case of the OSS shard hashing policy |
+| oss_sharding | boolean (default: false); This flag is for future use and should not be changed |
 | port | integer; TCP port on which the database is available. Generated automatically if omitted and returned as 0 |
 | proxy_policy | The default policy used for proxy binding to endpoints<br />Values:<br />'single'<br />'all-master-shards'<br />'all-nodes' |
 | rack_aware | boolean (default:&nbsp;false); Require the database to always replicate across multiple racks |
@@ -127,7 +127,7 @@ An API object that represents a managed database in the cluster.
 | shard_block_foreign_keys | boolean (default:&nbsp;true); In Lua scripts, `foreign_keys` prevent use of keys which could reside in a different shard (foreign keys) |
 | shard_key_regex | Custom keyname-based sharding rules.<br />`[{"regex": string}, ...]`<br />To use the default rules you should set the value to: <br />`[{"regex": ".*\\{(?<tag>.*)\\}.*"}, {"regex": "(?<tag>.*)"}]` |
 | shard_list | array of integers; Cluster unique IDs of all database shards. |
-| sharding | boolean (default:&nbsp;false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by either `oss_sharding` or `shard_key_regex` |
+| sharding | boolean (default: false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by `shard_key_regex` |
 | shards_count | integer, <nobr>(range: 1-512)</nobr> (default:&nbsp;1); Number of database server-side shards |
 | shards_placement | Control the density of shards <br />Values:<br />**'dense'**: Shards reside on as few nodes as possible <br /> **'sparse'**: Shards reside on as many nodes as possible |
 | skip_import_analyze | Enable/disable skipping the analysis stage when importing an RDB file<br />Values:<br />'enabled'<br />'disabled' |

--- a/content/operate/rs/7.8/references/rest-api/objects/bdb/_index.md
+++ b/content/operate/rs/7.8/references/rest-api/objects/bdb/_index.md
@@ -110,7 +110,7 @@ An API object that represents a managed database in the cluster.
 | oss_cluster | boolean (default:&nbsp;false); OSS Cluster mode option. Cannot be enabled with `'hash_slots_policy': 'legacy'` |
 | <span class="break-all">oss_cluster_api_preferred_endpoint_type</span> | Endpoint type in the OSS cluster API<br />Values:<br />**‘ip’**<br />‘hostname’ |
 | <span class="break-all">oss_cluster_api_preferred_ip_type</span> | Internal/external IP type in OSS cluster API. Default value for new endpoints<br />Values:<br />**'internal'** <br />'external' |
-| oss_sharding | boolean (default:&nbsp;false); An alternative to `shard_key_regex` for using the common case of the OSS shard hashing policy |
+| oss_sharding | boolean (default: false); This flag is for future use and should not be changed |
 | port | integer; TCP port on which the database is available. Generated automatically if omitted and returned as 0 |
 | proxy_policy | The default policy used for proxy binding to endpoints<br />Values:<br />'single'<br />'all-master-shards'<br />'all-nodes' |
 | rack_aware | boolean (default:&nbsp;false); Require the database to always replicate across multiple racks |
@@ -129,7 +129,7 @@ An API object that represents a managed database in the cluster.
 | shard_block_foreign_keys | boolean (default:&nbsp;true); In Lua scripts, `foreign_keys` prevent use of keys which could reside in a different shard (foreign keys) |
 | shard_key_regex | Custom keyname-based sharding rules.<br />`[{"regex": string}, ...]`<br />To use the default rules you should set the value to: <br />`[{"regex": ".*\\{(?<tag>.*)\\}.*"}, {"regex": "(?<tag>.*)"}]` |
 | shard_list | array of integers; Cluster unique IDs of all database shards. |
-| sharding | boolean (default:&nbsp;false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by either `oss_sharding` or `shard_key_regex` |
+| sharding | boolean (default: false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by `shard_key_regex` |
 | shards_count | integer, <nobr>(range: 1-512)</nobr> (default:&nbsp;1); Number of database server-side shards |
 | shards_placement | Control the density of shards <br />Values:<br />**'dense'**: Shards reside on as few nodes as possible <br /> **'sparse'**: Shards reside on as many nodes as possible |
 | skip_import_analyze | Enable/disable skipping the analysis stage when importing an RDB file<br />Values:<br />'enabled'<br />'disabled' |

--- a/content/operate/rs/references/rest-api/objects/bdb/_index.md
+++ b/content/operate/rs/references/rest-api/objects/bdb/_index.md
@@ -125,7 +125,7 @@ An API object that represents a managed database in the cluster.
 | oss_cluster | boolean (default:&nbsp;false); OSS Cluster mode option. Cannot be enabled with `'hash_slots_policy': 'legacy'` |
 | <span class="break-all">oss_cluster_api_preferred_endpoint_type</span> | Endpoint type in the OSS cluster API<br />Values:<br />**‘ip’**<br />‘hostname’ |
 | <span class="break-all">oss_cluster_api_preferred_ip_type</span> | Internal/external IP type in OSS cluster API. Default value for new endpoints<br />Values:<br />**'internal'** <br />'external' |
-| oss_sharding | boolean (default:&nbsp;false); An alternative to `shard_key_regex` for using the common case of the OSS shard hashing policy |
+| oss_sharding | boolean (default: false); This flag is for future use and should not be changed |
 | <span class="break-all">partial_request_timeout_seconds</span> | integer (default: 3); When a client connection sends a command, takes a server connection, and stops writing before the command is complete, it causes head-of-line blocking on this server connection. Such commands will time out after this many seconds and the client connection will be closed. |
 | port | integer; TCP port on which the database is available. Generated automatically if omitted and returned as 0 |
 | <span class="break-all">preemptive_drain_timeout_seconds</span> | integer (default: 2); Timeout in seconds for preemptive drain of client connections before a shard is taken down |
@@ -155,7 +155,7 @@ An API object that represents a managed database in the cluster.
 | <span class="break-all">shard_imbalance_threshold</span> | number (default: 314572800); Automatically balances shards only if their imbalance is greater than this threshold. This field is for future use and should not be changed. |
 | <span class="break-all">shard_imbalance_threshold_percentage</span> | integer (default: 20); Automatically balances shards only if their imbalance percentage is greater than this threshold. This field is for future use and should not be changed. |
 | shard_list | array of integers; Cluster unique IDs of all database shards. |
-| sharding | boolean (default:&nbsp;false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by either `oss_sharding` or `shard_key_regex` |
+| sharding | boolean (default: false); Cluster mode (server-side sharding). When true, shard hashing rules must be provided by `shard_key_regex` |
 | shards_count | integer, <nobr>(range: 1-512)</nobr> (default:&nbsp;1); Number of database server-side shards |
 | shards_placement | Control the density of shards <br />Values:<br />**'dense'**: Shards reside on as few nodes as possible <br /> **'sparse'**: Shards reside on as many nodes as possible |
 | skip_import_analyze | Enable/disable skipping the analysis stage when importing an RDB file<br />Values:<br />'enabled'<br />'disabled' |


### PR DESCRIPTION
Fixes #3481

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to REST API field descriptions; no runtime or API behavior changes in this diff.
> 
> **Overview**
> Updates the **BDB REST API object** reference across RS doc trees (7.4, 7.8, 7.22, and the unversioned `operate/rs` page) so sharding fields match current product behavior.
> 
> **`oss_sharding`** is no longer described as an OSS hashing alternative to **`shard_key_regex`**; it is documented as a **future-use flag that should not be changed**. **`sharding`** now states that when cluster mode is enabled, hashing rules must come from **`shard_key_regex` only**, dropping the previous “either `oss_sharding` or `shard_key_regex`” wording. Minor formatting on the default value text (`default: false`) is aligned in those rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d13c8a9a6b36133cf9d28621b5b3a14b2510572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->