### PR TITLE
DEV: (cmds) add new time series command pages

### DIFF
--- a/content/commands/ts.bget.md
+++ b/content/commands/ts.bget.md
@@ -99,9 +99,9 @@ is the inclusive lower-bound cursor for the read. The command selects samples wh
 | Value                | Name          | Description |
 | -------------------- | ------------- | ----------- |
 | Non-negative integer | Literal cursor | A Unix timestamp in milliseconds. Matching is inclusive. `0` is accepted and reads from the beginning. |
-| `-`                  | Earliest      | The timestamp of the earliest sample in the series, or `0` when the series is empty or missing. |
-| `+`                  | Latest        | The timestamp of the latest sample in the series, or `0` when the series is empty or missing. The cursor is inclusive, so the latest existing sample itself qualifies (aligned with [`TS.RANGE`]({{< relref "commands/ts.range/" >}})). With the default `min_count` of `1`, the call returns that sample immediately; with a larger `min_count`, it blocks until enough samples at or after that timestamp exist. Intended for the first call only. |
-| `$`                  | New           | The timestamp of the latest sample plus 1, or `0` when the series is empty or missing. Only samples reported after the command was received by the server qualify; the latest existing sample is excluded. |
+| `-`                  | Earliest      | The timestamp of the earliest sample in the series, or `0` when the series is empty or does not exist. |
+| `+`                  | Latest        | The timestamp of the latest sample in the series, or `0` when the series is empty or does not exist. The cursor is inclusive, so the latest existing sample itself qualifies (aligned with [`TS.RANGE`]({{< relref "commands/ts.range/" >}})). With the default `min_count` of `1`, the call returns that sample immediately; with a larger `min_count`, it blocks until enough samples at or after that timestamp exist. Intended for the first call only. |
+| `$`                  | New           | The timestamp of the latest sample plus 1, or `0` when the series is empty or does not exist. Only samples reported after the command was received by the server qualify; the latest existing sample is excluded. |
 
 The `+` and `$` semantics mirror the special IDs of [`XREAD`]({{< relref "commands/xread/" >}}) and [`XREADGROUP`]({{< relref "commands/xreadgroup/" >}}). The server resolves all sentinels exactly once, when the command is received, so the cursor stays stable while the client is blocked. Send `-`, `+`, and `$` to the server as-is; do not resolve them on the client side.
 
@@ -109,7 +109,7 @@ Use the following table to choose the cursor for the first call:
 
 | Goal                                          | First-call `timestamp` |
 | --------------------------------------------- | ---------------------- |
-| Read the full history, then tail              | `-` or `0`             |
+| Read the full history, then new samples       | `-` or `0`             |
 | Start from the current latest sample, inclusive | `+`                  |
 | Receive only samples added after the call     | `$`                    |
 
@@ -140,18 +140,18 @@ is the reply cap: the maximum number of samples to return. It must be a positive
 `MAX_COUNT` defaults to unlimited; set it explicitly when consuming large histories to bound the reply size and enable paging.
 </details>
 
-The `MIN_COUNT` and `MAX_COUNT` keyword pairs are optional and independent. Omit a pair entirely to apply the server default; do not send made-up defaults. When both are provided, emit the keyword tokens in uppercase and in the documented order (`MIN_COUNT` before `MAX_COUNT`). The server matches the tokens case-insensitively, but a keyword without a value, or any stray trailing token, is rejected as a wrong-arity error.
+The `MIN_COUNT` and `MAX_COUNT` keyword pairs are optional and independent. Omit a pair entirely to apply the server default. The keyword tokens are case-insensitive and can be given in any order. A keyword without a value, or any stray trailing token, is rejected as a wrong-arity error.
 
 ## Blocking and retrieval semantics
 
-- The command reads samples from `key` whose timestamp is greater than or equal to the resolved cursor.
+- From `key`, the command reads samples whose timestamp is greater than or equal to the resolved cursor.
 - If at least `min_count` matching samples are already available, the server returns immediately with up to `max_count` of the oldest qualifying samples.
-- If fewer than `min_count` matching samples are available and `timeout > 0`, the server blocks until `min_count` is reached, the timeout expires, or the key is removed. Each sample append ([`TS.ADD`]({{< relref "commands/ts.add/" >}}), [`TS.MADD`]({{< relref "commands/ts.madd/" >}}), [`TS.INCRBY`]({{< relref "commands/ts.incrby/" >}}), [`TS.DECRBY`]({{< relref "commands/ts.decrby/" >}}), and compaction-rule writes to the destination key) can wake the waiter.
+- If fewer than `min_count` matching samples are available and `timeout > 0`, the server blocks until `min_count` is reached, the timeout expires, or the key is removed. Each sample append ([`TS.ADD`]({{< relref "commands/ts.add/" >}}), [`TS.MADD`]({{< relref "commands/ts.madd/" >}}), [`TS.INCRBY`]({{< relref "commands/ts.incrby/" >}}), [`TS.DECRBY`]({{< relref "commands/ts.decrby/" >}}), and compaction-rule writes to the destination key) can unblock a blocked client.
 - On timeout, the server returns whatever is available, which can be empty or fewer than `min_count` samples. This is a successful reply, not an error.
-- If the key is removed while the client is blocked (`DEL`, `UNLINK`, `FLUSHDB`, `FLUSHALL`, expiry, or eviction), the server wakes the client and returns an empty list. This is a successful reply, not an error.
+- If the key is removed while the client is blocked (`DEL`, `UNLINK`, `FLUSHDB`, `FLUSHALL`, expiry, or eviction), the server returns an empty list to the blocked client. This is a successful reply, not an error.
 - If `timeout = 0`, the server never blocks: it returns the available matching samples immediately, even when fewer than `min_count` qualify.
 - Returned samples are sorted by increasing timestamp, including when samples were inserted out of order.
-- Multiple blocked clients waiting on the same key are independent waiters. One client receiving samples does not consume them for another client.
+- Multiple blocked clients waiting on the same key wait independently. One client receiving samples does not consume them for another client.
 
 ## Examples
 

