### PR TITLE
DOC-6753 fixes for some more 404s

### DIFF
--- a/content/develop/clients/dotnet/_index.md
+++ b/content/develop/clients/dotnet/_index.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/connect/clients/dotnet
 - /connect/clients/dotnet/
 - /clients/dotnet/
+- /develop/clients/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/clients/go/_index.md
+++ b/content/develop/clients/go/_index.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/connect/clients/go
 - /connect/clients/go/
 - /clients/go/
+- /develop/clients/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/clients/hiredis/_index.md
+++ b/content/develop/clients/hiredis/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /connect/clients/hiredis/
 - /clients/hiredis/
+- /develop/clients/c
 categories:
 - docs
 - develop

--- a/content/develop/clients/jedis/_index.md
+++ b/content/develop/clients/jedis/_index.md
@@ -4,6 +4,7 @@ aliases:
 - /connect/clients/java/
 - /connect/clients/jedis/
 - /clients/jedis/
+- /develop/clients/java
 categories:
 - docs
 - develop

--- a/content/develop/clients/nodejs/_index.md
+++ b/content/develop/clients/nodejs/_index.md
@@ -3,6 +3,8 @@ aliases:
 - /develop/connect/clients/nodejs
 - /connect/clients/nodejs/
 - /clients/nodejs/
+- /develop/clients/node-redis
+- /develop/clients/javascript
 categories:
 - docs
 - develop

--- a/content/develop/clients/php/_index.md
+++ b/content/develop/clients/php/_index.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/connect/clients/php
 - /connect/clients/php/
 - /clients/php/
+- /develop/clients/predis
 categories:
 - docs
 - develop

--- a/content/develop/clients/ruby/_index.md
+++ b/content/develop/clients/ruby/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /connect/clients/ruby/
 - /clients/ruby/
+- /develop/clients/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/clients/rust/_index.md
+++ b/content/develop/clients/rust/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /connect/clients/rust/
 - /clients/rust/
