### PR TITLE
DOC-6772 added aliases for singular forms of data type names

### DIFF
--- a/content/develop/data-types/arrays.md
+++ b/content/develop/data-types/arrays.md
@@ -1,4 +1,6 @@
 ---
+aliases:
+- /develop/data-types/array/
 bannerText: Array is a new data type that is currently in preview and may be subject to change.
 categories:
 - docs

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/hashes/
 - /manual/data-types/hashes/
+- /develop/data-types/hash/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/lists.md
+++ b/content/develop/data-types/lists.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/lists/
 - /manual/data-types/lists/
+- /develop/data-types/list/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/sets.md
+++ b/content/develop/data-types/sets.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/sets/
 - /manual/data-types/sets/
+- /develop/data-types/set/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/sorted-sets.md
+++ b/content/develop/data-types/sorted-sets.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/sorted-sets/
 - /manual/data-types/sorted-sets/
+- /develop/data-types/sorted-set/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/streams/_index.md
+++ b/content/develop/data-types/streams/_index.md
@@ -4,6 +4,7 @@ aliases:
 - /data-types/streams/
 - /develop/data-types/streams-tutorial/
 - /io/data-structures/streams/
+- /develop/data-types/stream/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/strings/_index.md
+++ b/content/develop/data-types/strings/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/strings/
 - /manual/data-types/strings/
+- /develop/data-types/string/
 categories:
 - docs
 - develop

--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /data-types/vector-sets/
 - /manual/data-types/vector-sets/
+- /develop/data-types/vector-set/
 categories:
 - docs
 - develop


### PR DESCRIPTION
There were some of these errors in the automatic 404 crawl report, so it seemed wise to fix them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only front matter aliases; no runtime or application logic changes.
> 
> **Overview**
> Adds **Hugo `aliases`** in front matter so singular `/develop/data-types/<type>/` paths resolve to the existing plural data-type docs, addressing **404s** from links or crawls that use singular names.
> 
> **Arrays** gets `/develop/data-types/array/`; **hashes, lists, sets, sorted sets, streams, strings, and vector sets** each gain a matching singular alias (e.g. `/develop/data-types/hash/`, `/develop/data-types/stream/`) alongside their existing legacy aliases. No page body or navigation content is changed—only redirect targets in YAML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efce69ca517f446e01372de832790f2a1715be0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->