--- a/content/commands/ts.bget.md
+++ b/content/commands/ts.bget.md
@@ -1,0 +1,301 @@
+---
+acl_categories:
+- '@read'
+- '@timeseries'
+arguments:
+- display_text: key
+  key_spec_index: 0
+  name: key
+  type: key
+- display_text: timestamp
+  name: timestamp
+  type: string
+- display_text: timeout
+  name: timeout
+  type: integer
+- arguments:
+  - display_text: min_count
+    name: min_count
+    token: MIN_COUNT
+    type: integer
+  name: MIN_COUNT
+  optional: true
+  type: block
+- arguments:
+  - display_text: max_count
+    name: max_count
+    token: MAX_COUNT
+    type: integer
+  name: MAX_COUNT
+  optional: true
+  type: block
+arity: -4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+- module
+complexity: O(log(n)+k) where n is the number of samples in the series and k is the
+  number of returned samples
+description: 'Blocking GET: wait up to timeout ms or until min_count samples with
+  timestamp >= timestamp are available, then return up to max_count of the oldest
+  such samples'
+group: timeseries
+hidden: false
+hints:
+- dont_cache
+key_specs:
+- RO: true
+  begin_search:
+    spec:
+      index: 1
+    type: index
+  find_keys:
+    spec:
+      keystep: 1
+      lastkey: 0
+      limit: 0
+    type: range
+linkTitle: TS.BGET
+module: TimeSeries
+railroad_diagram: /images/railroad/ts.bget.svg
+since: 8.10.0
+stack_path: docs/data-types/timeseries
+summary: 'Blocking GET: wait up to timeout ms or until min_count samples with timestamp
+  >= timestamp are available, then return up to max_count of the oldest such samples'
+syntax_fmt: "TS.BGET key timestamp timeout [MIN_COUNT\_min_count]\n  [MAX_COUNT\_\
+  max_count]"
+title: TS.BGET
+---
+Read a batch of time series samples at or after a cursor timestamp, blocking until enough samples are available. `TS.BGET` blocks until at least `min_count` samples with a timestamp greater than or equal to the resolved cursor are available, until `timeout` milliseconds elapse, or until the key is removed, whichever occurs first. It then returns up to `max_count` of the oldest qualifying samples, ordered by increasing timestamp, or an empty list when no matching samples are available.
+
+`TS.BGET` lets applications continuously consume historical and newly appended samples without polling [`TS.RANGE`]({{< relref "commands/ts.range/" >}}) manually. The key may be a regular time series or a compaction time series.
+
+[Examples](#examples)
+
+## Required arguments
+
+<details open>
+<summary><code>key</code></summary>
+
+is the key name for the time series. It may identify a regular series or a compaction series.
+</details>
+
+<details open>
+<summary><code>timestamp</code></summary>
+
+is the inclusive lower-bound cursor for the read. The command selects samples whose timestamp is greater than or equal to the resolved cursor (`sample_timestamp >= resolved_timestamp`).
+
+`timestamp` is either a non-negative integer Unix timestamp in milliseconds or one of the sentinels `-`, `+`, or `$`:
+
+| Value                | Name          | Description |
+| -------------------- | ------------- | ----------- |
+| Non-negative integer | Literal cursor | A Unix timestamp in milliseconds. Matching is inclusive. `0` is accepted and reads from the beginning. |
+| `-`                  | Earliest      | The timestamp of the earliest sample in the series, or `0` when the series is empty or missing. |
+| `+`                  | Latest        | The timestamp of the latest sample in the series, or `0` when the series is empty or missing. The cursor is inclusive, so the latest existing sample itself qualifies (aligned with [`TS.RANGE`]({{< relref "commands/ts.range/" >}})). With the default `min_count` of `1`, the call returns that sample immediately; with a larger `min_count`, it blocks until enough samples at or after that timestamp exist. Intended for the first call only. |
+| `$`                  | New           | The timestamp of the latest sample plus 1, or `0` when the series is empty or missing. Only samples reported after the command was received by the server qualify; the latest existing sample is excluded. |
+
+The `+` and `$` semantics mirror the special IDs of [`XREAD`]({{< relref "commands/xread/" >}}) and [`XREADGROUP`]({{< relref "commands/xreadgroup/" >}}). The server resolves all sentinels exactly once, when the command is received, so the cursor stays stable while the client is blocked. Send `-`, `+`, and `$` to the server as-is; do not resolve them on the client side.
+
+Use the following table to choose the cursor for the first call:
+
+| Goal                                          | First-call `timestamp` |
+| --------------------------------------------- | ---------------------- |
+| Read the full history, then tail              | `-` or `0`             |
+| Start from the current latest sample, inclusive | `+`                  |
+| Receive only samples added after the call     | `$`                    |
+
+For every subsequent call, use `last_returned_timestamp + 1` so you receive no misses and no duplicates. Do not reuse `+` or `$` after the first call. If no samples are returned, you can retry with the same cursor, subject to your application's delivery policy.
+</details>
+
+<details open>
+<summary><code>timeout</code></summary>
+
+is the maximum time to wait, expressed as a non-negative integer number of milliseconds. `timeout = 0` means do not block: the command returns whatever is available immediately, even when fewer than `min_count` samples qualify.
+
+The client-side command/read timeout is separate from this argument and should exceed it. A client socket or read timeout that fires before the Redis `timeout` is a network timeout, not a `TS.BGET` timeout.
+</details>
+
+## Optional arguments
+
+<details open>
+<summary><code>MIN_COUNT min_count</code></summary>
+
+is the unblock threshold: the number of qualifying samples required before the command returns ahead of the timeout. It must be a positive integer and defaults to `1`. With the default of `1`, the command returns all available samples (up to `max_count`) immediately if at least one sample qualifies; otherwise it waits up to `timeout`.
+</details>
+
+<details open>
+<summary><code>MAX_COUNT max_count</code></summary>
+
+is the reply cap: the maximum number of samples to return. It must be a positive integer and greater than or equal to `min_count`. When `MAX_COUNT` is not provided, the reply is unbounded. When more matching samples exist than `max_count`, the server returns the oldest `max_count` samples first, so you can page forward.
+
+`MAX_COUNT` defaults to unlimited; set it explicitly when consuming large histories to bound the reply size and enable paging.
+</details>
+
+The `MIN_COUNT` and `MAX_COUNT` keyword pairs are optional and independent. Omit a pair entirely to apply the server default; do not send made-up defaults. When both are provided, emit the keyword tokens in uppercase and in the documented order (`MIN_COUNT` before `MAX_COUNT`). The server matches the tokens case-insensitively, but a keyword without a value, or any stray trailing token, is rejected as a wrong-arity error.
+
+## Blocking and retrieval semantics
+
+- The command reads samples from `key` whose timestamp is greater than or equal to the resolved cursor.
+- If at least `min_count` matching samples are already available, the server returns immediately with up to `max_count` of the oldest qualifying samples.
+- If fewer than `min_count` matching samples are available and `timeout > 0`, the server blocks until `min_count` is reached, the timeout expires, or the key is removed. Each sample append ([`TS.ADD`]({{< relref "commands/ts.add/" >}}), [`TS.MADD`]({{< relref "commands/ts.madd/" >}}), [`TS.INCRBY`]({{< relref "commands/ts.incrby/" >}}), [`TS.DECRBY`]({{< relref "commands/ts.decrby/" >}}), and compaction-rule writes to the destination key) can wake the waiter.
+- On timeout, the server returns whatever is available, which can be empty or fewer than `min_count` samples. This is a successful reply, not an error.
+- If the key is removed while the client is blocked (`DEL`, `UNLINK`, `FLUSHDB`, `FLUSHALL`, expiry, or eviction), the server wakes the client and returns an empty list. This is a successful reply, not an error.
+- If `timeout = 0`, the server never blocks: it returns the available matching samples immediately, even when fewer than `min_count` qualify.
+- Returned samples are sorted by increasing timestamp, including when samples were inserted out of order.
+- Multiple blocked clients waiting on the same key are independent waiters. One client receiving samples does not consume them for another client.
+
+## Examples
+
+<details open>
+<summary><b>Read history and tail new samples</b></summary>
+
+Create a time series and add three samples.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE sensor:1
+OK
+127.0.0.1:6379> TS.ADD sensor:1 100 1.0
+(integer) 100
+127.0.0.1:6379> TS.ADD sensor:1 200 2.0
+(integer) 200
+127.0.0.1:6379> TS.ADD sensor:1 300 3.0
+(integer) 300
+{{< / highlight >}}
+
+Read all historical samples without blocking. The default `min_count` of `1` is already met and `max_count` is unlimited.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 0 0
+1) 1) (integer) 100
+   2) 1
+2) 1) (integer) 200
+   2) 2
+3) 1) (integer) 300
+   2) 3
+{{< / highlight >}}
+
+The `-` sentinel is equivalent for a full read from the earliest sample.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 - 0
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Page through history in bounded batches</b></summary>
+
+Read at most two samples per call, advancing the cursor to `last_returned_timestamp + 1` on each subsequent call.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 - 1000 MAX_COUNT 2
+1) 1) (integer) 100
+   2) 1
+2) 1) (integer) 200
+   2) 2
+127.0.0.1:6379> TS.BGET sensor:1 201 1000 MAX_COUNT 2
+1) 1) (integer) 300
+   2) 3
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Start from the latest sample</b></summary>
+
+Start from the current latest sample (inclusive). With the default `min_count` of `1`, this returns immediately.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 + 5000
+1) 1) (integer) 300
+   2) 3
+{{< / highlight >}}
+
+With `MIN_COUNT 2`, the same `+` call blocks until a second sample with timestamp greater than or equal to 300 arrives, or returns the available samples after 5000 milliseconds.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 + 5000 MIN_COUNT 2
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Tail only new samples</b></summary>
+
+Use `$` to ignore everything that already exists and receive only samples added after the call.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 $ 5000
+{{< / highlight >}}
+
+If another client runs `TS.ADD sensor:1 400 4.0` within 5000 milliseconds, the blocked call returns `[[400, 4]]`. If no new sample arrives, it returns an empty array.
+</details>
+
+<details open>
+<summary><b>Partial flush on timeout</b></summary>
+
+When `MIN_COUNT` cannot be reached, the command returns the available samples after the timeout. Here `MIN_COUNT 10` cannot be reached, so the two qualifying samples are returned after 1000 milliseconds.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 101 1000 MIN_COUNT 10
+1) 1) (integer) 200
+   2) 2
+2) 1) (integer) 300
+   2) 3
+{{< / highlight >}}
+
+When nothing qualifies by the timeout, the reply is an empty array.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1 301 1000
+(empty array)
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Read from a compaction series</b></summary>
+
+`key` may be a compaction series. The command can return compaction samples and can block for future compaction output.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.BGET sensor:1:avg - 10000
+{{< / highlight >}}
+</details>
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Not supported</span><br /> | <span title="Not supported">&#x274c; Flexible & Annual</span><br /><span title="Not supported">&#x274c; Free & Fixed</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="ts-bget-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}})) pairs representing (timestamp, value), ordered by increasing timestamp. The array is empty when no matching samples are available by the time the command returns, or when the key was removed while the command was blocked.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid timestamp, invalid timeout, invalid `min_count` or `max_count`, `min_count` greater than `max_count`, wrong number of arguments, wrong key type, the command is used where blocking is not allowed (for example, inside `MULTI` or a Lua script), etc.
+
+-tab-sep-
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of ([Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}), [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}})) pairs representing (timestamp, value), ordered by increasing timestamp. The array is empty when no matching samples are available by the time the command returns, or when the key was removed while the command was blocked.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid timestamp, invalid timeout, invalid `min_count` or `max_count`, `min_count` greater than `max_count`, wrong number of arguments, wrong key type, the command is used where blocking is not allowed (for example, inside `MULTI` or a Lua script), etc.
+
+{{< /multitabs >}}
+
+## See also
+
+[`TS.GET`]({{< relref "commands/ts.get/" >}}) | [`TS.RANGE`]({{< relref "commands/ts.range/" >}}) | [`TS.REVRANGE`]({{< relref "commands/ts.revrange/" >}})
+
+## Related topics
+
+[RedisTimeSeries]({{< relref "/develop/data-types/timeseries/" >}})