+- /develop/clients/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/dotnet/_index.md
+++ b/content/develop/use-cases/agent-memory/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/go/_index.md
+++ b/content/develop/use-cases/agent-memory/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/java-jedis/_index.md
+++ b/content/develop/use-cases/agent-memory/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/java
+- /develop/use-cases/agent-memory/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/java-lettuce/_index.md
+++ b/content/develop/use-cases/agent-memory/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/nodejs/_index.md
+++ b/content/develop/use-cases/agent-memory/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/php/_index.md
+++ b/content/develop/use-cases/agent-memory/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/redis-py/_index.md
+++ b/content/develop/use-cases/agent-memory/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/ruby/_index.md
+++ b/content/develop/use-cases/agent-memory/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/agent-memory/rust/_index.md
+++ b/content/develop/use-cases/agent-memory/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/agent-memory/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/dotnet/_index.md
+++ b/content/develop/use-cases/cache-aside/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/go/_index.md
+++ b/content/develop/use-cases/cache-aside/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/java-jedis/_index.md
+++ b/content/develop/use-cases/cache-aside/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/java
+- /develop/use-cases/cache-aside/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/java-lettuce/_index.md
+++ b/content/develop/use-cases/cache-aside/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/nodejs/_index.md
+++ b/content/develop/use-cases/cache-aside/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/php/_index.md
+++ b/content/develop/use-cases/cache-aside/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/redis-py/_index.md
+++ b/content/develop/use-cases/cache-aside/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/ruby/_index.md
+++ b/content/develop/use-cases/cache-aside/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/cache-aside/rust/_index.md
+++ b/content/develop/use-cases/cache-aside/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/cache-aside/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/dotnet/_index.md
+++ b/content/develop/use-cases/feature-store/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/go/_index.md
+++ b/content/develop/use-cases/feature-store/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/java-jedis/_index.md
+++ b/content/develop/use-cases/feature-store/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/java
+- /develop/use-cases/feature-store/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/java-lettuce/_index.md
+++ b/content/develop/use-cases/feature-store/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/nodejs/_index.md
+++ b/content/develop/use-cases/feature-store/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/php/_index.md
+++ b/content/develop/use-cases/feature-store/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/redis-py/_index.md
+++ b/content/develop/use-cases/feature-store/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/ruby/_index.md
+++ b/content/develop/use-cases/feature-store/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/feature-store/rust/_index.md
+++ b/content/develop/use-cases/feature-store/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/feature-store/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/dotnet/_index.md
+++ b/content/develop/use-cases/job-queue/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/go/_index.md
+++ b/content/develop/use-cases/job-queue/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/java-jedis/_index.md
+++ b/content/develop/use-cases/job-queue/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/java
+- /develop/use-cases/job-queue/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/java-lettuce/_index.md
+++ b/content/develop/use-cases/job-queue/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/nodejs/_index.md
+++ b/content/develop/use-cases/job-queue/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/php/_index.md
+++ b/content/develop/use-cases/job-queue/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/redis-py/_index.md
+++ b/content/develop/use-cases/job-queue/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/ruby/_index.md
+++ b/content/develop/use-cases/job-queue/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/job-queue/rust/_index.md
+++ b/content/develop/use-cases/job-queue/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/job-queue/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/dotnet/_index.md
+++ b/content/develop/use-cases/leaderboard/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/go/_index.md
+++ b/content/develop/use-cases/leaderboard/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/java-jedis/_index.md
+++ b/content/develop/use-cases/leaderboard/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/java
+- /develop/use-cases/leaderboard/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/java-lettuce/_index.md
+++ b/content/develop/use-cases/leaderboard/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/nodejs/_index.md
+++ b/content/develop/use-cases/leaderboard/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/php/_index.md
+++ b/content/develop/use-cases/leaderboard/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/redis-py/_index.md
+++ b/content/develop/use-cases/leaderboard/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/ruby/_index.md
+++ b/content/develop/use-cases/leaderboard/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/leaderboard/rust/_index.md
+++ b/content/develop/use-cases/leaderboard/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/leaderboard/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/dotnet/_index.md
+++ b/content/develop/use-cases/prefetch-cache/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/go/_index.md
+++ b/content/develop/use-cases/prefetch-cache/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/java-jedis/_index.md
+++ b/content/develop/use-cases/prefetch-cache/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/java
+- /develop/use-cases/prefetch-cache/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/java-lettuce/_index.md
+++ b/content/develop/use-cases/prefetch-cache/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/nodejs/_index.md
+++ b/content/develop/use-cases/prefetch-cache/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/php/_index.md
+++ b/content/develop/use-cases/prefetch-cache/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/redis-py/_index.md
+++ b/content/develop/use-cases/prefetch-cache/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/ruby/_index.md
+++ b/content/develop/use-cases/prefetch-cache/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/prefetch-cache/rust/_index.md
+++ b/content/develop/use-cases/prefetch-cache/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/prefetch-cache/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/dotnet/_index.md
+++ b/content/develop/use-cases/pub-sub/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/go/_index.md
+++ b/content/develop/use-cases/pub-sub/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/java-jedis/_index.md
+++ b/content/develop/use-cases/pub-sub/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/java
+- /develop/use-cases/pub-sub/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/java-lettuce/_index.md
+++ b/content/develop/use-cases/pub-sub/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/nodejs/_index.md
+++ b/content/develop/use-cases/pub-sub/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/php/_index.md
+++ b/content/develop/use-cases/pub-sub/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/redis-py/_index.md
+++ b/content/develop/use-cases/pub-sub/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/ruby/_index.md
+++ b/content/develop/use-cases/pub-sub/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/pub-sub/rust/_index.md
+++ b/content/develop/use-cases/pub-sub/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/pub-sub/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/dotnet/_index.md
+++ b/content/develop/use-cases/rate-limiter/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/go/_index.md
+++ b/content/develop/use-cases/rate-limiter/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/java-jedis/_index.md
+++ b/content/develop/use-cases/rate-limiter/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/java
+- /develop/use-cases/rate-limiter/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/java-lettuce/_index.md
+++ b/content/develop/use-cases/rate-limiter/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/nodejs/_index.md
+++ b/content/develop/use-cases/rate-limiter/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/php/_index.md
+++ b/content/develop/use-cases/rate-limiter/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/redis-py/_index.md
+++ b/content/develop/use-cases/rate-limiter/redis-py/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/demo_server.py
+- /develop/use-cases/rate-limiter/token_bucket.py
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/redis-py/_index.md
+++ b/content/develop/use-cases/rate-limiter/redis-py/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /develop/use-cases/rate-limiter/demo_server.py
 - /develop/use-cases/rate-limiter/token_bucket.py
