### PR TITLE
DOC-6767 added Go scan/buffer API page

### DIFF
--- a/content/develop/clients/go/scan-buffer.md
+++ b/content/develop/clients/go/scan-buffer.md
@@ -1,0 +1,103 @@
+---
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+description: Scan go-redis command results into Go values and use buffers for large string payloads.
+linkTitle: Efficient result handling
+title: Handle command results efficiently
+weight: 37
+---
+
+`go-redis` can convert command results directly into Go values. This is useful
+when you want to keep application code close to your domain types instead of
+working with strings and maps everywhere. You can scan [hash]({{< relref "/develop/data-types/hashes" >}})
+results into structs, scan list-style command results into slices, and use
+byte buffers for large [string]({{< relref "/develop/data-types/strings" >}})
+values.
+
+## Initialize
+
+Import the packages you need:
+
+{{< clients-example set="go_scan_buffer" step="import" lang_filter="Go" description="Foundational: Import go-redis and supporting packages for scanning and buffer examples" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+Connect to Redis:
+
+{{< clients-example set="go_scan_buffer" step="connect" lang_filter="Go" description="Foundational: Connect to Redis before running scan and buffer examples" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Scan hashes into structs
+
+Use struct tags of the form `redis:"field"` to map Redis hash fields to Go
+struct fields. The `Scan()` method converts matching fields to the destination
+types and returns an error if a conversion fails.
+
+The following example stores a hash with [`HSET`]({{< relref "/commands/hset" >}})
+and then scans the result of [`HGETALL`]({{< relref "/commands/hgetall" >}})
+into a `Bike` struct:
+
+{{< clients-example set="go_scan_buffer" step="scan_hash" lang_filter="Go" description="Structured results: Scan all hash fields into a Go struct using redis field tags" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+You can also scan a subset of fields with [`HMGET`]({{< relref "/commands/hmget" >}}).
+Fields that are not returned keep their Go zero values:
+
+{{< clients-example set="go_scan_buffer" step="scan_hash_subset" lang_filter="Go" description="Structured results: Scan selected hash fields and leave missing fields at their zero values" difficulty="intermediate" buildsUpon="scan_hash" >}}
+{{< /clients-example >}}
+
+## Scan lists into slices
+
+Commands that return a list of strings, such as [`LRANGE`]({{< relref "/commands/lrange" >}}),
+can use `ScanSlice()` to convert the result into a typed Go slice:
+
+{{< clients-example set="go_scan_buffer" step="scan_list" lang_filter="Go" description="Structured results: Convert a list command result into a typed Go slice with ScanSlice" difficulty="beginner" >}}
+{{< /clients-example >}}
+
+## Use byte buffers
+
+For large string payloads, you can avoid creating a new string for every read by
+providing a caller-owned byte buffer. Use `SetFromBuffer()` to write a `[]byte`
+value and `GetToBuffer()` to read the value into an existing buffer.
+
+{{< note >}}
+The buffer APIs require `github.com/redis/go-redis/v9` v9.21.0
+or later.
+{{< /note >}}
+&nbsp;
+
+{{< clients-example set="go_scan_buffer" step="buffer_round_trip" lang_filter="Go" description="Buffer optimization: Write and read Redis string values using caller-owned byte buffers" difficulty="intermediate" >}}
+{{< /clients-example >}}
+
+`GetToBuffer()` returns a `*redis.ZeroCopyStringCmd`. Use `Val()` or `Result()`
+to get the number of bytes read, `Bytes()` to access the populated slice
+(`buf[:n]`), and `Err()` to check for errors such as `redis.Nil` when the key
+does not exist.
+
+{{< note >}}
+`GetToBuffer()` requires a buffer large enough to hold the whole value. It also
+opts out of automatic retries because a failed read might already have written
+partial data into your buffer. If a buffer is too small, `Err()` reports a
+`buffer too small` error.
+{{< /note >}}
+
+The following example shows how to detect a buffer that is too small:
+
+{{< clients-example set="go_scan_buffer" step="buffer_too_small" lang_filter="Go" description="Buffer sizing: Detect and handle a buffer that is too small for the Redis value" difficulty="intermediate" buildsUpon="buffer_round_trip" >}}
+{{< /clients-example >}}
+
+`SetFromBuffer()` does not set an expiration. If you need a TTL, call
+[`EXPIRE`]({{< relref "/commands/expire" >}}) separately with `Expire()`, or use
+`Set()` with an expiration when the extra allocation is acceptable.
+
+## More information
+
+See the [`go-redis`](https://github.com/redis/go-redis) repository for more
+examples and API details.

--- a/local_examples/client-specific/go/scan_buffer_examples_test.go
+++ b/local_examples/client-specific/go/scan_buffer_examples_test.go
@@ -1,0 +1,164 @@
+// EXAMPLE: go_scan_buffer
+// HIDE_START
+package example_commands_test
+
+// HIDE_END
+// STEP_START import
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// STEP_END
+
+func ExampleClient_scanBuffer() {
+	// STEP_START connect
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password
+		DB:       0,  // use default DB
+		Protocol: 2,
+	})
+	defer rdb.Close()
+	// STEP_END
+
+	// REMOVE_START
+	keys := []string{"scanbuf:bike:1", "scanbuf:stock", "scanbuf:payload"}
+	if err := rdb.Del(ctx, keys...).Err(); err != nil {
+		panic(err)
+	}
+	defer rdb.Del(ctx, keys...)
+	// REMOVE_END
+
+	// STEP_START scan_hash
+	type Bike struct {
+		Model string `redis:"model"`
+		Brand string `redis:"brand"`
+		Price int    `redis:"price"`
+	}
+
+	if err := rdb.HSet(ctx, "scanbuf:bike:1",
+		"model", "Deimos",
+		"brand", "Ergonom",
+		"price", 4972,
+	).Err(); err != nil {
+		panic(err)
+	}
+
+	var bike Bike
+	if err := rdb.HGetAll(ctx, "scanbuf:bike:1").Scan(&bike); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Model: %s, brand: %s, price: $%d\n",
+		bike.Model, bike.Brand, bike.Price)
+	// >>> Model: Deimos, brand: Ergonom, price: $4972
+	// STEP_END
+
+	// REMOVE_START
+	if bike != (Bike{Model: "Deimos", Brand: "Ergonom", Price: 4972}) {
+		panic(fmt.Sprintf("unexpected bike: %+v", bike))
+	}
+	// REMOVE_END
+
+	// STEP_START scan_hash_subset
+	type BikeStock struct {
+		Model string `redis:"model"`
+		Stock int    `redis:"stock"`
+		Price int    `redis:"price"`
+	}
+
+	var partial BikeStock
+	if err := rdb.HMGet(ctx, "scanbuf:bike:1", "model", "stock").Scan(&partial); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Model: %s, stock: %d, price: $%d\n",
+		partial.Model, partial.Stock, partial.Price)
+	// >>> Model: Deimos, stock: 0, price: $0
+	// STEP_END
+
+	// REMOVE_START
+	if partial != (BikeStock{Model: "Deimos"}) {
+		panic(fmt.Sprintf("unexpected partial bike: %+v", partial))
+	}
+	// REMOVE_END
+
+	// STEP_START scan_list
+	if err := rdb.RPush(ctx, "scanbuf:stock", 3, 4, 5).Err(); err != nil {
+		panic(err)
+	}
+
+	var stockCounts []int
+	if err := rdb.LRange(ctx, "scanbuf:stock", 0, -1).ScanSlice(&stockCounts); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Stock counts:", stockCounts)
+	// >>> Stock counts: [3 4 5]
+	// STEP_END
+
+	// REMOVE_START
+	if fmt.Sprint(stockCounts) != "[3 4 5]" {
+		panic(fmt.Sprintf("unexpected stock counts: %v", stockCounts))
+	}
+	// REMOVE_END
+
+	// STEP_START buffer_round_trip
+	payload := []byte("compact bike data")
+
+	if err := rdb.SetFromBuffer(ctx, "scanbuf:payload", payload).Err(); err != nil {
+		panic(err)
+	}
+	fmt.Println("OK") // >>> OK
+
+	buf := make([]byte, len(payload))
+	cmd := rdb.GetToBuffer(ctx, "scanbuf:payload", buf)
+	n, err := cmd.Result()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Read %d bytes: %s\n", n, string(cmd.Bytes()))
+	// >>> Read 17 bytes: compact bike data
+	// STEP_END
+
+	// REMOVE_START
+	if n != len(payload) || string(cmd.Bytes()) != string(payload) {
+		panic("unexpected buffer round trip")
+	}
+	// REMOVE_END
+
+	// STEP_START buffer_too_small
+	smallBuf := make([]byte, 4)
+	smallCmd := rdb.GetToBuffer(ctx, "scanbuf:payload", smallBuf)
+
+	if err := smallCmd.Err(); err != nil {
+		if strings.Contains(err.Error(), "buffer too small") {
+			fmt.Println("Buffer too small")
+		} else {
+			panic(err)
+		}
+	}
+	// >>> Buffer too small
+	// STEP_END
+
+	// REMOVE_START
+	if smallCmd.Err() == nil {
+		panic("expected a buffer-too-small error")
+	}
+	// REMOVE_END
+
+	// Output:
+	// Model: Deimos, brand: Ergonom, price: $4972
+	// Model: Deimos, stock: 0, price: $0
+	// Stock counts: [3 4 5]
+	// OK
+	// Read 17 bytes: compact bike data
+	// Buffer too small
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and example tests only; no production code or runtime behavior changes.
> 
> **Overview**
> Adds a new Go client doc page **Handle command results efficiently** (`scan-buffer.md`) that explains mapping Redis results into Go types and using caller-owned buffers for large strings.
> 
> The page covers **`Scan()`** with `redis` struct tags on **`HGETALL`** / **`HMGET`**, **`ScanSlice()`** on list commands like **`LRANGE`**, and **`SetFromBuffer()`** / **`GetToBuffer()`** (v9.21.0+), including notes on **`ZeroCopyStringCmd`**, no automatic retries on buffer reads, TTL behavior for **`SetFromBuffer()`**, and handling **`buffer too small`** errors.
> 
> A runnable **`go_scan_buffer`** example test (`scan_buffer_examples_test.go`) backs the embedded **`clients-example`** steps used throughout the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2512c05efaf8527854acecb2172747ba0d36f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->