--- a/content/commands/ts.nrange.md
+++ b/content/commands/ts.nrange.md
@@ -1,0 +1,453 @@
+---
+acl_categories:
+- '@read'
+- '@timeseries'
+arguments:
+- display_text: numkeys
+  name: numkeys
+  type: integer
+- display_text: key
+  key_spec_index: 0
+  multiple: true
+  name: key
+  type: key
+- display_text: fromTimestamp
+  name: fromTimestamp
+  type: string
+- display_text: toTimestamp
+  name: toTimestamp
+  type: string
+- display_text: latest
+  name: latest
+  optional: true
+  token: LATEST
+  type: pure-token
+- arguments:
+  - display_text: filter_by_ts_token
+    name: filter_by_ts_token
+    token: FILTER_BY_TS
+    type: pure-token
+  - display_text: ts
+    multiple: true
+    name: ts
+    type: integer
+  name: filter_by_ts_block
+  optional: true
+  type: block
+- arguments:
+  - display_text: filter_by_value_token
+    name: filter_by_value_token
+    token: FILTER_BY_VALUE
+    type: pure-token
+  - display_text: min
+    name: min
+    type: double
+  - display_text: max
+    name: max
+    type: double
+  name: filter_by_value_block
+  optional: true
+  type: block
+- arguments:
+  - display_text: count_token
+    name: count_token
+    token: COUNT
+    type: pure-token
+  - display_text: count
+    name: count
+    type: integer
+  name: count_block
+  optional: true
+  type: block
+- arguments:
+  - arguments:
+    - display_text: align_token
+      name: align_token
+      token: ALIGN
+      type: pure-token
+    - display_text: align
+      name: align
+      type: string
+    name: align_block
+    optional: true
+    type: block
+  - display_text: aggregation
+    name: aggregation
+    token: AGGREGATION
+    type: pure-token
+  - display_text: aggregators
+    name: aggregators
+    type: string
+  - display_text: bucketDuration
+    name: bucketDuration
+    type: integer
+  - arguments:
+    - display_text: buckettimestamp_token
+      name: buckettimestamp_token
+      token: BUCKETTIMESTAMP
+      type: pure-token
+    - arguments:
+      - display_text: start
+        name: start
+        token: start
+        type: pure-token
+      - display_text: start
+        name: start
+        token: '-'
+        type: pure-token
+      - display_text: end
+        name: end
+        token: end
+        type: pure-token
+      - display_text: end
+        name: end
+        token: +
+        type: pure-token
+      - display_text: mid
+        name: mid
+        token: mid
+        type: pure-token
+      - display_text: mid
+        name: mid
+        token: '~'
+        type: pure-token
+      name: bt
+      type: oneof
+    name: buckettimestamp_block
+    optional: true
+    type: block
+  - display_text: empty_token
+    name: empty_token
+    optional: true
+    token: EMPTY
+    type: pure-token
+  name: aggregation_block
+  optional: true
+  type: block
+arity: -5
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+- module
+- movablekeys
+complexity: O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples
+  per chunk), k = Number of samples that are in the requested range
+description: Query a range across multiple time series in forward direction, returning
+  the results pivoted by timestamp (one value column per key)
+group: timeseries
+hidden: false
+key_specs:
+- RO: true
+  access: true
+  begin_search:
+    spec:
+      index: 1
+    type: index
+  find_keys:
+    spec:
+      firstkey: 1
+      keynumidx: 0
+      keystep: 1
+    type: keynum
+linkTitle: TS.NRANGE
+module: TimeSeries
+railroad_diagram: /images/railroad/ts.nrange.svg
+since: 8.10.0
+stack_path: docs/data-types/timeseries
+summary: Query a range across multiple time series in forward direction, returning
+  the results pivoted by timestamp (one value column per key)
+syntax_fmt: "TS.NRANGE numkeys key [key ...] fromTimestamp toTimestamp [LATEST]\n\
+  \  [FILTER_BY_TS ts [ts ...]] [FILTER_BY_VALUE min max] [COUNT count]\n  [[ALIGN\
+  \ align] AGGREGATION aggregators bucketDuration\n  [BUCKETTIMESTAMP <start | - |\
+  \ end | + | mid | ~>] [EMPTY]]"
+title: TS.NRANGE
+---
+Query a range across an explicit list of time series in the forward direction, returning the results pivoted by timestamp with one value column per key. Rows are ordered by increasing timestamp, and the value array in each row preserves the order of the input keys.
+
+{{< note >}}
+In a Redis cluster, all specified keys must hash to the same slot. `TS.NRANGE` is a single-shard command: it does not split a request across shards or merge replies from multiple shards.
+{{< /note >}}
+
+[Examples](#examples)
+
+## Required arguments
+
+<details open>
+<summary><code>numkeys</code></summary>
+
+is the number of time series keys that follow. It must be a positive integer and must equal the number of `key` arguments.
+</details>
+
+<details open>
+<summary><code>key [key ...]</code></summary>
+
+are the explicit time series keys to query. Key order and duplicate keys are significant: the output has one value column per `key` argument, in the order the keys are given. A repeated key produces a separate value column for each occurrence.
+</details>
+
+<details open>
+<summary><code>fromTimestamp</code></summary>
+
+is the start timestamp for the range query (integer Unix timestamp in milliseconds) or `-` to denote the timestamp of the earliest sample among the specified time series. The range is inclusive.
+</details>
+
+<details open>
+<summary><code>toTimestamp</code></summary>
+
+is the end timestamp for the range query (integer Unix timestamp in milliseconds) or `+` to denote the timestamp of the latest sample among the specified time series. The range is inclusive.
+</details>
+
+## Optional arguments
+
+<details open>
+<summary><code>LATEST</code></summary>
+
+is used when a time series is a compaction. With `LATEST`, TS.NRANGE also reports the compacted value of the latest, possibly partial, bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.NRANGE does not report the latest, possibly partial, bucket. When a time series is not a compaction, `LATEST` is ignored.
+
+The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest, possibly partial, bucket is also required. In such a case, use `LATEST`.
+</details>
+
+<details open>
+<summary><code>FILTER_BY_TS ts...</code></summary>
+
+filters samples by a list of specific timestamps. A sample passes the filter if its exact timestamp is specified and falls within `[fromTimestamp, toTimestamp]`. Samples are filtered before pivoting.
+
+When used together with `AGGREGATION`: samples are filtered before being aggregated.
+</details>
+
+<details open>
+<summary><code>FILTER_BY_VALUE min max</code></summary>
+
+filters samples by minimum and maximum values. A sample passes the filter if its value is within the inclusive range `[min, max]`. `min` and `max` cannot be NaN values. Samples are filtered before pivoting.
+
+When used together with `AGGREGATION`: samples are filtered before being aggregated.
+</details>
+
+<details open>
+<summary><code>COUNT count</code></summary>
+
+limits the number of returned pivot rows, keeping the rows with the lowest timestamps. The limit is applied after the per-timestamp merge.
+</details>
+
+<details open>
+<summary><code>ALIGN align</code></summary>
+
+is a time bucket alignment control for `AGGREGATION`. It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+
+`align` values include:
+
+ - `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`) which can't be `-`
+ - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
+ - A specific timestamp: align the reference timestamp to a specific time
+
+<note><b>Note:</b> When not provided, alignment is set to `0`.</note>
+</details>
+
+<details open>
+<summary><code>AGGREGATION aggregators bucketDuration</code></summary>
+
+aggregates samples into time buckets.
+
+Unlike [`TS.RANGE`]({{< relref "commands/ts.range/" >}}), TS.NRANGE requires exactly one aggregator per key. The aggregators are given as separate, space-separated arguments — one per `key`, in the same order as the keys — and not as a single comma-joined token. The aggregator in position _i_ applies to the key in position _i_, and all keys share the same `bucketDuration`. The comma-joined form (for example `AGGREGATION min,avg,max`) is rejected.
+
+  - each `aggregator` is one of the following:
+
+    | aggregator   | Description                                                     |
+    | ------------ | --------------------------------------------------------------- |
+    | `avg`        | Arithmetic mean of all non-NaN values                           |
+    | `sum`        | Sum of all non-NaN values                                       |
+    | `min`        | Minimum non-NaN value                                           |
+    | `max`        | Maximum non-NaN value                                           |
+    | `range`      | Difference between the maximum and the minimum non-NaN values   |
+    | `count`      | Number of non-NaN values                                        |
+    | `countNaN`   | Number of NaN values                                            |
+    | `countAll`   | Number of values, including NaN and non-NaN                     |
+    | `first`      | The non-NaN value with the lowest timestamp in the bucket       |
+    | `last`       | The non-NaN value with the highest timestamp in the bucket      |
+    | `std.p`      | Population standard deviation of the non-NaN values             |
+    | `std.s`      | Sample standard deviation of the non-NaN values                 |
+    | `var.p`      | Population variance of the non-NaN values                       |
+    | `var.s`      | Sample variance of the non-NaN values                           |
+    | `twa`        | Time-weighted average over the bucket's timeframe (ignores NaN values) |
+
+  - `bucketDuration` is the duration of each bucket, in milliseconds.
+
+  Without `ALIGN`, bucket start times are multiples of `bucketDuration`.
+
+  With `ALIGN align`, bucket start times are multiples of `bucketDuration` with remainder `align % bucketDuration`.
+
+  The first bucket start time is less than or equal to `fromTimestamp`.
+</details>
+
+<details open>
+<summary><code>[BUCKETTIMESTAMP bt]</code></summary>
+
+controls how bucket timestamps are reported.
+
+| `bt`             | Timestamp reported for each bucket                            |
+| ---------------- | ------------------------------------------------------------- |
+| `-` or `start`   | the bucket's start time (default)                             |
+| `+` or `end`     | the bucket's end time                                         |
+| `~` or `mid`     | the bucket's mid time (rounded down if not an integer)        |
+</details>
+
+<details open>
+<summary><code>[EMPTY]</code></summary>
+
+is a flag, which, when specified, reports aggregations also for empty buckets.
+
+| aggregator           | Value reported for each empty bucket |
+| -------------------- | ------------------------------------ |
+| `sum`, `count`       | `0`                                  |
+| `last`               | The value of the last sample before the bucket's start. `NaN` when no such sample. |
+| `twa`                | Average value over the bucket's timeframe based on linear interpolation of the last sample before the bucket's start and the first sample after the bucket's end. `NaN` when no such samples. |
+| `min`, `max`, `range`, `avg`, `first`, `std.p`, `std.s` | `NaN` |
+
+Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the earliest sample or begin after the latest sample in the time series. When a bucket is reported for one key but a different key has no data in that bucket, that key's value cell is `NaN`.
+</details>
+
+## Examples
+
+<details open>
+<summary><b>Pivot raw samples from multiple series by timestamp</b></summary>
+
+Create two time series and add samples at partially overlapping timestamps.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE sensor:1
+OK
+127.0.0.1:6379> TS.CREATE sensor:2
+OK
+127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 2000 12
+1) (integer) 1000
+2) (integer) 2000
+127.0.0.1:6379> TS.MADD sensor:2 1000 20 sensor:2 3000 25
+1) (integer) 1000
+2) (integer) 3000
+{{< / highlight >}}
+
+Query both series and pivot the samples by timestamp. One row is returned for every distinct timestamp produced by at least one key, with the values ordered by input key. A key with no sample at a row's timestamp has a `NaN` value cell.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.NRANGE 2 sensor:1 sensor:2 - +
+1) 1) (integer) 1000
+   2) 1) 10
+      2) 20
+2) 1) (integer) 2000
+   2) 1) 12
+      2) NaN
+3) 1) (integer) 3000
+   2) 1) NaN
+      2) 25
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Aggregate each series with a per-key aggregator</b></summary>
+
+In aggregation mode, supply exactly one aggregator per key, in key order. Here `sensor:1` is aggregated with `avg` and `sensor:2` with `sum`, both over 1000-millisecond buckets.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 1100 20 sensor:1 2000 30
+1) (integer) 1000
+2) (integer) 1100
+3) (integer) 2000
+127.0.0.1:6379> TS.MADD sensor:2 1000 5 sensor:2 1100 15 sensor:2 2000 25
+1) (integer) 1000
+2) (integer) 1100
+3) (integer) 2000
+127.0.0.1:6379> TS.NRANGE 2 sensor:1 sensor:2 - + AGGREGATION avg sum 1000
+1) 1) (integer) 1000
+   2) 1) 15
+      2) 20
+2) 1) (integer) 2000
+   2) 1) 30
+      2) 25
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Repeat a key to apply several aggregators to one series</b></summary>
+
+Because each value column maps to one key argument, you apply several aggregators to the same physical series by repeating its key. This query returns the `min` and the `max` of `sensor:1` per bucket as two separate value columns.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.NRANGE 2 sensor:1 sensor:1 - + AGGREGATION min max 1000
+1) 1) (integer) 1000
+   2) 1) 10
+      2) 20
+2) 1) (integer) 2000
+   2) 1) 30
+      2) 30
+{{< / highlight >}}
+</details>
+
+## Details
+
+### Semantics
+
+`TS.NRANGE` behaves like running a compatible [`TS.RANGE`]({{< relref "commands/ts.range/" >}}) over each input key and then performing a server-side outer join by timestamp. Rows are returned from the lowest timestamp to the highest.
+
+In raw mode (no `AGGREGATION`):
+
+- One row is returned for every distinct timestamp produced by at least one key.
+- If a key has no sample at that timestamp, that key's value cell is `NaN`.
+
+In aggregation mode (with `AGGREGATION`):
+
+- Exactly one aggregator applies to each key position; the aggregator at position _i_ maps to the key at position _i_.
+- All keys share one `bucketDuration`.
+- A missing bucket for one key is represented as `NaN` when another key emits that bucket timestamp.
+- With `EMPTY`, empty buckets can produce rows in which every value is `NaN`.
+
+### NaN values
+
+A `NaN` value cell can mean that a key had no sample (or no aggregation bucket) at the row's timestamp, or that the key stored or aggregated to a real `NaN`. These two cases are indistinguishable in the reply.
+
+| Case                                            | Cell value                                      |
+| ----------------------------------------------- | ----------------------------------------------- |
+| Key has a raw sample at the row timestamp        | The sample value                                |
+| Key has no raw sample at the row timestamp       | `NaN`                                           |
+| Key has aggregated data for the row bucket       | The aggregated value                            |
+| Key has no data for the row bucket               | `NaN`                                           |
+| Key stores or aggregates to a real `NaN`         | `NaN`, indistinguishable from missing data      |
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Not supported</span><br /> | <span title="Not supported">&#x274c; Flexible & Annual</span><br /><span title="Not supported">&#x274c; Free & Fixed</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="ts-nrange-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of pivot rows, ordered by increasing timestamp. Each row is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) (the timestamp) and an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) values, one per key in input order. A missing value is reported as `NaN`. The reply is an empty array when no samples match.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong number of aggregators, wrong key type, etc.
+
+-tab-sep-
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of pivot rows, ordered by increasing timestamp. Each row is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) (the timestamp) and an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}}) values, one per key in input order. A missing value is reported as `NaN`. The reply is an empty array when no samples match.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong number of aggregators, wrong key type, etc.
+
+{{< /multitabs >}}
+
+## See also
+
+[`TS.NREVRANGE`]({{< relref "commands/ts.nrevrange/" >}}) | [`TS.RANGE`]({{< relref "commands/ts.range/" >}}) | [`TS.MRANGE`]({{< relref "commands/ts.mrange/" >}})
+
+## Related topics
+
+[RedisTimeSeries]({{< relref "/develop/data-types/timeseries/" >}})

--- a/content/commands/ts.nrange.md
+++ b/content/commands/ts.nrange.md
@@ -142,7 +142,7 @@ command_flags:
 complexity: O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples
   per chunk), k = Number of samples that are in the requested range
 description: Query a range across multiple time series in forward direction, returning
-  the results pivoted by timestamp (one value column per key)
+  the results pivoted by timestamp (one value per key)
 group: timeseries
 hidden: false
 key_specs:
@@ -164,17 +164,17 @@ railroad_diagram: /images/railroad/ts.nrange.svg
 since: 8.10.0
 stack_path: docs/data-types/timeseries
 summary: Query a range across multiple time series in forward direction, returning
-  the results pivoted by timestamp (one value column per key)
+  the results pivoted by timestamp (one value per key)
 syntax_fmt: "TS.NRANGE numkeys key [key ...] fromTimestamp toTimestamp [LATEST]\n\
   \  [FILTER_BY_TS ts [ts ...]] [FILTER_BY_VALUE min max] [COUNT count]\n  [[ALIGN\
   \ align] AGGREGATION aggregators bucketDuration\n  [BUCKETTIMESTAMP <start | - |\
   \ end | + | mid | ~>] [EMPTY]]"
 title: TS.NRANGE
 ---
