### PR TITLE
RS: Fixed generate_self_signed_certificates.sh -f description

### DIFF
--- a/content/operate/rs/7.22/security/certificates/create-certificates.md
+++ b/content/operate/rs/7.22/security/certificates/create-certificates.md
@@ -31,7 +31,7 @@ You can run the `generate_self_signed_certs.sh` script with the following option
 |----------|-------------|
 | `-h`<br />`--help` | Displays usage instructions. (Optional) |
 | `-d <days>`<br />`--days <days>` | Number of days the self-signed certificate is valid for. Setting this field longer than a year (365 days) is not recommended. (Optional, default: 365) |
-| `-f <names>`<br /><nobr>`--fqdnNames <names>`</nobr> | Space-separated list of [fully qualified domain names (FQDNs)](https://en.wikipedia.org/wiki/Fully_qualified_domain_name). Used for [storage area networks (SANs)](https://en.wikipedia.org/wiki/Storage_area_network). (Required)<br />Example: `-f "redis.example.com redis-1.example.com"` |
+| `-f <names>`<br /><nobr>`--fqdnNames <names>`</nobr> | Space-separated list of [fully qualified domain names (FQDNs)](https://en.wikipedia.org/wiki/Fully_qualified_domain_name). Used for [Subject Alternative Names (SANs)](https://en.wikipedia.org/wiki/Public_key_certificate#Subject_Alternative_Name_certificate). (Required)<br />Example: `-f "redis.example.com redis-1.example.com"` |
 | `-t <type>`<br />`--type <type>` | Type of certificate to generate. (Optional, default: all) <br />Values:<br />**cm**: Cluster Manager UI certificate<br />**api**: REST API certificate<br /> **proxy**: database endpoint proxy certificate<br />**syncer**: syncer component certificate<br />**metrics**: metrics exporter certificate<br />**all**: generates all certificate types |
 
 ### Step 1: Generate new certificates 

--- a/content/operate/rs/security/certificates/create-certificates.md
+++ b/content/operate/rs/security/certificates/create-certificates.md
@@ -30,7 +30,7 @@ You can run the `generate_self_signed_certs.sh` script with the following option
 |----------|-------------|
 | `-h`<br />`--help` | Displays usage instructions. (Optional) |
 | `-d <days>`<br />`--days <days>` | Number of days the self-signed certificate is valid for. Setting this field longer than a year (365 days) is not recommended. (Optional, default: 365) |
-| `-f <names>`<br /><nobr>`--fqdnNames <names>`</nobr> | Space-separated list of [fully qualified domain names (FQDNs)](https://en.wikipedia.org/wiki/Fully_qualified_domain_name). Used for [storage area networks (SANs)](https://en.wikipedia.org/wiki/Storage_area_network). (Required)<br />Example: `-f "redis.example.com redis-1.example.com"` |
+| `-f <names>`<br /><nobr>`--fqdnNames <names>`</nobr> | Space-separated list of [fully qualified domain names (FQDNs)](https://en.wikipedia.org/wiki/Fully_qualified_domain_name). Used for [Subject Alternative Names (SANs)](https://en.wikipedia.org/wiki/Public_key_certificate#Subject_Alternative_Name_certificate). (Required)<br />Example: `-f "redis.example.com redis-1.example.com"` |
 | `-t <type>`<br />`--type <type>` | Type of certificate to generate. (Optional, default: all) <br />Values:<br />**cm**: Cluster Manager UI certificate<br />**api**: REST API certificate<br /> **proxy**: database endpoint proxy certificate<br />**syncer**: syncer component certificate<br />**metrics**: metrics exporter certificate<br />**all**: generates all certificate types |
 
 ### Step 1: Generate new certificates 


### PR DESCRIPTION
Fixes #3499

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and link correction with no runtime or security behavior changes.
> 
> **Overview**
> Corrects the `generate_self_signed_certs.sh` **`-f` / `--fqdnNames`** option text in the RS **Create certificates** docs (both `content/operate/rs/security/certificates/create-certificates.md` and the `7.22` copy).
> 
> The FQDN list is described as used for **Subject Alternative Names (SANs)** in TLS certificates, replacing the mistaken **storage area networks** wording and link. No script, command, or procedure steps change—only that table row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8508c1e59861c5e7ed4bb17b842d486a6b0ef585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->