### PR TITLE
DEV: modules lifecycle starting with Redis 8

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/modules-lifecycle.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/modules-lifecycle.md
@@ -11,9 +11,28 @@ weight: 7
 ---
 Redis Software follows the [Redis Software lifecycle]({{< relref "/operate/rs/installing-upgrading/product-lifecycle" >}}).  (For complete details, see the Redis Software [subscription agreement](https://redis.com/software-subscription-agreement).)
 
-The modules included in Redis Stack also follow a release lifecycle and schedule. Here, you'll find the "end-of-life" dates for each module and release.
+The lifecycle model for modules changed with Redis 8.0. This page is organized into two sections accordingly:
 
-## Module release numbering
+- [Redis 8.0 and later](#redis-80-and-later): modules are built into Redis Open Source and share the Redis lifecycle.
+- [Before Redis 8.0](#before-redis-80): legacy modules follow their own per-module release lifecycle and end-of-life schedule.
+
+## Redis 8.0 and later
+
+Starting with Redis 8.0, the capabilities that were previously distributed as separate modules—Search and query (RediSearch), JSON (RedisJSON), Time series (RedisTimeSeries), and Probabilistic (RedisBloom)—are built into Redis Open Source. [Redis 8 in Redis Open Source replaces Redis Stack]({{< relref "/operate/oss_and_stack" >}}), so there is no separate module to install or version.
+
+As a result:
+
+- **Modules are versioned in lockstep with Redis.** Redis 8.0 ships all of these capabilities as version 8.0, and each Redis version requires the exact matching module version. Redis X.Y requires modules of version X.Y.
+
+- **Modules share the Redis lifecycle.** Because the whole feature set (Redis X.Y plus its modules X.Y) ships and is supported as a single unit, the end-of-life for the modules follows the Redis lifecycle rather than a separate per-module schedule. For Redis Software, this is the [Redis Software product lifecycle]({{< relref "/operate/rs/installing-upgrading/product-lifecycle" >}}), where the end-of-life for each major release occurs 24 months after the formal release of the subsequent major version.
+
+The module APIs continue to follow [semantic versioning](https://semver.org/).
+
+## Before Redis 8.0
+
+The following sections describe the release lifecycle and end-of-life schedule for module versions released before Redis 8.0, when modules were distributed and versioned separately as part of Redis Stack.
+
+### Module release numbering
 
 Redis modules use a three-place numbering scheme to identify released versions.
 
@@ -23,31 +42,31 @@ The format is "Major1.Major2.Minor".
 
 - The _Minor_ section of the version number represents quality improvements and fixes to existing capabilities.  The minor release number is increased when release quality improves.
 
-## Module end-of-life schedule {#modules-endoflife-schedule}
+### Module end-of-life schedule {#modules-endoflife-schedule}
 
 End-of-Life for a given Major version is 18 months after the formal release of
 that version or 12 months after the release of the next subsequent (following) version, whichever comes last.
 
-### RediSearch
+#### RediSearch
 
 {{< table-csv "redisearch-lifecycle.csv" 2 >}}
 
-### RedisJSON
+#### RedisJSON
 
 {{< table-csv "redisjson-lifecycle.csv" 2 >}}
 
-### RedisGraph
+#### RedisGraph
 
 {{< table-csv "redisgraph-lifecycle.csv" 2 >}}
 
-### RedisTimeSeries
+#### RedisTimeSeries
 
 {{< table-csv "redistimeseries-lifecycle.csv" 2 >}}
 
-### RedisBloom
+#### RedisBloom
 
 {{< table-csv "redisbloom-lifecycle.csv" 2 >}}
 
-### RedisGears
+#### RedisGears
 
 {{< table-csv "redisgears-lifecycle.csv" 2 >}}


### PR DESCRIPTION
This PR addresses DOC-4312 (backlog).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only editorial restructure with no code or config changes; existing page links and the modules EOL anchor remain valid.
> 
> **Overview**
> **Restructures** the **Module lifecycle** page so readers see two eras: **Redis 8.0 and later** versus **before Redis 8.0**.
> 
> The new **Redis 8.0 and later** section explains that Search/JSON/Time series/Bloom ship **inside** Redis Open Source (no separate Stack module install), that capability versions **match the Redis X.Y release**, and that **EOL follows the Redis / Redis Software product lifecycle** instead of per-module tables. Legacy numbering rules, EOL policy, and CSV lifecycle tables are unchanged in substance but moved under **Before Redis 8.0**, with headings demoted one level (`###` / `####`) so the page hierarchy matches the split. The `{#modules-endoflife-schedule}` anchor is kept on the legacy EOL section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 572b22eceb5a905232e66bc4efcaefc4d82fa6f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->