### PR TITLE
OP: add RediSearch release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.10-release-notes.md
@@ -13,10 +13,23 @@ weight: 90
 ---
 ## Requirements
 
-RediSearch v2.10.30 requires:
+RediSearch v2.10.31 requires:
 
 - Minimum Redis compatibility version (database): 7.4
 - Minimum Redis Enterprise Software version (cluster): 7.8
+
+## v2.10.31 (June 2026)
+
+This is a maintenance release for Redis Search 2.10.
+Update urgency: `LOW`: No need to upgrade unless there are new features you want to use.
+
+**Bug Fixes**
+
+- [#9938](https://github.com/redisearch/redisearch/pull/9938) Server can crash in fork GC when the last document with an empty TAG value is deleted from an INDEXEMPTY WITHSUFFIXTRIE field. (MOD-15996) 
+- [#10104](https://github.com/redisearch/redisearch/pull/10104) FT.SEARCH and FT.AGGREGATE return Unknown argument errors on 2.10 shards during rolling upgrades when a newer coordinator injects internal query arguments. (MOD-16047) 
+- [#9578](https://github.com/redisearch/redisearch/pull/9578) Server can crash when FT.CREATE is called with an extremely large number of arguments or fields. (MOD-6411) 
+- [#9810](https://github.com/redisearch/redisearch/pull/9810) FT.SYNUPDATE leaves the synonym map partially mutated when an update batch exceeds synonym or group-ID limits. (MOD-15402) 
+- [#9533](https://github.com/redisearch/redisearch/pull/9533) FT.INFO num_records grows without bound for indexes with vector fields because vector records were counted on insert but never decremented. (MOD-15487)
 
 ## v2.10.30 (May 2026)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md
@@ -27,10 +27,10 @@ Update urgency: `LOW`: No need to upgrade unless there are new features you want
 
 **Bug Fixes**
 
-• [[#10105](https://github.com/redisearch/redisearch/pull/10105)](https://github.com/RediSearch/RediSearch/pull/10105) FT.SEARCH and FT.AGGREGATE return Unknown argument errors on 2.8 shards during rolling upgrades when a newer coordinator injects internal query arguments. (MOD-16047) 
-• [[#9579](https://github.com/redisearch/redisearch/pull/9579)](https://github.com/RediSearch/RediSearch/pull/9579) Server becomes unresponsive when FT.CREATE is called with an extremely large number of fields. (MOD-6411) 
-• [[#9825](https://github.com/redisearch/redisearch/pull/9825)](https://github.com/RediSearch/RediSearch/pull/9825) FT.SYNUPDATE leaves the synonym map partially mutated when an update batch exceeds synonym or group-ID limits. (MOD-15402) 
-• [[#9534](https://github.com/redisearch/redisearch/pull/9534)](https://github.com/RediSearch/RediSearch/pull/9534) FT.INFO num_records is skewed for indexes with vector fields because vector entries are never decremented on deletion. (MOD-15487)
+* [#10105](https://github.com/redisearch/redisearch/pull/10105) FT.SEARCH and FT.AGGREGATE return Unknown argument errors on 2.8 shards during rolling upgrades when a newer coordinator injects internal query arguments. (MOD-16047) 
+* [#9579](https://github.com/redisearch/redisearch/pull/9579) Server becomes unresponsive when FT.CREATE is called with an extremely large number of fields. (MOD-6411) 
+* [#9825](https://github.com/redisearch/redisearch/pull/9825) FT.SYNUPDATE leaves the synonym map partially mutated when an update batch exceeds synonym or group-ID limits. (MOD-15402) 
+* [#9534](https://github.com/redisearch/redisearch/pull/9534) FT.INFO num_records is skewed for indexes with vector fields because vector entries are never decremented on deletion. (MOD-15487)
 
 ## v2.6.36 (May 2026)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.6-release-notes.md
@@ -15,10 +15,22 @@ weight: 92
 ---
 ## Requirements
 
-RediSearch v2.6.36 requires:
+RediSearch v2.6.37 requires:
 
 - Minimum Redis compatibility version (database): 6.0.16
 - Minimum Redis Enterprise Software version (cluster): 6.2.8
+
+## v2.6.37 (June 2026)
+
+This is a maintenance release for Redis Search 2.6.
+Update urgency: `LOW`: No need to upgrade unless there are new features you want to use.
+
+**Bug Fixes**
+
+• [[#10105](https://github.com/redisearch/redisearch/pull/10105)](https://github.com/RediSearch/RediSearch/pull/10105) FT.SEARCH and FT.AGGREGATE return Unknown argument errors on 2.8 shards during rolling upgrades when a newer coordinator injects internal query arguments. (MOD-16047) 
+• [[#9579](https://github.com/redisearch/redisearch/pull/9579)](https://github.com/RediSearch/RediSearch/pull/9579) Server becomes unresponsive when FT.CREATE is called with an extremely large number of fields. (MOD-6411) 
+• [[#9825](https://github.com/redisearch/redisearch/pull/9825)](https://github.com/RediSearch/RediSearch/pull/9825) FT.SYNUPDATE leaves the synonym map partially mutated when an update batch exceeds synonym or group-ID limits. (MOD-15402) 
+• [[#9534](https://github.com/redisearch/redisearch/pull/9534)](https://github.com/RediSearch/RediSearch/pull/9534) FT.INFO num_records is skewed for indexes with vector fields because vector entries are never decremented on deletion. (MOD-15487)
 
 ## v2.6.36 (May 2026)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md
@@ -13,10 +13,22 @@ weight: 91
 ---
 ## Requirements
 
-RediSearch v2.8.37 requires:
+RediSearch v2.8.38 requires:
 
 - Minimum Redis compatibility version (database): 7.2
 - Minimum Redis Enterprise Software version (cluster): 7.2.4
+
+## v2.8.38 (June 2026)
+
+This is a maintenance release for Redis Search 2.8.
+Update urgency: `LOW`: No need to upgrade unless there are new features you want to use.
+
+**Bug Fixes**
+
+• [[#10105](https://github.com/redisearch/redisearch/pull/10105)](https://github.com/RediSearch/RediSearch/pull/10105) FT.SEARCH and FT.AGGREGATE return Unknown argument errors on 2.8 shards during rolling upgrades when a newer coordinator injects internal query arguments. (MOD-16047)
+• [[#9579](https://github.com/redisearch/redisearch/pull/9579)](https://github.com/RediSearch/RediSearch/pull/9579) Server becomes unresponsive when FT.CREATE is called with an extremely large number of fields. (MOD-6411)
+• [[#9825](https://github.com/redisearch/redisearch/pull/9825)](https://github.com/RediSearch/RediSearch/pull/9825) FT.SYNUPDATE leaves the synonym map partially mutated when an update batch exceeds synonym or group-ID limits. (MOD-15402)
+• [[#9534](https://github.com/redisearch/redisearch/pull/9534)](https://github.com/RediSearch/RediSearch/pull/9534) FT.INFO num_records grows without bound for indexes with vector fields due to missing decrement on deletion. (MOD-15487)
 
 ## v2.8.37 (May 2026)
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisearch/redisearch-2.8-release-notes.md
@@ -25,10 +25,10 @@ Update urgency: `LOW`: No need to upgrade unless there are new features you want
 
 **Bug Fixes**
 
-• [[#10105](https://github.com/redisearch/redisearch/pull/10105)](https://github.com/RediSearch/RediSearch/pull/10105) FT.SEARCH and FT.AGGREGATE return Unknown argument errors on 2.8 shards during rolling upgrades when a newer coordinator injects internal query arguments. (MOD-16047)
-• [[#9579](https://github.com/redisearch/redisearch/pull/9579)](https://github.com/RediSearch/RediSearch/pull/9579) Server becomes unresponsive when FT.CREATE is called with an extremely large number of fields. (MOD-6411)
-• [[#9825](https://github.com/redisearch/redisearch/pull/9825)](https://github.com/RediSearch/RediSearch/pull/9825) FT.SYNUPDATE leaves the synonym map partially mutated when an update batch exceeds synonym or group-ID limits. (MOD-15402)
-• [[#9534](https://github.com/redisearch/redisearch/pull/9534)](https://github.com/RediSearch/RediSearch/pull/9534) FT.INFO num_records grows without bound for indexes with vector fields due to missing decrement on deletion. (MOD-15487)
+* [#10105](https://github.com/redisearch/redisearch/pull/10105) FT.SEARCH and FT.AGGREGATE return Unknown argument errors on 2.8 shards during rolling upgrades when a newer coordinator injects internal query arguments. (MOD-16047)
+* [#9579](https://github.com/redisearch/redisearch/pull/9579) Server becomes unresponsive when FT.CREATE is called with an extremely large number of fields. (MOD-6411)
+* [#9825](https://github.com/redisearch/redisearch/pull/9825) FT.SYNUPDATE leaves the synonym map partially mutated when an update batch exceeds synonym or group-ID limits. (MOD-15402)
+* [#9534](https://github.com/redisearch/redisearch/pull/9534) FT.INFO num_records grows without bound for indexes with vector fields due to missing decrement on deletion. (MOD-15487)
 
 ## v2.8.37 (May 2026)
 


### PR DESCRIPTION
Release notes for RediSearch versions v2.6.37, v2.8.38, and 2.10.31.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to release notes; no application or infrastructure code changes.
> 
> **Overview**
> Documents **June 2026** maintenance releases for RediSearch **v2.6.37** and **v2.8.38** in the Stack/Enterprise release-note pages, and updates each file’s **Requirements** line to point at the new patch versions.
> 
> Adds a new top section for each release with **LOW** upgrade urgency and the same four bug fixes (rolling-upgrade `FT.SEARCH` / `FT.AGGREGATE` argument errors, unresponsive server on huge `FT.CREATE` schemas, partial `FT.SYNUPDATE` mutation on limit violations, and incorrect `FT.INFO` `num_records` for vector indexes). Wording for the vector-field fix differs slightly between the 2.6 and 2.8 entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit add47447d04190d82137d5a73eb1dabd2e70a3cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->