-Query a range across an explicit list of time series in the forward direction, returning the results pivoted by timestamp with one value column per key. Rows are ordered by increasing timestamp, and the value array in each row preserves the order of the input keys.
+Query a range across an explicit list of time series in the forward direction, returning the results pivoted by timestamp with one value per key in each row. Rows are ordered by increasing timestamp, and each row's values follow the order of the input keys.
 
 {{< note >}}
-In a Redis cluster, all specified keys must hash to the same slot. `TS.NRANGE` is a single-shard command: it does not split a request across shards or merge replies from multiple shards.
+In a Redis cluster, all specified keys must map to the same hash slot. `TS.NRANGE` is a [single hash slot]({{< relref "/operate/oss_and_stack/reference/cluster-spec#key-distribution-model" >}}) command; it does not split a request across shards or merge replies from multiple hash slots.
 {{< /note >}}
 
 [Examples](#examples)
@@ -190,7 +190,7 @@ is the number of time series keys that follow. It must be a positive integer and
 <details open>
 <summary><code>key [key ...]</code></summary>
 
-are the explicit time series keys to query. Key order and duplicate keys are significant: the output has one value column per `key` argument, in the order the keys are given. A repeated key produces a separate value column for each occurrence.
+are the explicit time series keys to query. Key order and duplicate keys are significant: the reply has one value per `key` argument, in the order the keys are given. A repeated key produces a separate value for each occurrence.
 </details>
 
 <details open>
@@ -311,7 +311,7 @@ is a flag, which, when specified, reports aggregations also for empty buckets.
 | `twa`                | Average value over the bucket's timeframe based on linear interpolation of the last sample before the bucket's start and the first sample after the bucket's end. `NaN` when no such samples. |
 | `min`, `max`, `range`, `avg`, `first`, `std.p`, `std.s` | `NaN` |
 
-Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the earliest sample or begin after the latest sample in the time series. When a bucket is reported for one key but a different key has no data in that bucket, that key's value cell is `NaN`.
+Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the earliest sample or begin after the latest sample in the time series. When a bucket is reported for one key but a different key has no data in that bucket, that key's value is `NaN`.
 </details>
 
 ## Examples
@@ -322,22 +322,22 @@ Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is report
 Create two time series and add samples at partially overlapping timestamps.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.CREATE sensor:1
+127.0.0.1:6379> TS.CREATE {sensor}:1
 OK
-127.0.0.1:6379> TS.CREATE sensor:2
+127.0.0.1:6379> TS.CREATE {sensor}:2
 OK
-127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 2000 12
+127.0.0.1:6379> TS.MADD {sensor}:1 1000 10 {sensor}:1 2000 12
 1) (integer) 1000
 2) (integer) 2000
-127.0.0.1:6379> TS.MADD sensor:2 1000 20 sensor:2 3000 25
+127.0.0.1:6379> TS.MADD {sensor}:2 1000 20 {sensor}:2 3000 25
 1) (integer) 1000
 2) (integer) 3000
 {{< / highlight >}}
 
-Query both series and pivot the samples by timestamp. One row is returned for every distinct timestamp produced by at least one key, with the values ordered by input key. A key with no sample at a row's timestamp has a `NaN` value cell.
+Query both series and pivot the samples by timestamp. One row is returned for every distinct timestamp produced by at least one key, with the values ordered by input key. A key with no sample at a row's timestamp has a `NaN` value.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.NRANGE 2 sensor:1 sensor:2 - +
+127.0.0.1:6379> TS.NRANGE 2 {sensor}:1 {sensor}:2 - +
 1) 1) (integer) 1000
    2) 1) 10
       2) 20
@@ -353,18 +353,18 @@ Query both series and pivot the samples by timestamp. One row is returned for ev
 <details open>
 <summary><b>Aggregate each series with a per-key aggregator</b></summary>
 
-In aggregation mode, supply exactly one aggregator per key, in key order. Here `sensor:1` is aggregated with `avg` and `sensor:2` with `sum`, both over 1000-millisecond buckets.
+In aggregation mode, supply exactly one aggregator per key, in key order. Here `{sensor}:1` is aggregated with `avg` and `{sensor}:2` with `sum`, both over 1000-millisecond buckets.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 1100 20 sensor:1 2000 30
+127.0.0.1:6379> TS.MADD {sensor}:1 1000 10 {sensor}:1 1100 20 {sensor}:1 2000 30
 1) (integer) 1000
 2) (integer) 1100
 3) (integer) 2000
-127.0.0.1:6379> TS.MADD sensor:2 1000 5 sensor:2 1100 15 sensor:2 2000 25
+127.0.0.1:6379> TS.MADD {sensor}:2 1000 5 {sensor}:2 1100 15 {sensor}:2 2000 25
 1) (integer) 1000
 2) (integer) 1100
 3) (integer) 2000
-127.0.0.1:6379> TS.NRANGE 2 sensor:1 sensor:2 - + AGGREGATION avg sum 1000
+127.0.0.1:6379> TS.NRANGE 2 {sensor}:1 {sensor}:2 - + AGGREGATION avg sum 1000
 1) 1) (integer) 1000
    2) 1) 15
       2) 20
