### PR TITLE
Collapsible shortcode for use in RS release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
@@ -31,13 +31,11 @@ This version offers:
 
 - Enabled `client_eviction` by default to fix an issue where a massive volume of traffic directed at a single hot key could cause high latency and out-of-memory errors.
 
-### Redis database versions
+### Redis database versions and feature sets
 
 Redis Software version 8.0.20 includes the following Redis database versions: 8.6.2, 8.4.0, 8.2.1, 8.0.2, 7.4.3, 7.2.7, and 6.2.13.
 
 The [default Redis database version]({{<relref "/operate/rs/databases/configure/db-defaults#database-version">}}) is 8.6.
-
-### Redis feature sets
 
 Redis Software includes multiple feature sets, compatible with different Redis database versions.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-tba.md
@@ -41,6 +41,8 @@ The [default Redis database version]({{<relref "/operate/rs/databases/configure/
 
 Redis Software includes multiple feature sets, compatible with different Redis database versions.
 
+{{< collapsible "Show feature set details" >}}
+
 The following table shows which Redis modules are compatible with each Redis database version included in this release.
 
 | Redis database version | Compatible Redis modules |
@@ -52,6 +54,8 @@ The following table shows which Redis modules are compatible with each Redis dat
 | 7.4 | [RediSearch 2.10]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md" >}})<br />[RedisJSON 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.8-release-notes.md" >}})<br />[RedisTimeSeries 1.12]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.12-release-notes.md" >}})<br />[RedisBloom 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.8-release-notes.md" >}}) |
 | 7.2 | [RediSearch 2.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md" >}})<br />[RedisJSON 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.6-release-notes.md" >}})<br />[RedisTimeSeries 1.10]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.10-release-notes.md" >}})<br />[RedisBloom 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.6-release-notes.md" >}}) |
 | 6.2 | [RediSearch 2.6]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md" >}})<br />[RedisJSON 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisjson/redisjson-2.4-release-notes.md" >}})<br />[RedisTimeSeries 1.8]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redistimeseries/redistimeseries-1.8-release-notes.md" >}})<br />[RedisBloom 2.4]({{< relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisbloom/redisbloom-2.4-release-notes.md" >}}) |
+
+{{< /collapsible >}}
 
 ### Resolved issues
 
@@ -115,6 +119,8 @@ See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networ
 
 ### Supported platforms
 
+{{< collapsible "Show supported platforms" >}}
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Software and Redis Stack modules.
 
 <span title="Warning icon" class="font-serif">:warning:</span> Deprecation warning – The platform is still supported for this version of Redis Software, but support will be removed in a future release.
