### PR TITLE
DEV: update OSS version mgmt page

### DIFF
--- a/content/operate/oss_and_stack/install/version-mgmt.md
+++ b/content/operate/oss_and_stack/install/version-mgmt.md
@@ -32,8 +32,8 @@ Redis uses a **MAJOR.MINOR.PATCH** versioning scheme:
 | **Redis 8.8** | GA | TBD |
 | **Redis 8.6** | GA | TBD |
 | **Redis 8.4** | GA | TBD |
-| **Redis 8.2** | GA | TBD |
-| **Redis 8.0** | GA | TBD |
+| **Redis 8.2** | GA | September 1, 2030 |
+| **Redis 8.0** | GA | December 1, 2026 |
 | **Redis 7.4** | GA | December 1, 2029 |
 | **Redis 7.2** | GA | December 1, 2029 |
 | **Redis 6.2** | GA | April 1, 2027 |


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to published EOL dates; no runtime, auth, or deployment behavior is affected.
> 
> **Overview**
> Updates the **Redis Open Source version management** doc so **Redis 8.2** and **Redis 8.0** no longer show **TBD** in the supported-versions table.
> 
> **Redis 8.2** is now listed with EOL **September 1, 2030**; **Redis 8.0** with EOL **December 1, 2026**. Other rows (8.8, 8.6, 8.4, 7.x, 6.2) are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68482d94fd64cfa8604c6473a28a3b88e22b5e30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->