### PR TITLE
RS 8.0.20 June maintenance release notes

### DIFF
--- a/content/operate/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/operate/rs/references/cli-utilities/rladmin/tune.md
@@ -285,7 +285,7 @@ rladmin tune proxy { <id> | all }
 |-----------------|----------------------------|-------------------------------------------------------------------------------------|
 | id              | integer                    | ID of the specified proxy                                                           |
 | all             |                            | Configures settings for all proxies                                                 |
-| client_eviction | boolean (default: true) | If `true,`, enables client eviction based on `maxmemory_clients`. |
+| client_eviction | boolean (default: true) | If `true`, enables client eviction based on `maxmemory_clients`. |
 | incoming_connections_capacity | integer (default: 0) | The maximum number of concurrent incoming connections, also known as the maximum burst size. The default is 0, which means no limit. |
 | incoming_connections_min_capacity | integer (default: 10) | The minimum number of free slots required before accepting new connections after an overflow. |
 | incoming_connections_rate_limit | integer (default: 0) | The maximum number of incoming connections per second. The default is 0, which means no limit. |

--- a/content/operate/rs/references/cli-utilities/rladmin/tune.md
+++ b/content/operate/rs/references/cli-utilities/rladmin/tune.md
@@ -285,7 +285,7 @@ rladmin tune proxy { <id> | all }
 |-----------------|----------------------------|-------------------------------------------------------------------------------------|
 | id              | integer                    | ID of the specified proxy                                                           |
 | all             |                            | Configures settings for all proxies                                                 |
-| client_eviction | boolean (default: false) | If `true,`, enables client eviction based on `maxmemory_clients`. |
+| client_eviction | boolean (default: true) | If `true,`, enables client eviction based on `maxmemory_clients`. |
 | incoming_connections_capacity | integer (default: 0) | The maximum number of concurrent incoming connections, also known as the maximum burst size. The default is 0, which means no limit. |
 | incoming_connections_min_capacity | integer (default: 10) | The minimum number of free slots required before accepting new connections after an overflow. |
 | incoming_connections_rate_limit | integer (default: 0) | The maximum number of incoming connections per second. The default is 0, which means no limit. |

--- a/content/operate/rs/references/rest-api/objects/proxy.md
+++ b/content/operate/rs/references/rest-api/objects/proxy.md
@@ -16,7 +16,7 @@ An API object that represents a [proxy](https://en.wikipedia.org/wiki/Proxy_serv
 |------|------------|-------------|
 | uid | integer | Unique ID of the proxy (read-only) |
 | backlog | integer | TCP listen queue backlog |
-| client_eviction | boolean (default: false) | If `true,`, enables client eviction based on `maxmemory_clients`. |
+| client_eviction | boolean (default: true) | If `true,`, enables client eviction based on `maxmemory_clients`. |
 | client_keepcnt | integer | Client TCP keepalive count |
 | client_keepidle | integer | Client TCP keepalive idle |
 | client_keepintvl | integer | Client TCP keepalive interval |

--- a/content/operate/rs/references/rest-api/objects/proxy.md
+++ b/content/operate/rs/references/rest-api/objects/proxy.md
@@ -16,7 +16,7 @@ An API object that represents a [proxy](https://en.wikipedia.org/wiki/Proxy_serv
 |------|------------|-------------|
 | uid | integer | Unique ID of the proxy (read-only) |
 | backlog | integer | TCP listen queue backlog |
-| client_eviction | boolean (default: true) | If `true,`, enables client eviction based on `maxmemory_clients`. |
+| client_eviction | boolean (default: true) | If `true`, enables client eviction based on `maxmemory_clients`. |
 | client_keepcnt | integer | Client TCP keepalive count |
 | client_keepidle | integer | Client TCP keepalive idle |
 | client_keepintvl | integer | Client TCP keepalive interval |

--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -121,7 +121,11 @@ Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
 
 Make sure the following ports are open before upgrading Redis Software.
 
-Ports reserved as of Redis Software version 8.0.18:
+The following port was added as a reserved port in Redis Software version 8.0.18; however, it is optional instead of reserved in Redis Software version 8.0.20-tba:
+
+| Port | Process name | Usage |
+|------|--------------|-------|
+| 3357 | reconciliation_tree_grpc | Internal communication |
 
 | Port | Process name | Usage | 
 |------|--------------|-------|
@@ -220,6 +224,8 @@ The following table provides a snapshot of supported platforms as of this Redis 
 ## Known issues
 
 - RS196225: After upgrading to Redis Software version 8.0.x, previously working LDAP filters that use an `OR` clause to match multiple attributes can fail to find a unique DN for some users.
+
+    This issue was fixed in Redis Software version 8.0.20-tba.
 
 - RS193156: Active Directory LDAP authentication can fail in the Cluster Manager UI after upgrading to Redis Software version 8.0.16-33 due to an issue with LDAP TLS client certificate handling. Users previously authenticated through Active Directory can no longer sign in to the Cluster Manager UI after the upgrade.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -121,7 +121,7 @@ Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
 
 Make sure the following ports are open before upgrading Redis Software.
 
-The following port was added as a reserved port in Redis Software version 8.0.18; however, it is optional instead of reserved in Redis Software version 8.0.20-tba:
+The following port was added as a reserved port in Redis Software version 8.0.18; however, it is optional instead of reserved in Redis Software version 8.0.20-44:
 
 | Port | Process name | Usage |
 |------|--------------|-------|
@@ -225,7 +225,7 @@ The following table provides a snapshot of supported platforms as of this Redis 
 
 - RS196225: After upgrading to Redis Software version 8.0.x, previously working LDAP filters that use an `OR` clause to match multiple attributes can fail to find a unique DN for some users.
 
-    This issue was fixed in Redis Software version 8.0.20-tba.
+    This issue was fixed in Redis Software version 8.0.20-44.
 
 - RS193156: Active Directory LDAP authentication can fail in the Cluster Manager UI after upgrading to Redis Software version 8.0.16-33 due to an issue with LDAP TLS client certificate handling. Users previously authenticated through Active Directory can no longer sign in to the Cluster Manager UI after the upgrade.
 
@@ -259,6 +259,10 @@ The following table provides a snapshot of supported platforms as of this Redis 
 - RS155734: Endpoint availability metrics do not work as expected due to a calculation error.
 
 ## Known limitations
+
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
 
 #### Trim ACKED not supported for Active-Active 8.4 databases
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
@@ -31,15 +31,15 @@ This version offers:
 
 - Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed at a single hot key could cause high latency and out-of-memory errors.
 
-### Redis database versions
+### Redis database versions and feature sets
 
 Redis Software version 8.0.20 includes the following Redis database versions: 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, and 6.2.13.
 
 The [default Redis database version]({{<relref "/operate/rs/databases/configure/db-defaults#database-version">}}) is 8.6.
 
-### Redis feature sets
-
 Redis Software includes multiple feature sets, compatible with different Redis database versions.
+
+{{< collapsible "Show feature set details" >}}
 
 The following table shows which Redis modules are compatible with each Redis database version included in this release.
 
@@ -52,6 +52,8 @@ The following table shows which Redis modules are compatible with each Redis dat
 | 7.4 | [RediSearch 2.10]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md" >}})<br />[RedisJSON 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.8-release-notes.md" >}})<br />[RedisTimeSeries 1.12]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.12-release-notes.md" >}})<br />[RedisBloom 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.8-release-notes.md" >}}) |
 | 7.2 | [RediSearch 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md" >}})<br />[RedisJSON 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.6-release-notes.md" >}})<br />[RedisTimeSeries 1.10]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.10-release-notes.md" >}})<br />[RedisBloom 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.6-release-notes.md" >}}) |
 | 6.2 | [RediSearch 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md" >}})<br />[RedisJSON 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.4-release-notes.md" >}})<br />[RedisTimeSeries 1.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.8-release-notes.md" >}})<br />[RedisBloom 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.4-release-notes.md" >}}) |
