### PR TITLE
Clarify RDI target database reingest behavior

### DIFF
--- a/content/operate/rc/rdi/view-edit.md
+++ b/content/operate/rc/rdi/view-edit.md
@@ -56,7 +56,7 @@ You can change the target database for your pipeline if the new target database 
 
 3. Select **Change target** to continue.
 
-Changing the target database restarts the pipeline and re-ingests all data into the new target database.
+Changing the target database restarts the pipeline, but it does not automatically re-ingest all data into the new target database. If you want the existing data re-ingested after the change, manually [reset the pipeline](#reset-data-pipeline).
 
 ## Metrics
 


### PR DESCRIPTION
## Summary\n- Clarify that changing the RDI target database restarts the pipeline but does not automatically re-ingest all data\n- Link readers to the manual reset step if they need the existing data re-ingested after the change\n\n## Ticket\n- RDSC-5615\n\n## Validation\n- Docs-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or security impact.
> 
> **Overview**
> Updates **Change target database** in the RDI view/edit docs so it matches actual behavior: switching targets **restarts** the pipeline but **does not** automatically re-ingest existing data into the new target.
> 
> Readers who need a full reload are pointed to **[reset the pipeline](#reset-data-pipeline)** after the change. A small formatting fix removes an incorrect list bullet on that note and adds a trailing newline at the end of the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b0473b92d773f1f7e80bef6ba4baa3a70e8884. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->