### PR TITLE
RS: Fixed RedisJSON 8.6 version typo in RS release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
@@ -103,7 +103,7 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 | Redis database version | Compatible Redis modules |
 |------------------------|--------------------------|
-| 8.6 | RediSearch 8.6<br />RedisJSON 8.4<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
+| 8.6 | RediSearch 8.6<br />RedisJSON 8.6<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
 | 8.4 | RediSearch 8.4<br />RedisJSON 8.4<br />RedisTimeSeries 8.4<br />RedisBloom 8.4<br />See [What's new in Redis 8.4]({{<relref "/develop/whats-new/8-4">}}) and [Redis Open Source 8.4 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes">}}) |
 | 8.2 | RediSearch 8.2<br />RedisJSON 8.2<br />RedisTimeSeries 8.2<br />RedisBloom 8.2<br />See [What's new in Redis 8.2]({{<relref "/develop/whats-new/8-2">}}) and [Redis Open Source 8.2 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes">}}) |
 | 8.0 | RediSearch 8.0<br />RedisJSON 8.0<br />RedisTimeSeries 8.0<br />RedisBloom 8.0<br />See [What's new in Redis 8.0]({{<relref "/develop/whats-new/8-0">}}) and [Redis Open Source 8.0 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes">}}) |

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
@@ -37,7 +37,7 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 | Redis database version | Compatible Redis modules |
 |------------------------|--------------------------|
-| 8.6 | RediSearch 8.6<br />RedisJSON 8.4<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
+| 8.6 | RediSearch 8.6<br />RedisJSON 8.6<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
 | 8.4 | RediSearch 8.4<br />RedisJSON 8.4<br />RedisTimeSeries 8.4<br />RedisBloom 8.4<br />See [What's new in Redis 8.4]({{<relref "/develop/whats-new/8-4">}}) and [Redis Open Source 8.4 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes">}}) |
 | 8.2 | RediSearch 8.2<br />RedisJSON 8.2<br />RedisTimeSeries 8.2<br />RedisBloom 8.2<br />See [What's new in Redis 8.2]({{<relref "/develop/whats-new/8-2">}}) and [Redis Open Source 8.2 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes">}}) |
 | 8.0 | RediSearch 8.0<br />RedisJSON 8.0<br />RedisTimeSeries 8.0<br />RedisBloom 8.0<br />See [What's new in Redis 8.0]({{<relref "/develop/whats-new/8-0">}}) and [Redis Open Source 8.0 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes">}}) |

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -61,7 +61,7 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 | Redis database version | Compatible Redis modules |
 |------------------------|--------------------------|
-| 8.6 | RediSearch 8.6<br />RedisJSON 8.4<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
+| 8.6 | RediSearch 8.6<br />RedisJSON 8.6<br />RedisTimeSeries 8.6<br />RedisBloom 8.6<br />See [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6">}}) and [Redis Open Source 8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes">}}) |
 | 8.4 | RediSearch 8.4<br />RedisJSON 8.4<br />RedisTimeSeries 8.4<br />RedisBloom 8.4<br />See [What's new in Redis 8.4]({{<relref "/develop/whats-new/8-4">}}) and [Redis Open Source 8.4 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes">}}) |
 | 8.2 | RediSearch 8.2<br />RedisJSON 8.2<br />RedisTimeSeries 8.2<br />RedisBloom 8.2<br />See [What's new in Redis 8.2]({{<relref "/develop/whats-new/8-2">}}) and [Redis Open Source 8.2 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes">}}) |
 | 8.0 | RediSearch 8.0<br />RedisJSON 8.0<br />RedisTimeSeries 8.0<br />RedisBloom 8.0<br />See [What's new in Redis 8.0]({{<relref "/develop/whats-new/8-0">}}) and [Redis Open Source 8.0 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes">}}) |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only correction in release notes; no product or runtime behavior changes.
> 
> **Overview**
> Corrects a documentation typo in the **Redis feature sets** compatibility table for three Redis Software 8.0 release note pages (`rs-8-0-18-23`, `rs-8-0-18-36`, `rs-8-0-20-19`).
> 
> On the **Redis database version 8.6** row, **RedisJSON** is updated from **8.4** to **8.6** so it matches RediSearch, RedisTimeSeries, and RedisBloom on that row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d96c2d9c1772acbc687d3300a1a6568faf218b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->