### PR TITLE
RS: Copied Search 8.4 rolling upgrade limitation to all affected RS release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-64.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-64.md
@@ -211,6 +211,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-76.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-76.md
@@ -114,6 +114,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-81.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-10-81.md
@@ -116,6 +116,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
@@ -220,6 +220,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
@@ -131,6 +131,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
@@ -243,6 +243,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
@@ -145,6 +145,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -194,6 +194,10 @@ The following table shows the SHA256 checksums for the available packages:
 
 ## Known limitations
 
+#### Redis Search query failures during rolling upgrades across the 8.4 version boundary
+
+Redis Search queries can fail during a rolling upgrade when a cluster contains shards running Redis versions earlier than 8.4 and shards running Redis version 8.4 or later, due to an internal protocol change introduced in version 8.4. This issue affects only clusters where `parallel_shards_upgrade` has been changed from its default value of `0`. If both conditions apply, expect Redis Search downtime until all nodes are upgraded.
+
 #### Trim ACKED not supported for Active-Active 8.4 databases
 
 For Active-Active databases running Redis database version 8.4, the `ACKED` option is not supported for trimming commands.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to release notes; no product code or configuration behavior changes.
> 
> **Overview**
> Adds the same **Known limitations** entry to eight Redis Software 8.0.x release note pages (`rs-8-0-10-64`, `10-76`, `10-81`, `16-29`, `16-33`, `18-23`, `18-36`, `20-19`), matching text already on the RS 8.0 releases index.
> 
> The new section documents that **Redis Search** queries can fail during rolling upgrades that cross the Redis **8.4** boundary when mixed shard versions coexist, tied to an 8.4 protocol change. It notes the issue applies only if **`parallel_shards_upgrade`** is non-default (not `0`), and that Redis Search may be unavailable until every node finishes upgrading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b766ad9292dc4f3de6086bad658bf0c409ab216b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->