### PR TITLE
RS: Added supported platforms link back to RS 8.0.20 release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -135,6 +135,8 @@ See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networ
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Software release. See the [supported platforms reference]({{< relref "/operate/rs/references/supported-platforms" >}}) for more details about operating system compatibility.
+
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Software and Redis Stack modules.
 
 <span title="Warning icon" class="font-serif">:warning:</span> Deprecation warning – The platform is still supported for this version of Redis Software, but support will be removed in a future release.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
@@ -117,6 +117,8 @@ See [Ports and port ranges used by Redis Software]({{<relref "/operate/rs/networ
 
 ### Supported platforms
 
+The following table provides a snapshot of supported platforms as of this Redis Software release. See the [supported platforms reference]({{< relref "/operate/rs/references/supported-platforms" >}}) for more details about operating system compatibility.
+
 {{< collapsible "Show supported platforms" >}}
 
 <span title="Check mark icon">&#x2705;</span> Supported – The platform is supported for this version of Redis Software and Redis Stack modules.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only copy and internal doc links; no product or runtime impact.
> 
> **Overview**
> Adds the standard **Supported platforms** intro to the `8.0.20-19` and `8.0.20-44` Redis Software release notes. Each section now states that the table is a snapshot for that release and links to the [supported platforms reference](`/operate/rs/references/supported-platforms`) for full OS compatibility details—matching other RS 8.0 release note pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96ed9e3898e3dff0f741e0e9eeb3c7b874795b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->