@@ -377,10 +377,10 @@ In aggregation mode, supply exactly one aggregator per key, in key order. Here `
 <details open>
 <summary><b>Repeat a key to apply several aggregators to one series</b></summary>
 
-Because each value column maps to one key argument, you apply several aggregators to the same physical series by repeating its key. This query returns the `min` and the `max` of `sensor:1` per bucket as two separate value columns.
+Because each value maps to one key argument, you apply several aggregators to the same physical series by repeating its key. This query returns the `min` and the `max` of `{sensor}:1` per bucket as two separate values.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.NRANGE 2 sensor:1 sensor:1 - + AGGREGATION min max 1000
+127.0.0.1:6379> TS.NRANGE 2 {sensor}:1 {sensor}:1 - + AGGREGATION min max 1000
 1) 1) (integer) 1000
    2) 1) 10
       2) 20
@@ -399,7 +399,7 @@ Because each value column maps to one key argument, you apply several aggregator
 In raw mode (no `AGGREGATION`):
 
 - One row is returned for every distinct timestamp produced by at least one key.
-- If a key has no sample at that timestamp, that key's value cell is `NaN`.
+- If a key has no sample at that timestamp, that key's value is `NaN`.
 
 In aggregation mode (with `AGGREGATION`):
 
@@ -410,15 +410,15 @@ In aggregation mode (with `AGGREGATION`):
 
 ### NaN values
 
-A `NaN` value cell can mean that a key had no sample (or no aggregation bucket) at the row's timestamp, or that the key stored or aggregated to a real `NaN`. These two cases are indistinguishable in the reply.
+A `NaN` value can mean that a key had no sample (or no aggregation bucket) at the row's timestamp, or that the key stored or aggregated to a real `NaN`. These two cases are indistinguishable in the reply.
 
-| Case                                            | Cell value                                      |
+| Case                                            | Value                                           |
 | ----------------------------------------------- | ----------------------------------------------- |
 | Key has a raw sample at the row timestamp        | The sample value                                |
 | Key has no raw sample at the row timestamp       | `NaN`                                           |
 | Key has aggregated data for the row bucket       | The aggregated value                            |
 | Key has no data for the row bucket               | `NaN`                                           |
-| Key stores or aggregates to a real `NaN`         | `NaN`, indistinguishable from missing data      |
+| Key stores or aggregates to a real `NaN`         | `NaN`, indistinguishable from no data           |
 
 ## Redis Software and Redis Cloud compatibility
 

--- a/content/commands/ts.nrevrange.md
+++ b/content/commands/ts.nrevrange.md
@@ -1,0 +1,453 @@
+---
+acl_categories:
+- '@read'
+- '@timeseries'
+arguments:
+- display_text: numkeys
+  name: numkeys
+  type: integer
+- display_text: key
+  key_spec_index: 0
+  multiple: true
+  name: key
+  type: key
+- display_text: fromTimestamp
+  name: fromTimestamp
+  type: string
+- display_text: toTimestamp
+  name: toTimestamp
+  type: string
+- display_text: latest
+  name: latest
+  optional: true
+  token: LATEST
+  type: pure-token
+- arguments:
+  - display_text: filter_by_ts_token
+    name: filter_by_ts_token
+    token: FILTER_BY_TS
+    type: pure-token
+  - display_text: ts
+    multiple: true
+    name: ts
+    type: integer
+  name: filter_by_ts_block
+  optional: true
+  type: block
+- arguments:
+  - display_text: filter_by_value_token
+    name: filter_by_value_token
+    token: FILTER_BY_VALUE
+    type: pure-token
+  - display_text: min
+    name: min
+    type: double
+  - display_text: max
+    name: max
+    type: double
+  name: filter_by_value_block
+  optional: true
+  type: block
+- arguments:
+  - display_text: count_token
+    name: count_token
+    token: COUNT
+    type: pure-token
+  - display_text: count
+    name: count
+    type: integer
+  name: count_block
+  optional: true
+  type: block
+- arguments:
+  - arguments:
+    - display_text: align_token
+      name: align_token
+      token: ALIGN
+      type: pure-token
+    - display_text: align
+      name: align
+      type: string
+    name: align_block
+    optional: true
+    type: block
+  - display_text: aggregation
+    name: aggregation
+    token: AGGREGATION
+    type: pure-token
+  - display_text: aggregators
+    name: aggregators
+    type: string
+  - display_text: bucketDuration
+    name: bucketDuration
+    type: integer
+  - arguments:
+    - display_text: buckettimestamp_token
+      name: buckettimestamp_token
+      token: BUCKETTIMESTAMP
+      type: pure-token
+    - arguments:
+      - display_text: start
+        name: start
+        token: start
+        type: pure-token
+      - display_text: start
+        name: start
+        token: '-'
+        type: pure-token
+      - display_text: end
+        name: end
+        token: end
+        type: pure-token
+      - display_text: end
+        name: end
+        token: +
+        type: pure-token
+      - display_text: mid
+        name: mid
+        token: mid
+        type: pure-token
+      - display_text: mid
+        name: mid
+        token: '~'
+        type: pure-token
+      name: bt
+      type: oneof
+    name: buckettimestamp_block
+    optional: true
+    type: block
+  - display_text: empty_token
+    name: empty_token
+    optional: true
+    token: EMPTY
+    type: pure-token
+  name: aggregation_block
+  optional: true
+  type: block
+arity: -5
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+- module
+- movablekeys
+complexity: O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples
+  per chunk), k = Number of samples that are in the requested range
+description: Query a range across multiple time series in reverse direction, returning
+  the results pivoted by timestamp (one value column per key)
+group: timeseries
+hidden: false
+key_specs:
+- RO: true
+  access: true
+  begin_search:
+    spec:
+      index: 1
+    type: index
+  find_keys:
+    spec:
+      firstkey: 1
+      keynumidx: 0
+      keystep: 1
+    type: keynum
+linkTitle: TS.NREVRANGE
+module: TimeSeries
+railroad_diagram: /images/railroad/ts.nrevrange.svg
+since: 8.10.0
+stack_path: docs/data-types/timeseries
+summary: Query a range across multiple time series in reverse direction, returning
+  the results pivoted by timestamp (one value column per key)
+syntax_fmt: "TS.NREVRANGE numkeys key [key ...] fromTimestamp toTimestamp\n  [LATEST]\
+  \ [FILTER_BY_TS ts [ts ...]] [FILTER_BY_VALUE min max]\n  [COUNT count] [[ALIGN\
+  \ align] AGGREGATION aggregators\n  bucketDuration [BUCKETTIMESTAMP <start | - |\
+  \ end | + | mid | ~>]\n  [EMPTY]]"
+title: TS.NREVRANGE
+---
+Query a range across an explicit list of time series in the reverse direction, returning the results pivoted by timestamp with one value column per key. Rows are ordered by decreasing timestamp, and the value array in each row preserves the order of the input keys.
+
+{{< note >}}
+In a Redis cluster, all specified keys must hash to the same slot. `TS.NREVRANGE` is a single-shard command: it does not split a request across shards or merge replies from multiple shards.
+{{< /note >}}
+
+[Examples](#examples)
+
+## Required arguments
+
+<details open>
+<summary><code>numkeys</code></summary>
+
+is the number of time series keys that follow. It must be a positive integer and must equal the number of `key` arguments.
+</details>
+
+<details open>
+<summary><code>key [key ...]</code></summary>
+
+are the explicit time series keys to query. Key order and duplicate keys are significant: the output has one value column per `key` argument, in the order the keys are given. A repeated key produces a separate value column for each occurrence.
+</details>
+
+<details open>
+<summary><code>fromTimestamp</code></summary>
+
+is the start timestamp for the range query (integer Unix timestamp in milliseconds) or `-` to denote the timestamp of the earliest sample among the specified time series. The range is inclusive.
+</details>
+
+<details open>
+<summary><code>toTimestamp</code></summary>
+
+is the end timestamp for the range query (integer Unix timestamp in milliseconds) or `+` to denote the timestamp of the latest sample among the specified time series. The range is inclusive.
+</details>
+
+## Optional arguments
+
+<details open>
+<summary><code>LATEST</code></summary>
+
+is used when a time series is a compaction. With `LATEST`, TS.NREVRANGE also reports the compacted value of the latest, possibly partial, bucket, given that this bucket's start time falls within `[fromTimestamp, toTimestamp]`. Without `LATEST`, TS.NREVRANGE does not report the latest, possibly partial, bucket. When a time series is not a compaction, `LATEST` is ignored.
+
+The data in the latest bucket of a compaction is possibly partial. A bucket is _closed_ and compacted only upon arrival of a new sample that _opens_ a new _latest_ bucket. There are cases, however, when the compacted value of the latest, possibly partial, bucket is also required. In such a case, use `LATEST`.
+</details>
+
+<details open>
+<summary><code>FILTER_BY_TS ts...</code></summary>
+
+filters samples by a list of specific timestamps. A sample passes the filter if its exact timestamp is specified and falls within `[fromTimestamp, toTimestamp]`. Samples are filtered before pivoting.
+
+When used together with `AGGREGATION`: samples are filtered before being aggregated.
+</details>
+
+<details open>
+<summary><code>FILTER_BY_VALUE min max</code></summary>
+
+filters samples by minimum and maximum values. A sample passes the filter if its value is within the inclusive range `[min, max]`. `min` and `max` cannot be NaN values. Samples are filtered before pivoting.
+
+When used together with `AGGREGATION`: samples are filtered before being aggregated.
+</details>
+
+<details open>
+<summary><code>COUNT count</code></summary>
+
+limits the number of returned pivot rows, keeping the rows with the highest timestamps. The limit is applied after the per-timestamp merge.
+</details>
+
+<details open>
+<summary><code>ALIGN align</code></summary>
+
+is a time bucket alignment control for `AGGREGATION`. It controls the time bucket timestamps by changing the reference timestamp on which a bucket is defined.
+
+`align` values include:
+
+ - `start` or `-`: The reference timestamp will be the query start interval time (`fromTimestamp`) which can't be `-`
+ - `end` or `+`: The reference timestamp will be the query end interval time (`toTimestamp`) which can't be `+`
+ - A specific timestamp: align the reference timestamp to a specific time
+
+<note><b>Note:</b> When not provided, alignment is set to `0`.</note>
+</details>
+
+<details open>
+<summary><code>AGGREGATION aggregators bucketDuration</code></summary>
+
+aggregates samples into time buckets.
+
+Unlike [`TS.REVRANGE`]({{< relref "commands/ts.revrange/" >}}), TS.NREVRANGE requires exactly one aggregator per key. The aggregators are given as separate, space-separated arguments — one per `key`, in the same order as the keys — and not as a single comma-joined token. The aggregator in position _i_ applies to the key in position _i_, and all keys share the same `bucketDuration`. The comma-joined form (for example `AGGREGATION min,avg,max`) is rejected.
+
+  - each `aggregator` is one of the following:
+
+    | aggregator   | Description                                                     |
+    | ------------ | --------------------------------------------------------------- |
+    | `avg`        | Arithmetic mean of all non-NaN values                           |
+    | `sum`        | Sum of all non-NaN values                                       |
+    | `min`        | Minimum non-NaN value                                           |
+    | `max`        | Maximum non-NaN value                                           |
+    | `range`      | Difference between the maximum and the minimum non-NaN values   |
+    | `count`      | Number of non-NaN values                                        |
+    | `countNaN`   | Number of NaN values                                            |
+    | `countAll`   | Number of values, including NaN and non-NaN                     |
+    | `first`      | The non-NaN value with the lowest timestamp in the bucket       |
+    | `last`       | The non-NaN value with the highest timestamp in the bucket      |
+    | `std.p`      | Population standard deviation of the non-NaN values             |
+    | `std.s`      | Sample standard deviation of the non-NaN values                 |
+    | `var.p`      | Population variance of the non-NaN values                       |
+    | `var.s`      | Sample variance of the non-NaN values                           |
+    | `twa`        | Time-weighted average over the bucket's timeframe (ignores NaN values) |
+
+  - `bucketDuration` is the duration of each bucket, in milliseconds.
+
+  Without `ALIGN`, bucket start times are multiples of `bucketDuration`.
+
+  With `ALIGN align`, bucket start times are multiples of `bucketDuration` with remainder `align % bucketDuration`.
+
+  The first bucket start time is less than or equal to `fromTimestamp`.
+</details>
+
+<details open>
+<summary><code>[BUCKETTIMESTAMP bt]</code></summary>
+
+controls how bucket timestamps are reported.
+
+| `bt`             | Timestamp reported for each bucket                            |
+| ---------------- | ------------------------------------------------------------- |
+| `-` or `start`   | the bucket's start time (default)                             |
+| `+` or `end`     | the bucket's end time                                         |
+| `~` or `mid`     | the bucket's mid time (rounded down if not an integer)        |
+</details>
+
+<details open>
+<summary><code>[EMPTY]</code></summary>
+
+is a flag, which, when specified, reports aggregations also for empty buckets.
+
+| aggregator           | Value reported for each empty bucket |
+| -------------------- | ------------------------------------ |
+| `sum`, `count`       | `0`                                  |
+| `last`               | The value of the last sample before the bucket's start. `NaN` when no such sample. |
+| `twa`                | Average value over the bucket's timeframe based on linear interpolation of the last sample before the bucket's start and the first sample after the bucket's end. `NaN` when no such samples. |
+| `min`, `max`, `range`, `avg`, `first`, `std.p`, `std.s` | `NaN` |
+
+Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the earliest sample or begin after the latest sample in the time series. When a bucket is reported for one key but a different key has no data in that bucket, that key's value cell is `NaN`.
+</details>
+
+## Examples
+
+<details open>
+<summary><b>Pivot raw samples from multiple series by timestamp</b></summary>
+
+Create two time series and add samples at partially overlapping timestamps.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE sensor:1
+OK
+127.0.0.1:6379> TS.CREATE sensor:2
+OK
+127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 2000 12
+1) (integer) 1000
+2) (integer) 2000
+127.0.0.1:6379> TS.MADD sensor:2 1000 20 sensor:2 3000 25
+1) (integer) 1000
+2) (integer) 3000
+{{< / highlight >}}
+
+Query both series and pivot the samples by timestamp. One row is returned for every distinct timestamp produced by at least one key, ordered from the highest timestamp to the lowest, with the values ordered by input key. A key with no sample at a row's timestamp has a `NaN` value cell.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.NREVRANGE 2 sensor:1 sensor:2 - +
+1) 1) (integer) 3000
+   2) 1) NaN
+      2) 25
+2) 1) (integer) 2000
+   2) 1) 12
+      2) NaN
+3) 1) (integer) 1000
+   2) 1) 10
+      2) 20
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Aggregate each series with a per-key aggregator</b></summary>
+
+In aggregation mode, supply exactly one aggregator per key, in key order. Here `sensor:1` is aggregated with `avg` and `sensor:2` with `sum`, both over 1000-millisecond buckets.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 1100 20 sensor:1 2000 30
+1) (integer) 1000
+2) (integer) 1100
+3) (integer) 2000
+127.0.0.1:6379> TS.MADD sensor:2 1000 5 sensor:2 1100 15 sensor:2 2000 25
+1) (integer) 1000
+2) (integer) 1100
+3) (integer) 2000
+127.0.0.1:6379> TS.NREVRANGE 2 sensor:1 sensor:2 - + AGGREGATION avg sum 1000
+1) 1) (integer) 2000
+   2) 1) 30
+      2) 25
+2) 1) (integer) 1000
+   2) 1) 15
+      2) 20
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Repeat a key to apply several aggregators to one series</b></summary>
+
+Because each value column maps to one key argument, you apply several aggregators to the same physical series by repeating its key. This query returns the `min` and the `max` of `sensor:1` per bucket as two separate value columns.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.NREVRANGE 2 sensor:1 sensor:1 - + AGGREGATION min max 1000
+1) 1) (integer) 2000
+   2) 1) 30
+      2) 30
+2) 1) (integer) 1000
+   2) 1) 10
+      2) 20
+{{< / highlight >}}
+</details>
+
+## Details
+
+### Semantics
+
+`TS.NREVRANGE` behaves like running a compatible [`TS.REVRANGE`]({{< relref "commands/ts.revrange/" >}}) over each input key and then performing a server-side outer join by timestamp. Rows are returned from the highest timestamp to the lowest.
+
+In raw mode (no `AGGREGATION`):
+
+- One row is returned for every distinct timestamp produced by at least one key.
+- If a key has no sample at that timestamp, that key's value cell is `NaN`.
+
+In aggregation mode (with `AGGREGATION`):
+
+- Exactly one aggregator applies to each key position; the aggregator at position _i_ maps to the key at position _i_.
+- All keys share one `bucketDuration`.
+- A missing bucket for one key is represented as `NaN` when another key emits that bucket timestamp.
+- With `EMPTY`, empty buckets can produce rows in which every value is `NaN`.
+
+### NaN values
+
+A `NaN` value cell can mean that a key had no sample (or no aggregation bucket) at the row's timestamp, or that the key stored or aggregated to a real `NaN`. These two cases are indistinguishable in the reply.
+
+| Case                                            | Cell value                                      |
+| ----------------------------------------------- | ----------------------------------------------- |
+| Key has a raw sample at the row timestamp        | The sample value                                |
+| Key has no raw sample at the row timestamp       | `NaN`                                           |
+| Key has aggregated data for the row bucket       | The aggregated value                            |
+| Key has no data for the row bucket               | `NaN`                                           |
+| Key stores or aggregates to a real `NaN`         | `NaN`, indistinguishable from missing data      |
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Not supported</span><br /> | <span title="Not supported">&#x274c; Flexible & Annual</span><br /><span title="Not supported">&#x274c; Free & Fixed</nobr></span> |  
+
+## Return information
+
+{{< multitabs id="ts-nrevrange-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of pivot rows, ordered by decreasing timestamp. Each row is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) (the timestamp) and an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) values, one per key in input order. A missing value is reported as `NaN`. The reply is an empty array when no samples match.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong number of aggregators, wrong key type, etc.
+
+-tab-sep-
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of pivot rows, ordered by decreasing timestamp. Each row is an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of an [Integer reply]({{< relref "/develop/reference/protocol-spec#integers" >}}) (the timestamp) and an [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) of [Double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}}) values, one per key in input order. A missing value is reported as `NaN`. The reply is an empty array when no samples match.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid arguments, wrong number of aggregators, wrong key type, etc.
+
+{{< /multitabs >}}
+
+## See also
+
+[`TS.NRANGE`]({{< relref "commands/ts.nrange/" >}}) | [`TS.REVRANGE`]({{< relref "commands/ts.revrange/" >}}) | [`TS.MREVRANGE`]({{< relref "commands/ts.mrevrange/" >}})
+
+## Related topics
+
+[RedisTimeSeries]({{< relref "/develop/data-types/timeseries/" >}})

--- a/content/commands/ts.nrevrange.md
+++ b/content/commands/ts.nrevrange.md
@@ -142,7 +142,7 @@ command_flags:
 complexity: O(numkeys*(n/m+k)) where n = Number of samples, m = Chunk size (samples
   per chunk), k = Number of samples that are in the requested range
 description: Query a range across multiple time series in reverse direction, returning
-  the results pivoted by timestamp (one value column per key)
+  the results pivoted by timestamp (one value per key)
 group: timeseries
 hidden: false
 key_specs:
@@ -164,17 +164,17 @@ railroad_diagram: /images/railroad/ts.nrevrange.svg
 since: 8.10.0
 stack_path: docs/data-types/timeseries
 summary: Query a range across multiple time series in reverse direction, returning
-  the results pivoted by timestamp (one value column per key)
+  the results pivoted by timestamp (one value per key)
 syntax_fmt: "TS.NREVRANGE numkeys key [key ...] fromTimestamp toTimestamp\n  [LATEST]\
   \ [FILTER_BY_TS ts [ts ...]] [FILTER_BY_VALUE min max]\n  [COUNT count] [[ALIGN\
   \ align] AGGREGATION aggregators\n  bucketDuration [BUCKETTIMESTAMP <start | - |\
   \ end | + | mid | ~>]\n  [EMPTY]]"
 title: TS.NREVRANGE
 ---
-Query a range across an explicit list of time series in the reverse direction, returning the results pivoted by timestamp with one value column per key. Rows are ordered by decreasing timestamp, and the value array in each row preserves the order of the input keys.
+Query a range across an explicit list of time series in the reverse direction, returning the results pivoted by timestamp with one value per key in each row. Rows are ordered by decreasing timestamp, and each row's values follow the order of the input keys.
 
 {{< note >}}
-In a Redis cluster, all specified keys must hash to the same slot. `TS.NREVRANGE` is a single-shard command: it does not split a request across shards or merge replies from multiple shards.
+In a Redis cluster, all specified keys must map to the same hash slot. `TS.NREVRANGE` is a [single hash slot]({{< relref "/operate/oss_and_stack/reference/cluster-spec#key-distribution-model" >}}) command; it does not split a request across shards or merge replies from multiple hash slots.
 {{< /note >}}
 
 [Examples](#examples)
@@ -190,7 +190,7 @@ is the number of time series keys that follow. It must be a positive integer and
 <details open>
 <summary><code>key [key ...]</code></summary>
 
-are the explicit time series keys to query. Key order and duplicate keys are significant: the output has one value column per `key` argument, in the order the keys are given. A repeated key produces a separate value column for each occurrence.
+are the explicit time series keys to query. Key order and duplicate keys are significant: the output has one value per `key` argument, in the order the keys are given. A repeated key produces a separate value for each occurrence.
 </details>
 
 <details open>
@@ -311,7 +311,7 @@ is a flag, which, when specified, reports aggregations also for empty buckets.
 | `twa`                | Average value over the bucket's timeframe based on linear interpolation of the last sample before the bucket's start and the first sample after the bucket's end. `NaN` when no such samples. |
 | `min`, `max`, `range`, `avg`, `first`, `std.p`, `std.s` | `NaN` |
 
-Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the earliest sample or begin after the latest sample in the time series. When a bucket is reported for one key but a different key has no data in that bucket, that key's value cell is `NaN`.
+Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is reported for buckets that end before the earliest sample or begin after the latest sample in the time series. When a bucket is reported for one key but a different key has no data in that bucket, that key's value is `NaN`.
 </details>
 
 ## Examples
@@ -322,22 +322,22 @@ Regardless of the values of `fromTimestamp` and `toTimestamp`, no data is report
 Create two time series and add samples at partially overlapping timestamps.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.CREATE sensor:1
+127.0.0.1:6379> TS.CREATE {sensor}:1
 OK
-127.0.0.1:6379> TS.CREATE sensor:2
+127.0.0.1:6379> TS.CREATE {sensor}:2
 OK
-127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 2000 12
+127.0.0.1:6379> TS.MADD {sensor}:1 1000 10 {sensor}:1 2000 12
 1) (integer) 1000
 2) (integer) 2000
-127.0.0.1:6379> TS.MADD sensor:2 1000 20 sensor:2 3000 25
+127.0.0.1:6379> TS.MADD {sensor}:2 1000 20 {sensor}:2 3000 25
 1) (integer) 1000
 2) (integer) 3000
 {{< / highlight >}}
 
-Query both series and pivot the samples by timestamp. One row is returned for every distinct timestamp produced by at least one key, ordered from the highest timestamp to the lowest, with the values ordered by input key. A key with no sample at a row's timestamp has a `NaN` value cell.
+Query both series and pivot the samples by timestamp. One row is returned for every distinct timestamp produced by at least one key, ordered from the highest timestamp to the lowest, with the values ordered by input key. A key with no sample at a row's timestamp has a `NaN` value.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.NREVRANGE 2 sensor:1 sensor:2 - +
+127.0.0.1:6379> TS.NREVRANGE 2 {sensor}:1 {sensor}:2 - +
 1) 1) (integer) 3000
    2) 1) NaN
       2) 25
@@ -353,18 +353,18 @@ Query both series and pivot the samples by timestamp. One row is returned for ev
 <details open>
 <summary><b>Aggregate each series with a per-key aggregator</b></summary>
 
-In aggregation mode, supply exactly one aggregator per key, in key order. Here `sensor:1` is aggregated with `avg` and `sensor:2` with `sum`, both over 1000-millisecond buckets.
+In aggregation mode, supply exactly one aggregator per key, in key order. Here `{sensor}:1` is aggregated with `avg` and `{sensor}:2` with `sum`, both over 1000-millisecond buckets.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.MADD sensor:1 1000 10 sensor:1 1100 20 sensor:1 2000 30
+127.0.0.1:6379> TS.MADD {sensor}:1 1000 10 {sensor}:1 1100 20 {sensor}:1 2000 30
 1) (integer) 1000
 2) (integer) 1100
 3) (integer) 2000
-127.0.0.1:6379> TS.MADD sensor:2 1000 5 sensor:2 1100 15 sensor:2 2000 25
+127.0.0.1:6379> TS.MADD {sensor}:2 1000 5 {sensor}:2 1100 15 {sensor}:2 2000 25
 1) (integer) 1000
 2) (integer) 1100
 3) (integer) 2000
-127.0.0.1:6379> TS.NREVRANGE 2 sensor:1 sensor:2 - + AGGREGATION avg sum 1000
+127.0.0.1:6379> TS.NREVRANGE 2 {sensor}:1 {sensor}:2 - + AGGREGATION avg sum 1000
 1) 1) (integer) 2000
    2) 1) 30
       2) 25
@@ -377,10 +377,10 @@ In aggregation mode, supply exactly one aggregator per key, in key order. Here `
 <details open>
 <summary><b>Repeat a key to apply several aggregators to one series</b></summary>
 