+
+{{< /collapsible >}}
 
 ### Resolved issues
 
@@ -115,6 +117,8 @@ See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networ
 
 ### Supported platforms
 
+{{< collapsible "Show supported platforms" >}}
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Software and Redis Stack modules.
 
 <span title="Warning icon" class="font-serif">:warning:</span> Deprecation warning – The platform is still supported for this version of Redis Software, but support will be removed in a future release.
@@ -149,6 +153,8 @@ See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networ
 5. <a name="table-note-5"></a>Supported only if [FIPS was enabled during RHEL installation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening#proc_installing-the-system-with-fips-mode-enabled_switching-rhel-to-fips-mode) to ensure FIPS compliance.
 
 6. <a name="table-note-6"></a>Amazon Linux 2023 support was added in Redis Software version 8.0.20.
+
+{{< /collapsible >}}
 
 ## Downloads
 
@@ -210,7 +216,7 @@ Some CVEs announced for Redis Open Source do not affect Redis Software due to di
 
 Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
-Redis 8.6.x:
+{{< collapsible "Redis 8.6.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -236,7 +242,9 @@ Redis 8.6.x:
 
 - Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
-Redis 8.4.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 8.4.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -262,7 +270,9 @@ Redis 8.4.x:
 
 - Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
-Redis 8.2.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 8.2.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -314,7 +324,9 @@ Redis 8.2.x:
 
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
-Redis 8.0.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 8.0.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -364,7 +376,9 @@ Redis 8.0.x:
 
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
-Redis 7.4.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 7.4.x" >}}
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -414,7 +428,9 @@ Redis 7.4.x:
 
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
-Redis 7.2.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 7.2.x" >}}
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -472,7 +488,9 @@ Redis 7.2.x:
 
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.2.1)
 
-Redis 7.0.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 7.0.x" >}}
 
 - (CVE-2024-31449) An authenticated user may use a specially crafted Lua script to trigger a stack buffer overflow in the bit library, which may potentially lead to remote code execution.
 
@@ -506,7 +524,9 @@ Redis 7.0.x:
 
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
-Redis 6.2.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 6.2.x" >}}
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -599,3 +619,5 @@ Redis 6.2.x:
 - (CVE-2021-29478) An integer overflow bug in Redis 6.2 could be exploited to corrupt the heap and potentially result with remote code execution. The vulnerability involves changing the default set-max-intset-entries configuration value, creating a large set key that consists of integer values and using the COPY command to duplicate it. The integer overflow bug exists in all versions of Redis starting with 2.6, where it could result with a corrupted RDB or DUMP payload, but not exploited through COPY (which did not exist before 6.2). (Redis 6.2.3)
 
 - (CVE-2021-29477) An integer overflow bug in Redis version 6.0 or newer could be exploited using the STRALGO LCS command to corrupt the heap and potentially result in remote code execution. The integer overflow bug exists in all versions of Redis starting with 6.0. (Redis 6.2.3)
+
+{{< /collapsible >}}

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
@@ -1,5 +1,5 @@
 ---
-Title: Redis Software release notes 8.0.20-tba (June 2026)
+Title: Redis Software release notes 8.0.20-44 (June 2026)
 alwaysopen: false
 categories:
 - docs
@@ -7,7 +7,7 @@ categories:
 - rs
 compatibleOSSVersion: Redis 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, 6.2.13
 description: Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed at a single hot key could cause high latency and out-of-memory errors. Bug fixes for Active-Active databases, LDAP, and ACLs. Internal fixes and improvements.
-linkTitle: 8.0.20-tba (June 2026)
+linkTitle: 8.0.20-44 (June 2026)
 weight: 80
 ---
 
@@ -154,23 +154,27 @@ See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networ
 
 The following table shows the SHA256 checksums for the available packages:
 
-| Package | SHA256 checksum (8.0.20-tba June release) |
+| Package | SHA256 checksum (8.0.20-44 June release) |
 |---------|---------------------------------------|
-| Ubuntu 20 | <span class="break-all"></span> |
-| Ubuntu 22 (amd64) | <span class="break-all"></span> |
-| Ubuntu 22 (arm64) | <span class="break-all"></span> |
-| Red Hat Enterprise Linux (RHEL) 8 | <span class="break-all"></span> |
-| Red Hat Enterprise Linux (RHEL) 9 (amd64) | <span class="break-all"></span> |
-| Red Hat Enterprise Linux (RHEL) 9 (arm64) | <span class="break-all"></span> |
-| Amazon Linux 2 | <span class="break-all"></span> |
-| Amazon Linux 2023 (amd64) | <span class="break-all"></span> |
-| Amazon Linux 2023 (arm64) | <span class="break-all"></span> |
+| Ubuntu 20 | <span class="break-all">5ec8fe4fcbafe4a164e37fb63e3f46213f1d6b2fc8a0aeb3eacc9b81507f5aae</span> |
+| Ubuntu 22 (amd64) | <span class="break-all">955fd01910b8029f181dc122c454881c4c053a61fe041cbec58c426558da3172</span> |
+| Ubuntu 22 (arm64) | <span class="break-all">fcb8dae0cec60ca38f6ba51b42b387b51227ad38a6b07de14774ad1ca79b73f6</span> |
+| Red Hat Enterprise Linux (RHEL) 8 | <span class="break-all">01d1a6497236ff2b69cdf414a84d9ad84434dd385c33c5dd6f88258bb410a95f</span> |
+| Red Hat Enterprise Linux (RHEL) 9 (amd64) | <span class="break-all">b25df42b067176be8b45e26f90189c8976ca9a7f16441ae22f69be411e4bf867</span> |
+| Red Hat Enterprise Linux (RHEL) 9 (arm64) | <span class="break-all">c2e09d8aec20d8cbb4df3ddc6e4437b9a7a0f744d00dcc260d95b22d1f73e4a2</span> |
+| Amazon Linux 2 | <span class="break-all">8d5022802449461488cce1afdfc91d600749d6c0b637a602a6b021566b7298ef</span> |
+| Amazon Linux 2023 (amd64) | <span class="break-all">fa1f61dfb46c03988456c6641ee47c5918f4e20e008d81430972f05df0f1c8eb</span> |
+| Amazon Linux 2023 (arm64) | <span class="break-all">bbc58c8d6f7b8fd866c4db188a7d4ab29b9972e900cc06c0dcd698cfafc90ecf</span> |
 
 ## Known issues
 
 - RS155734: Endpoint availability metrics do not work as expected due to a calculation error.
 
 ## Known limitations
+
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
 
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
@@ -204,7 +208,7 @@ As part of Redis's commitment to security, Redis Software implements the latest 
 
 Some CVEs announced for Redis Open Source do not affect Redis Software due to different or additional functionality available in Redis Software that is not available in Redis Open Source.
 
-Redis Software 8.0.20-tba supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
+Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
 Redis 8.6.x:
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
@@ -1,0 +1,591 @@
+---
+Title: Redis Software release notes 8.0.20-tba (June 2026)
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+compatibleOSSVersion: Redis 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, 6.2.13
+description: Bug fixes for Active-Active databases, LDAP, and ACLs. Internal fixes and improvements.
+linkTitle: 8.0.20-tba (June 2026)
+weight: 80
+---
+
+This is a maintenance release for ​[​Redis Software version 8.0.20](https://redis.io/downloads/#Redis_Software).
+
+## Highlights
+
+This version offers:
+
+- Bug fixes for Active-Active databases
+
+- Bug fixes for LDAP and ACLs
+
+- Internal fixes and improvements
+
+## New in this release
+
+### Redis database versions
+
+Redis Software version 8.0.20 includes the following Redis database versions: 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, and 6.2.13.
+
+The [default Redis database version]({{<relref "/operate/rs/databases/configure/db-defaults#database-version">}}) is 8.6.
+
+### Redis feature sets
+
+Redis Software includes multiple feature sets, compatible with different Redis database versions.
+
+The following table shows which Redis modules are compatible with each Redis database version included in this release.
+
+| Redis database version | Compatible Redis modules |
+|------------------------|--------------------------|
+| 8.6 | RediSearch 8.6<br />RedisJSON 8.4<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
+| 8.4 | RediSearch 8.4<br />RedisJSON 8.4<br />RedisTimeSeries 8.4<br />RedisBloom 8.4<br />See [What's new in Redis 8.4]({{<relref "/develop/whats-new/8-4">}}) and [Redis Open Source 8.4 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes">}}) |
+| 8.2 | RediSearch 8.2<br />RedisJSON 8.2<br />RedisTimeSeries 8.2<br />RedisBloom 8.2<br />See [What's new in Redis 8.2]({{<relref "/develop/whats-new/8-2">}}) and [Redis Open Source 8.2 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes">}}) |
+| 8.0 | RediSearch 8.0<br />RedisJSON 8.0<br />RedisTimeSeries 8.0<br />RedisBloom 8.0<br />See [What's new in Redis 8.0]({{<relref "/develop/whats-new/8-0">}}) and [Redis Open Source 8.0 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes">}}) |
+| 7.4 | [RediSearch 2.10]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md" >}})<br />[RedisJSON 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.8-release-notes.md" >}})<br />[RedisTimeSeries 1.12]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.12-release-notes.md" >}})<br />[RedisBloom 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.8-release-notes.md" >}}) |
+| 7.2 | [RediSearch 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md" >}})<br />[RedisJSON 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.6-release-notes.md" >}})<br />[RedisTimeSeries 1.10]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.10-release-notes.md" >}})<br />[RedisBloom 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.6-release-notes.md" >}}) |
+| 6.2 | [RediSearch 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md" >}})<br />[RedisJSON 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.4-release-notes.md" >}})<br />[RedisTimeSeries 1.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.8-release-notes.md" >}})<br />[RedisBloom 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.4-release-notes.md" >}}) |
+
+### Resolved issues
+
+- RS185386: Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed as a single hot key could cause high latency and out-of-memory errors.
+
+- RS190875: Fixed an issue where ciphers that use SHA-1 could not be removed when FIPS mode was enabled. FIPS mode now excludes SHA and CHACHA20 from `control_cipher_suites`.
+
+- RS192582: Fixed an issue where the creation of Redis 8.x Active-Active databases could fail when no modules were specified due to missing module semantic versions in requests.
+
+- RS194243: Fixed a memory leak in the Active-Active database syncer that could occur when a participating cluster became unavailable but was not removed from the CRDB configuration.
+
+- RS195089: Fixed an issue where a major reconfiguration of an Active-Active database could cause an unnecessary full synchronization across all participating clusters.
+
+- RS196225: Fixed an issue where LDAP filters that use an `OR` clause to match multiple attributes could fail to find a unique DN for some users after upgrading to Redis Software version 8.0.x.
+
+- RS196954: Fixed an issue where a user configuration could become corrupted if it was deleted and updated concurrently, which broke ACL authentication for all databases on the cluster and prevented users from connecting.
+
+- RS199012: Fixed a memory leak in `dmcproxy` that could occur when a multi-key command received a local `MOVED` or `CROSSSLOT` response.
+
+- RS199077: Fixed an issue where orphaned resource manager tasks could remain stuck in a cancelling state.
+
+## Version changes
+
+### OpenSSL version
+
+Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+
+### Reserved ports
+
+Make sure the following ports are open before upgrading Redis Software.
+
+The following port was added as a reserved port in Redis Software version 8.0.18; however, it is now optional instead of reserved in this release:
+
+| Port | Process name | Usage |
+|------|--------------|-------|
+| 3357 | reconciliation_tree_grpc | Internal communication |
+
+Ports reserved as of Redis Software version 7.22.0:
+
+| Port | Process name | Usage |
+|------|--------------|-------|
+| 3346 | cluster_api_internal | Cluster API internal port |
+| 3351 | cluster_watchdog_grpc_api | Cluster watchdog now supports gRPC |
+| 3352 | grpc_service_mesh | gRPC communication between nodes |
+| 3353 | local_grpc_service_mesh | Local gRPC services |
+| 3354 | grpc_gossip_envoy | gRPC gossip protocol communication between nodes |
+| 3355 | authentication_service | Authentication service internal port |
+
+Ports reserved as of Redis Software version 7.8.2:
+
+| Port | Process name | Usage |
+|------|--------------|-------|
+| 3347 | cert_exporter | Reports cluster certificate metrics |
+| 3348 | process_exporter | Reports process metrics for DMC and Redis processes |
+| 3349 | cluster_wd_exporter | Reports cluster watchdog metrics |
+| 3350 | db_controller | Internode communication |
+| 9091 | node_exporter | Reports host node metrics related to CPU, memory, disk, and more |
+| 9125 | statsd_exporter | Reports push metrics related to the DMC and syncer, and some cluster and node metrics |
+
+See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networking/port-configurations#ports-and-port-ranges-used-by-redis-enterprise-software">}}) for a complete list.
+
+### Supported platforms
+
+<span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Software and Redis Stack modules.
+
+<span title="Warning icon" class="font-serif">:warning:</span> Deprecation warning – The platform is still supported for this version of Redis Software, but support will be removed in a future release.
+
+| Redis Software<br />major versions | 8.0 | 7.22 | 7.8 | 7.4 | 7.2 | 6.4 | 6.2 |
+|---------------------------------|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
+| **Release date** | Oct 2025 | May 2025 | Nov 2024 | Feb 2024 | Aug 2023 | Feb 2023 | Aug 2021 |
+| [**End-of-life date**]({{< relref "/operate/rs/installing-upgrading/product-lifecycle#endoflife-schedule" >}}) | Determined after<br />next major release | Oct 2027 | May 2027 | Nov 2026 | Feb 2026 | Aug 2025 | Feb 2025 |
+| **Platforms** | | | | | | | |
+| RHEL 9 &<br />compatible distros<sup>[1](#table-note-1)</sup> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | – | – | – |
+| RHEL 9<br />FIPS mode<sup>[5](#table-note-5)</sup> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | – | – | – | – |
+| RHEL 8 &<br />compatible distros<sup>[1](#table-note-1)</sup> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| RHEL 7 &<br />compatible distros<sup>[1](#table-note-1)</sup> | – | – | – | – | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> |
+| Ubuntu 22.04<sup>[2](#table-note-2)</sup> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | – | – | – | – |
+| Ubuntu 20.04<sup>[2](#table-note-2)</sup> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | – |
+| Ubuntu 18.04<sup>[2](#table-note-2)</sup> | – | – | – | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> |
+| Ubuntu 16.04<sup>[2](#table-note-2)</sup> | – | – | – | – | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> |
+| Amazon Linux 2023<sup>[6](#table-note-6)</sup> | <span title="Supported">&#x2705;</span> | – | – | – | – | – | – |
+| Amazon Linux 2 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | – |
+| Amazon Linux 1 | – | – | – | – | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> | <span title="Deprecated" class="font-serif">:warning:</span> |
+| Kubernetes<sup>[3](#table-note-3)</sup> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+| Docker<sup>[4](#table-note-4)</sup> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> |
+
+1. <a name="table-note-1"></a>The RHEL-compatible distributions CentOS, CentOS Stream, Alma, and Rocky are supported if they have full RHEL compatibility. Oracle Linux running the Red Hat Compatible Kernel (RHCK) is supported, but the Unbreakable Enterprise Kernel (UEK) is not supported.
+
+2. <a name="table-note-2"></a>The server version of Ubuntu is recommended for production installations. The desktop version is only recommended for development deployments.
+
+3. <a name="table-note-3"></a>See the [Redis Enterprise for Kubernetes documentation]({{< relref "/operate/kubernetes/reference/supported_k8s_distributions" >}}) for details about support per version and Kubernetes distribution.
+
+4. <a name="table-note-4"></a>[Docker images]({{< relref "/operate/rs/installing-upgrading/quickstarts/docker-quickstart" >}}) of Redis Software are certified for development and testing only.
+
+5. <a name="table-note-5"></a>Supported only if [FIPS was enabled during RHEL installation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening#proc_installing-the-system-with-fips-mode-enabled_switching-rhel-to-fips-mode) to ensure FIPS compliance.
+
+6. <a name="table-note-6"></a>Amazon Linux 2023 support was added in Redis Software version 8.0.20.
+
+## Downloads
+
+The following table shows the SHA256 checksums for the available packages:
+
+| Package | SHA256 checksum (8.0.20-tba June release) |
+|---------|---------------------------------------|
+| Ubuntu 20 | <span class="break-all"></span> |
+| Ubuntu 22 (amd64) | <span class="break-all"></span> |
+| Ubuntu 22 (arm64) | <span class="break-all"></span> |
+| Red Hat Enterprise Linux (RHEL) 8 | <span class="break-all"></span> |
+| Red Hat Enterprise Linux (RHEL) 9 (amd64) | <span class="break-all"></span> |
+| Red Hat Enterprise Linux (RHEL) 9 (arm64) | <span class="break-all"></span> |
+| Amazon Linux 2 | <span class="break-all"></span> |
+| Amazon Linux 2023 (amd64) | <span class="break-all"></span> |
+| Amazon Linux 2023 (arm64) | <span class="break-all"></span> |
+
+## Known issues
+
+- RS155734: Endpoint availability metrics do not work as expected due to a calculation error.
+
+## Known limitations
+
+#### Trim ACKED not supported for Active-Active 8.4 databases
+
+For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.
+
+#### Rolling upgrade limitation for clusters with custom or deprecated modules
+
+Due to module handling changes introduced in Redis Software version 8.0, upgrading a cluster that contains custom or deprecated modules, such as RedisGraph and RedisGears v2, can become stuck when adding a new node to the cluster during a rolling upgrade.
+
+#### Module commands limitation during Active-Active database upgrades to Redis 8.0
+
+When upgrading an Active-Active database to Redis version 8.0, you cannot use module commands until all Active-Active database instances have been upgraded. Currently, these commands are not blocked automatically.
+
+#### Redis 8.0 database cannot be created with flash
+
+You cannot create a Redis 8.0 database with flash storage enabled. Create a Redis 8.0 database with RAM-only storage instead, or use Redis 8.2 for flash-enabled (Redis Flex) databases.
+
+#### Cluster Manager UI limitations
+
+The following legacy UI features are not yet available in the new Cluster Manager UI:
+
+- Purge an Active-Active instance.
+
+    Use [`crdb-cli crdb purge-instance`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/purge-instance" >}}) instead.
+
+## Security
+
+#### Redis Open Source security fixes compatibility
+
+As part of Redis's commitment to security, Redis Software implements the latest [security fixes](https://github.com/redis/redis/releases) available with [Redis Open Source](https://github.com/redis/redis). Redis Software has already included the fixes for the relevant CVEs.
+
+Some CVEs announced for Redis Open Source do not affect Redis Software due to different or additional functionality available in Redis Software that is not available in Redis Open Source.
+
+Redis Software 8.0.20-tba supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
+
+Redis 8.6.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+Redis 8.4.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+Redis 8.2.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+- RedisBloom: Restore invalid filter.
+
+- (CVE-2025-62507) A user can run the `XACKDEL` command with multiple IDs and trigger a stack buffer overflow, which can potentially lead to remote code execution.
+
+- The `HGETEX` command can lead to a buffer overflow.
+
+- Integer overflow in `hllPatLen`.
+
+- RedisBloom: Cuckoo filter counter overflow.
+
+- RedisBloom: Invalid Bloom filters can cause arbitrary memory reads and writes.
+
+- RedisBloom: Reachable assert in `TopK_Create`
+
+- RedisBloom: Out-of-bounds access with empty Bloom chains.
+
+- RedisBloom: Division by zero in Cuckoo filter insertion.
+
+- (CVE-2025-46818) An authenticated user may use a specially crafted Lua script to manipulate different LUA objects and potentially run their own code in the context of another user.
+
+- (CVE-2025-46819) An authenticated user may use a specially crafted LUA script to read out-of-bound data or crash the server and lead to subsequent denial of service.
+
+- (CVE-2025-46817) An authenticated user may use a specially crafted Lua script to cause an integer overflow and potentially lead to remote code execution.
+
+- (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
+
+Redis 8.0.x:
+
+- VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+- RedisBloom: Restore invalid filter.
+
+- The `HGETEX` command can lead to a buffer overflow.
+
+- Integer overflow in `hllPatLen`.
+
+- RedisBloom: Cuckoo filter counter overflow.
+
+- RedisBloom: Invalid Bloom filters can cause arbitrary memory reads and writes.
+
+- RedisBloom: Reachable assert in `TopK_Create`
+
+- RedisBloom: Out-of-bounds access with empty Bloom chains.
+
+- RedisBloom: Division by zero in Cuckoo filter insertion.
+
+- (CVE-2025-46818) An authenticated user may use a specially crafted Lua script to manipulate different LUA objects and potentially run their own code in the context of another user.
+
+- (CVE-2025-46819) An authenticated user may use a specially crafted LUA script to read out-of-bound data or crash the server and lead to subsequent denial of service.
+
+- (CVE-2025-46817) An authenticated user may use a specially crafted Lua script to cause an integer overflow and potentially lead to remote code execution.
+
+- (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
+
+Redis 7.4.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+- RedisBloom: Restore invalid filter.
+
+- Integer overflow in `hllPatLen`.
+
+- RedisBloom: Cuckoo filter counter overflow.
+
+- RedisBloom: Invalid Bloom filters can cause arbitrary memory reads and writes.
+
+- RedisBloom: Reachable assert in `TopK_Create`
+
+- RedisBloom: Out-of-bounds access with empty Bloom chains.
+
+- RedisBloom: Division by zero in Cuckoo filter insertion.
+
+- (CVE-2025-46818) An authenticated user may use a specially crafted Lua script to manipulate different LUA objects and potentially run their own code in the context of another user.
+
+- (CVE-2025-46819) An authenticated user may use a specially crafted LUA script to read out-of-bound data or crash the server and lead to subsequent denial of service.
+
+- (CVE-2025-46817) An authenticated user may use a specially crafted Lua script to cause an integer overflow and potentially lead to remote code execution.
+
+- (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
+
+- (CVE-2025-32023) An authenticated user can use a specially crafted string to trigger a stack/heap out-of-bounds write on HyperLogLog operations, which can lead to remote code execution.
+
+- (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
+
+Redis 7.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+- RedisBloom: Restore invalid filter.
+
+- Integer overflow in `hllPatLen`.
+
+- RedisBloom: Cuckoo filter counter overflow.
+
+- RedisBloom: Invalid Bloom filters can cause arbitrary memory reads and writes.
+
+- RedisBloom: Reachable assert in `TopK_Create`
+
+- RedisBloom: Out-of-bounds access with empty Bloom chains.
+
+- RedisBloom: Division by zero in Cuckoo filter insertion.
+
+- (CVE-2025-46818) An authenticated user may use a specially crafted Lua script to manipulate different LUA objects and potentially run their own code in the context of another user.
+
+- (CVE-2025-46819) An authenticated user may use a specially crafted LUA script to read out-of-bound data or crash the server and lead to subsequent denial of service.
+
+- (CVE-2025-46817) An authenticated user may use a specially crafted Lua script to cause an integer overflow and potentially lead to remote code execution.
+
+- (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
+
+- (CVE-2025-32023) An authenticated user can use a specially crafted string to trigger a stack/heap out-of-bounds write on HyperLogLog operations, which can lead to remote code execution.
+
+- (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
+
+- (CVE-2024-31449) An authenticated user may use a specially crafted Lua script to trigger a stack buffer overflow in the bit library, which may potentially lead to remote code execution.
+
+- (CVE-2024-31228) An authenticated user can trigger a denial-of-service by using specially crafted, long string match patterns on supported commands such as `KEYS`, `SCAN`, `PSUBSCRIBE`, `FUNCTION LIST`, `COMMAND LIST`, and ACL definitions. Matching of extremely long patterns may result in unbounded recursion, leading to stack overflow and process crashes.
+
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
+
+- (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.2.1)
+
+Redis 7.0.x:
+
+- (CVE-2024-31449) An authenticated user may use a specially crafted Lua script to trigger a stack buffer overflow in the bit library, which may potentially lead to remote code execution.
+
+- (CVE-2024-31228) An authenticated user can trigger a denial-of-service by using specially crafted, long string match patterns on supported commands such as `KEYS`, `SCAN`, `PSUBSCRIBE`, `FUNCTION LIST`, `COMMAND LIST`, and ACL definitions. Matching of extremely long patterns may result in unbounded recursion, leading to stack overflow and process crashes.
+
+- (CVE-2023-41056) In some cases, Redis may incorrectly handle resizing of memory buffers, which can result in incorrect accounting of buffer sizes and lead to heap overflow and potential remote code execution.
+
+- (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.0.13)
+
+- (CVE-2023-36824) Extracting key names from a command and a list of arguments may, in some cases, trigger a heap overflow and result in reading random heap memory, heap corruption, and potentially remote code execution. Specifically: using `COMMAND GETKEYS*` and validation of key names in ACL rules. (Redis 7.0.12)
+
+- (CVE-2023-28856) Authenticated users can use the `HINCRBYFLOAT` command to create an invalid hash field that will crash Redis on access. (Redis 7.0.11)
+
+- (CVE-2023-28425) Specially crafted `MSETNX` commands can lead to assertion and denial-of-service. (Redis 7.0.10)
+
+- (CVE-2023-25155) Specially crafted `SRANDMEMBER`, `ZRANDMEMBER`, and `HRANDFIELD` commands can trigger an integer overflow, resulting in a runtime assertion and termination of the Redis server process. (Redis 7.0.9)
+
+- (CVE-2023-22458) Integer overflow in the Redis `HRANDFIELD` and `ZRANDMEMBER` commands can lead to denial-of-service. (Redis 7.0.8)
+
+- (CVE-2022-36021) String matching commands (like `SCAN` or `KEYS`) with a specially crafted pattern to trigger a denial-of-service attack on Redis can cause it to hang and consume 100% CPU time. (Redis 7.0.9)
+
+- (CVE-2022-35977) Integer overflow in the Redis `SETRANGE` and `SORT`/`SORT_RO` commands can drive Redis to OOM panic. (Redis 7.0.8)
+
+- (CVE-2022-35951) Executing an `XAUTOCLAIM` command on a stream key in a specific state, with a specially crafted `COUNT` argument, may cause an integer overflow, a subsequent heap overflow, and potentially lead to remote code execution. The problem affects Redis versions 7.0.0 or newer. (Redis 7.0.5)
+
+- (CVE-2022-31144) A specially crafted `XAUTOCLAIM` command on a stream key in a specific state may result in heap overflow and potentially remote code execution. The problem affects Redis versions 7.0.0 or newer. (Redis 7.0.4)
+
+- (CVE-2022-24834) A specially crafted Lua script executing in Redis can trigger a heap overflow in the cjson and cmsgpack libraries, and result in heap corruption and potentially remote code execution. The problem exists in all versions of Redis with Lua scripting support, starting from 2.6, and affects only authenticated and authorized users. (Redis 7.0.12)
+
+- (CVE-2022-24736) An attacker attempting to load a specially crafted Lua script can cause NULL pointer dereference which will result in a crash of the `redis-server` process. This issue affects all versions of Redis. (Redis 7.0.0)
+
+- (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
+
+Redis 6.2.x:
+
+- (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
+
+- (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
+
+- Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
+
+- RedisBloom: Integer overflow in `TopK` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `td_histogram_t` RDB loading may lead to heap buffer overflow.
+
+- RedisBloom: Missing validation in `CuckooFilter` RDB loading may lead to heap out-of-bounds access.
+
+- RedisBloom: Missing validation in `SBChain` and `CMSketch` RDB loading may lead to heap out-of-bounds write.
+
+- Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
+
+- RedisBloom: Restore invalid filter.
+
+- Integer overflow in `hllPatLen`.
+
+- RedisBloom: Cuckoo filter counter overflow.
+
+- RedisBloom: Invalid Bloom filters can cause arbitrary memory reads and writes.
+
+- RedisBloom: Reachable assert in `TopK_Create`
+
+- RedisBloom: Out-of-bounds access with empty Bloom chains.
+
+- RedisBloom: Division by zero in Cuckoo filter insertion.
+
+- (CVE-2025-46818) An authenticated user may use a specially crafted Lua script to manipulate different LUA objects and potentially run their own code in the context of another user.
+
+- (CVE-2025-46819) An authenticated user may use a specially crafted LUA script to read out-of-bound data or crash the server and lead to subsequent denial of service.
+
+- (CVE-2025-46817) An authenticated user may use a specially crafted Lua script to cause an integer overflow and potentially lead to remote code execution.
+
+- (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
+
+- (CVE-2025-32023) An authenticated user can use a specially crafted string to trigger a stack/heap out-of-bounds write on HyperLogLog operations, which can lead to remote code execution.
+
+- (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
+
+- (CVE-2024-31449) An authenticated user may use a specially crafted Lua script to trigger a stack buffer overflow in the bit library, which may potentially lead to remote code execution.
+
+- (CVE-2024-31228) An authenticated user can trigger a denial-of-service by using specially crafted, long string match patterns on supported commands such as `KEYS`, `SCAN`, `PSUBSCRIBE`, `FUNCTION LIST`, `COMMAND LIST`, and ACL definitions. Matching of extremely long patterns may result in unbounded recursion, leading to stack overflow and process crashes.
+
+- (CVE-2023-28856) Authenticated users can use the `HINCRBYFLOAT` command to create an invalid hash field that will crash Redis on access. (Redis 6.2.12)
+
+- (CVE-2023-25155) Specially crafted `SRANDMEMBER`, `ZRANDMEMBER`, and `HRANDFIELD` commands can trigger an integer overflow, resulting in a runtime assertion and termination of the Redis server process. (Redis 6.2.11)
+
+- (CVE-2023-22458) Integer overflow in the Redis `HRANDFIELD` and `ZRANDMEMBER` commands can lead to denial-of-service. (Redis 6.2.9)
+
+- (CVE-2022-36021) String matching commands (like `SCAN` or `KEYS`) with a specially crafted pattern to trigger a denial-of-service attack on Redis can cause it to hang and consume 100% CPU time. (Redis 6.2.11)
+
+- (CVE-2022-35977) Integer overflow in the Redis `SETRANGE` and `SORT`/`SORT_RO` commands can drive Redis to OOM panic. (Redis 6.2.9)
+
+- (CVE-2022-24834) A specially crafted Lua script executing in Redis can trigger a heap overflow in the cjson and cmsgpack libraries, and result in heap corruption and potentially remote code execution. The problem exists in all versions of Redis with Lua scripting support, starting from 2.6, and affects only authenticated and authorized users. (Redis 6.2.13)
+
+- (CVE-2022-24736) An attacker attempting to load a specially crafted Lua script can cause NULL pointer dereference which will result in a crash of the `redis-server` process. This issue affects all versions of Redis. (Redis 6.2.7)
+
+- (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 6.2.7)
+
+- (CVE-2021-41099) Integer to heap buffer overflow handling certain string commands and network payloads, when `proto-max-bulk-len` is manually configured to a non-default, very large value. (Redis 6.2.6)
+
+- (CVE-2021-32762) Integer to heap buffer overflow issue in `redis-cli` and `redis-sentinel` parsing large multi-bulk replies on some older and less common platforms. (Redis 6.2.6)
+
+- (CVE-2021-32761) An integer overflow bug in Redis version 2.2 or newer can be exploited using the `BITFIELD` command to corrupt the heap and potentially result with remote code execution. (Redis 6.2.5)
+
+- (CVE-2021-32687) Integer to heap buffer overflow with intsets, when `set-max-intset-entries` is manually configured to a non-default, very large value. (Redis 6.2.6)
+
+- (CVE-2021-32675) Denial Of Service when processing RESP request payloads with a large number of elements on many connections. (Redis 6.2.6)
+
+- (CVE-2021-32672) Random heap reading issue with Lua Debugger. (Redis 6.2.6)
+
+- (CVE-2021-32628) Integer to heap buffer overflow handling ziplist-encoded data types, when configuring a large, non-default value for `hash-max-ziplist-entries`, `hash-max-ziplist-value`, `zset-max-ziplist-entries` or `zset-max-ziplist-value`. (Redis 6.2.6)
+
+- (CVE-2021-32627) Integer to heap buffer overflow issue with streams, when configuring a non-default, large value for `proto-max-bulk-len` and `client-query-buffer-limit`. (Redis 6.2.6)
+
+- (CVE-2021-32626) Specially crafted Lua scripts may result with Heap buffer overflow. (Redis 6.2.6)
+
+- (CVE-2021-32625) An integer overflow bug in Redis version 6.0 or newer can be exploited using the STRALGO LCS command to corrupt the heap and potentially result with remote code execution. This is a result of an incomplete fix by CVE-2021-29477. (Redis 6.2.4)
+
+- (CVE-2021-29478) An integer overflow bug in Redis 6.2 could be exploited to corrupt the heap and potentially result with remote code execution. The vulnerability involves changing the default set-max-intset-entries configuration value, creating a large set key that consists of integer values and using the COPY command to duplicate it. The integer overflow bug exists in all versions of Redis starting with 2.6, where it could result with a corrupted RDB or DUMP payload, but not exploited through COPY (which did not exist before 6.2). (Redis 6.2.3)
+
+- (CVE-2021-29477) An integer overflow bug in Redis version 6.0 or newer could be exploited using the STRALGO LCS command to corrupt the heap and potentially result in remote code execution. The integer overflow bug exists in all versions of Redis starting with 6.0. (Redis 6.2.3)

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
@@ -39,7 +39,7 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 | Redis database version | Compatible Redis modules |
 |------------------------|--------------------------|
-| 8.6 | RediSearch 8.6<br />RedisJSON 8.4<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
+| 8.6 | RediSearch 8.6<br />RedisJSON 8.6<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
 | 8.4 | RediSearch 8.4<br />RedisJSON 8.4<br />RedisTimeSeries 8.4<br />RedisBloom 8.4<br />See [What's new in Redis 8.4]({{<relref "/develop/whats-new/8-4">}}) and [Redis Open Source 8.4 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes">}}) |
 | 8.2 | RediSearch 8.2<br />RedisJSON 8.2<br />RedisTimeSeries 8.2<br />RedisBloom 8.2<br />See [What's new in Redis 8.2]({{<relref "/develop/whats-new/8-2">}}) and [Redis Open Source 8.2 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes">}}) |
 | 8.0 | RediSearch 8.0<br />RedisJSON 8.0<br />RedisTimeSeries 8.0<br />RedisBloom 8.0<br />See [What's new in Redis 8.0]({{<relref "/develop/whats-new/8-0">}}) and [Redis Open Source 8.0 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes">}}) |

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
@@ -6,7 +6,7 @@ categories:
 - operate
 - rs
 compatibleOSSVersion: Redis 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, 6.2.13
-description: Bug fixes for Active-Active databases, LDAP, and ACLs. Internal fixes and improvements.
+description: Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed at a single hot key could cause high latency and out-of-memory errors. Bug fixes for Active-Active databases, LDAP, and ACLs. Internal fixes and improvements.
 linkTitle: 8.0.20-tba (June 2026)
 weight: 80
 ---
@@ -17,6 +17,8 @@ This is a maintenance release for ​[​Redis Software version 8.0.20](https://
 
 This version offers:
 
+- Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed at a single hot key could cause high latency and out-of-memory errors
+
 - Bug fixes for Active-Active databases
 
 - Bug fixes for LDAP and ACLs
@@ -24,6 +26,10 @@ This version offers:
 - Internal fixes and improvements
 
 ## New in this release
+
+### Enhancements
+
+- Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed at a single hot key could cause high latency and out-of-memory errors.
 
 ### Redis database versions
 
@@ -49,7 +55,7 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ### Resolved issues
 
-- RS185386: Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed as a single hot key could cause high latency and out-of-memory errors.
+- RS185386: Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed at a single hot key could cause high latency and out-of-memory errors.
 
 - RS190875: Fixed an issue where ciphers that use SHA-1 could not be removed when FIPS mode was enabled. FIPS mode now excludes SHA and CHACHA20 from `control_cipher_suites`.
 

--- a/layouts/shortcodes/collapsible.html
+++ b/layouts/shortcodes/collapsible.html
@@ -1,0 +1,49 @@
+{{- /*
+  collapsible: wraps content in a native <details> element that is collapsed
+  by default and expands on click. Unlike the `expand` shortcode, it has no
+  fixed height, so it handles long sections (CVE lists, supported platforms,
+  feature sets) without clipping.
+
+  Usage:
+    {{< collapsible "Supported platforms" >}}
+    ...markdown or HTML...
+    {{< /collapsible >}}
+
+  Or with named params:
+    {{< collapsible title="Supported platforms" open="true" >}}
+*/ -}}
+{{- $title := "" -}}
+{{- $open := false -}}
+{{- if .IsNamedParams -}}
+  {{- $title = .Get "title" -}}
+  {{- $open = eq (.Get "open") "true" -}}
+{{- else -}}
+  {{- $title = .Get 0 -}}
+{{- end -}}
+
+{{- /*
+  Always run the inner content through markdownify. These angle-bracket
+  shortcodes don't get markdown processing from the page, so we apply it here.
+  goldmark passes inline/raw HTML (such as <span> tags) through untouched, so
+  mixed HTML + markdown (tables, lists) renders correctly either way.
+*/ -}}
+{{- $inner := .Inner | markdownify -}}
+
+<details class="collapsible my-4 border border-redis-pen-700/10 rounded-md"{{ if $open }} open{{ end }}>
+  <summary class="collapsible-label cursor-pointer list-none px-4 py-3 font-medium select-none">
+    <div class="flex flex-row gap-3 items-center hover:text-redis-red-500 transition-colors ease-in-out duration-150">
+      {{- $title -}}
+      <div class="collapsible-chevron transition-transform duration-300 ease-in-out">
+        {{- partial "icons/chevron.html" -}}
+      </div>
+    </div>
+  </summary>
+  <div class="collapsible-content px-4 pb-4 pt-1">
+    {{- $inner -}}
+  </div>
+</details>
+
+<style>
+  .collapsible > summary::-webkit-details-marker { display: none; }
+  .collapsible[open] > summary .collapsible-chevron { transform: rotate(180deg); }
+</style>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and Hugo theme shortcode only; no application or runtime code changes.
> 
> **Overview**
> Documents the **Redis Software 8.0.20-44 (June 2026)** maintenance release and aligns reference pages with product behavior in that build.
> 
> Adds a new release-notes page covering highlights (default **`client_eviction`** for hot-key/OOM mitigation), resolved tickets (Active-Active, LDAP `OR` filters, ACL concurrency, FIPS ciphers, `dmcproxy` leaks, and others), download checksums, Amazon Linux 2023 support, and collapsible security/CVE sections per Redis OSS version.
> 
> Updates the **8.0.x** index: notes that port **3357** is optional (not reserved) from 8.0.20-44, marks **RS196225** fixed in 8.0.20-44, and documents **Redis Search** failures during rolling upgrades across the 8.4 boundary when `parallel_shards_upgrade` ≠ 0.
> 
> Changes **`client_eviction`** default documentation from `false` to **`true`** in `rladmin tune proxy` and the REST **proxy** object (and fixes a typo in the description).
> 
> Introduces a Hugo **`collapsible`** shortcode (`<details>`) so long release-note blocks (platforms, feature sets, CVE lists) expand without the fixed-height clipping of `expand`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f147fd3c823c114cd1f25bdc213ef0dba4b640aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->