### PR TITLE
Document RDI rejected records

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
+++ b/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
@@ -304,7 +304,7 @@ configuration above contains the following properties:
 - `error_handling`: The strategy to use when an invalid record is encountered. The available
   strategies are `ignore` and  `dlq` (store rejected messages in a dead letter queue).
   The default is `dlq`. See
-  [What does RDI do if the data is corrupted or invalid?]({{< relref "/integrate/redis-data-integration/faq#what-does-rdi-do-if-the-data-is-corrupted-or-invalid" >}})
+  [Rejected records]({{< relref "/integrate/redis-data-integration/data-pipelines/rejected-records" >}})
   for more information about the dead letter queue.
 
 {{< note >}}When `type` is set to `flink`, fine-tuning of the processor and the

--- a/content/integrate/redis-data-integration/data-pipelines/rejected-records.md
+++ b/content/integrate/redis-data-integration/data-pipelines/rejected-records.md
@@ -1,0 +1,89 @@
+---
+Title: Rejected records
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+- rdi
+description: Learn how RDI stores records that cannot be processed.
+group: di
+linkTitle: Rejected records
+summary: Redis Data Integration stores records that cannot be processed in a dead letter queue.
+type: integration
+weight: 45
+---
+
+Redis Data Integration (RDI) sends records that it cannot process to a dead letter
+queue (DLQ). In the Redis Cloud UI, these records are called **rejected records**.
+
+Rejected records help you understand which source tables are affected and why
+specific records could not continue through the pipeline. They are intended for
+troubleshooting and support, not for normal pipeline operation.
+
+## When records are rejected
+
+RDI can reject a record when it cannot safely transform or write the change event.
+Common causes include:
+
+- The incoming change event is malformed or missing required metadata.
+- A transformation job fails while processing the record.
+- A target write fails, for example because the target key already has an incompatible data type.
+
+By default, RDI stores rejected records instead of silently dropping them. You can
+change this behavior with the `processors.error_handling` setting. See the
+[pipeline configuration file]({{< relref "/integrate/redis-data-integration/data-pipelines/pipeline-config" >}})
+for more information.
+
+## How RDI stores rejected records
+
+RDI stores rejected records in the RDI database as capped Redis streams. Each DLQ
+stream corresponds to a source table and tracks the records rejected for that
+table.
+
+The maximum number of records stored per DLQ stream is controlled by
+`processors.dlq_max_messages`. When the stream reaches the configured limit,
+older entries are evicted as newer entries are added.
+
+## What to inspect
+
+Start with the rejected count for each affected table, then inspect a sample
+record from the table with the highest count or the table that matters most to
+your application.
+
+Useful fields include:
+
+- The affected table.
+- The rejection time.
+- The rejected operation, such as create, update, delete, or snapshot read.
+- The rejection reason.
+- The transformation job or operation, when the failure happened during transformation.
+
+{{< note >}}
+Rejected records can contain source data when you inspect them directly with CLI
+or API tools. Treat DLQ contents as sensitive customer data. The Redis Cloud UI
+shows a limited set of troubleshooting metadata and does not show the original
+record payload.
+{{< /note >}}
+
+## Resolve rejected records
+
+Use the rejection reason to identify the likely fix:
+
+- If a transformation job failed, update the job configuration and deploy the pipeline change.
+- If target writes failed because of incompatible existing keys, update the target data or key mapping.
+- If records are malformed, inspect the source connector and source database change data capture configuration.
+
+RDI does not automatically replay records from the DLQ after you fix the cause.
+If you need existing source data to be processed again, reset the pipeline after
+applying the fix. See [Reset data pipeline]({{< relref "/operate/rc/rdi/view-edit#reset-data-pipeline" >}})
+for Redis Cloud, or use the appropriate self-managed RDI reset workflow.
+
+## CLI and API access
+
+For self-managed RDI, use the [`redis-di get-rejected`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-get-rejected" >}})
+command to inspect rejected records.
+
+RDI API v2 also includes DLQ inspection endpoints. See the
+[API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}})
+for endpoint details.

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -103,6 +103,9 @@ with Redis Insight or with the
 [`redis-di get-rejected`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-get-rejected" >}})
 command from the CLI.
 
+See [Rejected records]({{< relref "/integrate/redis-data-integration/data-pipelines/rejected-records" >}})
+for more information.
+
 ## Can I use RDI without persistence enabled?
 
 By default, RDI requires persistence to be enabled on the RDI database. This ensures that RDI can recover both its configuration and the last known state if the cluster crashes.

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -103,8 +103,7 @@ with Redis Insight or with the
 [`redis-di get-rejected`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-get-rejected" >}})
 command from the CLI.
 
-See [Rejected records]({{< relref "/integrate/redis-data-integration/data-pipelines/rejected-records" >}})
-for more information.
+See [Rejected records]({{< relref "/integrate/redis-data-integration/data-pipelines/rejected-records" >}}) for more information about DLQ.
 
 ## Can I use RDI without persistence enabled?
 

--- a/content/operate/rc/rdi/view-edit.md
+++ b/content/operate/rc/rdi/view-edit.md
@@ -23,7 +23,7 @@ The pipeline page has the following tabs:
 - [Dataset](#dataset)
 - [Transformations](#transformations)
 
-The following sections describe each of these tabs, as well as any actions that you can perform.
+The following sections describe each of these tabs, as well as related diagnostic views and actions.
 
 ## Dashboard
 
@@ -39,7 +39,7 @@ The **Dashboard** tab shows an overview and high-level statistics for the data p
     | **Error** | There is an error in the data pipeline. [Reset the pipeline](#reset-data-pipeline) and contact support if the issue persists. |
 - **Total ingested**: Total number of records ingested from the source database.
 - **Pending**: Total number of records that are being processed and have not been inserted into the target database.
-- **Record health**: The number of records that were rejected from the database, and the number of records that were filtered from being inserted into the database.
+- **Record health**: The number of records that were rejected from the database, and the number of records that were filtered from being inserted into the database. If there are rejected records, select the rejected count to open the [Rejected records](#rejected-records) view.
 - **Data latency**: How long it takes for a new record to be ingested from the source database.
 
 ### Change target database
@@ -73,7 +73,7 @@ The **Metrics** tab shows the following metrics for each data stream:
 | **Updated** | Number of updated records from the source table that have been updated in the target database. |
 | **Deleted** | Number of deleted records from the source table that have been deleted in the target database. |
 | **Filtered** | Number of records from the source table that were filtered from being inserted into the target database. |
-| **Rejected** | Number of records from the source table that could not be parsed or inserted into the target database. |
+| **Rejected** | Number of records from the source table that could not be parsed or inserted into the target database. Select a rejected count to open the [Rejected records](#rejected-records) view for that table. |
 
 <!--
 ### View metrics endpoints
@@ -86,6 +86,22 @@ Prometheus endpoints are exposed on Redis Cloud's internal network. To access th
 
 For more information about available RDI metrics, see [Observability]({{< relref "/integrate/redis-data-integration/observability" >}}).
 -->
+
+## Rejected records
+
+The **Rejected records** view shows records that RDI sent to the dead letter queue (DLQ) because processing failed. Open it from the rejected count on the **Dashboard** tab or from a table-level rejected count on the **Metrics** tab.
+
+The view shows:
+
+- The total number of rejected records.
+- The number of affected tables.
+- The affected tables and their rejected counts.
+- Rejected record IDs and rejection times.
+- Safe troubleshooting metadata, such as the rejection reason, operation, affected table, and transformation job details when available.
+
+Redis Cloud does not show the original source record payload in this view.
+
+For more information about why records are rejected and how RDI stores them, see [Rejected records]({{< relref "/integrate/redis-data-integration/data-pipelines/rejected-records" >}}).
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Add a public RDI Rejected records page explaining DLQ behavior, storage, safe troubleshooting fields, and CLI/API access
- Add a Cloud RDI Rejected records section to the View and edit page and link Dashboard/Metrics rejected counts to it
- Link existing pipeline config and FAQ DLQ mentions to the new page

## Validation
- git diff --check
- targeted rg checks for rejected-records links and anchors
- npm run test -w @redislabs/rdi-ui -- src/pages/ManagePipelinePage/pages/DlqPage/DlqPage.test.tsx src/pages/ManagePipelinePage/ManagePipelinePage.test.tsx src/routing/config.test.ts
- ./node_modules/.bin/eslint packages/pipeline/src/constants/externalLinks.ts packages/pipeline/src/pages/ManagePipelinePage/ManagePipelinePage.tsx packages/pipeline/src/pages/ManagePipelinePage/ManagePipelinePage.test.tsx packages/pipeline/src/pages/ManagePipelinePage/pages/DlqPage/DlqPage.style.ts packages/pipeline/src/pages/ManagePipelinePage/pages/DlqPage/DlqPage.test.tsx packages/pipeline/src/pages/ManagePipelinePage/pages/DlqPage/components/DlqPageView/DlqPageView.tsx packages/pipeline/src/routing/config.test.ts
- npm run type-check -w @redislabs/rdi-ui

Hugo build note: after installing local Node deps for PostCSS in the temporary docs worktree, `hugo --logLevel debug --gc` still fails on an existing docs-nav rendering issue in `content/commands/acl-list.md`: `can't evaluate field ByWeight in type []interface {}`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or configuration behavior changes.
> 
> **Overview**
> Adds a dedicated **Rejected records** doc for RDI that explains DLQ behavior, per-table capped streams (`processors.dlq_max_messages`), what to inspect, how to fix common causes, and that DLQ entries are not auto-replayed (reset may be needed). It also notes CLI/API access and that Redis Cloud shows limited metadata without source payloads.
> 
> **Redis Cloud** `view-edit` docs gain a **Rejected records** section describing how to open the view from Dashboard or Metrics rejected counts and what the UI shows. Existing mentions of `processors.error_handling` / invalid data in **pipeline-config** and the **FAQ** now link to the new page instead of only the FAQ anchor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4491ba3a229d87503930a98dd797a7851415627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->