### PR TITLE
Change gsutil commands to preserve non-latest css/scss files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -486,8 +486,26 @@ jobs:
     - name: Deploy latest to GCS
       run: |
         bucket_path="${{ needs.setup_and_build_latest.outputs.bucket_path }}"
-        gsutil -m rsync -r -c -j html -d public gs://$BUCKET/$bucket_path
-        gsutil -m rsync -r -c -j html -d public gs://$BUCKET/docs/$bucket_path
+
+        # The -d flag mirrors the bucket to this build, deleting any object not
+        # present locally -- including older fingerprinted css/index.min.{hash}.css
+        # files. Browser/Cloudflare-cached HTML can still reference an old hash for
+        # hours after a deploy, so deleting it produces 404s. Exclude css/scss from
+        # the destructive syncs, then additively upload this build's css/scss (no -d)
+        # so old and new hashes coexist. Mirrors the versioned matrix deploy jobs.
+        upload_assets() {
+          local dest="$1"
+          for d in css scss; do
+            if [ -d "public/$d" ]; then
+              gsutil -m rsync -r -c -j css "public/$d" "${dest}/$d"
+            fi
+          done
+        }
+
+        gsutil -m rsync -r -c -j html -d -x '^(css|scss)/' public gs://$BUCKET/$bucket_path
+        gsutil -m rsync -r -c -j html -d -x '^(css|scss)/' public gs://$BUCKET/docs/$bucket_path
+        upload_assets "gs://$BUCKET/$bucket_path"
+        upload_assets "gs://$BUCKET/docs/$bucket_path"
 
   # Deploy Kubernetes versions to GCS
   deploy_kubernetes:


### PR DESCRIPTION
Browser/Cloudflare-cached HTML can still reference an old hash for a while after a latest deploy, so we need to keep non-latest css files around 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only GCS sync behavior change; reduces user-facing 404 risk without touching app auth or data paths.
> 
> **Overview**
> Fixes **404s on fingerprinted CSS** after a latest docs deploy when browsers or Cloudflare still serve HTML that points at an older `index.min.{hash}.css`.
> 
> The **Deploy latest to GCS** step no longer runs a single destructive `gsutil rsync -d` over the whole `public` tree. It **excludes `css/` and `scss/`** from those mirror syncs (`-x '^(css|scss)/'`) for both `gs://$BUCKET/$bucket_path` and `gs://$BUCKET/docs/$bucket_path`, then **additively** uploads this build’s `css` and `scss` via a new `upload_assets` helper (rsync **without** `-d`). Old and new hashed assets can coexist, matching the approach already used in the versioned matrix deploy jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6774368679b1c794c4e95c4bb65ba3b2b736399. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->