### PR TITLE
DOC-6777 added FastAPI integration page

### DIFF
--- a/.claude/state/assess-comments.coverage.md
+++ b/.claude/state/assess-comments.coverage.md
@@ -27,11 +27,11 @@ whether to commit the change.
 
 | Capability | Confidence | Real encounters | Last verified | Evidence |
 |---|---|---|---|---|
-| Branch/PR identification + arg handling | 🟢 corroborated | 4 | 2026-06-23 | #3415, #3507, #3374, #3536 |
-| Multi-source collection (inline + top-level + reviews) | 🟢 corroborated | 5 | 2026-06-23 | #3415, #3507, #3510, #3374, #3536 |
-| GraphQL thread-resolution pull (`isResolved`/`isOutdated`) | 🟢 corroborated | 3 | 2026-06-23 | #3510 (12/12 resolved), #3374 (15/15), #3536 (2/2 open) |
-| Source-role tagging (bugbot/security/history/summary/ci/human) | 🟢 corroborated | 4 | 2026-06-23 | #3415, #3507, #3374, #3536 |
-| Open/resolved split | 🟢 corroborated | 3 | 2026-06-23 | #3510, #3374, #3536 (0 resolved / 2 open) |
+| Branch/PR identification + arg handling | 🟢 corroborated | 5 | 2026-06-25 | #3415, #3507, #3374, #3536, #3543 |
+| Multi-source collection (inline + top-level + reviews) | 🟢 corroborated | 6 | 2026-06-25 | #3415, #3507, #3510, #3374, #3536, #3543 |
+| GraphQL thread-resolution pull (`isResolved`/`isOutdated`) | 🟢 corroborated | 4 | 2026-06-25 | #3510 (12/12 resolved), #3374 (15/15), #3536 (2/2 open), #3543 (1/1 open) |
+| Source-role tagging (bugbot/security/history/summary/ci/human) | 🟢 corroborated | 5 | 2026-06-25 | #3415, #3507, #3374, #3536, #3543 |
+| Open/resolved split | 🟢 corroborated | 4 | 2026-06-25 | #3510, #3374, #3536, #3543 (1 open / 0 resolved) |
 | Fix-quality spot-check (genuinely fixed vs silenced) | 🟢 corroborated | 2 | 2026-06-23 | #3510 (term removals landed), #3374 (`num_docs`, dropIndex landed) |
 | "Resolved ≠ fixed" flag — **legitimate deferral** variant | 🟡 seen once | 1 | 2026-06-23 | #3510 (TS.BGET:122 left pending eng) |
 | "Resolved ≠ fixed" flag — **still-broken** variant | ❓ untested | 0 | — | never confirmed a resolved thread that was actually still broken |
@@ -42,8 +42,8 @@ whether to commit the change.
 | Approval-over-open-finding cross-check | 🟢 corroborated | 3 | 2026-06-23 | #3415 (dwdougherty), #3374 (dwdougherty low-confidence over open HIGH), #3536 (dwdougherty high-confidence — tested — over 2 open Mediums: benign variant) |
 | Depth cap / prioritisation under load | 🟡 seen once | 1 | 2026-06-23 | #3374 (19 candidate findings → 4 deep-verified) |
 | Mandatory deep-verify of resolved+not-outdated HIGH | ❓ untested | 0 | — | rule added 2026-06-23; not yet fired on a fresh run |
-| Bot calibration (fixed-vs-dismissed ratio) | 🟢 corroborated | 2 | 2026-06-23 | #3374 (bugbot signal mostly accepted); #3536 (bugbot 5/5 findings valid across 2 rounds — high trust) |
-| Codex second-opinion availability gate | 🟢 corroborated | 2 | 2026-06-23 | #3415, #3374 (CLI on PATH; #3374 had a real Codex review) |
+| Bot calibration (fixed-vs-dismissed ratio) | 🟢 corroborated | 3 | 2026-06-25 | #3374 (bugbot signal mostly accepted); #3536 (bugbot 5/5 findings valid across 2 rounds — high trust); #3543 (bugbot 1/1 valid — lifespan asymmetry real; Jit 0 findings) |
+| Codex second-opinion availability gate | 🟢 corroborated | 3 | 2026-06-25 | #3415, #3374 (CLI on PATH; #3374 had a real Codex review); #3543 (codex on PATH) |
 
 ## Worked examples library
 

