### PR TITLE
K8s: cancun maint 3 RNs

### DIFF
--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-23-june2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-23-june2026.md
@@ -1,0 +1,35 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: This is a maintenance release to support Redis Enterprise Software version 8.0.20-44.
+hideListLinks: true
+linkTitle: 8.0.20-23 (June 2026)
+title: Redis Enterprise for Kubernetes 8.0.20-23 (June 2026) release notes
+weight: 29
+---
+
+## Highlights
+
+This is a maintenance release to support Redis Enterprise Software version 8.0.20-44. For version changes, supported distributions, and known limitations, see the [release notes for 8.0.18-11 (April 2026)]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026">}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:8.0.20-44.23` (`redislabs/redis:8.0.20-44.23.minimal` for minimal base image)
+- **Operator**: `redislabs/operator:8.0.20-23`
+- **Services Rigger**: `redislabs/k8s-controller:8.0.20-23`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.20-23`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `8.0.20-23.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-44.23` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-44.23.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.20-23`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.20-23`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.20-23`
+
+## Known limitations
+
+See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 8.0.20 release notes
 weight: 84
 ---
 
-Redis Enterprise for Kubernetes 8.0.20-21 is a maintenance release of [Redis Enterprise for Kubernetes 8.0.18]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/">}}). The latest release is 8.0.20-21 with support for Redis Enterprise Software version 8.0.20-19.
+Redis Enterprise for Kubernetes 8.0.20 is a maintenance release of [Redis Enterprise for Kubernetes 8.0.18]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/">}}). The latest release is 8.0.20-23 with support for Redis Enterprise Software version 8.0.20-44.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only release notes with no product or infrastructure code changes.
> 
> **Overview**
> Adds release notes for **Redis Enterprise for Kubernetes 8.0.20-23 (June 2026)**, a maintenance release aligned with Redis Enterprise Software **8.0.20-44**. The new page follows the same layout as prior 8.0.20 maintenance notes: highlights with a pointer to 8.0.18-11 for distributions/limitations, container image tags for Redis Enterprise, Operator, Services Rigger, and Call Home Client (including OpenShift/registry paths), and a known-limitations link back to the 8.0.20 section.
> 
> Updates the **8.0.20 releases** `_index.md` so the latest called out is **8.0.20-23** / **8.0.20-44** (replacing 8.0.20-21 / 8.0.20-19) and slightly generalizes the opening line from “8.0.20-21” to the **8.0.20** line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd6602e18837258f7576ffdb6158ba2c4affcd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->