### PR TITLE
Update Context Retriever Python Client PyPI link

### DIFF
--- a/content/embeds/rc-context-retriever-get-started.md
+++ b/content/embeds/rc-context-retriever-get-started.md
@@ -2,4 +2,4 @@ To set up a Redis Context Retriever on Redis Cloud, you need a database on Redis
 
 When you have a database, [Create a context retriever service]({{< relref "/operate/rc/context-engine/context-retriever/create-service" >}}) for your database on Redis Cloud.
 
-After you set up Context Retriever, you can [view your service]({{< relref "/operate/rc/context-engine/context-retriever/view-service" >}}). See the [Context Surfaces Python Client](https://pypi.org/project/context-surfaces/) for more information on how to call your tools.
+After you set up Context Retriever, you can [view your service]({{< relref "/operate/rc/context-engine/context-retriever/view-service" >}}). See the [Context Surfaces Python Client](https://pypi.org/project/redis-context-retriever/) for more information on how to call your tools.

--- a/content/operate/rc/context-engine/context-retriever/_index.md
+++ b/content/operate/rc/context-engine/context-retriever/_index.md
@@ -15,7 +15,7 @@ bannerChildren: true
 
 Redis Context Retriever helps teams expose operational context to AI agents through schema-first retrieval. It models the entities, fields, keys, and relationships that matter to an agent workflow, then presents that context through a governed tool surface the agent can call at runtime. Context Retriever helps an AI agent understand what business objects exist, how they connect, and which paths are safe to use.
 
-When you set up Redis Context Retriever, you model the objects that matter to your agent workflow and connect the relationships between them. You can do this through the UI, the [Context Surfaces Python Client](https://pypi.org/project/context-surfaces/), or the `ctxctl` CLI (available when you install the Python client). Context Retriever uses those relationships to automatically create and deploy retrieval tools from your entity model.
+When you set up Redis Context Retriever, you model the objects that matter to your agent workflow and connect the relationships between them. You can do this through the UI, the [Context Surfaces Python Client](https://pypi.org/project/redis-context-retriever/), or the `ctxctl` CLI (available when you install the Python client). Context Retriever uses those relationships to automatically create and deploy retrieval tools from your entity model.
 
 When an agent needs context during execution, it calls the MCP tools Context Retriever exposes. Instead of guessing which tool to use or generating SQL, the agent follows the defined entity paths and gets back structured, live, operational context.
 

--- a/content/operate/rc/context-engine/context-retriever/create-service.md
+++ b/content/operate/rc/context-engine/context-retriever/create-service.md
@@ -33,7 +33,7 @@ If you have not already created a Context Retriever service, you'll see a page w
 
 From here, you can either:
 
-- Select **Get started** to follow a step-by-step guide using the `ctxctl` CLI, which is installed with the [Context Surfaces Python Client](https://pypi.org/project/context-surfaces/). 
+- Select **Get started** to follow a step-by-step guide using the `ctxctl` CLI, which is installed with the [Context Surfaces Python Client](https://pypi.org/project/redis-context-retriever/). 
 - Select **Create custom service** to manually configure your own context retriever settings.
 
 For this guide, select **Create custom service**. 
@@ -109,6 +109,6 @@ After you set all fields for all of your entities, select **Create** to create y
 
 ## Next steps
 
-After your service is created, you can call the MCP tools Context Retriever exposes from your agent. See the [Context Surfaces Python Client](https://pypi.org/project/context-surfaces/) for more information on how to call your tools.
+After your service is created, you can call the MCP tools Context Retriever exposes from your agent. See the [Context Surfaces Python Client](https://pypi.org/project/redis-context-retriever/) for more information on how to call your tools.
 
 You can also [view your service]({{< relref "/operate/rc/context-engine/context-retriever/view-service" >}}).

--- a/content/operate/rc/context-engine/context-retriever/view-admin-keys.md
+++ b/content/operate/rc/context-engine/context-retriever/view-admin-keys.md
@@ -13,7 +13,7 @@ weight: 25
 
 After you have [created your first Context Retriever service]({{< relref "/operate/rc/context-engine/context-retriever/create-service" >}}), you can view and manage your admin keys from the **Admin keys** tab in the **Context Retriever** section of the Redis Cloud console.
 
-A Context Retriever **admin key** authorizes administrative operations against Context Retriever in your Redis Cloud account, such as creating, updating, or deleting services and their entity models. You can use it with the [Context Surfaces Python Client](https://pypi.org/project/context-surfaces/) and `cxtctl` CLI to create an Agent key and call your tools.
+A Context Retriever **admin key** authorizes administrative operations against Context Retriever in your Redis Cloud account, such as creating, updating, or deleting services and their entity models. You can use it with the [Context Surfaces Python Client](https://pypi.org/project/redis-context-retriever/) and `cxtctl` CLI to create an Agent key and call your tools.
 
 ## Admin keys tab
 

--- a/content/operate/rc/context-engine/context-retriever/view-service.md
+++ b/content/operate/rc/context-engine/context-retriever/view-service.md
@@ -54,7 +54,7 @@ The **Tools** section shows the tools that are available to your Agents.
 
 {{<image filename="images/rc/context-retriever-view-tools.png" alt="The Entities section for the Context Retriever service." >}}
 
-You can use your Agents to call your tools. For more information, see the [Context Surfaces Python Client](https://pypi.org/project/context-surfaces/)
+You can use your Agents to call your tools. For more information, see the [Context Surfaces Python Client](https://pypi.org/project/redis-context-retriever/)
 
 ### Actions
 


### PR DESCRIPTION
The original context retriever pypi package was
https://pypi.org/project/context-surfaces/

This still works for backwards compatibility but we prefer
https://pypi.org/project/redis-context-retriever/
Moving forward.

The docs currently have a mix of both, this moves everything to the new one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link updates with no code, config, or security impact.
> 
> **Overview**
> Standardizes **Context Retriever** docs so every PyPI link targets `https://pypi.org/project/redis-context-retriever/` instead of the legacy `context-surfaces` package URL.
> 
> Updates five Redis Cloud Context Retriever pages (section index, get-started embed, create-service, view-service, and view-admin-keys). Display name **Context Surfaces Python Client** is unchanged; only the hrefs move to the preferred package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6e091d93777d1096130f4958dedbfc8126842d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->