--- a/content/develop/clients/redis-py/async.md
+++ b/content/develop/clients/redis-py/async.md
@@ -21,7 +21,7 @@ namespace. It mirrors the synchronous client API, so most code patterns
 translate directly — you `await` commands instead of calling them.
 
 Use the async client for I/O-bound workloads, for integration with async web
-frameworks (such as [FastAPI](https://fastapi.tiangolo.com/), [Starlette](https://www.starlette.io/), [aiohttp](https://docs.aiohttp.org/en/stable/), or [Sanic](https://sanic.dev/en/), or when you need
+frameworks (such as [FastAPI]({{< relref "/integrate/fastapi" >}}), [Starlette](https://www.starlette.io/), [aiohttp](https://docs.aiohttp.org/en/stable/), or [Sanic](https://sanic.dev/en/), or when you need
 to run many concurrent Redis operations from a single process. For simple
 scripts, CPU-bound work, or codebases without an existing event loop, the
 synchronous client is usually a better choice.
@@ -139,7 +139,7 @@ Always close clients and pools when you're done:
   single scope.
 - For longer-lived clients, call `await r.aclose()` explicitly. (The older
   `close()` method is deprecated.)
-- For frameworks with startup/shutdown hooks — for example FastAPI's
+- For frameworks with startup/shutdown hooks — for example [FastAPI]({{< relref "/integrate/fastapi" >}})'s
   `lifespan` — create the client or pool at startup and close it at
   shutdown so connections aren't leaked between process restarts.
 

--- a/content/develop/use-cases/pub-sub/_index.md
+++ b/content/develop/use-cases/pub-sub/_index.md
@@ -94,7 +94,7 @@ The following frameworks and libraries use Redis pub/sub for broadcast messaging
 
 -   **Node.js**: [Socket.IO](https://socket.io/) Redis adapter for cross-node WebSocket fan-out
 -   **Python**: [`redis-py`](https://redis.readthedocs.io/) subscribers with
-    [FastAPI](https://fastapi.tiangolo.com/) or [Django Channels](https://channels.readthedocs.io/)
+    [FastAPI]({{< relref "/integrate/fastapi" >}}) or [Django Channels](https://channels.readthedocs.io/)
     for WebSocket push and event listeners
 -   **Java**: [Spring Data Redis](https://spring.io/projects/spring-data-redis) message listener
     containers for inter-service messaging

--- a/content/develop/use-cases/streaming/_index.md
+++ b/content/develop/use-cases/streaming/_index.md
@@ -112,7 +112,7 @@ The following libraries and frameworks use Redis Streams for event-driven worklo
     [`ioredis`](https://github.com/redis/ioredis) for stream producers and consumers in
     event-driven APIs.
 -   **Python**: [`redis-py`](https://redis.readthedocs.io/) with
-    [FastAPI](https://fastapi.tiangolo.com/) or [Django](https://www.djangoproject.com/) for
+    [FastAPI]({{< relref "/integrate/fastapi" >}}) or [Django](https://www.djangoproject.com/) for
     microservice event pipelines.
 -   **Infrastructure**:
     [Active-Active geo-distribution]({{< relref "/operate/rs/databases/active-active" >}}) on

--- a/content/integrate/fastapi/_index.md
+++ b/content/integrate/fastapi/_index.md
@@ -34,13 +34,8 @@ so anything redis-py can do is still available to you alongside the caching help
 
 ## Requirements
 
-| Dependency   | Supported versions |
-|--------------|--------------------|
-| Python       | 3.10 to 3.14       |
-| FastAPI      | 0.115+             |
-| redis-py     | 6.0 to 7.2         |
-| Pydantic     | 2.12.5+            |
-| Redis server | 7.4+               |
+See [Requirements](https://github.com/redis/fastapi-redis-sdk#requirements) on the
+GitHub repo for the full set of dependencies used by `fastapi-redis-sdk`.
 
 You also need a running Redis server. You can run one locally with
 [Redis Open Source]({{< relref "/operate/oss_and_stack/install/archive/install-redis" >}}),

--- a/content/integrate/fastapi/_index.md
+++ b/content/integrate/fastapi/_index.md
@@ -9,7 +9,7 @@ categories:
 - rs
 - rc
 description: Add idiomatic Redis connection management and dependency-injection caching
-  to FastAPI apps with the fastapi-redis-sdk.
+  to FastAPI apps.
 group: framework
 hideListLinks: false
 stack: true
@@ -22,7 +22,7 @@ weight: 9
 [FastAPI](https://fastapi.tiangolo.com/) is a modern, high-performance web framework
 for building APIs with Python. The official
 [fastapi-redis-sdk](https://github.com/redis/fastapi-redis-sdk) integrates Redis with
-FastAPI without boilerplate: it manages connection pools through the application
+FastAPI without any boilerplate. It manages connection pools through the application
 lifespan and exposes caching as injectable dependencies, including HTTP-native
 [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag),
 [`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304),
@@ -47,13 +47,15 @@ You also need a running Redis server. You can run one locally with
 use [Docker](https://hub.docker.com/_/redis), or connect to
 [Redis Cloud](https://redis.io/cloud/).
 
-## Install
+## Install and import
+
+Use the following command to install `fastapi-redis-sdk`:
 
 ```bash
 pip install fastapi-redis-sdk
 ```
 
-Although you install the package as `fastapi-redis-sdk`, you import it as
+Note that although you install the package as `fastapi-redis-sdk`, you import it as
 `redis_fastapi`:
 
 ```python

--- a/content/integrate/fastapi/_index.md
+++ b/content/integrate/fastapi/_index.md
@@ -38,8 +38,8 @@ so anything redis-py can do is still available to you alongside the caching help
 |--------------|--------------------|
 | Python       | 3.10 to 3.14       |
 | FastAPI      | 0.115+             |
-| redis-py     | 6.0+               |
-| Pydantic     | 2.0+               |
+| redis-py     | 6.0 to 7.2         |
+| Pydantic     | 2.12.5+            |
 | Redis server | 7.4+               |
 
 You also need a running Redis server. You can run one locally with
@@ -64,22 +64,18 @@ from redis_fastapi import FastAPIRedis
 
 Attach Redis to your app with the fluent builder. The `lifespan()` call hooks into
 the [FastAPI lifespan events](https://fastapi.tiangolo.com/advanced/events/) to open a
-connection pool at startup and close it cleanly on shutdown. Inject `RedisDep` (or
-`AsyncRedisDep` for `async` endpoints) to get a ready-to-use client:
+connection pool at startup and close it cleanly on shutdown. Inject `AsyncRedisDep`
+into your `async` endpoints to get a ready-to-use client:
 
 ```python
 from fastapi import FastAPI
-from redis_fastapi import FastAPIRedis, RedisDep, AsyncRedisDep
+from redis_fastapi import FastAPIRedis, AsyncRedisDep
 
 app = FastAPI()
 FastAPIRedis(app).lifespan()
 
 @app.get("/items")
-def get_items(redis: RedisDep):
-    return {"items": redis.get("items")}
-
-@app.get("/async-items")
-async def get_items_async(redis: AsyncRedisDep):
+async def get_items(redis: AsyncRedisDep):
     return {"items": await redis.get("items")}
 ```
 
@@ -194,7 +190,7 @@ from redis_fastapi import CacheBackendDep
 @app.get("/dashboard/{user_id}")
 async def dashboard(user_id: int, cache: CacheBackendDep):
     cached = await cache.get(f"stats:{user_id}", eviction_group="dashboard")
-    if cached:
+    if cached is not None:
         return cached
     result = await compute_dashboard(user_id)
     await cache.set(f"stats:{user_id}", result, ttl=300, eviction_group="dashboard")
@@ -223,8 +219,7 @@ export REDIS_CLUSTER=true
 export REDIS_URL=redis://node1:6379,node2:6379,node3:6379
 ```
 
-In cluster mode, `RedisDep` yields a `RedisCluster` client and `AsyncRedisDep` yields
-an `AsyncRedisCluster`.
+In cluster mode, `AsyncRedisDep` yields an `AsyncRedisCluster` client.
 
 ## Observability
 
@@ -240,9 +235,11 @@ pip install fastapi-redis-sdk[otel]
 FastAPIRedis(app).lifespan().caching().otel()
 ```
 
-You can also enable it with `REDIS_OTEL_ENABLED=true`. See the
+Calling `.otel()` on the builder is what activates the cache telemetry. To also emit
+redis-py's low-level command spans and connection-pool metrics, set
+`REDIS_OTEL_REDIS_ENABLED=true`. See the
 [SDK configuration guide](https://redis.github.io/fastapi-redis-sdk/guide/configuration/#opentelemetry)
-for the spans and metrics that are emitted.
+for the full list of spans and metrics that are emitted.
 
 ## More information
 

--- a/content/integrate/fastapi/_index.md
+++ b/content/integrate/fastapi/_index.md
@@ -1,0 +1,253 @@
+---
+LinkTitle: FastAPI
+Title: Redis with FastAPI
+alwaysopen: false
+categories:
+- docs
+- integrate
+- oss
+- rs
+- rc
+description: Add idiomatic Redis connection management and dependency-injection caching
+  to FastAPI apps with the fastapi-redis-sdk.
+group: framework
+hideListLinks: false
+stack: true
+summary: The fastapi-redis-sdk provides automatic connection pooling and dependency-injection
+  caching for FastAPI, with HTTP-native ETag and Cache-Control support.
+type: integration
+weight: 9
+---
+
+[FastAPI](https://fastapi.tiangolo.com/) is a modern, high-performance web framework
+for building APIs with Python. The official
+[fastapi-redis-sdk](https://github.com/redis/fastapi-redis-sdk) integrates Redis with
+FastAPI without boilerplate: it manages connection pools through the application
+lifespan and exposes caching as injectable dependencies, including HTTP-native
+[`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag),
+[`304 Not Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/304),
+and [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control)
+support.
+
+The SDK is built on the [redis-py]({{< relref "/develop/clients/redis-py" >}}) client,
+so anything redis-py can do is still available to you alongside the caching helpers.
+
+## Requirements
+
+| Dependency   | Supported versions |
+|--------------|--------------------|
+| Python       | 3.10 to 3.14       |
+| FastAPI      | 0.115+             |
+| redis-py     | 6.0+               |
+| Pydantic     | 2.0+               |
+| Redis server | 7.4+               |
+
+You also need a running Redis server. You can run one locally with
+[Redis Open Source]({{< relref "/operate/oss_and_stack/install/archive/install-redis" >}}),
+use [Docker](https://hub.docker.com/_/redis), or connect to
+[Redis Cloud](https://redis.io/cloud/).
+
+## Install
+
+```bash
+pip install fastapi-redis-sdk
+```
+
+Although you install the package as `fastapi-redis-sdk`, you import it as
+`redis_fastapi`:
+
+```python
+from redis_fastapi import FastAPIRedis
+```
+
+## Quick start
+
+Attach Redis to your app with the fluent builder. The `lifespan()` call hooks into
+the [FastAPI lifespan events](https://fastapi.tiangolo.com/advanced/events/) to open a
+connection pool at startup and close it cleanly on shutdown. Inject `RedisDep` (or
+`AsyncRedisDep` for `async` endpoints) to get a ready-to-use client:
+
+```python
+from fastapi import FastAPI
+from redis_fastapi import FastAPIRedis, RedisDep, AsyncRedisDep
+
+app = FastAPI()
+FastAPIRedis(app).lifespan()
+
+@app.get("/items")
+def get_items(redis: RedisDep):
+    return {"items": redis.get("items")}
+
+@app.get("/async-items")
+async def get_items_async(redis: AsyncRedisDep):
+    return {"items": await redis.get("items")}
+```
+
+The builder wraps any existing lifespan, so multiple libraries can register their own
+startup and shutdown logic without conflicting.
+
+## Configuration
+
+All settings are read from environment variables prefixed with `REDIS_`, or from a
+`.env` file in your project root. The simplest setup is a single connection URL:
+
+```bash
+export REDIS_URL=redis://user:pass@host:6379/0
+```
+
+Or configure individual fields:
+
+```bash
+export REDIS_HOST=redis.example.com
+export REDIS_PORT=6380
+export REDIS_PASSWORD=secret
+```
+
+When `REDIS_URL` is set, it takes precedence over the individual connection fields.
+The most commonly used variables are:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `REDIS_URL` | - | Full Redis URL (takes precedence over the fields below) |
+| `REDIS_HOST` | `localhost` | Redis host |
+| `REDIS_PORT` | `6379` | Redis port |
+| `REDIS_PASSWORD` | - | Redis password (stored securely as a Pydantic `SecretStr`) |
+| `REDIS_SSL` | `false` | Enable TLS (or use a `rediss://` URL) |
+| `REDIS_CLUSTER` | `false` | Enable [OSS Cluster mode](#cluster-mode) |
+| `REDIS_PREFIX` | `redis:fastapi` | Global prefix applied to all keys |
+| `REDIS_DEFAULT_TTL` | `0` | Default cache TTL in seconds (`0` = no expiry) |
+| `REDIS_MAX_CONNECTIONS` | - | Maximum pooled connections |
+
+Configuration is validated with [Pydantic Settings](https://docs.pydantic.dev/latest/concepts/pydantic_settings/),
+so invalid values (for example, a port outside 1–65535) fail fast at startup. For the
+full environment-variable reference, TLS options, and programmatic configuration, see
+the [SDK configuration guide](https://redis.github.io/fastapi-redis-sdk/guide/configuration/).
+
+## Caching
+
+Enable caching by adding `.caching()` to the builder chain. The SDK then offers two
+complementary approaches that share the same connection pool:
+
+| Approach | Best for |
+|----------|----------|
+| `cache()`, `cache_evict()`, `cache_put()` | Most endpoints — read, invalidate, and write-through |
+| `CacheBackend` | Complex invalidation, conditional or dynamic caching |
+
+### Dependency-injection factories
+
+`cache()`, `cache_evict()`, and `cache_put()` are
+[dependency](https://fastapi.tiangolo.com/tutorial/dependencies/) factories you attach
+to a route. Because all three share the same `key_builder`, a `GET`, `DELETE`, and
+`PUT` on the same path target the exact same cache key:
+
+```python
+from fastapi import Depends, FastAPI
+from redis_fastapi import FastAPIRedis, cache, cache_evict, cache_put, default_key_builder
+
+app = FastAPI()
+FastAPIRedis(app).lifespan().caching()
+
+# READ - cache the GET response for 5 minutes
+@app.get("/products/{product_id}", dependencies=[Depends(cache(ttl=300, eviction_group="products"))])
+async def get_product(product_id: int):
+    return await db.get_product(product_id)
+
+# INVALIDATE - evict the cached entry when the product is deleted
+@app.delete(
+    "/products/{product_id}",
+    dependencies=[Depends(cache_evict(eviction_group="products", key_builder=default_key_builder))],
+)
+async def delete_product(product_id: int):
+    await db.delete(product_id)
+
+# WRITE-THROUGH - refresh the cache so the next GET is a HIT
+@app.put(
+    "/products/{product_id}",
+    dependencies=[Depends(cache_put(eviction_group="products", key_builder=default_key_builder, ttl=300))],
+)
+async def replace_product(product_id: int, body: Product):
+    return await db.update(product_id, body)
+```
+
+Cached responses include an `X-Redis-Cache` header (`HIT` or `MISS`) along with
+`Cache-Control` and `ETag` headers.
+
+The example below drives a cached endpoint with FastAPI's
+[`TestClient`](https://fastapi.tiangolo.com/reference/testclient/) so you can see the
+`MISS` → `HIT` → eviction cycle, plus the HTTP caching headers, in action:
+
+{{< clients-example set="fastapi_tutorial" step="cache_hit_miss" lang_filter="Python" description="Foundational: cache a GET response so the first request is a MISS and the next is served from Redis as a HIT" difficulty="beginner" />}}
+
+Evicting a resource clears its cached entry, so the following read is a `MISS` again:
+
+{{< clients-example set="fastapi_tutorial" step="cache_evict" lang_filter="Python" description="Invalidate a cached entry so the next read recomputes the response" difficulty="beginner" buildsUpon="cache_hit_miss" />}}
+
+### CacheBackend for full control
+
+For conditional caching, cascade invalidation, dynamic TTLs, or caching intermediate
+results, inject `CacheBackendDep` and call its `get`/`set`/`delete`/`has`/`delete_group`
+methods directly. Values are serialized to and from JSON automatically:
+
+```python
+from redis_fastapi import CacheBackendDep
+
+@app.get("/dashboard/{user_id}")
+async def dashboard(user_id: int, cache: CacheBackendDep):
+    cached = await cache.get(f"stats:{user_id}", eviction_group="dashboard")
+    if cached:
+        return cached
+    result = await compute_dashboard(user_id)
+    await cache.set(f"stats:{user_id}", result, ttl=300, eviction_group="dashboard")
+    return result
+```
+
+See the [SDK caching guide](https://redis.github.io/fastapi-redis-sdk/guide/caching/)
+for detailed patterns and best practices.
+
+## HTTP caching
+
+Responses cached with the DI factories carry standard HTTP caching headers, so clients
+and proxies can revalidate cheaply. The SDK sets `Cache-Control` from the entry's TTL
+and emits a weak `ETag`; when a client returns that tag in an `If-None-Match` header,
+the server responds with `304 Not Modified` and no body:
+
+{{< clients-example set="fastapi_tutorial" step="http_caching" lang_filter="Python" description="Use ETag and Cache-Control headers so a revalidation request returns 304 Not Modified" difficulty="intermediate" buildsUpon="cache_hit_miss" />}}
+
+## Cluster mode
+
+To work with an [OSS Cluster]({{< relref "/operate/oss_and_stack/management/scaling" >}}),
+set `REDIS_CLUSTER=true` and point `REDIS_URL` at the cluster nodes:
+
+```bash
+export REDIS_CLUSTER=true
+export REDIS_URL=redis://node1:6379,node2:6379,node3:6379
+```
+
+In cluster mode, `RedisDep` yields a `RedisCluster` client and `AsyncRedisDep` yields
+an `AsyncRedisCluster`.
+
+## Observability
+
+The SDK can emit [OpenTelemetry](https://opentelemetry.io/) spans and metrics for every
+cache operation. Telemetry is opt-in and a zero-cost no-op when disabled. Install the
+optional dependency and enable it on the builder:
+
+```bash
+pip install fastapi-redis-sdk[otel]
+```
+
+```python
+FastAPIRedis(app).lifespan().caching().otel()
+```
+
+You can also enable it with `REDIS_OTEL_ENABLED=true`. See the
+[SDK configuration guide](https://redis.github.io/fastapi-redis-sdk/guide/configuration/#opentelemetry)
+for the spans and metrics that are emitted.
+
+## More information
+
+- [fastapi-redis-sdk on GitHub](https://github.com/redis/fastapi-redis-sdk)
+- [fastapi-redis-sdk documentation](https://redis.github.io/fastapi-redis-sdk/)
+- [fastapi-redis-sdk on PyPI](https://pypi.org/project/fastapi-redis-sdk/)
+- [redis-py client documentation]({{< relref "/develop/clients/redis-py" >}})
+- [FastAPI documentation](https://fastapi.tiangolo.com/)

--- a/content/integrate/fastapi/_index.md
+++ b/content/integrate/fastapi/_index.md
@@ -64,7 +64,7 @@ from redis_fastapi import FastAPIRedis
 
 ## Quick start
 
-Attach Redis to your app with the fluent builder. The `lifespan()` call hooks into
+Attach Redis to your app with the [fluent builder](https://en.wikipedia.org/wiki/Fluent_interface). The `lifespan()` call hooks into
 the [FastAPI lifespan events](https://fastapi.tiangolo.com/advanced/events/) to open a
 connection pool at startup and close it cleanly on shutdown. Inject `AsyncRedisDep`
 into your `async` endpoints to get a ready-to-use client:
@@ -93,7 +93,7 @@ All settings are read from environment variables prefixed with `REDIS_`, or from
 export REDIS_URL=redis://user:pass@host:6379/0
 ```
 
-Or configure individual fields:
+Alternatively, you can configure individual fields:
 
 ```bash
 export REDIS_HOST=redis.example.com
@@ -102,7 +102,7 @@ export REDIS_PASSWORD=secret
 ```
 
 When `REDIS_URL` is set, it takes precedence over the individual connection fields.
-The most commonly used variables are:
+The most commonly used variables are described in the table below:
 
 | Variable | Default | Description |
 |----------|---------|-------------|

--- a/content/integrate/redis-py/_index.md
+++ b/content/integrate/redis-py/_index.md
@@ -31,7 +31,7 @@ redis-py is the recommended Python client for Redis, providing a comprehensive i
 - **Sentinel Support**: High availability with Redis Sentinel integration
 - **Pipeline Support**: Command batching for improved performance
 - **Pub/Sub**: Real-time messaging with Redis publish/subscribe
-- **Framework Integration**: Seamless integration with Django, Flask, FastAPI, and other Python frameworks
+- **Framework Integration**: Seamless integration with Django, Flask, [FastAPI]({{< relref "/integrate/fastapi" >}}), and other Python frameworks
 
 ## Getting Started
 

--- a/local_examples/fastapi_tutorial/redis-py/cache_basics.py
+++ b/local_examples/fastapi_tutorial/redis-py/cache_basics.py
@@ -107,5 +107,10 @@ print(not_modified.status_code)
 assert miss.headers["Cache-Control"].startswith("max-age=")
 assert etag
 assert not_modified.status_code == 304
-client.__exit__(None, None, None)
 # REMOVE_END
+
+# HIDE_START
+# Close the TestClient context to run the shutdown lifespan and release the
+# Redis connection pool opened by client.__enter__() above.
+client.__exit__(None, None, None)
+# HIDE_END

--- a/local_examples/fastapi_tutorial/redis-py/cache_basics.py
+++ b/local_examples/fastapi_tutorial/redis-py/cache_basics.py
@@ -1,0 +1,107 @@
+# EXAMPLE: fastapi_tutorial
+# HIDE_START
+"""Verifiable fastapi-redis-sdk caching example.
+
+Requires a running Redis server (default: localhost:6379) plus
+`fastapi-redis-sdk` and `httpx` installed. The app is driven in-process with
+FastAPI's TestClient, so no separate server needs to be started.
+"""
+from datetime import datetime, timezone
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from redis_fastapi import (
+    FastAPIRedis,
+    cache,
+    cache_evict,
+    default_key_builder,
+)
+
+app = FastAPI()
+FastAPIRedis(app).lifespan().caching()
+
+
+@app.get(
+    "/cache-demo",
+    dependencies=[Depends(cache(ttl=30, eviction_group="demo"))],
+)
+async def cache_demo():
+    # Recomputed only on a cache MISS; the timestamp changes each time.
+    return {"generated_at": datetime.now(tz=timezone.utc).isoformat()}
+
+
+@app.delete(
+    "/cache-demo",
+    dependencies=[
+        Depends(cache_evict(eviction_group="demo", key_builder=default_key_builder))
+    ],
+)
+async def evict_cache_demo():
+    return {"evicted": "demo"}
+
+
+# Entering the TestClient context triggers the FastAPI lifespan, which is where
+# fastapi-redis-sdk opens its Redis connection pool.
+client = TestClient(app)
+client.__enter__()
+# HIDE_END
+
+# STEP_START cache_hit_miss
+# The first request is a MISS: the handler runs and the response is cached.
+first = client.get("/cache-demo")
+print(first.headers["X-Redis-Cache"])
+# >>> MISS
+
+# A second request within the TTL is a HIT, served from Redis without
+# re-running the handler, so the cached body is returned unchanged.
+second = client.get("/cache-demo")
+print(second.headers["X-Redis-Cache"])
+# >>> HIT
+
+print(first.json() == second.json())
+# >>> True
+# STEP_END
+
+# REMOVE_START
+assert first.headers["X-Redis-Cache"] == "MISS"
+assert second.headers["X-Redis-Cache"] == "HIT"
+assert first.json() == second.json()
+# REMOVE_END
+
+# STEP_START cache_evict
+# Deleting the resource evicts its cache entry, so the next read is a MISS
+# again and the handler recomputes a fresh response.
+client.delete("/cache-demo")
+
+third = client.get("/cache-demo")
+print(third.headers["X-Redis-Cache"])
+# >>> MISS
+
+print(third.json() == first.json())
+# >>> False
+# STEP_END
+
+# REMOVE_START
+assert third.headers["X-Redis-Cache"] == "MISS"
+assert third.json() != first.json()
+# REMOVE_END
+
+# STEP_START http_caching
+# Cached responses carry standard HTTP caching headers. Replaying the ETag with
+# If-None-Match lets the server answer 304 Not Modified with no body.
+cached = client.get("/cache-demo")
+etag = cached.headers["ETag"]
+print(cached.headers["Cache-Control"])
+# >>> max-age=30
+
+not_modified = client.get("/cache-demo", headers={"If-None-Match": etag})
+print(not_modified.status_code)
+# >>> 304
+# STEP_END
+
+# REMOVE_START
+assert etag
+assert not_modified.status_code == 304
+client.__exit__(None, None, None)
+# REMOVE_END

--- a/local_examples/fastapi_tutorial/redis-py/cache_basics.py
+++ b/local_examples/fastapi_tutorial/redis-py/cache_basics.py
@@ -88,19 +88,23 @@ assert third.json() != first.json()
 # REMOVE_END
 
 # STEP_START http_caching
-# Cached responses carry standard HTTP caching headers. Replaying the ETag with
-# If-None-Match lets the server answer 304 Not Modified with no body.
-cached = client.get("/cache-demo")
-etag = cached.headers["ETag"]
-print(cached.headers["Cache-Control"])
+# Cached responses carry standard HTTP caching headers. Evict first so the next
+# request is a fresh MISS whose Cache-Control reflects the full 30-second TTL.
+client.delete("/cache-demo")
+miss = client.get("/cache-demo")
+print(miss.headers["Cache-Control"])
 # >>> max-age=30
 
+# The cached response also carries a weak ETag. Replaying it with If-None-Match
+# lets the server answer 304 Not Modified with no body.
+etag = miss.headers["ETag"]
 not_modified = client.get("/cache-demo", headers={"If-None-Match": etag})
 print(not_modified.status_code)
 # >>> 304
 # STEP_END
 
 # REMOVE_START
+assert miss.headers["Cache-Control"].startswith("max-age=")
 assert etag
 assert not_modified.status_code == 304
 client.__exit__(None, None, None)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and example-only changes with no application runtime or security logic modified.
> 
> **Overview**
> Adds a new **Redis with FastAPI** integration page for **fastapi-redis-sdk**, covering lifespan wiring, `REDIS_*` configuration, DI caching (`cache` / `cache_evict` / `cache_put` and `CacheBackend`), HTTP `ETag`/`304` behavior, cluster mode, and optional OpenTelemetry.
> 
> The page embeds three **clients-example** steps backed by a new runnable `fastapi_tutorial` script (`cache_hit_miss`, `cache_evict`, `http_caching`) that exercises the SDK with FastAPI `TestClient` against Redis.
> 
> Several existing docs now link **FastAPI** to the internal integrate page instead of fastapi.tiangolo.com (redis-py async guide, pub/sub and streaming use-case ecosystem lists, redis-py integrate overview). The **assess-comments** coverage ledger is updated with PR **#3543** encounter counts and dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e105cb739eef8643c9560eb9d8e766658574efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->