### PR TITLE
DOC-6740 improve Claude hook with relrefs

### DIFF
--- a/.claude/hooks/check_shortcode_paths.py
+++ b/.claude/hooks/check_shortcode_paths.py
@@ -36,11 +36,16 @@ from collections import Counter
 # (name, regex capturing the path in group 1, resolver key). The pre-attribute
 # wildcard is [^}] (not [^>]) so a '>' inside an earlier attribute value (e.g.
 # alt="A > B") doesn't hide a later filename=/image=.
+# The pre-attribute body uses a tempered match (?:(?!\}\}).)*? — "any char until
+# the shortcode's closing }}" — so a '>' or '}' inside an earlier attribute value
+# (e.g. alt="A > B", alt="hash {slot}") can't hide a later filename=/image=, and
+# the match can't bleed into the next shortcode. (?![\w-]) stops "image" matching
+# "image-card".
 HARD_RULES = [
-    ("image",      re.compile(r'\{\{[<%]\s*image\s+[^}]*?\bfilename\s*=\s*["\']([^"\']+)["\']'), "static"),
-    ("image-card", re.compile(r'\{\{[<%]\s*image-card\s+[^}]*?\bimage\s*=\s*["\']([^"\']+)["\']'), "static"),
+    ("image",      re.compile(r'\{\{[<%]\s*image(?![\w-])(?:(?!\}\}).)*?\bfilename\s*=\s*["\']([^"\']+)["\']'), "static"),
+    ("image-card", re.compile(r'\{\{[<%]\s*image-card(?![\w-])(?:(?!\}\}).)*?\bimage\s*=\s*["\']([^"\']+)["\']'), "static"),
     ("embed-code", re.compile(r'\{\{[<%]\s*embed-code\s+["\']([^"\']+)["\']'), "static-code"),
-    ("embed-yaml", re.compile(r'\{\{[<%]\s*embed-yaml\s+["\']([^"\']+)["\']'), "embeds"),
+    ("embed-yaml", re.compile(r'\{\{[<%]\s*embed-yaml\s+["\']([^"\']+)["\']'), "embed-yaml"),
     ("embed-md",   re.compile(r'\{\{[<%]\s*embed-md\s+["\']([^"\']+)["\']'), "embeds"),
 ]
 
@@ -112,13 +117,21 @@ def resolve_static(root, ref, src_file):
     )
 
 
-def resolve_static_code(root, ref, _src):
-    rel = _strip_dots(_strip_frag(ref).lstrip("/"))
-    return exists_exact_any(os.path.join(root, "static", "code", rel),
-                            os.path.join(root, "static", "code", os.path.basename(rel)))
+def resolve_embed_code(root, ref, _src):
+    # embed-code does readFile "./static/code/<arg>" exactly, so the check is
+    # exact (and case-strict): no basename/extension/fragment leniency, which
+    # Hugo's readFile does not allow. Exact can't false-block a Hugo-valid embed.
+    return _exists_exact(os.path.join(root, "static", "code", ref.lstrip("/")))
+
+
+def resolve_embed_yaml(root, ref, _src):
+    # embed-yaml does readFile "./content/embeds/<arg>" exactly -> same exact check.
+    return _exists_exact(os.path.join(root, "content", "embeds", ref.lstrip("/")))
 
 
 def resolve_embeds(root, ref, _src):
+    # embed-md resolves via .Site.GetPage, which IS lenient (extensionless,
+    # basename, etc.), so accept the broader candidate set here.
     rel = _strip_frag(ref).lstrip("/")
     base = os.path.basename(rel)
     cands = []
@@ -133,7 +146,8 @@ def resolve_embeds(root, ref, _src):
 
 RESOLVERS = {
     "static": resolve_static,
-    "static-code": resolve_static_code,
+    "static-code": resolve_embed_code,
+    "embed-yaml": resolve_embed_yaml,
     "embeds": resolve_embeds,
 }
 
@@ -205,7 +219,11 @@ def _base_resolves(base):
     # block on case alone (this is the false-block-averse direction for links).
     parent, want = os.path.dirname(base), os.path.basename(base).lower()
     if os.path.isdir(parent):
