### PR TITLE
Fix hanging sentence in context retriever docs

### DIFF
--- a/content/operate/rc/context-engine/context-retriever/create-service.md
+++ b/content/operate/rc/context-engine/context-retriever/create-service.md
@@ -100,7 +100,7 @@ Expand each entry to view the currently defined fields for that entry. Select **
 
 - Enter the field name in the **Field** cell.
 - Select the **PK** checkbox if the field is a primary key. You must have at least one primary key. 
-- If the field is related to any other defined entities, select it from the **Related Entity** dropdown. This is usually set if the field contains primary keys of another entity. For example, you might have an
+- If the field is related to any other defined entities, select it from the **Related Entity** dropdown. This is usually set if the field contains primary keys of another entity. 
 - Select the field's **Type** from the dropdown.
 - In the **Index** cell, select one or more index types to enable searching and filtering on that field.
 - You can also add a description in the **Description** cell.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or configuration impact.
> 
> **Overview**
> Fixes a **Related Entity** bullet in `create-service.md` that ended mid-sentence with “For example, you might have an”.
> 
> The bullet now ends after explaining that the dropdown applies when the field holds another entity’s primary keys, with no incomplete example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14a220aafa15f441d394c86bc1b54e45aa40ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->