### PR TITLE
DEV: (cmds) Update FT.HYBRID VSIM FILTER clause

### DIFF
--- a/content/commands/ft.hybrid.md
+++ b/content/commands/ft.hybrid.md
@@ -506,7 +506,8 @@ summary: Performs hybrid search combining text search and vector similarity sear
 syntax_fmt: "FT.HYBRID index\n  SEARCH query\n    [SCORER scorer]\n    [YIELD_SCORE_AS\
   \ name]\n  VSIM vector_field $vector_param\n    [KNN count K k [EF_RUNTIME ef_runtime]] [SHARD_K_RATIO shard_k_ratio]]\n\
   \    [RANGE count RADIUS radius [EPSILON epsilon]]\n    [YIELD_SCORE_AS name]\n\
-  \    [FILTER filter]\n  [COMBINE RRF count [CONSTANT constant] [WINDOW window]\
+  \    [FILTER] count filter-expression [POLICY [ADHOC/BATCHES] BATCH_SIZE batch-size-value]\n\
+  \  [COMBINE RRF count [CONSTANT constant] [WINDOW window]\
   \ [YIELD_SCORE_AS name]]\n  [COMBINE LINEAR count [[ALPHA alpha] [BETA beta]] [WINDOW\
   \ window] [YIELD_SCORE_AS name]]\n  [LIMIT offset num]\n  [SORTBY count sortby\
   \ [ASC | DESC]]\n  [NOSORT]\n  [LOAD count field [field ...]]\n  [LOAD *]\n  [GROUPBY\


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to command syntax formatting; no runtime or API behavior is modified.
> 
> **Overview**
> Updates the **`FT.HYBRID`** command page **`syntax_fmt`** so the **VSIM** clause documents the **FILTER** option with the count-prefixed form and optional **POLICY** / **BATCH_SIZE**, instead of the simpler **`[FILTER filter]`** placeholder.
> 
> This is documentation-only in `content/commands/ft.hybrid.md` and brings the generated syntax string in line with how vector pre-filtering is described elsewhere on the same page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d025ddca018658cb9f02da83fba80d53225a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->