### PR TITLE
DEV: Remove the score calculation limitation from the scoring page

### DIFF
--- a/content/develop/ai/search-and-query/advanced-concepts/scoring.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/scoring.md
@@ -81,12 +81,6 @@ FT.SEARCH myIndex "foo" SCORER TFIDF.DOCNORM
 
 ## BM25STD (default)
 
-{{< warning >}}
-Deleting or replacing an indexed document can temporarily affect the scores of other documents that contain any of the same terms.
-As a result, `FT.SEARCH` score values may be inaccurate until the Redis Search garbage collector runs and removes the stale term data.
-{{< /warning >}}
-
-
 A variation on the basic `TFIDF` scorer, see [this Wikipedia article for more info](https://en.wikipedia.org/wiki/Okapi_BM25).
 
 The relevance score for each document is multiplied by the presumptive document score and a penalty is applied based on slop as in `TFIDF`.


### PR DESCRIPTION
This PR removes a limitation that has now been fixed in the 8.x OSS releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no code, configuration, or runtime impact.
> 
> **Overview**
> Removes an outdated **warning** on the **BM25STD (default)** scorer section that said deleting or replacing indexed documents could temporarily skew `FT.SEARCH` scores until the Search garbage collector ran.
> 
> That behavior is documented as fixed in Redis Open Source 8.x, so the limitation note is no longer accurate. No scorer behavior or API text is changed beyond dropping that block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd1f22af2ff4d38dab8af7db8d979489c5c1704. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->