-Because each value column maps to one key argument, you apply several aggregators to the same physical series by repeating its key. This query returns the `min` and the `max` of `sensor:1` per bucket as two separate value columns.
+Because each value maps to one key argument, you apply several aggregators to the same physical series by repeating its key. This query returns the `min` and the `max` of `{sensor}:1` per bucket as two separate values.
 
 {{< highlight bash >}}
-127.0.0.1:6379> TS.NREVRANGE 2 sensor:1 sensor:1 - + AGGREGATION min max 1000
+127.0.0.1:6379> TS.NREVRANGE 2 {sensor}:1 {sensor}:1 - + AGGREGATION min max 1000
 1) 1) (integer) 2000
    2) 1) 30
       2) 30
@@ -399,7 +399,7 @@ Because each value column maps to one key argument, you apply several aggregator
 In raw mode (no `AGGREGATION`):
 
 - One row is returned for every distinct timestamp produced by at least one key.
-- If a key has no sample at that timestamp, that key's value cell is `NaN`.
+- If a key has no sample at that timestamp, that key's value is `NaN`.
 
 In aggregation mode (with `AGGREGATION`):
 
@@ -410,15 +410,15 @@ In aggregation mode (with `AGGREGATION`):
 
 ### NaN values
 
-A `NaN` value cell can mean that a key had no sample (or no aggregation bucket) at the row's timestamp, or that the key stored or aggregated to a real `NaN`. These two cases are indistinguishable in the reply.
+A `NaN` value can mean that a key had no sample (or no aggregation bucket) at the row's timestamp, or that the key stored or aggregated to a real `NaN`. These two cases are indistinguishable in the reply.
 
-| Case                                            | Cell value                                      |
+| Case                                            | Value                                           |
 | ----------------------------------------------- | ----------------------------------------------- |
 | Key has a raw sample at the row timestamp        | The sample value                                |
 | Key has no raw sample at the row timestamp       | `NaN`                                           |
 | Key has aggregated data for the row bucket       | The aggregated value                            |
 | Key has no data for the row bucket               | `NaN`                                           |
-| Key stores or aggregates to a real `NaN`         | `NaN`, indistinguishable from missing data      |
+| Key stores or aggregates to a real `NaN`         | `NaN`, indistinguishable from no data           |
 
 ## Redis Software and Redis Cloud compatibility
 