-        for e in os.listdir(parent):
+        try:
+            entries = os.listdir(parent)
+        except OSError:
+            return True  # parent exists but unlistable -> fail open, don't block
+        for e in entries:
             stem = e[:-3] if e.endswith(".md") else e
             if stem.lower() == want:
                 return True
@@ -347,4 +365,7 @@ def run_hook():
 if __name__ == "__main__":
     if "--scan" in sys.argv:
         sys.exit(run_scan(sys.argv[1:]))
-    sys.exit(run_hook())
+    try:
+        sys.exit(run_hook())
+    except Exception:
+        sys.exit(0)  # never block an edit because of a hook bug (fail open)

--- a/.claude/hooks/check_shortcode_paths.py
+++ b/.claude/hooks/check_shortcode_paths.py
@@ -10,15 +10,19 @@ Two modes:
   * Scan mode (--scan [paths...] | --scan --all): validates the given files (or
     every content/**/*.md when --all) and prints a report. Used for dry-runs.
 
+Guiding principle: a false block is worse than a missed catch. When resolution
+is uncertain the hook errs toward NOT blocking.
+
 What gets checked:
   * file refs (image / image-card image / embed-code / embed-yaml / embed-md) —
     these point at concrete files (static/ or content/embeds/); a miss is a real
-    build bug, so it always blocks.
+    build bug, so it always blocks. File-ref existence is case-exact at the leaf
+    so wrong-case paths (which fail on a case-sensitive build host) are caught.
   * relref links — only ABSOLUTE targets (e.g. "/develop/clients/foo"), and only
     those the current edit INTRODUCED (diff-scoped against git HEAD). Relative
