### PR TITLE
Link header

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -133,4 +133,4 @@ page = ["HTML", "Markdown", "JSON"]
   [[server.headers]]
     for = "/**"
     [server.headers.values]
-      Link = '<.well-known/api-catalog>; rel="api-catalog", <develop/>; rel="service-doc", <.well-known/api-catalog>; rel="service-desc"'
+      Link = '</.well-known/api-catalog>; rel="api-catalog", </develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"'

--- a/config.toml
+++ b/config.toml
@@ -2,14 +2,6 @@
 baseURL = "https://redis.io"
 title = "Docs"
 
-# RFC 8288 Link response headers for agent discovery (hugo serve only).
-# For production, configure equivalent headers in your nginx ingress or CDN.
-[server]
-  [[server.headers]]
-    for = "/**"
-    [server.headers.values]
-      Link = '</.well-known/api-catalog>; rel="api-catalog", </docs/latest/develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"'
-
 timeout="75"
 refLinksErrorLevel = "WARNING"
 enableRobotsTXT = true
@@ -133,3 +125,12 @@ rdi_current_version = "1.18.1"
 [outputs]
 section = ["HTML", "RSS", "Markdown", "JSON"]
 page = ["HTML", "Markdown", "JSON"]
+
+# RFC 8288 Link response headers for agent discovery (hugo serve only).
+# For production, configure equivalent headers in your nginx ingress or CDN.
+# Must be at the end of config.toml — TOML tables apply to all following keys.
+[server]
+  [[server.headers]]
+    for = "/**"
+    [server.headers.values]
+      Link = '</.well-known/api-catalog>; rel="api-catalog", </docs/latest/develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"'

--- a/config.toml
+++ b/config.toml
@@ -129,8 +129,21 @@ page = ["HTML", "Markdown", "JSON"]
 # RFC 8288 Link response headers for agent discovery (hugo serve only).
 # For production, configure equivalent headers in your nginx ingress or CDN.
 # Must be at the end of config.toml — TOML tables apply to all following keys.
+#
+# Note: paths here are root-relative and assume no site prefix, which is correct
+# for standard `hugo serve`. If you run hugo serve with a --baseURL path prefix,
+# the HTML <link> elements in baseof.html (which use relURL) are the authoritative
+# implementation — these server headers are a development convenience only.
 [server]
   [[server.headers]]
     for = "/**"
     [server.headers.values]
       Link = '</.well-known/api-catalog>; rel="api-catalog", </develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"; type="application/linkset+json"'
+
+  # The api-catalog file is extensionless so servers infer a generic MIME type.
+  # Explicitly set application/linkset+json so RFC 9264/9727 clients parse it correctly.
+  # Production nginx should set the same Content-Type for /.well-known/api-catalog.
+  [[server.headers]]
+    for = "/.well-known/api-catalog"
+    [server.headers.values]
+      Content-Type = "application/linkset+json"

--- a/config.toml
+++ b/config.toml
@@ -133,4 +133,4 @@ page = ["HTML", "Markdown", "JSON"]
   [[server.headers]]
     for = "/**"
     [server.headers.values]
-      Link = '</.well-known/api-catalog>; rel="api-catalog", </docs/latest/develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"'
+      Link = '<.well-known/api-catalog>; rel="api-catalog", <develop/>; rel="service-doc", <.well-known/api-catalog>; rel="service-desc"'

--- a/config.toml
+++ b/config.toml
@@ -133,4 +133,4 @@ page = ["HTML", "Markdown", "JSON"]
   [[server.headers]]
     for = "/**"
     [server.headers.values]
-      Link = '</.well-known/api-catalog>; rel="api-catalog", </develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"'
+      Link = '</.well-known/api-catalog>; rel="api-catalog", </develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"; type="application/linkset+json"'

--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,14 @@
 baseURL = "https://redis.io"
 title = "Docs"
 
+# RFC 8288 Link response headers for agent discovery (hugo serve only).
+# For production, configure equivalent headers in your nginx ingress or CDN.
+[server]
+  [[server.headers]]
+    for = "/**"
+    [server.headers.values]
+      Link = '</.well-known/api-catalog>; rel="api-catalog", </docs/latest/develop/>; rel="service-doc", </.well-known/api-catalog>; rel="service-desc"'
+
 timeout="75"
 refLinksErrorLevel = "WARNING"
 enableRobotsTXT = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,10 +40,13 @@
 
     {{ block "head" . }}{{ end }}
 
-    {{- /* RFC 8288 web linking for agent discovery. Equivalent to HTTP Link response headers. */}}
-    <link rel="api-catalog" href="{{ "/.well-known/api-catalog" | absURL }}">
-    <link rel="service-doc" href="{{ "/docs/latest/develop/" | absURL }}">
-    <link rel="service-desc" href="{{ "/.well-known/api-catalog" | absURL }}" type="application/json">
+    {{- /* RFC 8288 web linking for agent discovery. Equivalent to HTTP Link response headers.
+         relURL keeps paths within the site prefix so links match where Hugo actually serves
+         the files. For full RFC 8615 compliance, nginx should also alias
+         /.well-known/api-catalog to this path at the host root. */}}
+    <link rel="api-catalog" href="{{ ".well-known/api-catalog" | relURL }}">
+    <link rel="service-doc" href="{{ "develop/" | relURL }}">
+    <link rel="service-desc" href="{{ ".well-known/api-catalog" | relURL }}" type="application/linkset+json">
 
     {{ partial "ai-metadata.html" . }}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,6 +40,11 @@
 
     {{ block "head" . }}{{ end }}
 