@@ -149,6 +155,8 @@ See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networ
 5. <a name="table-note-5"></a>Supported only if [FIPS was enabled during RHEL installation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/security_hardening/switching-rhel-to-fips-mode_security-hardening#proc_installing-the-system-with-fips-mode-enabled_switching-rhel-to-fips-mode) to ensure FIPS compliance.
 
 6. <a name="table-note-6"></a>Amazon Linux 2023 support was added in Redis Software version 8.0.20.
+
+{{< /collapsible >}}
 
 ## Downloads
 
@@ -206,7 +214,7 @@ Some CVEs announced for Redis Open Source do not affect Redis Software due to di
 
 Redis Software 8.0.20-tba supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2, and 6.2. Below is the list of Redis Open Source CVEs and other security vulnerabilities fixed by version.
 
-Redis 8.6.x:
+{{< collapsible "Redis 8.6.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -232,7 +240,9 @@ Redis 8.6.x:
 
 - Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
-Redis 8.4.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 8.4.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -258,7 +268,9 @@ Redis 8.4.x:
 
 - Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
-Redis 8.2.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 8.2.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -310,7 +322,9 @@ Redis 8.2.x:
 
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
-Redis 8.0.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 8.0.x" >}}
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -360,7 +374,9 @@ Redis 8.0.x:
 
 - (CVE-2025-49844) An authenticated user may use a specially crafted Lua script to manipulate the garbage collector, trigger a use-after-free, and potentially lead to remote code execution.
 
-Redis 7.4.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 7.4.x" >}}
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -410,7 +426,9 @@ Redis 7.4.x:
 
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
-Redis 7.2.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 7.2.x" >}}
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -468,7 +486,9 @@ Redis 7.2.x:
 
 - (CVE-2023-41053) Redis does not correctly identify keys accessed by `SORT_RO` and, as a result, may grant users executing this command access to keys that are not explicitly authorized by the ACL configuration. (Redis 7.2.1)
 
-Redis 7.0.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 7.0.x" >}}
 
 - (CVE-2024-31449) An authenticated user may use a specially crafted Lua script to trigger a stack buffer overflow in the bit library, which may potentially lead to remote code execution.
 
@@ -502,7 +522,9 @@ Redis 7.0.x:
 
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
-Redis 6.2.x:
+{{< /collapsible >}}
+
+{{< collapsible "Redis 6.2.x" >}}
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -595,3 +617,5 @@ Redis 6.2.x:
 - (CVE-2021-29478) An integer overflow bug in Redis 6.2 could be exploited to corrupt the heap and potentially result with remote code execution. The vulnerability involves changing the default set-max-intset-entries configuration value, creating a large set key that consists of integer values and using the COPY command to duplicate it. The integer overflow bug exists in all versions of Redis starting with 2.6, where it could result with a corrupted RDB or DUMP payload, but not exploited through COPY (which did not exist before 6.2). (Redis 6.2.3)
 
 - (CVE-2021-29477) An integer overflow bug in Redis version 6.0 or newer could be exploited using the STRALGO LCS command to corrupt the heap and potentially result in remote code execution. The integer overflow bug exists in all versions of Redis starting with 6.0. (Redis 6.2.3)
+
+{{< /collapsible >}}

--- a/layouts/shortcodes/collapsible.html
+++ b/layouts/shortcodes/collapsible.html
@@ -1,0 +1,49 @@
+{{- /*
+  collapsible: wraps content in a native <details> element that is collapsed
+  by default and expands on click. Unlike the `expand` shortcode, it has no
+  fixed height, so it handles long sections (CVE lists, supported platforms,
+  feature sets) without clipping.
+
+  Usage:
+    {{< collapsible "Supported platforms" >}}
+    ...markdown or HTML...
+    {{< /collapsible >}}
+
+  Or with named params:
+    {{< collapsible title="Supported platforms" open="true" >}}
+*/ -}}
+{{- $title := "" -}}
+{{- $open := false -}}
+{{- if .IsNamedParams -}}
+  {{- $title = .Get "title" -}}
+  {{- $open = eq (.Get "open") "true" -}}
+{{- else -}}
+  {{- $title = .Get 0 -}}
+{{- end -}}
+
+{{- /*
+  Always run the inner content through markdownify. These angle-bracket
+  shortcodes don't get markdown processing from the page, so we apply it here.
+  goldmark passes inline/raw HTML (such as <span> tags) through untouched, so
+  mixed HTML + markdown (tables, lists) renders correctly either way.
+*/ -}}
+{{- $inner := .Inner | markdownify -}}
+
+<details class="collapsible my-4 border border-redis-pen-700/10 rounded-md"{{ if $open }} open{{ end }}>
+  <summary class="collapsible-label cursor-pointer list-none px-4 py-3 font-medium select-none">
+    <div class="flex flex-row gap-3 items-center hover:text-redis-red-500 transition-colors ease-in-out duration-150">
+      {{- $title -}}
+      <div class="collapsible-chevron transition-transform duration-300 ease-in-out">
+        {{- partial "icons/chevron.html" -}}
+      </div>
+    </div>
+  </summary>
+  <div class="collapsible-content px-4 pb-4 pt-1">
+    {{- $inner -}}
+  </div>
+</details>
+
+<style>
+  .collapsible > summary::-webkit-details-marker { display: none; }
+  .collapsible[open] > summary .collapsible-chevron { transform: rotate(180deg); }
+</style>


### PR DESCRIPTION
You can use the new `collapsible` shortcode to wrap a section within a Markdown file. This section will be collapsed by default, and you can click the section to expand the full text.

I did not want to use the existing `expand` shortcode for this due to existing limitations like height and rendering issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Hugo layout only; no application or security logic changes.
> 
> **Overview**
> Adds a new Hugo **`collapsible`** shortcode that wraps content in a native `<details>` / `<summary>` block (collapsed by default, optional `open="true"`), runs inner content through **`markdownify`**, and styles it with chevron and Redis doc classes—intended as an alternative to **`expand`** for long sections without fixed-height clipping.
> 
> The RS **8.0.20-44** release note page is updated to use it: the module compatibility table sits under **“Redis database versions and feature sets”** inside **“Show feature set details”**; the supported platforms matrix is behind **“Show supported platforms”**; and each Redis Open Source security subsection (**8.6.x** through **6.2.x**) is its own collapsible instead of flat headings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e738ebede917b2d2f9e395e9555fd467fa3eea74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->