-    refs are skipped: Hugo's global-lookup fallback can't be replicated cheaply,
-    and that's where false positives live. Resolution is a plain filesystem
-    check (no page index, no front-matter parsing) — see resolve_relref.
+    refs are skipped (Hugo's global-lookup fallback can't be replicated cheaply).
+    Resolution is a plain filesystem check that also follows Hugo module mounts
+    (config.toml [[module.mounts]]) so mounted content isn't wrongly flagged.
 """
 
 import sys
@@ -27,11 +31,14 @@ import re
 import json
 import glob
 import subprocess
+from collections import Counter
 
-# (name, regex capturing the path in group 1, resolver key)
+# (name, regex capturing the path in group 1, resolver key). The pre-attribute
+# wildcard is [^}] (not [^>]) so a '>' inside an earlier attribute value (e.g.
+# alt="A > B") doesn't hide a later filename=/image=.
 HARD_RULES = [
-    ("image",      re.compile(r'\{\{[<%]\s*image\s+[^>]*?\bfilename\s*=\s*["\']([^"\']+)["\']'), "static"),
-    ("image-card", re.compile(r'\{\{[<%]\s*image-card\s+[^>]*?\bimage\s*=\s*["\']([^"\']+)["\']'), "static"),
+    ("image",      re.compile(r'\{\{[<%]\s*image\s+[^}]*?\bfilename\s*=\s*["\']([^"\']+)["\']'), "static"),
+    ("image-card", re.compile(r'\{\{[<%]\s*image-card\s+[^}]*?\bimage\s*=\s*["\']([^"\']+)["\']'), "static"),
     ("embed-code", re.compile(r'\{\{[<%]\s*embed-code\s+["\']([^"\']+)["\']'), "static-code"),
     ("embed-yaml", re.compile(r'\{\{[<%]\s*embed-yaml\s+["\']([^"\']+)["\']'), "embeds"),
     ("embed-md",   re.compile(r'\{\{[<%]\s*embed-md\s+["\']([^"\']+)["\']'), "embeds"),
@@ -61,6 +68,24 @@ def exists_any(*paths):
     return any(os.path.exists(p) for p in paths)
 
 
+def _exists_exact(p):
+    """os.path.exists, but also require the final path component's case to match
+    what's stored on disk, so wrong-case refs that fail on a case-sensitive build
+    host are caught. Falls back to True if the parent can't be listed, so it never
+    invents a false 'missing' (no false block)."""
+    if not os.path.exists(p):
+        return False
+    parent = os.path.dirname(p) or "."
+    try:
+        return os.path.basename(p) in os.listdir(parent)
+    except OSError:
+        return True
+
+
+def exists_exact_any(*paths):
+    return any(_exists_exact(p) for p in paths)
+
+
 def _strip_frag(ref):
     return re.split(r"[#?]", ref, 1)[0]
 
@@ -77,7 +102,7 @@ def resolve_static(root, ref, src_file):
     rel = ref.lstrip("/")
     stripped = _strip_dots(rel)
     cur = os.path.dirname(os.path.abspath(src_file))
-    return exists_any(
+    return exists_exact_any(
         os.path.join(root, "static", stripped),
         os.path.join(root, "assets", stripped),
         os.path.join(root, "content", stripped),  # page-bundle resource
@@ -89,8 +114,8 @@ def resolve_static(root, ref, src_file):
 
 def resolve_static_code(root, ref, _src):
     rel = _strip_dots(_strip_frag(ref).lstrip("/"))
-    return exists_any(os.path.join(root, "static", "code", rel),
-                      os.path.join(root, "static", "code", os.path.basename(rel)))
+    return exists_exact_any(os.path.join(root, "static", "code", rel),
+                            os.path.join(root, "static", "code", os.path.basename(rel)))
 
 
 def resolve_embeds(root, ref, _src):
@@ -103,7 +128,7 @@ def resolve_embeds(root, ref, _src):
         cands.append(c)
         if not c.endswith(".md"):
             cands.append(c + ".md")  # GetPage resolves extensionless refs
-    return exists_any(*cands)
+    return exists_exact_any(*cands)
 
 
 RESOLVERS = {
@@ -113,10 +138,50 @@ RESOLVERS = {
 }
 
 
+# ---- relref resolution (absolute only) ----------------------------------------
+
+_MOUNTS_CACHE = {}
+
+
+def _load_mounts(root):
+    """Parse [[module.mounts]] source/target pairs from config.toml so relrefs to
+    mounted (target) paths can be remapped to their physical (source) location.
+    Returns [(target_rel, source_rel)] with the leading path kept as written."""
+    mounts = []
+    try:
+        text = open(os.path.join(root, "config.toml"), encoding="utf-8").read()
+    except OSError:
+        return mounts
+    for block in re.split(r"\[\[module\.mounts\]\]", text)[1:]:
+        block = re.split(r"\n\s*\[", block)[0]  # stop at next table
+        s = re.search(r'source\s*=\s*"([^"]+)"', block)
+        t = re.search(r'target\s*=\s*"([^"]+)"', block)
+        if s and t:
+            mounts.append((t.group(1).strip("/"), s.group(1).strip("/")))
+    return mounts
+
+
+def _mounts(root):
+    if root not in _MOUNTS_CACHE:
+        _MOUNTS_CACHE[root] = _load_mounts(root)
+    return _MOUNTS_CACHE[root]
+
+
+def _mount_variants(path, root):
+    """A content-relative path plus any module-mount source equivalents."""
+    variants = [path]
+    full = "content/" + path
+    for target_rel, source_rel in _mounts(root):
+        if full == target_rel or full.startswith(target_rel + "/"):
+            remapped = source_rel + full[len(target_rel):]
+            if remapped.startswith("content/"):
+                variants.append(remapped[len("content/"):])
+    return variants
+
+
 def is_abs_relref(ref):
     """Only absolute, internal targets are resolvable confidently from disk."""
-    p = _strip_frag(ref).strip()
-    return p.startswith("/")
+    return _strip_frag(ref).strip().startswith("/")
 
 
 def _norm_relref(ref):
@@ -131,20 +196,13 @@ def _norm_relref(ref):
     return path
 
 
-def resolve_relref(root, ref):
-    """Resolve an ABSOLUTE relref to a content page by trying the handful of
-    filesystem forms a Hugo logical path can take. No index, no front matter."""
-    path = _norm_relref(ref).lstrip("/")
-    if not path:
-        return True  # site root / current section
-    base = os.path.join(root, "content", path)
+def _base_resolves(base):
     if os.path.isdir(base) or exists_any(
-        base + ".md",
-        os.path.join(base, "_index.md"),
-        os.path.join(base, "index.md"),
+        base + ".md", os.path.join(base, "_index.md"), os.path.join(base, "index.md")
     ):
         return True
-    # case-insensitive fallback (the filesystem may be case-sensitive on CI)
+    # case-insensitive fallback: relref URLs are case-folded by Hugo, so don't
+    # block on case alone (this is the false-block-averse direction for links).
     parent, want = os.path.dirname(base), os.path.basename(base).lower()
     if os.path.isdir(parent):
         for e in os.listdir(parent):
@@ -154,10 +212,25 @@ def resolve_relref(root, ref):
     return False
 
 
+def resolve_relref(root, ref):
+    """Resolve an ABSOLUTE relref to a content page by trying the handful of
+    filesystem forms a Hugo logical path can take, following module mounts. No
+    page index, no front-matter parsing."""
+    path = _norm_relref(ref).lstrip("/")
+    if not path:
+        return True  # site root / current section
+    return any(_base_resolves(os.path.join(root, "content", cand))
+               for cand in _mount_variants(path, root))
+
+
+# ---- diff scoping --------------------------------------------------------------
+
 def head_relrefs(path, root):
-    """relref targets in the committed (HEAD) version of the file, so only links
-    the current edit introduced get flagged. Returns None when the file isn't in
-    HEAD (new/untracked) or git is unavailable -> then every relref is checked."""
+    """relref targets in the committed (HEAD) version of the file. Returns:
+      * a list of ref strings  -> file is in HEAD; diff against it.
+      * "NEW"                  -> file is genuinely new/untracked; check all refs.
+      * None                   -> git unavailable/timeout/other error; SKIP relref
+                                  checks entirely (fail safe -> never false-block)."""
     rel = os.path.relpath(os.path.abspath(path), root)
     try:
         out = subprocess.run(
@@ -166,16 +239,21 @@ def head_relrefs(path, root):
         )
     except Exception:
         return None
-    if out.returncode != 0:
-        return None
-    return set(RELREF_RX.findall(out.stdout))
+    if out.returncode == 0:
+        return RELREF_RX.findall(out.stdout)
+    err = (out.stderr or "").lower()
+    if "does not exist in" in err or "exists on disk, but not in" in err:
+        return "NEW"  # confirmed new file -> check every relref
+    return None       # not a repo / other failure -> skip relref to avoid false blocks
 
 
-def check_file(path, root, prior_relrefs=None):
+def check_file(path, root, prior):
     """Return (broken, bad_links).
       broken    = image/embed file refs that don't exist (always checked).
