### PR TITLE
DEV: add links to the new search playground

### DIFF
--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -47,6 +47,9 @@ Here are the next steps to get you started:
 1. Learn how to [query your data]({{< relref "/develop/ai/search-and-query/query/" >}}).
 1. [Install Redis Insight]({{< relref "/operate/redisinsight" >}}), connect it to your Redis database, and then use [Redis Copilot]({{< relref "/develop/tools/insight" >}}#redis-copilot) to help you learn how to execute complex queries against your own data using simple, plain language prompts.
 
+{{< alert title="Try it out" >}}
+Experiment with Redis Search interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.
+{{< /alert >}}
 
 ## Enable Redis Search
 

--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -194,6 +194,10 @@ to include them in the search:
 1) "pt:C"
 2) "pt:B"
 {{< /clients-example >}}
+&nbsp;
+{{< alert title="Try it out" >}}
+Experiment with vector set commands interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.
+{{< /alert >}}
 
 ## More information
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only link additions with no runtime or security impact.
> 
> **Overview**
> Adds **Try it out** Hugo alerts on the **Redis Search** and **vector sets** overview pages so readers can open the [Redis playground](https://redis.io/try/sandbox) without installing anything. Copy is tailored per page (Search vs vector set commands). The vector sets page also inserts a `&nbsp;` before the alert for spacing after the last client example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b15855f95806e7c3d7305d8d9bc2edb60e06ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->