### PR TITLE
DEV: (cmds) add FT.ALIASLIST command page

### DIFF
--- a/content/commands/ft.aliaslist.md
+++ b/content/commands/ft.aliaslist.md
@@ -1,0 +1,89 @@
+---
+acl_categories:
+- '@search'
+arguments:
+- display_text: index
+  name: index
+  summary: Specifies the name of the index. The index must be created using `FT.CREATE`.
+  type: string
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+- module
+complexity: O(N) where N is the number of aliases
+description: Lists all aliases for the index
+group: search
+hidden: false
+linkTitle: FT.ALIASLIST
+module: search
+railroad_diagram: /images/railroad/ft.aliaslist.svg
+since: 8.10.0
+summary: Lists all aliases for the index
+syntax_fmt: FT.ALIASLIST index
+title: FT.ALIASLIST
+---
+Lists all aliases for the given `index`.
+
+## Required arguments
+
+<details open><summary><code>index</code></summary>
+
+is the name of the index for which to list aliases.
+
+</details>
+
+## Examples
+
+<details open>
+<summary><b>Add an alias to an index</b></summary>
+
+Add an alias to an index.
+
+{{< highlight bash >}}
+> FT.ALIASADD alias idx:bicycle
+OK
+{{< / highlight >}}
+
+List the aliases for `idx:bicycle`
+
+{{< highlight bash >}}
+> FT.ALIASLIST idx:bicycle
+1) "alias"
+{{< / highlight >}}
+</details>
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis Cloud<br />Flexible & Annual | Redis Cloud<br />Free & Fixed | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Not supported</span> | <span title="Not supported">&#x274c; Not supported</span> | <span title="Not supported">&#x274c; Not supported</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+
+* An [array]({{< relref "/develop/reference/protocol-spec#array" >}}) of [bulk strings]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), the names of existing index aliases, or an empty array if no aliases exist.
+* A [simple error]{{< relref "/develop/reference/protocol-spec#simple-errors" >}} when the provided index doesn't exist.
+
+-tab-sep-
+
+One of the following:
+
+* A [set]({{< relref "/develop/reference/protocol-spec#sets" >}}) of [bulk strings]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}), the names of index aliases, or an empty set if no aliases exist.
+* A [simple error]{{< relref "/develop/reference/protocol-spec#simple-errors" >}} when the provided index doesn't exist.
+
+{{< /multitabs >}}

--- a/static/images/railroad/ft.aliaslist.svg
+++ b/static/images/railroad/ft.aliaslist.svg
@@ -1,0 +1,49 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 304.5 62" width="304.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M254.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M172.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="50.0" y="20"></rect><text x="111.0" y="35">FT.ALIASLIST</text></g><path d="M172.0 31h10"></path><path d="M182.0 31h10"></path><g class="non-terminal ">
+<path d="M192.0 31h0.0"></path><path d="M254.5 31h0.0"></path><rect height="22" width="62.5" x="192.0" y="20"></rect><text x="223.25" y="35">index</text></g></g><path d="M254.5 31h10"></path><path d="M 264.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or API behavior changes in this repo.
> 
> **Overview**
> Adds documentation for the new RediSearch **`FT.ALIASLIST`** command (since **8.10.0**), which lists all aliases bound to a given index.
> 
> The new **`content/commands/ft.aliaslist.md`** page follows the existing search command layout: front matter (`readonly`/`module`, `O(N)` complexity), required `index` argument, an example flow using **`FT.ALIASADD`** then **`FT.ALIASLIST`**, a compatibility table (marked not supported across Redis Software/Cloud in this doc), and RESP2/RESP3 return shapes (array/set of alias names or error if the index is missing). A matching railroad diagram is added at **`static/images/railroad/ft.aliaslist.svg`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d13d6deea4657abb86e4830bcfd8881a82eda4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->