-      bad_links = absolute relrefs that don't resolve, minus any already present
-                  in prior_relrefs (so only newly-added links are flagged).
+      bad_links = absolute relrefs that don't resolve. prior controls relref scope:
+                  None  -> skip relref entirely;
+                  "NEW" -> check every relref (new file / dry-run);
+                  list  -> check only occurrences beyond those already in HEAD.
     """
     try:
         with open(path, encoding="utf-8") as f:
@@ -189,11 +267,14 @@ def check_file(path, root, prior_relrefs=None):
             if not RESOLVERS[key](root, ref, path):
                 broken.append((name, ref))
     bad_links = []
-    if not RELREF_DISABLED:
+    if not RELREF_DISABLED and prior is not None:
+        prior_counts = Counter() if prior == "NEW" else Counter(prior)
+        seen = Counter()
         for m in RELREF_RX.finditer(text):
             ref = m.group(1)
-            if prior_relrefs is not None and ref in prior_relrefs:
-                continue  # pre-existing link, not introduced by this edit
+            seen[ref] += 1
+            if seen[ref] <= prior_counts.get(ref, 0):
+                continue  # this occurrence already existed in HEAD
             if not is_abs_relref(ref):
                 continue  # relative / pure-anchor -> skip (can't resolve cheaply)
             if not resolve_relref(root, ref):
@@ -212,8 +293,8 @@ def run_scan(argv):
     sample_broken, sample_links = [], []
     by_type = {}
     for fp in files:
-        # scan mode checks ALL relrefs (prior=None), not just newly-added ones
-        broken, bad_links = check_file(fp, root, None)
+        # scan mode checks ALL relrefs ("NEW"), not just newly-added ones
+        broken, bad_links = check_file(fp, root, "NEW")
         if broken or bad_links:
             files_with_issue += 1
         if broken:
@@ -227,7 +308,7 @@ def run_scan(argv):
             for sc, ref in bad_links:
                 if len(sample_links) < 40:
                     sample_links.append(f"{os.path.relpath(fp, root)}: {sc} -> {ref}")
-    print(f"Scanned {len(files)} files under {root}")
+    print(f"Scanned {len(files)} files under {root}  ({files_with_issue} with issues)")
     print(f"BROKEN file refs: {total_broken}  {dict(sorted(by_type.items()))}")
     print(f"BROKEN relref links (absolute, all): {total_links}")
     if sample_broken:

--- a/.claude/hooks/check_shortcode_paths.py
+++ b/.claude/hooks/check_shortcode_paths.py
@@ -5,16 +5,20 @@ a doc build.
 
 Two modes:
   * Hook mode (default): reads the PostToolUse JSON blob on stdin, pulls
-    tool_input.file_path, validates that one markdown file. On a hard failure it
+    tool_input.file_path, validates that one markdown file. On a failure it
     prints to stderr and exits 2, which feeds the message back to Claude.
   * Scan mode (--scan [paths...] | --scan --all): validates the given files (or
     every content/**/*.md when --all) and prints a report. Used for dry-runs.
 
-Severity:
-  * hard  — image/image-card(image)/embed-code/embed-yaml/embed-md. These point
-            at concrete files (static/ or content/embeds/); a miss is a real bug.
-  * soft  — relref/image-card(url). Resolution is fuzzier (Hugo's GetPage does
-            section/anchor/relative magic), so misses are warnings only.
+What gets checked:
+  * file refs (image / image-card image / embed-code / embed-yaml / embed-md) —
+    these point at concrete files (static/ or content/embeds/); a miss is a real
+    build bug, so it always blocks.
+  * relref links — only ABSOLUTE targets (e.g. "/develop/clients/foo"), and only
+    those the current edit INTRODUCED (diff-scoped against git HEAD). Relative
+    refs are skipped: Hugo's global-lookup fallback can't be replicated cheaply,
+    and that's where false positives live. Resolution is a plain filesystem
+    check (no page index, no front-matter parsing) — see resolve_relref.
 """
 
 import sys
