### PR TITLE
RS: certificate_subject_line formatting requirements and fixed example for cert-based auth

### DIFF
--- a/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
@@ -118,6 +118,8 @@ The `certificate_subject_line` must:
 - Not contain spaces after the commas that separate attributes.
 
 - Exactly match the certificate's RFC 2253 subject.
+
+- Contain only one Organizational Unit (`OU`) value.
 {{</note>}}
 
 ## Authenticate REST API requests

--- a/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.22/security/certificates/certificate-based-authentication.md
@@ -96,17 +96,29 @@ Before you can connect to a database using certificate-based authentication, you
 
 ### Create certificate auth_method users {#create-cert-users}
 
-When you [create new users]({{<relref "/operate/rs/7.22/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body :
+When you [create new users]({{<relref "/operate/rs/7.22/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body:
 
 ```sh
 POST /v1/users
 {
   "auth_method": "certificate",
-  "certificate_subject_line": "CN=<Common Name>, OU=<Organization Unit>, O=<Organization>, L=<Locality>, ST=<State/Province>, C=<Country>"
+  "certificate_subject_line": "CN=<Common Name>,OU=<Organizational Unit>,O=<Organization>,L=<Locality>,ST=<State/Province>,C=<Country>"
 }
 ```
 
 Replace the placeholder values `<>` with your client certificate's subject values.
+
+{{<note>}}
+The `certificate_subject_line` must:
+
+- Follow [RFC 2253](https://www.rfc-editor.org/rfc/rfc2253) format.
+
+- List the attributes in reverse order, starting with the Common Name (`CN`).
+
+- Not contain spaces after the commas that separate attributes.
+
+- Exactly match the certificate's RFC 2253 subject.
+{{</note>}}
 
 ## Authenticate REST API requests
 

--- a/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
@@ -80,17 +80,29 @@ Before you can connect to a database using certificate-based authentication, you
 
 ### Create certificate auth_method users {#create-cert-users}
 
-When you [create new users]({{<relref "/operate/rs/7.8/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body :
+When you [create new users]({{<relref "/operate/rs/7.8/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body:
 
 ```sh
 POST /v1/users
 {
   "auth_method": "certificate",
-  "certificate_subject_line": "CN=<Common Name>, OU=<Organization Unit>, O=<Organization>, L=<Locality>, ST=<State/Province>, C=<Country>"
+  "certificate_subject_line": "CN=<Common Name>,OU=<Organizational Unit>,O=<Organization>,L=<Locality>,ST=<State/Province>,C=<Country>"
 }
 ```
 
 Replace the placeholder values `<>` with your client certificate's subject values.
+
+{{<note>}}
+The `certificate_subject_line` must:
+
+- Follow [RFC 2253](https://www.rfc-editor.org/rfc/rfc2253) format.
+
+- List the attributes in reverse order, starting with the Common Name (`CN`).
+
+- Not contain spaces after the commas that separate attributes.
+
+- Exactly match the certificate's RFC 2253 subject.
+{{</note>}}
 
 ## Authenticate REST API requests
 

--- a/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/7.8/security/certificates/certificate-based-authentication.md
@@ -102,6 +102,8 @@ The `certificate_subject_line` must:
 - Not contain spaces after the commas that separate attributes.
 
 - Exactly match the certificate's RFC 2253 subject.
+
+- Contain only one Organizational Unit (`OU`) value.
 {{</note>}}
 
 ## Authenticate REST API requests

--- a/content/operate/rs/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/security/certificates/certificate-based-authentication.md
@@ -162,11 +162,23 @@ PUT /v1/cluster
     POST /v1/users
     {
       "auth_method": "certificate",
-      "certificate_subject_line": "CN=<Common Name>, OU=<Organization Unit>, O=<Organization>, L=<Locality>, ST=<State/Province>, C=<Country>"
+      "certificate_subject_line": "CN=<Common Name>,OU=<Organizational Unit>,O=<Organization>,L=<Locality>,ST=<State/Province>,C=<Country>"
     }
     ```
 
     Replace the placeholder values `<>` with your client certificate's subject values.
+
+    {{<note>}}
+The `certificate_subject_line` must:
+
+- Follow [RFC 2253](https://www.rfc-editor.org/rfc/rfc2253) format.
+
+- List the attributes in reverse order, starting with the Common Name (`CN`).
+
+- Not contain spaces after the commas that separate attributes.
+
+- Exactly match the certificate's RFC 2253 subject.
+    {{</note>}}
 
 ### Authenticate REST API requests
 
@@ -186,17 +198,29 @@ To set up certificate-based authentication for databases:
 
 1. Enable mutual TLS for the relevant databases. See [Enable TLS]({{<relref "/operate/rs/security/encryption/tls/enable-tls">}}) for detailed instructions.
 
-1. When you [create new users]({{<relref "/operate/rs/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body :
+1. When you [create new users]({{<relref "/operate/rs/references/rest-api/requests/users#post-user">}}), include `"auth_method": "certificate"` and `certificate_subject_line` in the request body:
 
     ```sh
     POST /v1/users
     {
       "auth_method": "certificate",
-      "certificate_subject_line": "CN=<Common Name>, OU=<Organization Unit>, O=<Organization>, L=<Locality>, ST=<State/Province>, C=<Country>"
+      "certificate_subject_line": "CN=<Common Name>,OU=<Organizational Unit>,O=<Organization>,L=<Locality>,ST=<State/Province>,C=<Country>"
     }
     ```
 
     Replace the placeholder values `<>` with your client certificate's subject values.
+
+    {{<note>}}
+The `certificate_subject_line` must:
+
+- Follow [RFC 2253](https://www.rfc-editor.org/rfc/rfc2253) format.
+
+- List the attributes in reverse order, starting with the Common Name (`CN`).
+
+- Not contain spaces after the commas that separate attributes.
+
+- Exactly match the certificate's RFC 2253 subject.
+    {{</note>}}
 
 ### Authenticate database connections
 

--- a/content/operate/rs/security/certificates/certificate-based-authentication.md
+++ b/content/operate/rs/security/certificates/certificate-based-authentication.md
@@ -178,6 +178,8 @@ The `certificate_subject_line` must:
 - Not contain spaces after the commas that separate attributes.
 
 - Exactly match the certificate's RFC 2253 subject.
+
+- Contain only one Organizational Unit (`OU`) value.
     {{</note>}}
 
 ### Authenticate REST API requests
@@ -220,6 +222,8 @@ The `certificate_subject_line` must:
 - Not contain spaces after the commas that separate attributes.
 
 - Exactly match the certificate's RFC 2253 subject.
+
+- Contain only one Organizational Unit (`OU`) value.
     {{</note>}}
 
 ### Authenticate database connections


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to security how-to pages; no product or API behavior is modified.
> 
> **Overview**
> Updates Redis Software **certificate-based authentication** docs (current, 7.22, and 7.8) so `certificate_subject_line` examples and guidance match what the API expects.
> 
> The **POST /v1/users** example string is corrected to **RFC 2253** style: no spaces after commas, `OU` labeled as Organizational Unit, and attribute order starting with `CN`. Minor copy fixes remove stray spaces before colons in the same sections.
> 
> A new **note** lists requirements: RFC 2253 format, reverse attribute order from `CN`, exact match to the cert subject, and a **single** `OU` value. The same note appears wherever cert users are created (REST API and database setup on the main page).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f770ee5badff79d8fd25fb2b935ff00e7665966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->