### PR TITLE
DOC-6755 fixed incorrect Run in Browser link for PHP

### DIFF
--- a/local_examples/arrays_tutorial/predis/DtArraysTest.php
+++ b/local_examples/arrays_tutorial/predis/DtArraysTest.php
@@ -1,8 +1,8 @@
 // EXAMPLE: arrays_tutorial
 <?php
-// BINDER_ID php-arrays-tutorial
-
+// REMOVE_START
 use PHPUnit\Framework\TestCase;
+// REMOVE_END
 use Predis\Client as PredisClient;
 
 class DtArraysTest


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation example metadata only; no runtime or product behavior changes.
> 
> **Overview**
> Fixes the incorrect **Run in Browser** target for PHP on the arrays tutorial (DOC-6755).
> 
> In `DtArraysTest.php`, removes the `// BINDER_ID php-arrays-tutorial` marker so the example follows the same pattern as the other `arrays_tutorial` clients, which use only `// EXAMPLE: arrays_tutorial` for doc/runner binding. The stray binder id was pointing the browser runner at the wrong asset.
> 
> Also wraps the PHPUnit `TestCase` import in `REMOVE_START` / `REMOVE_END` so it is stripped from published snippets like the `extends TestCase` boilerplate already was.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77ae1de08384bd3b098550e6519407aa271f7c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->