### PR TITLE
DEV: (cmds) address community feedback re. JSON.TYPE

### DIFF
--- a/content/commands/json.type.md
+++ b/content/commands/json.type.md
@@ -35,6 +35,21 @@ title: JSON.TYPE
 ---
 Report the type of JSON value at `path`
 
+The returned type is one of the following strings:
+
+| Type | Description |
+|:-----|:------------|
+| `null` | A JSON null value. |
+| `boolean` | A JSON `true` or `false` value. |
+| `integer` | A number with no fractional part. |
+| `number` | A number with a fractional part (a floating-point value). <sup>[1](#table-note-1)</sup>|
+| `string` | A JSON string value. |
+| `object` | A JSON object (a collection of key-value pairs). |
+| `array` | A JSON array (an ordered list of values). |
+
+1. <a name="table-note-1"></a>
+A floating-point homogeneous array (FPHA) stored with the [`JSON.SET`]({{< relref "commands/json.set/" >}}) `FPHA` argument still reports as `array`, and its elements report as `number`. The FP type (`FP16`, `BF16`, `FP32`, or `FP64`) is an internal storage representation and is not exposed by `JSON.TYPE`.
+
 [Examples](#examples)
 
 ## Required arguments


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to the JSON.TYPE command page with no runtime or API behavior changes.
> 
> **Overview**
> Updates the **`JSON.TYPE`** command reference to document the full set of return type strings and clarify **FPHA** behavior.
> 
> Adds a **reference table** for each possible type (`null`, `boolean`, `integer`, `number`, `string`, `object`, `array`) with short descriptions, including the distinction between **`integer`** and **`number`**.
> 
> Adds a footnote explaining that arrays stored via **`JSON.SET`** with the **`FPHA`** argument still report as **`array`** (elements as **`number`**), and that internal FP storage types (`FP16`, `BF16`, `FP32`, `FP64`) are **not** exposed by **`JSON.TYPE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c2d83fb36ef3ba814ddde711c9062a3a7f81654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->