+- /develop/use-cases/rate-limiter/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/ruby/_index.md
+++ b/content/develop/use-cases/rate-limiter/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/rate-limiter/rust/_index.md
+++ b/content/develop/use-cases/rate-limiter/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/rate-limiter/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/dotnet/_index.md
+++ b/content/develop/use-cases/recommendation-engine/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/go/_index.md
+++ b/content/develop/use-cases/recommendation-engine/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/java-jedis/_index.md
+++ b/content/develop/use-cases/recommendation-engine/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/java
+- /develop/use-cases/recommendation-engine/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/java-lettuce/_index.md
+++ b/content/develop/use-cases/recommendation-engine/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/nodejs/_index.md
+++ b/content/develop/use-cases/recommendation-engine/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/php/_index.md
+++ b/content/develop/use-cases/recommendation-engine/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/redis-py/_index.md
+++ b/content/develop/use-cases/recommendation-engine/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/ruby/_index.md
+++ b/content/develop/use-cases/recommendation-engine/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/recommendation-engine/rust/_index.md
+++ b/content/develop/use-cases/recommendation-engine/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/recommendation-engine/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/dotnet/_index.md
+++ b/content/develop/use-cases/semantic-cache/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/go/_index.md
+++ b/content/develop/use-cases/semantic-cache/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/java-jedis/_index.md
+++ b/content/develop/use-cases/semantic-cache/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/java
+- /develop/use-cases/semantic-cache/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/java-lettuce/_index.md
+++ b/content/develop/use-cases/semantic-cache/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/nodejs/_index.md
+++ b/content/develop/use-cases/semantic-cache/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/php/_index.md
+++ b/content/develop/use-cases/semantic-cache/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/redis-py/_index.md
+++ b/content/develop/use-cases/semantic-cache/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/ruby/_index.md
+++ b/content/develop/use-cases/semantic-cache/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/semantic-cache/rust/_index.md
+++ b/content/develop/use-cases/semantic-cache/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/semantic-cache/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/dotnet/_index.md
+++ b/content/develop/use-cases/session-store/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/go/_index.md
+++ b/content/develop/use-cases/session-store/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/java-jedis/_index.md
+++ b/content/develop/use-cases/session-store/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/session-store/java
+- /develop/use-cases/session-store/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/java-lettuce/_index.md
+++ b/content/develop/use-cases/session-store/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/nodejs/_index.md
+++ b/content/develop/use-cases/session-store/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/php/_index.md
+++ b/content/develop/use-cases/session-store/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/redis-py/_index.md
+++ b/content/develop/use-cases/session-store/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/ruby/_index.md
+++ b/content/develop/use-cases/session-store/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/session-store/rust/_index.md
+++ b/content/develop/use-cases/session-store/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/session-store/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/dotnet/_index.md
+++ b/content/develop/use-cases/streaming/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/go/_index.md
+++ b/content/develop/use-cases/streaming/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/java-jedis/_index.md
+++ b/content/develop/use-cases/streaming/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/streaming/java
+- /develop/use-cases/streaming/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/java-lettuce/_index.md
+++ b/content/develop/use-cases/streaming/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/nodejs/_index.md
+++ b/content/develop/use-cases/streaming/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/php/_index.md
+++ b/content/develop/use-cases/streaming/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/redis-py/_index.md
+++ b/content/develop/use-cases/streaming/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/ruby/_index.md
+++ b/content/develop/use-cases/streaming/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/streaming/rust/_index.md
+++ b/content/develop/use-cases/streaming/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/streaming/redis-rs
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/dotnet/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/dotnet/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/stackexchange.redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/go/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/go/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/go-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/java-jedis/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/java-jedis/_index.md
@@ -1,4 +1,7 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/java
+- /develop/use-cases/time-series-dashboard/jedis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/java-lettuce/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/java-lettuce/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/lettuce
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/nodejs/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/nodejs/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/node-redis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/php/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/php/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/predis
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/redis-py/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/redis-py/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/python
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/ruby/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/ruby/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/redis-rb
 categories:
 - docs
 - develop

--- a/content/develop/use-cases/time-series-dashboard/rust/_index.md
+++ b/content/develop/use-cases/time-series-dashboard/rust/_index.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/use-cases/time-series-dashboard/redis-rs
 categories:
 - docs
 - develop


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only alias entries; low risk aside from verifying redirect targets don’t conflict with existing paths.
> 
> **Overview**
> Adds **Hugo `aliases`** in page front matter so old or alternate URLs resolve to the current client and use-case docs (DOC-6753).
> 
> **Client guides** (`content/develop/clients/*/`) now redirect library- or language-style paths (e.g. `/develop/clients/go-redis`, `stackexchange.redis`, `node-redis`, `javascript`, `java`, `c` for hiredis) to the canonical section pages.
> 
> **Use-case examples** under `content/develop/use-cases/` get matching aliases per stack (e.g. `.../cache-aside/python` → the `redis-py` page, `.../agent-memory/jedis` and `java` → `java-jedis`). The Python rate-limiter page also aliases legacy demo paths (`demo_server.py`, `token_bucket.py`).
> 
> No body content or routing logic changes—only redirect metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d8569f0a0a0c782e0e67e0223605dcc8a26c524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->