--- a/static/images/railroad/ts.bget.svg
+++ b/static/images/railroad/ts.bget.svg
@@ -1,0 +1,63 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 977.0 71" width="977.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M927.0 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M129.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="50.0" y="29"></rect><text x="89.75" y="44">TS.BGET</text></g><path d="M129.5 40h10"></path><path d="M139.5 40h10"></path><g class="non-terminal ">
+<path d="M149.5 40h0.0"></path><path d="M195.0 40h0.0"></path><rect height="22" width="45.5" x="149.5" y="29"></rect><text x="172.25" y="44">key</text></g><path d="M195.0 40h10"></path><path d="M205.0 40h10"></path><g class="non-terminal ">
+<path d="M215.0 40h0.0"></path><path d="M311.5 40h0.0"></path><rect height="22" width="96.5" x="215.0" y="29"></rect><text x="263.25" y="44">timestamp</text></g><path d="M311.5 40h10"></path><path d="M321.5 40h10"></path><g class="non-terminal ">
+<path d="M331.5 40h0.0"></path><path d="M411.0 40h0.0"></path><rect height="22" width="79.5" x="331.5" y="29"></rect><text x="371.25" y="44">timeout</text></g><path d="M411.0 40h10"></path><g>
+<path d="M421.0 40h0.0"></path><path d="M674.0 40h0.0"></path><path d="M421.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M441.0 20h213.0"></path></g><path d="M654.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M421.0 40h20"></path><g>
+<path d="M441.0 40h0.0"></path><path d="M654.0 40h0.0"></path><g>
+<path d="M441.0 40h0.0"></path><path d="M654.0 40h0.0"></path><g class="terminal ">
+<path d="M441.0 40h0.0"></path><path d="M537.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="441.0" y="29"></rect><text x="489.25" y="44">MIN&#95;COUNT</text></g><path d="M537.5 40h10"></path><path d="M547.5 40h10"></path><g class="non-terminal ">
+<path d="M557.5 40h0.0"></path><path d="M654.0 40h0.0"></path><rect height="22" width="96.5" x="557.5" y="29"></rect><text x="605.75" y="44">min&#95;count</text></g></g></g><path d="M654.0 40h20"></path></g><g>
+<path d="M674.0 40h0.0"></path><path d="M927.0 40h0.0"></path><path d="M674.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M694.0 20h213.0"></path></g><path d="M907.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M674.0 40h20"></path><g>
+<path d="M694.0 40h0.0"></path><path d="M907.0 40h0.0"></path><g>
+<path d="M694.0 40h0.0"></path><path d="M907.0 40h0.0"></path><g class="terminal ">
+<path d="M694.0 40h0.0"></path><path d="M790.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="694.0" y="29"></rect><text x="742.25" y="44">MAX&#95;COUNT</text></g><path d="M790.5 40h10"></path><path d="M800.5 40h10"></path><g class="non-terminal ">
+<path d="M810.5 40h0.0"></path><path d="M907.0 40h0.0"></path><rect height="22" width="96.5" x="810.5" y="29"></rect><text x="858.75" y="44">max&#95;count</text></g></g></g><path d="M907.0 40h20"></path></g></g><path d="M927.0 40h10"></path><path d="M 937.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/ts.nrange.svg
+++ b/static/images/railroad/ts.nrange.svg
@@ -1,0 +1,100 @@
+<svg class="railroad-diagram" height="229" viewBox="0 0 2582.5 229" width="2582.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 38v20m10 -20v20m-10 -10h20"></path></g><path d="M40 48h10"></path><g>
+<path d="M50 48h0.0"></path><path d="M2532.5 48h0.0"></path><g class="terminal ">
+<path d="M50.0 48h0.0"></path><path d="M146.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="50.0" y="37"></rect><text x="98.25" y="52">TS.NRANGE</text></g><path d="M146.5 48h10"></path><path d="M156.5 48h10"></path><g class="non-terminal ">
+<path d="M166.5 48h0.0"></path><path d="M246.0 48h0.0"></path><rect height="22" width="79.5" x="166.5" y="37"></rect><text x="206.25" y="52">numkeys</text></g><path d="M246.0 48h10"></path><path d="M256.0 48h10"></path><g>
+<path d="M266.0 48h0.0"></path><path d="M331.5 48h0.0"></path><path d="M266.0 48h10"></path><g class="non-terminal ">
+<path d="M276.0 48h0.0"></path><path d="M321.5 48h0.0"></path><rect height="22" width="45.5" x="276.0" y="37"></rect><text x="298.75" y="52">key</text></g><path d="M321.5 48h10"></path><path d="M276.0 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M276.0 68h45.5"></path></g><path d="M321.5 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M331.5 48h10"></path><path d="M341.5 48h10"></path><g class="non-terminal ">
+<path d="M351.5 48h0.0"></path><path d="M482.0 48h0.0"></path><rect height="22" width="130.5" x="351.5" y="37"></rect><text x="416.75" y="52">fromTimestamp</text></g><path d="M482.0 48h10"></path><path d="M492.0 48h10"></path><g class="non-terminal ">
+<path d="M502.0 48h0.0"></path><path d="M615.5 48h0.0"></path><rect height="22" width="113.5" x="502.0" y="37"></rect><text x="558.75" y="52">toTimestamp</text></g><path d="M615.5 48h10"></path><g>
+<path d="M625.5 48h0.0"></path><path d="M736.5 48h0.0"></path><path d="M625.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M645.5 28h71.0"></path></g><path d="M716.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M625.5 48h20"></path><g class="terminal ">
+<path d="M645.5 48h0.0"></path><path d="M716.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="645.5" y="37"></rect><text x="681.0" y="52">LATEST</text></g><path d="M716.5 48h20"></path></g><g>
+<path d="M736.5 48h0.0"></path><path d="M975.5 48h0.0"></path><path d="M736.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M756.5 28h199.0"></path></g><path d="M955.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M736.5 48h20"></path><g>
+<path d="M756.5 48h0.0"></path><path d="M955.5 48h0.0"></path><g class="terminal ">
+<path d="M756.5 48h0.0"></path><path d="M878.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="756.5" y="37"></rect><text x="817.5" y="52">FILTER&#95;BY&#95;TS</text></g><path d="M878.5 48h10"></path><path d="M888.5 48h10"></path><g>
+<path d="M898.5 48h0.0"></path><path d="M955.5 48h0.0"></path><path d="M898.5 48h10"></path><g class="non-terminal ">
+<path d="M908.5 48h0.0"></path><path d="M945.5 48h0.0"></path><rect height="22" width="37.0" x="908.5" y="37"></rect><text x="927.0" y="52">ts</text></g><path d="M945.5 48h10"></path><path d="M908.5 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M908.5 68h37.0"></path></g><path d="M945.5 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M955.5 48h20"></path></g><g>
+<path d="M975.5 48h0.0"></path><path d="M1294.0 48h0.0"></path><path d="M975.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M995.5 28h278.5"></path></g><path d="M1274.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M975.5 48h20"></path><g>
+<path d="M995.5 48h0.0"></path><path d="M1274.0 48h0.0"></path><g class="terminal ">
+<path d="M995.5 48h0.0"></path><path d="M1143.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="995.5" y="37"></rect><text x="1069.25" y="52">FILTER&#95;BY&#95;VALUE</text></g><path d="M1143.0 48h10"></path><path d="M1153.0 48h10"></path><g class="non-terminal ">
+<path d="M1163.0 48h0.0"></path><path d="M1208.5 48h0.0"></path><rect height="22" width="45.5" x="1163.0" y="37"></rect><text x="1185.75" y="52">min</text></g><path d="M1208.5 48h10"></path><path d="M1218.5 48h10"></path><g class="non-terminal ">
+<path d="M1228.5 48h0.0"></path><path d="M1274.0 48h0.0"></path><rect height="22" width="45.5" x="1228.5" y="37"></rect><text x="1251.25" y="52">max</text></g></g><path d="M1274.0 48h20"></path></g><g>
+<path d="M1294.0 48h0.0"></path><path d="M1479.0 48h0.0"></path><path d="M1294.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1314.0 28h145.0"></path></g><path d="M1459.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1294.0 48h20"></path><g>
+<path d="M1314.0 48h0.0"></path><path d="M1459.0 48h0.0"></path><g class="terminal ">
+<path d="M1314.0 48h0.0"></path><path d="M1376.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1314.0" y="37"></rect><text x="1345.25" y="52">COUNT</text></g><path d="M1376.5 48h10"></path><path d="M1386.5 48h10"></path><g class="non-terminal ">
+<path d="M1396.5 48h0.0"></path><path d="M1459.0 48h0.0"></path><rect height="22" width="62.5" x="1396.5" y="37"></rect><text x="1427.75" y="52">count</text></g></g><path d="M1459.0 48h20"></path></g><g>
+<path d="M1479.0 48h0.0"></path><path d="M2532.5 48h0.0"></path><path d="M1479.0 48a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path><g>
+<path d="M1499.0 20h1013.5"></path></g><path d="M2512.5 20a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path><path d="M1479.0 48h20"></path><g>
+<path d="M1499.0 48h0.0"></path><path d="M2512.5 48h0.0"></path><g>
+<path d="M1499.0 48h0.0"></path><path d="M1684.0 48h0.0"></path><path d="M1499.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1519.0 28h145.0"></path></g><path d="M1664.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1499.0 48h20"></path><g>
+<path d="M1519.0 48h0.0"></path><path d="M1664.0 48h0.0"></path><g class="terminal ">
+<path d="M1519.0 48h0.0"></path><path d="M1581.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1519.0" y="37"></rect><text x="1550.25" y="52">ALIGN</text></g><path d="M1581.5 48h10"></path><path d="M1591.5 48h10"></path><g class="non-terminal ">
+<path d="M1601.5 48h0.0"></path><path d="M1664.0 48h0.0"></path><rect height="22" width="62.5" x="1601.5" y="37"></rect><text x="1632.75" y="52">align</text></g></g><path d="M1664.0 48h20"></path></g><path d="M1684.0 48h10"></path><g class="terminal ">
+<path d="M1694.0 48h0.0"></path><path d="M1807.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="1694.0" y="37"></rect><text x="1750.75" y="52">AGGREGATION</text></g><path d="M1807.5 48h10"></path><path d="M1817.5 48h10"></path><g class="non-terminal ">
+<path d="M1827.5 48h0.0"></path><path d="M1941.0 48h0.0"></path><rect height="22" width="113.5" x="1827.5" y="37"></rect><text x="1884.25" y="52">aggregators</text></g><path d="M1941.0 48h10"></path><path d="M1951.0 48h10"></path><g class="non-terminal ">
+<path d="M1961.0 48h0.0"></path><path d="M2100.0 48h0.0"></path><rect height="22" width="139.0" x="1961.0" y="37"></rect><text x="2030.5" y="52">bucketDuration</text></g><path d="M2100.0 48h10"></path><g>
+<path d="M2110.0 48h0.0"></path><path d="M2410.0 48h0.0"></path><path d="M2110.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2130.0 28h260.0"></path></g><path d="M2390.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2110.0 48h20"></path><g>
+<path d="M2130.0 48h0.0"></path><path d="M2390.0 48h0.0"></path><g class="terminal ">
+<path d="M2130.0 48h0.0"></path><path d="M2277.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="2130.0" y="37"></rect><text x="2203.75" y="52">BUCKETTIMESTAMP</text></g><path d="M2277.5 48h10"></path><g>
+<path d="M2287.5 48h0.0"></path><path d="M2390.0 48h0.0"></path><path d="M2287.5 48h20"></path><g class="terminal ">
+<path d="M2307.5 48h0.0"></path><path d="M2370.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2307.5" y="37"></rect><text x="2338.75" y="52">start</text></g><path d="M2370.0 48h20"></path><path d="M2287.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2307.5 78h17.0"></path><path d="M2353.0 78h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2324.5" y="67"></rect><text x="2338.75" y="82">-</text></g><path d="M2370.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M2287.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2307.5 108h8.5"></path><path d="M2361.5 108h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2316.0" y="97"></rect><text x="2338.75" y="112">end</text></g><path d="M2370.0 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M2287.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2307.5 138h17.0"></path><path d="M2353.0 138h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2324.5" y="127"></rect><text x="2338.75" y="142">+</text></g><path d="M2370.0 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M2287.5 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2307.5 168h8.5"></path><path d="M2361.5 168h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2316.0" y="157"></rect><text x="2338.75" y="172">mid</text></g><path d="M2370.0 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M2287.5 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2307.5 198h17.0"></path><path d="M2353.0 198h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2324.5" y="187"></rect><text x="2338.75" y="202">~</text></g><path d="M2370.0 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M2390.0 48h20"></path></g><g>
+<path d="M2410.0 48h0.0"></path><path d="M2512.5 48h0.0"></path><path d="M2410.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2430.0 28h62.5"></path></g><path d="M2492.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2410.0 48h20"></path><g class="terminal ">
+<path d="M2430.0 48h0.0"></path><path d="M2492.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2430.0" y="37"></rect><text x="2461.25" y="52">EMPTY</text></g><path d="M2492.5 48h20"></path></g></g><path d="M2512.5 48h20"></path></g></g><path d="M2532.5 48h10"></path><path d="M 2542.5 48 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/ts.nrevrange.svg
+++ b/static/images/railroad/ts.nrevrange.svg
@@ -1,0 +1,100 @@
+<svg class="railroad-diagram" height="229" viewBox="0 0 2608.0 229" width="2608.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 38v20m10 -20v20m-10 -10h20"></path></g><path d="M40 48h10"></path><g>
+<path d="M50 48h0.0"></path><path d="M2558.0 48h0.0"></path><g class="terminal ">
+<path d="M50.0 48h0.0"></path><path d="M172.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="50.0" y="37"></rect><text x="111.0" y="52">TS.NREVRANGE</text></g><path d="M172.0 48h10"></path><path d="M182.0 48h10"></path><g class="non-terminal ">
+<path d="M192.0 48h0.0"></path><path d="M271.5 48h0.0"></path><rect height="22" width="79.5" x="192.0" y="37"></rect><text x="231.75" y="52">numkeys</text></g><path d="M271.5 48h10"></path><path d="M281.5 48h10"></path><g>
+<path d="M291.5 48h0.0"></path><path d="M357.0 48h0.0"></path><path d="M291.5 48h10"></path><g class="non-terminal ">
+<path d="M301.5 48h0.0"></path><path d="M347.0 48h0.0"></path><rect height="22" width="45.5" x="301.5" y="37"></rect><text x="324.25" y="52">key</text></g><path d="M347.0 48h10"></path><path d="M301.5 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M301.5 68h45.5"></path></g><path d="M347.0 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M357.0 48h10"></path><path d="M367.0 48h10"></path><g class="non-terminal ">
+<path d="M377.0 48h0.0"></path><path d="M507.5 48h0.0"></path><rect height="22" width="130.5" x="377.0" y="37"></rect><text x="442.25" y="52">fromTimestamp</text></g><path d="M507.5 48h10"></path><path d="M517.5 48h10"></path><g class="non-terminal ">
+<path d="M527.5 48h0.0"></path><path d="M641.0 48h0.0"></path><rect height="22" width="113.5" x="527.5" y="37"></rect><text x="584.25" y="52">toTimestamp</text></g><path d="M641.0 48h10"></path><g>
+<path d="M651.0 48h0.0"></path><path d="M762.0 48h0.0"></path><path d="M651.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M671.0 28h71.0"></path></g><path d="M742.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M651.0 48h20"></path><g class="terminal ">
+<path d="M671.0 48h0.0"></path><path d="M742.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="671.0" y="37"></rect><text x="706.5" y="52">LATEST</text></g><path d="M742.0 48h20"></path></g><g>
+<path d="M762.0 48h0.0"></path><path d="M1001.0 48h0.0"></path><path d="M762.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M782.0 28h199.0"></path></g><path d="M981.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M762.0 48h20"></path><g>
+<path d="M782.0 48h0.0"></path><path d="M981.0 48h0.0"></path><g class="terminal ">
+<path d="M782.0 48h0.0"></path><path d="M904.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="782.0" y="37"></rect><text x="843.0" y="52">FILTER&#95;BY&#95;TS</text></g><path d="M904.0 48h10"></path><path d="M914.0 48h10"></path><g>
+<path d="M924.0 48h0.0"></path><path d="M981.0 48h0.0"></path><path d="M924.0 48h10"></path><g class="non-terminal ">
+<path d="M934.0 48h0.0"></path><path d="M971.0 48h0.0"></path><rect height="22" width="37.0" x="934.0" y="37"></rect><text x="952.5" y="52">ts</text></g><path d="M971.0 48h10"></path><path d="M934.0 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M934.0 68h37.0"></path></g><path d="M971.0 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M981.0 48h20"></path></g><g>
+<path d="M1001.0 48h0.0"></path><path d="M1319.5 48h0.0"></path><path d="M1001.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1021.0 28h278.5"></path></g><path d="M1299.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1001.0 48h20"></path><g>
+<path d="M1021.0 48h0.0"></path><path d="M1299.5 48h0.0"></path><g class="terminal ">
+<path d="M1021.0 48h0.0"></path><path d="M1168.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="1021.0" y="37"></rect><text x="1094.75" y="52">FILTER&#95;BY&#95;VALUE</text></g><path d="M1168.5 48h10"></path><path d="M1178.5 48h10"></path><g class="non-terminal ">
+<path d="M1188.5 48h0.0"></path><path d="M1234.0 48h0.0"></path><rect height="22" width="45.5" x="1188.5" y="37"></rect><text x="1211.25" y="52">min</text></g><path d="M1234.0 48h10"></path><path d="M1244.0 48h10"></path><g class="non-terminal ">
+<path d="M1254.0 48h0.0"></path><path d="M1299.5 48h0.0"></path><rect height="22" width="45.5" x="1254.0" y="37"></rect><text x="1276.75" y="52">max</text></g></g><path d="M1299.5 48h20"></path></g><g>
+<path d="M1319.5 48h0.0"></path><path d="M1504.5 48h0.0"></path><path d="M1319.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1339.5 28h145.0"></path></g><path d="M1484.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1319.5 48h20"></path><g>
+<path d="M1339.5 48h0.0"></path><path d="M1484.5 48h0.0"></path><g class="terminal ">
+<path d="M1339.5 48h0.0"></path><path d="M1402.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1339.5" y="37"></rect><text x="1370.75" y="52">COUNT</text></g><path d="M1402.0 48h10"></path><path d="M1412.0 48h10"></path><g class="non-terminal ">
+<path d="M1422.0 48h0.0"></path><path d="M1484.5 48h0.0"></path><rect height="22" width="62.5" x="1422.0" y="37"></rect><text x="1453.25" y="52">count</text></g></g><path d="M1484.5 48h20"></path></g><g>
+<path d="M1504.5 48h0.0"></path><path d="M2558.0 48h0.0"></path><path d="M1504.5 48a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path><g>
+<path d="M1524.5 20h1013.5"></path></g><path d="M2538.0 20a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path><path d="M1504.5 48h20"></path><g>
+<path d="M1524.5 48h0.0"></path><path d="M2538.0 48h0.0"></path><g>
+<path d="M1524.5 48h0.0"></path><path d="M1709.5 48h0.0"></path><path d="M1524.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1544.5 28h145.0"></path></g><path d="M1689.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1524.5 48h20"></path><g>
+<path d="M1544.5 48h0.0"></path><path d="M1689.5 48h0.0"></path><g class="terminal ">
+<path d="M1544.5 48h0.0"></path><path d="M1607.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1544.5" y="37"></rect><text x="1575.75" y="52">ALIGN</text></g><path d="M1607.0 48h10"></path><path d="M1617.0 48h10"></path><g class="non-terminal ">
+<path d="M1627.0 48h0.0"></path><path d="M1689.5 48h0.0"></path><rect height="22" width="62.5" x="1627.0" y="37"></rect><text x="1658.25" y="52">align</text></g></g><path d="M1689.5 48h20"></path></g><path d="M1709.5 48h10"></path><g class="terminal ">
+<path d="M1719.5 48h0.0"></path><path d="M1833.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="1719.5" y="37"></rect><text x="1776.25" y="52">AGGREGATION</text></g><path d="M1833.0 48h10"></path><path d="M1843.0 48h10"></path><g class="non-terminal ">
+<path d="M1853.0 48h0.0"></path><path d="M1966.5 48h0.0"></path><rect height="22" width="113.5" x="1853.0" y="37"></rect><text x="1909.75" y="52">aggregators</text></g><path d="M1966.5 48h10"></path><path d="M1976.5 48h10"></path><g class="non-terminal ">
+<path d="M1986.5 48h0.0"></path><path d="M2125.5 48h0.0"></path><rect height="22" width="139.0" x="1986.5" y="37"></rect><text x="2056.0" y="52">bucketDuration</text></g><path d="M2125.5 48h10"></path><g>
+<path d="M2135.5 48h0.0"></path><path d="M2435.5 48h0.0"></path><path d="M2135.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2155.5 28h260.0"></path></g><path d="M2415.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2135.5 48h20"></path><g>
+<path d="M2155.5 48h0.0"></path><path d="M2415.5 48h0.0"></path><g class="terminal ">
+<path d="M2155.5 48h0.0"></path><path d="M2303.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="2155.5" y="37"></rect><text x="2229.25" y="52">BUCKETTIMESTAMP</text></g><path d="M2303.0 48h10"></path><g>
+<path d="M2313.0 48h0.0"></path><path d="M2415.5 48h0.0"></path><path d="M2313.0 48h20"></path><g class="terminal ">
+<path d="M2333.0 48h0.0"></path><path d="M2395.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2333.0" y="37"></rect><text x="2364.25" y="52">start</text></g><path d="M2395.5 48h20"></path><path d="M2313.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2333.0 78h17.0"></path><path d="M2378.5 78h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2350.0" y="67"></rect><text x="2364.25" y="82">-</text></g><path d="M2395.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M2313.0 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2333.0 108h8.5"></path><path d="M2387.0 108h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2341.5" y="97"></rect><text x="2364.25" y="112">end</text></g><path d="M2395.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M2313.0 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2333.0 138h17.0"></path><path d="M2378.5 138h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2350.0" y="127"></rect><text x="2364.25" y="142">+</text></g><path d="M2395.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M2313.0 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2333.0 168h8.5"></path><path d="M2387.0 168h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2341.5" y="157"></rect><text x="2364.25" y="172">mid</text></g><path d="M2395.5 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M2313.0 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2333.0 198h17.0"></path><path d="M2378.5 198h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2350.0" y="187"></rect><text x="2364.25" y="202">~</text></g><path d="M2395.5 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M2415.5 48h20"></path></g><g>
+<path d="M2435.5 48h0.0"></path><path d="M2538.0 48h0.0"></path><path d="M2435.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2455.5 28h62.5"></path></g><path d="M2518.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2435.5 48h20"></path><g class="terminal ">
+<path d="M2455.5 48h0.0"></path><path d="M2518.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2455.5" y="37"></rect><text x="2486.75" y="52">EMPTY</text></g><path d="M2518.0 48h20"></path></g></g><path d="M2538.0 48h20"></path></g></g><path d="M2558.0 48h10"></path><path d="M 2568.0 48 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature. The examples and return information have been vetted on a recent build of Redis (Docker, 8.10-m01-int).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime or application code changes.
> 
> **Overview**
> Adds documentation for three **Redis 8.10** RedisTimeSeries commands (`since: 8.10.0`), with command metadata, examples vetted on 8.10, RESP2/RESP3 return sections, and compatibility tables (not yet on Redis Software/Cloud).
> 
> **`TS.BGET`** documents blocking batch reads from a single series (or compaction key): cursor sentinels `-` / `+` / `$` (aligned with `XREAD`), `MIN_COUNT` / `MAX_COUNT`, timeout and blocking semantics, and paging via `last_returned_timestamp + 1`.
> 
> **`TS.NRANGE`** and **`TS.NREVRANGE`** document multi-key range queries over an explicit key list (`numkeys`), with results **pivoted by timestamp** (one value per key per row). They cover cluster single-hash-slot requirements, filters/aggregation options shared with `TS.RANGE`/`TS.REVRANGE`, and the **per-key aggregator** syntax (space-separated aggregators, not comma-joined).
> 
> Railroad syntax diagrams are added under `static/images/railroad/` for each command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e67ca6a55e74ff4b20016f44c1b3f9e981d3c2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->