+    {{- /* RFC 8288 web linking for agent discovery. Equivalent to HTTP Link response headers. */}}
+    <link rel="api-catalog" href="{{ "/.well-known/api-catalog" | absURL }}">
+    <link rel="service-doc" href="{{ "/docs/latest/develop/" | absURL }}">
+    <link rel="service-desc" href="{{ "/.well-known/api-catalog" | absURL }}" type="application/json">
+
     {{ partial "ai-metadata.html" . }}
 
     {{ partial "fonts.html" . }}

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,32 +1,44 @@
 {
-  "apis": [
+  "linkset": [
     {
-      "id": "redis-commands",
-      "title": "Redis Commands Reference",
-      "description": "Complete reference for all Redis commands, including syntax, arguments, complexity, and examples.",
-      "humanURL": "https://redis.io/docs/latest/commands/",
-      "tags": ["redis", "commands", "reference"]
+      "anchor": "https://redis.io/docs/latest/commands/",
+      "service-doc": [
+        {
+          "href": "https://redis.io/docs/latest/commands/",
+          "type": "text/html",
+          "title": "Redis Commands Reference"
+        }
+      ]
     },
     {
-      "id": "redis-developer-docs",
-      "title": "Redis Developer Documentation",
-      "description": "Guides, quickstarts, and tutorials for building applications with Redis, including vector search, AI agents, and client libraries.",
-      "humanURL": "https://redis.io/docs/latest/develop/",
-      "tags": ["redis", "develop", "ai", "vector-search", "clients"]
+      "anchor": "https://redis.io/docs/latest/develop/",
+      "service-doc": [
+        {
+          "href": "https://redis.io/docs/latest/develop/",
+          "type": "text/html",
+          "title": "Redis Developer Documentation"
+        }
+      ]
     },
     {
-      "id": "redis-cloud-api",
-      "title": "Redis Cloud REST API",
-      "description": "REST API for managing Redis Cloud subscriptions, databases, and accounts programmatically.",
-      "humanURL": "https://redis.io/docs/latest/operate/rc/api/",
-      "tags": ["redis-cloud", "rest-api", "management"]
+      "anchor": "https://redis.io/docs/latest/operate/rc/api/",
+      "service-doc": [
+        {
+          "href": "https://redis.io/docs/latest/operate/rc/api/",
+          "type": "text/html",
+          "title": "Redis Cloud REST API"
+        }
+      ]
     },
     {
-      "id": "redis-data-integration-api",
-      "title": "Redis Data Integration (RDI) API",
-      "description": "API reference for Redis Data Integration, enabling Change Data Capture pipelines from relational databases into Redis.",
-      "humanURL": "https://redis.io/docs/latest/integrate/redis-data-integration/reference/",
-      "tags": ["rdi", "cdc", "data-integration"]
+      "anchor": "https://redis.io/docs/latest/integrate/redis-data-integration/reference/",
+      "service-doc": [
+        {
+          "href": "https://redis.io/docs/latest/integrate/redis-data-integration/reference/",
+          "type": "text/html",
+          "title": "Redis Data Integration (RDI) API"
+        }
+      ]
     }
   ]
 }

--- a/static/.well-known/api-catalog
+++ b/static/.well-known/api-catalog
@@ -1,0 +1,32 @@
+{
+  "apis": [
+    {
+      "id": "redis-commands",
+      "title": "Redis Commands Reference",
+      "description": "Complete reference for all Redis commands, including syntax, arguments, complexity, and examples.",
+      "humanURL": "https://redis.io/docs/latest/commands/",
+      "tags": ["redis", "commands", "reference"]
+    },
+    {
+      "id": "redis-developer-docs",
+      "title": "Redis Developer Documentation",
+      "description": "Guides, quickstarts, and tutorials for building applications with Redis, including vector search, AI agents, and client libraries.",
+      "humanURL": "https://redis.io/docs/latest/develop/",
+      "tags": ["redis", "develop", "ai", "vector-search", "clients"]
+    },
+    {
+      "id": "redis-cloud-api",
+      "title": "Redis Cloud REST API",
+      "description": "REST API for managing Redis Cloud subscriptions, databases, and accounts programmatically.",
+      "humanURL": "https://redis.io/docs/latest/operate/rc/api/",
+      "tags": ["redis-cloud", "rest-api", "management"]
+    },
+    {
+      "id": "redis-data-integration-api",
+      "title": "Redis Data Integration (RDI) API",
+      "description": "API reference for Redis Data Integration, enabling Change Data Capture pipelines from relational databases into Redis.",
+      "humanURL": "https://redis.io/docs/latest/integrate/redis-data-integration/reference/",
+      "tags": ["rdi", "cdc", "data-integration"]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Static metadata and HTTP headers only; no runtime, auth, or data-path changes, with production behavior still dependent on separate ingress/CDN config.
> 
> **Overview**
> Adds **agent/API discovery** for the docs site using RFC 8288-style linking and a **linkset** catalog at `static/.well-known/api-catalog`.
> 
> Every page now emits HTML `<link>` tags in `baseof.html` for `api-catalog`, `service-doc` (developer docs), and `service-desc` (the catalog as `application/linkset+json`), with `relURL` so paths work under a site prefix. The catalog JSON lists anchors and `service-doc` entries for commands, develop docs, Redis Cloud API, and RDI reference.
> 
> For local **`hugo serve`**, `config.toml` adds matching **`Link` response headers** on all routes and sets **`Content-Type: application/linkset+json`** for the catalog file. Comments note that production should mirror these headers (and host-root `/.well-known` aliasing) in nginx or the CDN.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f278e24f2b96712f6b63d65d4ff72a190dfd55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->