@@ -22,6 +26,7 @@ import os
 import re
 import json
 import glob
+import subprocess
 
 # (name, regex capturing the path in group 1, resolver key)
 HARD_RULES = [
@@ -31,16 +36,11 @@ HARD_RULES = [
     ("embed-yaml", re.compile(r'\{\{[<%]\s*embed-yaml\s+["\']([^"\']+)["\']'), "embeds"),
     ("embed-md",   re.compile(r'\{\{[<%]\s*embed-md\s+["\']([^"\']+)["\']'), "embeds"),
 ]
-# relref/image-card url resolution can't be replicated faithfully without Hugo
-# (global lookup, aliases, generated /commands pages), and Hugo itself only WARNs
-# on broken relrefs (config.toml: refLinksErrorLevel = "WARNING"). So these are
-# OFF by default to keep the hook false-positive-free. Flip CHECK_RELREF to True
-# (or set CHECK_SHORTCODE_RELREF=1 in the env) to surface them as non-blocking notes.
-CHECK_RELREF = os.environ.get("CHECK_SHORTCODE_RELREF") == "1"
-SOFT_RULES = [
-    ("relref",         re.compile(r'\{\{[<%]\s*relref\s+["\']([^"\']+)["\']'), "relref"),
-    ("image-card-url", re.compile(r'\{\{[<%]\s*image-card\s+[^>]*?\burl\s*=\s*["\']([^"\']+)["\']'), "relref"),
-]
+
+# relref is validated only for ABSOLUTE targets, diff-scoped to links the current
+# edit introduced (see head_relrefs). Set SHORTCODE_SKIP_RELREF=1 to turn it off.
+RELREF_DISABLED = os.environ.get("SHORTCODE_SKIP_RELREF") == "1"
+RELREF_RX = re.compile(r'\{\{[<%]\s*relref\s+["\']([^"\']+)["\']')
 
 
 def find_root(start):
@@ -106,67 +106,99 @@ def resolve_embeds(root, ref, _src):
     return exists_any(*cands)
 
 
-def resolve_relref(root, ref, src_file):
-    # strip anchor / query, then trailing slash
-    path = _strip_frag(ref).rstrip("/")
-    if not path:
-        return True  # pure anchor ref to current page
-    if path.startswith("/"):
-        bases = [os.path.join(root, "content", path.lstrip("/"))]
-    else:
-        cur = os.path.dirname(os.path.abspath(src_file))
-        bases = [os.path.join(cur, path), os.path.join(root, "content", path)]
-    candidates = []
-    for b in bases:
-        if b.endswith(".md"):
-            candidates.append(b)  # ref already carried the .md extension
-        else:
-            candidates += [b + ".md", os.path.join(b, "_index.md"), os.path.join(b, "index.md")]
-            if os.path.isdir(b):
-                candidates.append(b)  # section dir served without an _index.md
-    if exists_any(*candidates):
-        return True
-    # case-insensitive fallback (Hugo is lenient about case)
-    lc = {c.lower() for c in candidates}
-    for b in bases:
-        parent = os.path.dirname(b)
-        if os.path.isdir(parent):
-            for entry in os.listdir(parent):
-                if os.path.join(parent, entry).lower() in lc:
-                    return True
-    return False
-
-
 RESOLVERS = {
     "static": resolve_static,
     "static-code": resolve_static_code,
     "embeds": resolve_embeds,
-    "relref": resolve_relref,
 }
 
 
-def check_file(path, root):
-    """Return (hard_misses, soft_misses) as lists of (shortcode, ref)."""
+def is_abs_relref(ref):
+    """Only absolute, internal targets are resolvable confidently from disk."""
+    p = _strip_frag(ref).strip()
+    return p.startswith("/")
+
+
+def _norm_relref(ref):
+    """Reduce a relref target to a logical content path: drop anchor/query, a
+    trailing slash, an author-written /index.md|/_index.md|/index|/_index, or .md."""
+    path = _strip_frag(ref).rstrip("/")
+    for suf in ("/index.md", "/_index.md", "/index", "/_index"):
+        if path.endswith(suf):
+            return path[: -len(suf)]
+    if path.endswith(".md"):
+        path = path[:-3]
+    return path
+
+
+def resolve_relref(root, ref):
+    """Resolve an ABSOLUTE relref to a content page by trying the handful of
+    filesystem forms a Hugo logical path can take. No index, no front matter."""
+    path = _norm_relref(ref).lstrip("/")
+    if not path:
+        return True  # site root / current section
+    base = os.path.join(root, "content", path)
+    if os.path.isdir(base) or exists_any(
+        base + ".md",
+        os.path.join(base, "_index.md"),
+        os.path.join(base, "index.md"),
+    ):
+        return True
+    # case-insensitive fallback (the filesystem may be case-sensitive on CI)
+    parent, want = os.path.dirname(base), os.path.basename(base).lower()
+    if os.path.isdir(parent):
+        for e in os.listdir(parent):
+            stem = e[:-3] if e.endswith(".md") else e
+            if stem.lower() == want:
+                return True
+    return False
+
+
+def head_relrefs(path, root):
+    """relref targets in the committed (HEAD) version of the file, so only links
+    the current edit introduced get flagged. Returns None when the file isn't in
+    HEAD (new/untracked) or git is unavailable -> then every relref is checked."""
+    rel = os.path.relpath(os.path.abspath(path), root)
+    try:
+        out = subprocess.run(
+            ["git", "-C", root, "show", f"HEAD:{rel}"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception:
+        return None
+    if out.returncode != 0:
+        return None
+    return set(RELREF_RX.findall(out.stdout))
+
+
+def check_file(path, root, prior_relrefs=None):
+    """Return (broken, bad_links).
+      broken    = image/embed file refs that don't exist (always checked).
+      bad_links = absolute relrefs that don't resolve, minus any already present
+                  in prior_relrefs (so only newly-added links are flagged).
+    """
     try:
         with open(path, encoding="utf-8") as f:
             text = f.read()
     except (OSError, UnicodeDecodeError):
         return [], []
-    hard, soft = [], []
+    broken = []
     for name, rx, key in HARD_RULES:
         for m in rx.finditer(text):
             ref = m.group(1)
             if not RESOLVERS[key](root, ref, path):
-                hard.append((name, ref))
-    if CHECK_RELREF:
-        for name, rx, key in SOFT_RULES:
-            for m in rx.finditer(text):
-                ref = m.group(1)
-                if ref.startswith(("http://", "https://", "//", "mailto:")):
-                    continue
-                if not RESOLVERS[key](root, ref, path):
-                    soft.append((name, ref))
-    return hard, soft
+                broken.append((name, ref))
+    bad_links = []
+    if not RELREF_DISABLED:
+        for m in RELREF_RX.finditer(text):
+            ref = m.group(1)
+            if prior_relrefs is not None and ref in prior_relrefs:
+                continue  # pre-existing link, not introduced by this edit
+            if not is_abs_relref(ref):
+                continue  # relative / pure-anchor -> skip (can't resolve cheaply)
+            if not resolve_relref(root, ref):
+                bad_links.append(("relref", ref))
+    return broken, bad_links
 
 
 def run_scan(argv):
@@ -176,32 +208,34 @@ def run_scan(argv):
     else:
         files = [a for a in argv if a != "--scan"]
         root = (find_root(files[0]) if files else find_root(os.getcwd())) or os.getcwd()
-    total_hard = total_soft = files_with_hard = 0
-    sample_hard, sample_soft = [], []
+    total_broken = total_links = files_with_issue = 0
+    sample_broken, sample_links = [], []
     by_type = {}
     for fp in files:
-        hard, soft = check_file(fp, root)
-        if hard:
-            files_with_hard += 1
-            total_hard += len(hard)
-            for sc, ref in hard:
+        # scan mode checks ALL relrefs (prior=None), not just newly-added ones
+        broken, bad_links = check_file(fp, root, None)
+        if broken or bad_links:
+            files_with_issue += 1
+        if broken:
+            total_broken += len(broken)
+            for sc, ref in broken:
                 by_type[sc] = by_type.get(sc, 0) + 1
-                if len(sample_hard) < 40:
-                    sample_hard.append(f"{os.path.relpath(fp, root)}: {sc} -> {ref}")
-        if soft:
-            total_soft += len(soft)
-            for sc, ref in soft:
-                if len(sample_soft) < 40:
-                    sample_soft.append(f"{os.path.relpath(fp, root)}: {sc} -> {ref}")
+                if len(sample_broken) < 40:
+                    sample_broken.append(f"{os.path.relpath(fp, root)}: {sc} -> {ref}")
+        if bad_links:
+            total_links += len(bad_links)
+            for sc, ref in bad_links:
+                if len(sample_links) < 40:
+                    sample_links.append(f"{os.path.relpath(fp, root)}: {sc} -> {ref}")
     print(f"Scanned {len(files)} files under {root}")
-    print(f"HARD misses: {total_hard} across {files_with_hard} files  {dict(sorted(by_type.items()))}")
-    print(f"SOFT misses: {total_soft}")
-    if sample_hard:
-        print("\n--- sample HARD misses (these would block an edit) ---")
-        print("\n".join(sample_hard))
-    if sample_soft:
-        print("\n--- sample SOFT misses (warn only) ---")
-        print("\n".join(sample_soft))
+    print(f"BROKEN file refs: {total_broken}  {dict(sorted(by_type.items()))}")
+    print(f"BROKEN relref links (absolute, all): {total_links}")
+    if sample_broken:
+        print("\n--- sample broken file refs (always block) ---")
+        print("\n".join(sample_broken))
+    if sample_links:
+        print("\n--- sample broken absolute relrefs (block only when newly added) ---")
+        print("\n".join(sample_links))
     return 0
 
 
@@ -216,16 +250,17 @@ def run_hook():
     root = find_root(fp)
     if not root or "/content/" not in os.path.abspath(fp).replace(os.sep, "/") + "/":
         return 0
-    hard, soft = check_file(fp, root)
-    if not hard and not soft:
+    prior = head_relrefs(fp, root)
+    broken, bad_links = check_file(fp, root, prior)
+    if not broken and not bad_links:
         return 0
     lines = [f"Shortcode reference check for {os.path.relpath(fp, root)}:"]
-    for sc, ref in hard:
-        lines.append(f"  [broken] {sc} points at a file that does not exist: {ref}")
-    for sc, ref in soft:
-        lines.append(f"  [warn]   {sc} could not be resolved (verify it exists): {ref}")
+    for sc, ref in broken:
+        lines.append(f"  [broken file] {sc} points at a file that does not exist: {ref}")
+    for sc, ref in bad_links:
+        lines.append(f"  [broken link] relref target does not resolve to a page: {ref}")
     sys.stderr.write("\n".join(lines) + "\n")
-    return 2 if hard else 0
+    return 2
 
 
 if __name__ == "__main__":

--- a/.codex/skills/claude-review/references/claude-review-patterns.md
+++ b/.codex/skills/claude-review/references/claude-review-patterns.md
@@ -42,6 +42,15 @@ When adding a new entry, use this schema:
 **False-positive guard:** Some generated files are intentionally not committed; check repo convention before requiring an artifact update.
 **Suggested review prompt:** Trace every new or changed docs reference to its backing shortcode, data file, example file, or generated artifact, and flag broken links or stale mappings.
 
+## Validator Source-Of-Truth Drift
+
+**Status:** candidate
+**Source:** `.claude/hooks/check_shortcode_paths.py` review, 2026-06-12.
+**What to check:** When reviewing hooks, linters, or validators that model Hugo shortcodes, generated references, or build-time resolution, read the template, config, or runtime source of truth they approximate. Compare exact semantics: base directory, extension handling, fragment/query stripping, relative paths, case handling, mounts, fallback rules, and failure behavior when git or other context is unavailable. Run scan modes and small synthetic probes against existing files when the validator exposes them.
+**Pass criterion:** The validator rejects paths the real build would fail and does not accept paths the real build cannot resolve. Diff-scoped checks should degrade safely when source-control context is unavailable.
+**False-positive guard:** Do not report every approximation. Report only mismatches that can wrongly block a plausible edit or silently miss a build-breaking reference.
+**Suggested review prompt:** For any docs validator, ask: what is the real source of truth this code models, and where does the model differ in ways that affect blocking or misses?
+
 ## Timeout And Race Assumptions
 
 **Status:** established


### PR DESCRIPTION
Claude initially said that checking relrefs in the post-edit hook would be prohibitively complicated. However, most of the relrefs we actually use in the docs can be checked fairly easily (it's the stuff we don't use that causes problems). Given that there was a dodgy link in one of my use case pages the other day, I figured it would be worth having a simple relref check even if it doesn't handle everything. It should at least help prevent hallucinations of common pathnames, like the one in the use case page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The hook can block doc edits when relref or path heuristics disagree with Hugo, though git-unavailable skip and fail-open paths reduce that; mis-scoped blocking would affect every PostToolUse markdown edit.
> 
> **Overview**
> Extends **`check_shortcode_paths.py`** so Claude edits to `content/**/*.md` can be blocked for bad **absolute `relref`** targets, not only missing image/embed file paths. Relative relrefs stay unchecked; **`SHORTCODE_SKIP_RELREF=1`** disables relref validation.
> 
> **Relref behavior:** Resolution is filesystem-based with Hugo-style path normalization and **`config.toml` `[[module.mounts]]`** remapping. In hook mode, only relrefs **new vs `git show HEAD:`** are validated; git errors/timeouts **skip** relref checks entirely. Scan mode (`--scan`) still reports all absolute relrefs.
> 
> **File-ref tightening:** Shortcode regexes use tempered matching so `>`/`}` in attributes do not hide `filename`/`image`. Static/embed checks use **case-exact** leaf names where the build is strict; **`embed-code`** / **`embed-yaml`** match exact `readFile` paths. Broken file refs and broken new relrefs both **exit 2**; uncaught hook exceptions **exit 0** (fail open).
> 
> Also adds a **Validator Source-Of-Truth Drift** candidate pattern to **`.codex/skills/claude-review/references/claude-review-patterns.md`** for reviewing Hugo approximators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6a492b71f091b665024aaea5041c8cdf976ab6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->