### PR TITLE
Fix oversized client-example pages: slice snippets, embed each file once (#3398)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ ndjson: json_transform
 serve_hugo:
 	@hugo serve
 
+# Passive post-build report of unusually large rendered pages (warn-only).
+check_page_sizes:
+	@python3 build/check_page_sizes.py public
+
 clean:
 	@rm -Rf ./public/
 	@rm -Rf ./resources/

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -503,34 +503,60 @@ select {
   @apply rounded-none p-0;
 }
 
-.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > code > .line:not(.hl),
-.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > .lntable .lntd code > .lnt,
-.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > .lntable .lntd code > .line:not(.hl) {
+.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > code > .line:not(.hl),
+.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > .lntable .lntd code > .lnt,
+.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > .lntable .lntd code > .line:not(.hl) {
   @apply hidden;
 }
 
-.codetabs > .panel:where([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > code > .line:not(.hl),
-.codetabs > .panel:where([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > .lntable .lntd code > .lnt,
-.codetabs > .panel:where([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > .lntable .lntd code > .line:not(.hl) {
+.codetabs > .panel:where([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > code > .line:not(.hl),
+.codetabs > .panel:where([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > .lntable .lntd code > .lnt,
+.codetabs > .panel:where([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > .lntable .lntd code > .line:not(.hl) {
   @apply opacity-60;
 }
 
-.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > .language-Go > .hl {
+.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > .language-Go > .hl {
   tab-size: 3ch;
   left: -3ch;
   position: relative;
 }
 
-.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > .language-C\# > .hl
+.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > .language-C\# > .hl
 {
   left: -8ch;
   position: relative;
 }
 
-.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]) .highlight .chroma > .language-Java > .hl
+.codetabs > .panel:not([aria-expanded]):not([data-lang="redis-cli"]):not([data-fullfile-key]) .highlight .chroma > .language-Java > .hl
 {
   left: -4ch;
   position: relative;
+}
+
+/* --- Sliced-snippet panels (data-fullfile-key): show the step slice by default, */
+/*     reveal the deduped full file (cloned from <template>) on eyeball expand. --- */
+.codetabs > .panel[data-fullfile-key] .full-file-view {
+  display: none;
+}
+
+.codetabs > .panel[data-fullfile-key][aria-expanded] .step-code-view {
+  display: none;
+}
+
+.codetabs > .panel[data-fullfile-key][aria-expanded] .full-file-view {
+  display: block;
+}
+
+/* When expanded, dim the context lines and keep the step's lines at full opacity. */
+.codetabs > .panel[data-fullfile-key][aria-expanded] .full-file-view .highlight .chroma > code > .line:not(.hl),
+.codetabs > .panel[data-fullfile-key][aria-expanded] .full-file-view .highlight .chroma > .lntable .lntd code > .lnt,
+.codetabs > .panel[data-fullfile-key][aria-expanded] .full-file-view .highlight .chroma > .lntable .lntd code > .line:not(.hl) {
+  @apply opacity-60;
+}
+
+.codetabs > .panel[data-fullfile-key][aria-expanded] .full-file-view .highlight .chroma > code > .hl,
+.codetabs > .panel[data-fullfile-key][aria-expanded] .full-file-view .highlight .chroma > .lntable .lntd code > .hl {
+  opacity: 1 !important;
 }
 
 .codetabs > .panel .highlight .chroma > code > .hl,

--- a/build/check_page_sizes.py
+++ b/build/check_page_sizes.py
@@ -15,7 +15,11 @@ import sys
 
 logger = logging.getLogger("check_page_sizes")
 
-DEFAULT_WARN_MB = 5.0
+# The heaviest legitimate pages (e.g. the Streams tutorial, with many steps and
+# every client language) land around 7 MB. The default sits above that so the
+# check flags genuine regressions (the bug it guards against produced 40 MB+
+# pages) rather than the expected heavy pages. Override with --warn-mb.
+DEFAULT_WARN_MB = 10.0
 
 
 def parse_args() -> argparse.Namespace:

--- a/build/check_page_sizes.py
+++ b/build/check_page_sizes.py
@@ -39,7 +39,7 @@ def page_sizes(public_dir: str) -> list[tuple[int, str]]:
     sizes: list[tuple[int, str]] = []
     for root, _dirs, files in os.walk(public_dir):
         for name in files:
-            if name == "index.html":
+            if name.endswith(".html"):
                 path = os.path.join(root, name)
                 sizes.append((os.path.getsize(path), os.path.relpath(path, public_dir)))
     sizes.sort(reverse=True)

--- a/build/check_page_sizes.py
+++ b/build/check_page_sizes.py
@@ -1,0 +1,73 @@
+"""Report rendered HTML pages that are unusually large.
+
+Client code examples are pulled from external client-library repos on every
+build, so a page's weight can grow silently when an upstream example file gets
+bigger. This is a passive, post-build check: it scans the rendered ``public/``
+tree and warns about pages over a size threshold. It never mutates anything and,
+by default, never fails the build (exit 0) -- pass ``--fail`` to make CI block
+on offenders instead.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+logger = logging.getLogger("check_page_sizes")
+
+DEFAULT_WARN_MB = 5.0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("public_dir", nargs="?", default="public",
+                        help="path to the rendered site (default: public)")
+    parser.add_argument("--warn-mb", type=float, default=DEFAULT_WARN_MB,
+                        help=f"warn above this size in MB (default: {DEFAULT_WARN_MB})")
+    parser.add_argument("--fail", action="store_true",
+                        help="exit non-zero if any page exceeds the threshold")
+    parser.add_argument("--top", type=int, default=25,
+                        help="how many of the largest pages to list (default: 25)")
+    return parser.parse_args()
+
+
+def page_sizes(public_dir: str) -> list[tuple[int, str]]:
+    sizes: list[tuple[int, str]] = []
+    for root, _dirs, files in os.walk(public_dir):
+        for name in files:
+            if name == "index.html":
+                path = os.path.join(root, name)
+                sizes.append((os.path.getsize(path), os.path.relpath(path, public_dir)))
+    sizes.sort(reverse=True)
+    return sizes
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = parse_args()
+
+    if not os.path.isdir(args.public_dir):
+        logger.error("check_page_sizes: %r is not a directory", args.public_dir)
+        return 1
+
+    threshold = int(args.warn_mb * 1024 * 1024)
+    sizes = page_sizes(args.public_dir)
+    offenders = [(size, rel) for size, rel in sizes if size > threshold]
+
+    if not offenders:
+        logger.info("check_page_sizes: no pages over %.1f MB (%d pages scanned).",
+                    args.warn_mb, len(sizes))
+        return 0
+
+    logger.warning("check_page_sizes: %d page(s) over %.1f MB:",
+                   len(offenders), args.warn_mb)
+    for size, rel in offenders[:args.top]:
+        logger.warning("  %6.1f MB  %s", size / 1024 / 1024, rel)
+    if len(offenders) > args.top:
+        logger.warning("  ... and %d more", len(offenders) - args.top)
+
+    return 1 if args.fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -133,7 +133,7 @@
             {{ $sliceParams := dict "language" $language "contentPath" $examplePath "options" "linenos=false" "sliceRange" $namedRange }}
             {{ $content = partial "tabs/source.html" $sliceParams }}
             {{ $hlRange = $namedRange }}
-            {{ $fullFileKey = substr (md5 $examplePath) 0 10 }}
+            {{ $fullFileKey = md5 $examplePath }}
 
             {{/* Embed the full highlighted file once per page, deduped by file path.
                  .Page.Store persists across a page's output formats; this assumes the
@@ -150,7 +150,7 @@
         {{ else }}
             {{/* Legacy path: whole file with hl_lines (no contiguous per-step range).
                  Embed the file inline once per page; repeats are cloned client-side. */}}
-            {{ $legacyKey := substr (md5 $examplePath) 0 10 }}
+            {{ $legacyKey := md5 $examplePath }}
             {{ $seenLegacy := $.Page.Store.Get "tceLegacyKeys" }}
             {{ if not $seenLegacy }}{{ $seenLegacy = slice }}{{ end }}
             {{ if in $seenLegacy $examplePath }}

--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -95,18 +95,48 @@
 
     {{ if and ($example) $langMatches }}
         {{ $examplePath := index $example "target" }}
-        {{ $options := printf "linenos=false" }}
+        {{ if hasPrefix $language "java" }}{{ $language = "java"}}{{ end }}
 
+        {{/* Per-step contiguous line range (from named_steps) drives slicing. */}}
+        {{ $namedRange := "" }}
         {{ if and (ne $step "") (isset $example "named_steps") (isset $example.named_steps $step) }}
-            {{ $options = printf "%s,hl_lines=%s" $options (index $example.named_steps $step) }}
+            {{ $namedRange = index $example.named_steps $step }}
+        {{ end }}
+        {{ $sliceable := and (ne $namedRange "") (not (strings.Contains $namedRange " ")) (eq (len (split $namedRange "-")) 2) }}
+
+        {{ $content := "" }}
+        {{ $fullFileKey := "" }}
+        {{ $hlRange := "" }}
+        {{ $emitFullTemplate := false }}
+        {{ $fullContent := "" }}
+
+        {{ if $sliceable }}
+            {{/* Default view: only the step's lines, shown in full (no dimming). */}}
+            {{ $sliceParams := dict "language" $language "contentPath" $examplePath "options" "linenos=false" "sliceRange" $namedRange }}
+            {{ $content = partial "tabs/source.html" $sliceParams }}
+            {{ $hlRange = $namedRange }}
+            {{ $fullFileKey = substr (md5 $examplePath) 0 10 }}
+
+            {{/* Embed the full highlighted file once per page, deduped by file path. */}}
+            {{ $seen := $.Page.Store.Get "tceFullKeys" }}
+            {{ if not $seen }}{{ $seen = slice }}{{ end }}
+            {{ if not (in $seen $examplePath) }}
+                {{ $emitFullTemplate = true }}
+                {{ $.Page.Store.Set "tceFullKeys" ($seen | append $examplePath) }}
+                {{ $fullParams := dict "language" $language "contentPath" $examplePath "options" "linenos=false" }}
+                {{ $fullContent = partial "tabs/source.html" $fullParams }}
+            {{ end }}
         {{ else }}
-            {{ if and (isset $example "highlight") (index $example "highlight") }}
+            {{/* Legacy path: whole file with hl_lines (no contiguous per-step range). */}}
+            {{ $options := printf "linenos=false" }}
+            {{ if ne $namedRange "" }}
+                {{ $options = printf "%s,hl_lines=%s" $options $namedRange }}
+            {{ else if and (isset $example "highlight") (index $example "highlight") }}
                 {{ $options = printf "%s,hl_lines=%s" $options (delimit (index $example "highlight") " ") }}
             {{ end }}
+            {{ $params := dict "language" $language "contentPath" $examplePath "options" $options }}
+            {{ $content = partial "tabs/source.html" $params }}
         {{ end }}
-        {{ if hasPrefix $language "java" }}{{ $language = "java"}}{{ end }}
-        {{ $params := dict "language" $language "contentPath" $examplePath "options" $options }}
-        {{ $content := partial "tabs/source.html" $params }}
 
         {{/* Extract binderId if it exists */}}
         {{ $binderId := index $example "binderId" }}
@@ -119,7 +149,7 @@
             {{ $displayName = "JavaScript (ioredis)" }}
         {{ end }}
 
-        {{ $clientTab := dict "title" $client "displayName" $displayName "language" $client "quickstartSlug" $quickstartSlug "content" $content "sourceUrl" (index $example "sourceUrl") "binderId" $binderId }}
+        {{ $clientTab := dict "title" $client "displayName" $displayName "language" $client "quickstartSlug" $quickstartSlug "content" $content "sourceUrl" (index $example "sourceUrl") "binderId" $binderId "fullFileKey" $fullFileKey "hlRange" $hlRange "emitFullTemplate" $emitFullTemplate "fullContent" $fullContent }}
         {{ if gt (len $commands) 0 }}
             {{ $clientTab = merge $clientTab (dict "commands" $commands) }}
         {{ end }}

--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -109,6 +109,8 @@
         {{ $hlRange := "" }}
         {{ $emitFullTemplate := false }}
         {{ $fullContent := "" }}
+        {{ $legacySrcKey := "" }}
+        {{ $legacyCloneKey := "" }}
 
         {{ if $sliceable }}
             {{/* Default view: only the step's lines, shown in full (no dimming). */}}
@@ -127,15 +129,24 @@
                 {{ $fullContent = partial "tabs/source.html" $fullParams }}
             {{ end }}
         {{ else }}
-            {{/* Legacy path: whole file with hl_lines (no contiguous per-step range). */}}
-            {{ $options := printf "linenos=false" }}
-            {{ if ne $namedRange "" }}
-                {{ $options = printf "%s,hl_lines=%s" $options $namedRange }}
-            {{ else if and (isset $example "highlight") (index $example "highlight") }}
-                {{ $options = printf "%s,hl_lines=%s" $options (delimit (index $example "highlight") " ") }}
+            {{/* Legacy path: whole file with hl_lines (no contiguous per-step range).
+                 Embed the file inline once per page; repeats are cloned client-side. */}}
+            {{ $legacyKey := substr (md5 $examplePath) 0 10 }}
+            {{ $seenLegacy := $.Page.Store.Get "tceLegacyKeys" }}
+            {{ if not $seenLegacy }}{{ $seenLegacy = slice }}{{ end }}
+            {{ if in $seenLegacy $examplePath }}
+                {{ $legacyCloneKey = $legacyKey }}
+            {{ else }}
+                {{ $.Page.Store.Set "tceLegacyKeys" ($seenLegacy | append $examplePath) }}
+                {{ $legacySrcKey = $legacyKey }}
+                {{ $options := printf "linenos=false" }}
+                {{ if ne $namedRange "" }}
+                    {{ $options = printf "%s,hl_lines=%s" $options $namedRange }}
+                {{ else if and (isset $example "highlight") (index $example "highlight") }}
+                    {{ $options = printf "%s,hl_lines=%s" $options (delimit (index $example "highlight") " ") }}
+                {{ end }}
+                {{ $content = partial "tabs/source.html" (dict "language" $language "contentPath" $examplePath "options" $options) }}
             {{ end }}
-            {{ $params := dict "language" $language "contentPath" $examplePath "options" $options }}
-            {{ $content = partial "tabs/source.html" $params }}
         {{ end }}
 
         {{/* Extract binderId if it exists */}}
@@ -149,7 +160,7 @@
             {{ $displayName = "JavaScript (ioredis)" }}
         {{ end }}
 
-        {{ $clientTab := dict "title" $client "displayName" $displayName "language" $client "quickstartSlug" $quickstartSlug "content" $content "sourceUrl" (index $example "sourceUrl") "binderId" $binderId "fullFileKey" $fullFileKey "hlRange" $hlRange "emitFullTemplate" $emitFullTemplate "fullContent" $fullContent }}
+        {{ $clientTab := dict "title" $client "displayName" $displayName "language" $client "quickstartSlug" $quickstartSlug "content" $content "sourceUrl" (index $example "sourceUrl") "binderId" $binderId "fullFileKey" $fullFileKey "hlRange" $hlRange "emitFullTemplate" $emitFullTemplate "fullContent" $fullContent "legacySrcKey" $legacySrcKey "legacyCloneKey" $legacyCloneKey }}
         {{ if gt (len $commands) 0 }}
             {{ $clientTab = merge $clientTab (dict "commands" $commands) }}
         {{ end }}

--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -102,7 +102,23 @@
         {{ if and (ne $step "") (isset $example "named_steps") (isset $example.named_steps $step) }}
             {{ $namedRange = index $example.named_steps $step }}
         {{ end }}
-        {{ $sliceable := and (ne $namedRange "") (not (strings.Contains $namedRange " ")) (eq (len (split $namedRange "-")) 2) }}
+        {{/* Slice only for a well-formed, in-bounds "start-end" pair. named_steps is
+             generated from externally-sourced files, so guard against drift: a
+             malformed value (e.g. "5-", "5-x") would crash int and abort the build,
+             and an out-of-bounds start would make source.html fall back to the whole
+             file while the wrapper still emitted a template — double-embedding it. */}}
+        {{ $sliceable := false }}
+        {{ if and (ne $namedRange "") (findRE `^[0-9]+-[0-9]+$` $namedRange) }}
+            {{ $parts := split $namedRange "-" }}
+            {{ $rStart := int (index $parts 0) }}
+            {{ $rEnd := int (index $parts 1) }}
+            {{ if and (ge $rStart 1) (ge $rEnd $rStart) }}
+                {{ $total := len (split (readFile $examplePath) "\n") }}
+                {{ if le $rStart $total }}
+                    {{ $sliceable = true }}
+                {{ end }}
+            {{ end }}
+        {{ end }}
 
         {{ $content := "" }}
         {{ $fullFileKey := "" }}
@@ -119,7 +135,10 @@
             {{ $hlRange = $namedRange }}
             {{ $fullFileKey = substr (md5 $examplePath) 0 10 }}
 
-            {{/* Embed the full highlighted file once per page, deduped by file path. */}}
+            {{/* Embed the full highlighted file once per page, deduped by file path.
+                 .Page.Store persists across a page's output formats; this assumes the
+                 HTML output renders this partial (the .md/.json outputs process raw
+                 content and never invoke it, so they can't mark a file "seen" first). */}}
             {{ $seen := $.Page.Store.Get "tceFullKeys" }}
             {{ if not $seen }}{{ $seen = slice }}{{ end }}
             {{ if not (in $seen $examplePath) }}

--- a/layouts/partials/tabs/README.md
+++ b/layouts/partials/tabs/README.md
@@ -3,4 +3,25 @@
 Some credits:
 
 * Radio tabs: https://www.codeinwp.com/snippets/accessible-pure-css-tabs/
-* Hugo scaffold: https://blog.jverkamp.com/2021/01/27/a-tabbed-view-for-hugo/ 
+* Hugo scaffold: https://blog.jverkamp.com/2021/01/27/a-tabbed-view-for-hugo/
+
+## Client-example code: slice + dedup
+
+`clients-example` panels would otherwise embed the *entire* source file for
+every step and every language, so a long tutorial (e.g. Streams) ballooned to
+tens of MB of HTML. To keep pages small while preserving the eyeball ("show the
+step in the context of the whole file") toggle:
+
+* **Per-step range (`named_steps`):** `source.html` slices the file to the step's
+  contiguous line range and renders only that as the default `.step-code-view`.
+  The full highlighted file is emitted **once per page** in a hidden
+  `<template id="tce-fullsrc-{key}">` (deduped by file path via `.Page.Store`).
+  The panel carries `data-fullfile-key` and `data-hl-range`; the eyeball
+  (`toggleVisibleLinesForCodetabs` in `static/js/codetabs.js`) clones that
+  template on demand, re-tagging the range as `.hl`.
+* **No per-step range (legacy):** the whole file is rendered inline **once per
+  page** (`data-legacy-src`); repeat occurrences are emitted empty
+  (`data-legacy-clone`) and hydrated client-side from that single copy.
+
+Net effect: every distinct source file is embedded at most once per page.
+`build/check_page_sizes.py` (`make check_page_sizes`) guards against regrowth.

--- a/layouts/partials/tabs/README.md
+++ b/layouts/partials/tabs/README.md
@@ -23,5 +23,7 @@ step in the context of the whole file") toggle:
   page** (`data-legacy-src`); repeat occurrences are emitted empty
   (`data-legacy-clone`) and hydrated client-side from that single copy.
 
-Net effect: every distinct source file is embedded at most once per page.
+Net effect: each source file is embedded once per page. (The rare exception is a
+file used by *both* paths on one page — some steps with a range, some without —
+which yields one template plus one legacy copy; harmless and uncommon.)
 `build/check_page_sizes.py` (`make check_page_sizes`) guards against regrowth.

--- a/layouts/partials/tabs/source.html
+++ b/layouts/partials/tabs/source.html
@@ -1,3 +1,19 @@
 {{ $rawContent := readFile .contentPath }}
+{{/* When a contiguous "start-end" sliceRange is given, emit only that slice so the
+     step snippet stays small instead of re-embedding the whole file per step. */}}
+{{ with .sliceRange }}
+  {{ $bounds := split . "-" }}
+  {{ if eq (len $bounds) 2 }}
+    {{ $start := int (index $bounds 0) }}
+    {{ $end := int (index $bounds 1) }}
+    {{ $lines := split $rawContent "\n" }}
+    {{ $total := len $lines }}
+    {{ if and (ge $start 1) (le $start $total) (ge $end $start) }}
+      {{ if gt $end $total }}{{ $end = $total }}{{ end }}
+      {{ $slice := first (add (sub $end $start) 1) (after (sub $start 1) $lines) }}
+      {{ $rawContent = delimit $slice "\n" }}
+    {{ end }}
+  {{ end }}
+{{ end }}
 {{ $content := highlight $rawContent .language .options }}
 {{ return $content }}

--- a/layouts/partials/tabs/source.html
+++ b/layouts/partials/tabs/source.html
@@ -1,19 +1,31 @@
 {{ $rawContent := readFile .contentPath }}
-{{/* When a contiguous "start-end" sliceRange is given, emit only that slice so the
-     step snippet stays small instead of re-embedding the whole file per step. */}}
+{{ $result := "" }}
+{{ $sliced := false }}
+{{/* When a contiguous "start-end" sliceRange is given, highlight the WHOLE file
+     first (so Chroma keeps full lexer context) and then slice the rendered line
+     spans. Slicing the raw text before highlighting would mis-colour a snippet
+     that begins inside a multi-line string or comment. */}}
 {{ with .sliceRange }}
   {{ $bounds := split . "-" }}
   {{ if eq (len $bounds) 2 }}
     {{ $start := int (index $bounds 0) }}
     {{ $end := int (index $bounds 1) }}
-    {{ $lines := split $rawContent "\n" }}
-    {{ $total := len $lines }}
+    {{ $full := highlight $rawContent $.language $.options | string }}
+    {{ $body := replaceRE `</code></pre></div>\s*$` "" $full }}
+    {{ $segs := split $body `<span class="line">` }}
+    {{ $lineSegs := after 1 $segs }}
+    {{ $total := len $lineSegs }}
     {{ if and (ge $start 1) (le $start $total) (ge $end $start) }}
       {{ if gt $end $total }}{{ $end = $total }}{{ end }}
-      {{ $slice := first (add (sub $end $start) 1) (after (sub $start 1) $lines) }}
-      {{ $rawContent = delimit $slice "\n" }}
+      {{ $selected := first (add (sub $end $start) 1) (after (sub $start 1) $lineSegs) }}
+      {{ $out := index $segs 0 }}
+      {{ range $selected }}{{ $out = print $out `<span class="line">` . }}{{ end }}
+      {{ $result = print $out `</code></pre></div>` | safeHTML }}
+      {{ $sliced = true }}
     {{ end }}
   {{ end }}
 {{ end }}
-{{ $content := highlight $rawContent .language .options }}
-{{ return $content }}
+{{ if not $sliced }}
+  {{ $result = highlight $rawContent .language .options }}
+{{ end }}
+{{ return $result }}

--- a/layouts/partials/tabs/wrapper.html
+++ b/layouts/partials/tabs/wrapper.html
@@ -161,10 +161,13 @@
 
         {{ $hasCliTrim := and (eq (index $tab "title") "redis-cli") (index $tab "hasCliTrim") }}
         {{ $cliLimitInt := index $tab "limitInt" }}
+        {{ $fullFileKey := index $tab "fullFileKey" }}
+        {{ $hlRange := index $tab "hlRange" }}
         <div class="panel {{ if ne $i 0 }}panel-hidden{{ end }} w-full mt-0 {{ if not $showFooter}}pb-8{{end}}"
              id="{{ $pid }}"
              data-lang="{{ $dataLang }}"
              {{ if $hasCliTrim }}data-cli-trimmable="true" data-cli-preview-lines="{{ $cliLimitInt }}" style="--cli-preview-lines: {{ $cliLimitInt }};"{{ end }}
+             {{ if $fullFileKey }}data-fullfile-key="{{ $fullFileKey }}"{{ if $hlRange }} data-hl-range="{{ $hlRange }}"{{ end }}{{ end }}
              {{ if $binderId }}data-binder-id="{{ $binderId }}"{{ end }}
              {{ if $commands }}data-required-commands="{{ delimit $commands "," }}"{{ end }}
              data-codetabs-id="{{ $id }}"
@@ -175,6 +178,9 @@
             <div class="cli-output-shell cli-output-shell-trimmable">
                 {{ index $tab "content" }}
             </div>
+            {{ else if $fullFileKey }}
+            <div class="step-code-view">{{ index $tab "content" }}</div>
+            {{ if index $tab "emitFullTemplate" }}<template id="tce-fullsrc-{{ $fullFileKey }}">{{ index $tab "fullContent" }}</template>{{ end }}
             {{ else }}
             {{ index $tab "content" }}
             {{ end }}

--- a/layouts/partials/tabs/wrapper.html
+++ b/layouts/partials/tabs/wrapper.html
@@ -181,6 +181,10 @@
             {{ else if $fullFileKey }}
             <div class="step-code-view">{{ index $tab "content" }}</div>
             {{ if index $tab "emitFullTemplate" }}<template id="tce-fullsrc-{{ $fullFileKey }}">{{ index $tab "fullContent" }}</template>{{ end }}
+            {{ else if index $tab "legacyCloneKey" }}
+            <div class="legacy-clone" data-legacy-clone="{{ index $tab "legacyCloneKey" }}"></div>
+            {{ else if index $tab "legacySrcKey" }}
+            <div data-legacy-src="{{ index $tab "legacySrcKey" }}">{{ index $tab "content" }}</div>
             {{ else }}
             {{ index $tab "content" }}
             {{ end }}

--- a/static/js/codetabs.js
+++ b/static/js/codetabs.js
@@ -180,7 +180,13 @@ function ensureFullFileView(panel) {
   const range = panel.getAttribute('data-hl-range');
   if (range) markHighlightedLines(view, range);
 
-  panel.appendChild(view);
+  // Place the full file where the slice was (before the footer), not at the end.
+  const stepView = panel.querySelector('.step-code-view');
+  if (stepView) {
+    stepView.insertAdjacentElement('afterend', view);
+  } else {
+    panel.appendChild(view);
+  }
   return true;
 }
 

--- a/static/js/codetabs.js
+++ b/static/js/codetabs.js
@@ -198,7 +198,9 @@ function hydrateLegacyClones() {
     if (target.childElementCount > 0) return;
     const key = target.getAttribute('data-legacy-clone');
     const source = document.querySelector('[data-legacy-src="' + key + '"]');
-    if (source) target.innerHTML = source.innerHTML;
+    if (source) {
+      source.childNodes.forEach((node) => target.appendChild(node.cloneNode(true)));
+    }
   });
 }
 

--- a/static/js/codetabs.js
+++ b/static/js/codetabs.js
@@ -141,6 +141,49 @@ function toggleVisibleLines(evt) {
     .toggleAttribute('aria-expanded');
 }
 
+// Mark the lines covered by a Chroma hl_lines-style range (e.g. "11-14" or
+// "11-14 20-22") as highlighted, so the dimming CSS treats them as the step.
+function markHighlightedLines(view, range) {
+  let lines = view.querySelectorAll('.chroma > code > .line');
+  if (lines.length === 0) {
+    lines = view.querySelectorAll('.chroma > .lntable .lntd code > .line');
+  }
+  if (lines.length === 0) return;
+
+  range.trim().split(/\s+/).forEach((part) => {
+    const bounds = part.split('-');
+    const start = parseInt(bounds[0], 10);
+    const end = bounds.length > 1 ? parseInt(bounds[1], 10) : start;
+    if (isNaN(start)) return;
+    const last = isNaN(end) ? start : end;
+    for (let i = start; i <= last; i++) {
+      const line = lines[i - 1];
+      if (line) line.classList.add('hl');
+    }
+  });
+}
+
+// Lazily build the full-file view for a sliced-snippet panel by cloning the
+// page's deduped <template> for this file. Returns true once the view exists.
+function ensureFullFileView(panel) {
+  const key = panel.getAttribute('data-fullfile-key');
+  if (!key) return false;
+  if (panel.querySelector('.full-file-view')) return true;
+
+  const template = document.getElementById('tce-fullsrc-' + key);
+  if (!template || !template.content) return false;
+
+  const view = document.createElement('div');
+  view.className = 'full-file-view';
+  view.appendChild(template.content.cloneNode(true));
+
+  const range = panel.getAttribute('data-hl-range');
+  if (range) markHighlightedLines(view, range);
+
+  panel.appendChild(view);
+  return true;
+}
+
 function toggleVisibleLinesForCodetabs(button) {
   const codetabsId = button.getAttribute('data-codetabs-id');
   const codetabsContainer = document.getElementById(codetabsId);
@@ -153,6 +196,12 @@ function toggleVisibleLinesForCodetabs(button) {
 
   if (visiblePanel.getAttribute('data-lang') === 'redis-cli') {
     return;
+  }
+
+  // Sliced-snippet panels keep only the step in the DOM; build the full file
+  // from the deduped template the first time it is revealed.
+  if (!visiblePanel.hasAttribute('aria-expanded')) {
+    ensureFullFileView(visiblePanel);
   }
 
   // Toggle aria-expanded attribute

--- a/static/js/codetabs.js
+++ b/static/js/codetabs.js
@@ -184,6 +184,18 @@ function ensureFullFileView(panel) {
   return true;
 }
 
+// Repeat occurrences of a whole-file (no per-step range) example are emitted
+// empty; hydrate them by cloning the page's single static copy so the file is
+// embedded only once per page.
+function hydrateLegacyClones() {
+  document.querySelectorAll('[data-legacy-clone]').forEach((target) => {
+    if (target.childElementCount > 0) return;
+    const key = target.getAttribute('data-legacy-clone');
+    const source = document.querySelector('[data-legacy-src="' + key + '"]');
+    if (source) target.innerHTML = source.innerHTML;
+  });
+}
+
 function toggleVisibleLinesForCodetabs(button) {
   const codetabsId = button.getAttribute('data-codetabs-id');
   const codetabsContainer = document.getElementById(codetabsId);
@@ -322,6 +334,9 @@ function onchangeCodeTab(e) {
 
 // Initialize codetabs - script is deferred so DOM is already ready
 (function initCodetabs() {
+  // Fill repeat whole-file panels from the page's single static copy.
+  hydrateLegacyClones();
+
   // Helper function to normalize language names to match dropdown values
   function normalizeLangParam(langParam) {
     if (!langParam) return null;


### PR DESCRIPTION
Fixes #3398.

## Problem

`layouts/partials/tabs/source.html` read and highlighted the **entire** example
source file for **every step** and **every client language**. The per-step
`named_steps` range was passed only as `hl_lines` (a visual highlight), so Chroma
still emitted the whole file each time. The Streams tutorial (34 steps × all
clients) rendered to a **~41 MB** HTML document that froze browser tabs and broke
tools that fetch the page. It affects ~100 client-example pages; Streams is just
the worst.

## Approach

This implements the slice + hidden full-file `<template>` + eyeball-clone approach
outlined by the maintainers in #3398. The goal is to keep the "eyeball" toggle
(show the step in the context of the whole file) while embedding each source file
**at most once per page**:

- **Per-step range:** slice the file to the step's contiguous `named_steps` range
  and render only that as the default `.step-code-view`. The full highlighted file
  is emitted **once per page** in a hidden `<template id="tce-fullsrc-{key}">`
  (deduped by file path via `.Page.Store`). The eyeball
  (`toggleVisibleLinesForCodetabs`) clones that template on demand and re-tags the
  step's lines as `.hl`; existing dimming CSS handles the rest.
- **No per-step range (legacy):** render the whole file inline once
  (`data-legacy-src`); repeat occurrences on the same page are emitted empty
  (`data-legacy-clone`) and hydrated client-side from that single copy.
- **Highlighting:** the whole file is highlighted first (full lexer context) and
  the rendered `<span class="line">` segments are sliced — slicing raw text before
  Chroma would mis-colour a snippet that starts inside a multi-line string/comment.

Panels with no contiguous range and the `redis-cli` tab are otherwise unchanged;
all new CSS/JS is scoped to `data-fullfile-key`, so other code blocks are untouched.

## Impact (local build, all client languages incl. Rust)

| page | before | after |
|------|-------:|------:|
| data-types/streams | 41.6 MB | 7.3 MB |
| data-types/lists | 15.7 MB | 6.8 MB |
| data-types/json/path | 11.9 MB | 3.1 MB |

No page exceeds 10 MB after the change (5,600+ pages). A warn-only
`build/check_page_sizes.py` (`make check_page_sizes`) guards against silent
regrowth when example files are re-pulled from upstream client repos.

## Testing

- Full `hugo` build clean (0 errors); build time unchanged (~18 s).
- Slice highlighting compared token-for-token against full-file context across
  11k+ slice lines in 8 languages — 0 mismatches.
- Eyeball expand/collapse, line highlighting, copy-to-clipboard, language
  switching, and legacy-clone hydration verified in-browser and headlessly.
- Range validation guards against malformed/out-of-bounds `named_steps` values
  (which would otherwise abort the build or double-embed a file).

## Known limitation

A file used by **both** the ranged and legacy paths on the same page is embedded
twice (one template + one legacy copy) — ~191 KB on `timeseries` (amplified by a
duplicate `STEP_START` marker upstream in the go-redis example) and ~14 KB on
`lettuce/vecsets`. Uncommon and small; noted in `layouts/partials/tabs/README.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Hugo templates and client-side codetabs behavior on many tutorial pages; regressions could affect highlighting, expand/collapse, or copy—but changes are scoped to `data-fullfile-key`/legacy markers and include build-time range guards.
> 
> **Overview**
> **Fixes oversized tutorial HTML** by stopping repeated full-file Chroma output for every step and client language on `clients-example` pages (e.g. Streams ~42 MB → ~7 MB).
> 
> **Per-step `named_steps` ranges:** `source.html` highlights the whole file for lexer context, then slices rendered line spans to the step range for the default view. `tabbed-clients-example.html` emits that slice in `.step-code-view`, stores one deduped full file per path in a hidden `<template>` (`.Page.Store`), and validates ranges so bad upstream metadata cannot break the build or double-embed. The eyeball toggle in `codetabs.js` clones the template into `.full-file-view` and applies `.hl` from `data-hl-range`; CSS under `data-fullfile-key` switches slice vs full file and dims context lines.
> 
> **Legacy steps without a contiguous range:** the whole file is inlined once (`data-legacy-src`); later tabs use `data-legacy-clone` and `hydrateLegacyClones()` on load.
> 
> Adds warn-only **`make check_page_sizes`** (`build/check_page_sizes.py`, default 10 MB) and documents the behavior in `layouts/partials/tabs/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7065b41e121a98c6d06eac50a9c393c5b50af060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->