### PR TITLE
Update PrivateLink docs for GA

### DIFF
--- a/content/operate/rc/security/aws-privatelink.md
+++ b/content/operate/rc/security/aws-privatelink.md
@@ -31,7 +31,6 @@ See [Connect to Redis Cloud with AWS PrivateLink](https://www.youtube.com/watch?
 ## Limitations
 
 Be aware of the following limitations when using PrivateLink with Redis Cloud:
-- You cannot use the [OSS Cluster API]({{< relref "/operate/rc/databases/configuration/clustering#oss-cluster-api" >}}) with PrivateLink yet. Support for the OSS Cluster API will be supported in the near future.
 - If you use Layer 3 connectivity options like VPC peering or Transit Gateway together with PrivateLink in the same consumer VPC, the database endpoints exposed through PrivateLink's private DNS will resolve to the VPC endpoint and not to the IPs associated with the Layer 3 connectivity options.
 - Your subnets must have at least 16 available IP addresses for the resource endpoint.
 - Some AWS regions do not support PrivateLink Resource Endpoints. See [AWS VPC Lattice Pricing](https://aws.amazon.com/vpc/lattice/pricing/) for a list of regions that support AWS PrivateLink Resource Endpoints.
@@ -45,9 +44,6 @@ Be aware of the following limitations when using PrivateLink with Redis Cloud:
     - `ilc1-az2`
 
     We recommend avoiding these availability zones when creating your Redis Cloud database if you plan to use AWS PrivateLink.
-- Redis Cloud [Bring your Own Cloud]({{< relref "/operate/rc/subscriptions/bring-your-own-cloud" >}}) subscriptions are not supported with PrivateLink.
-- The pre-handoff feature of [Smart client handoffs]({{< relref "/develop/clients/sch#redis-cloud" >}}) is not currently supported with AWS PrivateLink, but relaxed timeouts are available and enabled by default.
-- The only supported principal type is an AWS account.
 
 ## Prerequisites
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to the Limitations list; no product or security behavior changes in code.
> 
> **Overview**
> Updates the **Limitations** section for Redis Cloud AWS PrivateLink **GA** by removing restrictions that no longer apply.
> 
> Dropped bullets include: OSS Cluster API not supported (with “coming soon” note), BYOC subscriptions incompatible with PrivateLink, Smart Client Handoffs pre-handoff unsupported (and the relaxed-timeouts note), and principals limited to AWS accounts only. Remaining limitations (L3 + PrivateLink DNS, subnet IP count, regions/AZs, VPC Lattice) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a5737777ddf4691b89f195cf9684bdfdc16a9f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->