### PR TITLE
DEV: update search pages for asian lang additions

### DIFF
--- a/content/commands/ft.create.md
+++ b/content/commands/ft.create.md
@@ -346,9 +346,9 @@ if set, indicates the default language for documents in the index. Default is En
 is a document attribute set as the document language.
 
 A stemmer is used for the supplied language during indexing. If an unsupported language is sent, the command returns an error. The supported
-languages are `arabic`, `armenian`, `basque`, `catalan`, `danish`, `dutch`, `english`, `finnish`, `french`, `german`, `greek`, `hindi`,
-`hungarian`, `indonesian`, `irish`, `italian`, `lithuanian`, `nepali`, `norwegian`, `portuguese`, `romanian`, `russian`, `serbian`,
-`spanish`, `swedish`, `tamil`, `turkish`, `yiddish`, and `chinese`.
+languages are `arabic`, `armenian`, `basque`, `catalan`, `chinese` (see below), `danish`, `dutch`, `english`, `finnish`, `french`, `german`, `greek`, `hindi`,
+`hungarian`, `indonesian`, `irish`, `italian`, `lithuanian`, `malay`, `nepali`, `norwegian`, `portuguese`, `romanian`, `russian`, `serbian`,
+`spanish`, `swedish`, `tagalog`, `tamil`, `turkish`, and `yiddish`.
 
 When adding Chinese language documents, set `LANGUAGE chinese` for the indexer to properly tokenize the terms. If you use the default language, then search terms are extracted based on punctuation characters and whitespace. The Chinese language tokenizer makes use of a segmentation algorithm (via [Friso](https://github.com/lionsoul2014/friso)), which segments text and checks it against a predefined dictionary. See [Stemming]({{< relref "/develop/ai/search-and-query/advanced-concepts/stemming" >}}) for more information.
 </details>

--- a/content/develop/ai/search-and-query/advanced-concepts/stemming.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/stemming.md
@@ -84,6 +84,7 @@ The following languages are supported and can be passed to the engine when index
 * `armenian`
 * `basque`
 * `catalan`
+* `chinese` (see below)
 * `danish`
 * `dutch`
 * `english`
@@ -97,6 +98,7 @@ The following languages are supported and can be passed to the engine when index
 * `irish`
 * `italian`
 * `lithuanian`
+* `malay`
 * `nepali`
 * `norwegian`
 * `portuguese`
@@ -105,10 +107,10 @@ The following languages are supported and can be passed to the engine when index
 * `serbian`
 * `spanish`
 * `swedish`
+* `tagalog`
 * `tamil`
 * `turkish`
 * `yiddish`
-* `chinese` (see below)
 
 ## Chinese support
 


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to language lists; no runtime, API, or security behavior changes in this repo.
> 
> **Overview**
> Documents **Redis 8.10** search language support by updating the shared supported-language lists in **`FT.CREATE`** (`LANGUAGE` / `LANGUAGE_FIELD`) and the **Stemming** advanced-concepts page.
> 
> **`malay`** and **`tagalog`** are added to both lists. **`chinese`** is listed in alphabetical order with an inline “(see below)” note instead of appearing only at the end of the stemming list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ddbac43437beb50b689dec8b94946ac317a28b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->