### PR TITLE
Add categories to search widget

### DIFF
--- a/layouts/partials/search-modal.html
+++ b/layouts/partials/search-modal.html
@@ -125,13 +125,23 @@
       }
   
       function sortData(data) {
+        // Override the natural category for results coming from specific sites
+        const deriveCategory = (record) => {
+          const url = (record && record.url) || ''
+          if (/^https?:\/\/(www\.)?redis\.io\/blog(\/|$|\?|#)/i.test(url)) return 'Blog'
+          if (/^https?:\/\/(www\.)?redis\.io\/tutorials(\/|$|\?|#)/i.test(url)) return 'Tutorials'
+          if (/^https?:\/\/support\.redislabs\.com(\/|$|\?|#)/i.test(url)) return 'Support'
+          return record.hierarchy && record.hierarchy[0]
+        }
+
         // Get a list of unique times
         const getCategories = (data) =>
           data.reduce((a, c) => {
-            if (!a.includes(c.hierarchy[0])) {
-              a.push(c.hierarchy[0])
+            const cat = deriveCategory(c)
+            if (!a.includes(cat)) {
+              a.push(cat)
             }
-  
+
             return a
           }, [])
 
@@ -151,7 +161,7 @@
             obj.category = category
   
             data.forEach((record) => {
-              if (record.hierarchy[0] === category) {
+              if (deriveCategory(record) === category) {
                 obj[record.title] = {
                   path: constructSectionTitle(record),
                   product: record.hierarchy[2],


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Client-side display logic only in the search modal; no API, auth, or data changes.
> 
> **Overview**
> Search results are now grouped under **Blog**, **Tutorials**, and **Support** when their URLs match `redis.io/blog`, `redis.io/tutorials`, or `support.redislabs.com`, instead of relying only on `hierarchy[0]`.
> 
> A new `deriveCategory` helper in `sortData` drives both the unique category list and which hits appear under each section header in the modal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 896826bf56573580ad043f196c4c4ded2859f173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->