### PR TITLE
DOC-6792 add agent experience-notes system: /reflect capture + /finalize distiller

### DIFF
--- a/.claude/skills/_shared/commit-trailers.md
+++ b/.claude/skills/_shared/commit-trailers.md
@@ -1,0 +1,79 @@
+# Commit trailer vocabulary & format (shared)
+
+Canonical definition of the experience-note trailer vocabulary and the commit-message format,
+shared by **`/reflect`** (which *writes* notes) and **`/finalize`** (which *distills* them into
+the durable squash commit). Both skills reference this file so the vocabulary can't drift
+between capture and distillation. Change it here, once.
+
+> This file is referenced by `.claude/skills/reflect/SKILL.md` and
+> `.claude/skills/finalize/SKILL.md`. It is **not** a skill itself (no `SKILL.md`), so it
+> won't be invoked directly.
+
+## Subject line
+
+This repo does **not** use Conventional Commits (`type(scope):`). The subject stays in the
+existing house convention — `DOC-XXXX <summary>` (the Jira workflow keys off the ticket id),
+or the `RS:` / `DEV:` area prefixes. Neither skill rewrites the subject; they own the **body
+and the trailers** only.
+
+## Trailer vocabulary
+
+**Core** — reach for these first; each one changes what a future agent *does*:
+
+| Trailer | Use it for |
+|---|---|
+| `Constraint:` | A load-bearing invariant. Breaking it is a bug. |
+| `Rejected:` | `<approach> \| <why not>` — a dead end already burned, so it isn't re-proposed. |
+| `Directive:` | A message to the next editor of this code, pinned here. |
+| `Learned:` | One-line index to the body reflection (keeps "show me commits that taught us something" a clean `git log` query). |
+
+**Situational** — only when they genuinely apply:
+
+| Trailer | Use it for |
+|---|---|
+| `Reversibility:` | `clean` / `migration-needed` / `irreversible` — how freely a future agent can experiment here. |
+| `Gaps:` | What was *not* verified — where to be skeptical / add tests. |
+| `Ticket:` | `DOC-NNNN` or a link, so commits thread back to the ticket. Duplicates the subject's id on purpose — belt-and-braces, and keeps the trailer query clean if the subject convention ever changes. |
+| `Recheck:` | An expiry *condition* for a fact that tracks a moving target, e.g. `when AR* commands reach GA`. (Especially for docs.) |
+
+**A field only earns its place if reading it before touching the code would change a
+decision.** Provenance-only fields ("this came from review") don't qualify — don't invent
+fields casually. Prose belongs in the body, not in a trailer value.
+
+## Message shape
+
+```
+DOC-XXXX <summary>
+
+<the change in a sentence or two, then prose — the why, the surprise, the
+dead end. This is what humans and the semantic history bot read.>
+
+Learned: <one-line index to the body>
+Constraint: <invariant that must hold>
+Rejected: <approach> | <reason it was dropped>
+Directive: <warning to the next editor>
+Ticket: DOC-XXXX
+```
+
+## Format rules (or the trailers won't parse)
+
+- Trailers are a single, **contiguous block at the very end** of the message — no blank lines
+  *inside* the block, and nothing after it.
+- A stray blank line in the block, or an earlier `Foo: bar`-looking line in the body, will
+  break git's trailer extraction. Keep `Key: value` patterns out of the prose body.
+- Keep each value on **one line** where you can. Standard trailers (`Co-Authored-By`, etc.)
+  live in the same block and are fine.
+
+## Reading trailers (downstream consumers)
+
+Always pass `unfold`, or a value folded across lines (RFC-822 continuation) comes back
+wrapped and a naive reader sees a truncated/oddly-split value:
+
+```
+git log -1 --format='%(trailers:only,unfold)'           # verify a single commit
+git log main..HEAD --format='%(trailers:only,unfold)'   # all notes on a branch (the distiller's input)
+git log -1 --format='%(trailers:key=Learned,valueonly)' # one keyed field
+```
+
+If a verify prints nothing but trailers were written, the block isn't contiguous/last — fix
+the blank lines.

--- a/.claude/skills/_shared/commit-trailers.md
+++ b/.claude/skills/_shared/commit-trailers.md
@@ -70,10 +70,24 @@ Always pass `unfold`, or a value folded across lines (RFC-822 continuation) come
 wrapped and a naive reader sees a truncated/oddly-split value:
 
 ```
-git log -1 --format='%(trailers:only,unfold)'           # verify a single commit
-git log main..HEAD --format='%(trailers:only,unfold)'   # all notes on a branch (the distiller's input)
-git log -1 --format='%(trailers:key=Learned,valueonly)' # one keyed field
+git log -1 --format='%(trailers:only,unfold)'                     # verify a single commit
+git log --reverse main..HEAD --format='%(trailers:only,unfold)'   # all notes on a branch, oldest-first (the distiller's input)
+git log -1 --format='%(trailers:key=Learned,valueonly)'           # one keyed field
 ```
 
 If a verify prints nothing but trailers were written, the block isn't contiguous/last — fix
 the blank lines.
+
+## Author-reflection PR comments (the fallback channel)
+
+When a note can't go on a commit (e.g. the commit is already pushed), `/reflect` may post it
+as a PR comment instead. To stop `/finalize` from mistaking it for reviewer critique, such a
+comment **must begin with the marker line**:
+
+```
+<!-- reflect-note -->
+```
+
+`/finalize` treats PR comments **with** this marker as author-side reflection (part of the
+oldest-first arc) and comments **without** it as reviewer/bot critique. The marker is an HTML
+comment, so it's invisible in the rendered PR.

--- a/.claude/skills/finalize/SKILL.md
+++ b/.claude/skills/finalize/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: finalize
+description: "Distil a PR's accumulated knowledge into the durable squash commit message — reconcile the /reflect experience notes across its commits with the review feedback into one end-state record, and propose promoting cross-cutting lessons to learning skills/memory. Use just before squash-merging a PR. Prepares the message and the gh merge command; does not merge."
+---
+
+# Finalize — distil a PR into its durable commit
+
+`/reflect` scatters provisional experience notes across a PR's WIP commits while the work
+happens. The PR then accumulates review feedback. **This skill compresses both into the one
+commit that survives the squash** — the durable, location-reachable record a future agent
+meets via `git log` / `git blame`.
+
+Vocabulary, subject convention, and format are defined once in
+[`../_shared/commit-trailers.md`](../_shared/commit-trailers.md) — **read it first**, then
+read this for *how to reconcile and where to put the output*.
+
+## Where this sits
+
+```
+/reflect          →  WIP commit messages         [episodic, provisional, disposable]
+PR review + bots  →  PR comments                 [external critique]
+        ↓  THIS SKILL, just before squash
+/finalize         →  squash commit message        [durable, location-reachable]
+        ↓  fork
+promotion         →  learning skills / memory      [cross-cutting, always-loaded]
+```
+
+## The one principle: reconcile to the *end state*, not concatenate
+
+The easy version — collect every trailer and paste them in — is wrong, because **the PR's job
+is to change its own mind.** A WIP note the PR later contradicted must be **dropped**, not
+carried, or it lands frozen and wrong on `main`:
+
+> WIP commit 1: `Rejected: server-side sessions | too much infra`. Review pushes back; commit
+> 4 *adopts* server-side sessions. Concatenation carries `Rejected: server-side sessions` onto
+> `main` — now actively misleading. Reconciliation drops it (or flips it to a `Constraint`).
+
+So read the whole arc **in order** (commits + comments + check outcomes) and emit only what is
+still true at the end. This is judgment work — it's why this is a skill, and why it's a
+human-triggered pre-merge step, not an automated merge hook.
+
+## Step 1 — Gather
+
+- **Author-side notes:** `git log main..HEAD --format='%(trailers:only,unfold)'` for the
+  trailers, plus the commit bodies for the prose. (Drop the deliberate no-note commits.)
+- **Reviewer/bot critique:** the PR comments. Reuse `/docs:assess-comments` if available (it
+  already collects, role-tags, and splits open/resolved across tools); otherwise read them
+  directly (`gh api repos/<o>/<r>/pulls/<n>/comments`, `.../issues/<n>/comments`,
+  `.../pulls/<n>/reviews`). Note which findings were *fixed* vs *dismissed* vs *still open*.
+- **Check outcomes:** whether CI / security / Bugbot ended clean.
+
+## Step 2 — Reconcile
+
+Walk the arc in commit/comment order and produce the **end state**:
+
+- **Drop** any WIP note a later commit or review overturned.
+- **Merge** duplicates and near-duplicates into one line; prefer the latest, most specific.
+- **Resolve contradictions** in favour of what the final code actually does — verify against
+  the diff, don't trust the note.
+- **Fold in review outcomes** as their *verdict*, not a transcript: a review thread that
+  settled on a rule becomes one `Constraint:`; an approach the review killed becomes
+  `Rejected:`. Copy what survived, not the conversation.
+- An *open* unresolved concern is **not** end-state knowledge — leave it on the PR, don't
+  bury it in a trailer.
+
+## Step 3 — Sort & propose promotion
+
+Same split `/reflect` Step 3 makes, now over the reconciled set:
+
+- **Location-bound** (a future agent editing this area needs it) → durable trailer on the
+  squash commit.
+- **Cross-cutting** (must apply regardless of what's edited — a preference, a process rule, a
+  standing gotcha, a project-wide constraint) → **propose** an edit to the relevant learning
+  skill or a memory file. A commit can't guarantee it'll be seen. **Propose, don't apply
+  silently** — show the user the exact addition and target file.
+
+## Step 4 — Compose
+
+Write the distilled message per the shared shape: `DOC-XXXX` subject, a tight body paragraph
+(the durable narrative for humans + the history bot), then the reconciled trailer block. Far
+fewer trailers than the inputs held — distillation is compression, not collection.
+
+## Step 5 — Hand off (do **not** merge)
+
+This repo squashes with `squash_merge_commit_message = COMMIT_MESSAGES` (verified
+2026-06-25), so the **default** squash body is every WIP commit message concatenated — exactly
+the raw dump we're avoiding. Override it explicitly; never rely on the default:
+
+```
+gh pr merge <n> --squash \
+  --subject "DOC-XXXX <summary>" \
+  --body-file <distilled-message-file>
+```
+
+Present three things and **stop**:
+1. the distilled squash message (subject + body + trailers),
+2. any promotion proposals (target file + exact addition),
+3. the ready-to-run `gh pr merge … --body-file` command.
+
+The human triggers the merge. Reconciliation is judgment-heavy and a squash-merge is hard to
+reverse, so finalize *prepares*; it does not press the button. (An opt-in auto-merge could be
+added later, but it inherits all the risk below.)
+
+## Limits (read honestly)
+
+- **Under-distilling is recoverable; a wrong frozen trailer on `main` is not.** When the arc
+  is ambiguous, drop the trailer and leave the nuance in body prose. Bias to fewer, certain
+  trailers.
+- It **reconciles text, it doesn't relive the work** — its only knowledge is what `/reflect`
+  and the reviewers serialised. Garbage in stays garbage; verify contradictions against the
+  actual diff.
+- A merge-time **automated backstop** (GitHub Action) is the weakest possible version of this
+  — least context, no human, and under `COMMIT_MESSAGES` it must *also* override `--body-file`
+  or it concatenates raw. Keep it phase 2, and conservative.
+- If Step 3 promotion is skipped, cross-cutting lessons die in a commit nobody re-reads and
+  the always-loaded tier starves. It is not optional.

--- a/.claude/skills/finalize/SKILL.md
+++ b/.claude/skills/finalize/SKILL.md
@@ -45,9 +45,13 @@ human-triggered pre-merge step, not an automated merge hook.
   the trailers, plus the commit bodies for the prose. **`--reverse` is required** — the arc
   walk in Step 2 is oldest-first, and the default `git log` order (newest-first) would invert
   the timeline and let stale, overturned notes win. (Drop the deliberate no-note commits.)
-- **Reviewer/bot critique:** the PR comments. Reuse `/docs:assess-comments` if available (it
-  already collects, role-tags, and splits open/resolved across tools); otherwise read them
-  directly (`gh api repos/<o>/<r>/pulls/<n>/comments`, `.../issues/<n>/comments`,
+  Also fold in any PR comment carrying the `<!-- reflect-note -->` marker — those are
+  author-side reflection routed to a comment because the commit was already pushed, **not**
+  critique (see [`../_shared/commit-trailers.md`](../_shared/commit-trailers.md)).
+- **Reviewer/bot critique:** the PR comments **without** the `<!-- reflect-note -->` marker.
+  Reuse `/docs:assess-comments` if available (it already collects, role-tags, and splits
+  open/resolved across tools); otherwise read them directly
+  (`gh api repos/<o>/<r>/pulls/<n>/comments`, `.../issues/<n>/comments`,
   `.../pulls/<n>/reviews`). Note which findings were *fixed* vs *dismissed* vs *still open*.
 - **Check outcomes:** whether CI / security / Bugbot ended clean.
 

--- a/.claude/skills/finalize/SKILL.md
+++ b/.claude/skills/finalize/SKILL.md
@@ -82,9 +82,13 @@ Same split `/reflect` Step 3 makes, now over the reconciled set:
 
 ## Step 4 — Compose
 
-Write the distilled message per the shared shape: `DOC-XXXX` subject, a tight body paragraph
+Write the distilled message per the shared shape: a `DOC-XXXX` subject, a tight body paragraph
 (the durable narrative for humans + the history bot), then the reconciled trailer block. Far
 fewer trailers than the inputs held — distillation is compression, not collection.
+
+Keep the **subject** and the **body-file** separate: the body-file holds the body paragraph
+and the trailer block **only — no subject line**. The subject is passed via `--subject` in
+Step 5, so repeating it in the file would duplicate the title into the commit body.
 
 ## Step 5 — Hand off (do **not** merge)
 

--- a/.claude/skills/finalize/SKILL.md
+++ b/.claude/skills/finalize/SKILL.md
@@ -41,8 +41,10 @@ human-triggered pre-merge step, not an automated merge hook.
 
 ## Step 1 — Gather
 
-- **Author-side notes:** `git log main..HEAD --format='%(trailers:only,unfold)'` for the
-  trailers, plus the commit bodies for the prose. (Drop the deliberate no-note commits.)
+- **Author-side notes:** `git log --reverse main..HEAD --format='%(trailers:only,unfold)'` for
+  the trailers, plus the commit bodies for the prose. **`--reverse` is required** — the arc
+  walk in Step 2 is oldest-first, and the default `git log` order (newest-first) would invert
+  the timeline and let stale, overturned notes win. (Drop the deliberate no-note commits.)
 - **Reviewer/bot critique:** the PR comments. Reuse `/docs:assess-comments` if available (it
   already collects, role-tags, and splits open/resolved across tools); otherwise read them
   directly (`gh api repos/<o>/<r>/pulls/<n>/comments`, `.../issues/<n>/comments`,

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -125,6 +125,12 @@ git log -1 --format='%(trailers:only,unfold)'
 If that prints nothing but you wrote trailers, the block isn't contiguous/last — fix the
 blank lines.
 
+> **Pass `unfold` downstream too.** Any consumer that reads these trailers — the squash-time
+> distiller, a dashboard, a `git log` query — should use `%(trailers:...,unfold)`. Without
+> `unfold`, a value folded across multiple lines (RFC-822 continuation) is returned in its
+> raw wrapped form, so a naive reader sees a truncated or oddly-split value. Keep values
+> single-line where you can; pass `unfold` for when you can't.
+
 ## Step 4 — Sort: is this lesson actually location-bound?
 
 The note you just wrote belongs in the commit **only if it's retrievable by location** —

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: reflect
+description: "Capture an agent experience note into the commit message — the lived reasoning behind a change (what was learned, what was rejected, what future-you must not break), written where the work happens so it travels with the code. Use right after finishing a meaningful chunk of coding/writing, when about to commit, or to amend the last un-pushed commit. Skip for mechanical changes. Feeds the squash-time distiller and the learning skills."
+---
+
+# Reflect — experience notes in the commit message
+
+You did the work, so you hold context that exists nowhere else and lasts about five
+minutes: the false starts, the *why*, the thing that surprised you. This skill serialises
+that context into the **commit message** while you still have it, so a future you — in the
+IDE, with only `git log` and `git blame` on the file in front of you — gets it back at the
+exact spot it matters.
+
+This is **judgment work, not a logging step.** Most commits deserve no note. The value is
+in the few that do, and in the compression. A note on every commit is noise the
+squash-time distiller has to filter back out.
+
+## Where this sits in the pipeline
+
+```
+/reflect (here)        →  WIP commit messages          [episodic, provisional, disposable]
+PR review + bots       →  PR comments                  [external critique, via assess-comments]
+            ↓ at squash/merge
+distiller (later skill)→  surviving commit trailers    [durable, location-reachable]
+            ↓
+promotion              →  learning skills / memory      [cross-cutting, always-loaded]
+```
+
+Two rules follow from this and they are not negotiable:
+
+1. **WIP notes are provisional and disposable.** Squash throws them away. So write freely —
+   being wrong here is *fine*, it's the interim space. Do **not** treat a WIP note as the
+   durable record.
+2. **The durable write happens later, once, at squash** — by the distiller (or you,
+   pre-merge), after the PR has had its say. Never promote a note to "final" mid-cycle; the
+   review may overturn it.
+
+## Step 1 — Is it worth a note? (default: no)
+
+Write a note only if one of these is true. If none are, **commit normally and stop.**
+
+- You **learned** something a future editor here wouldn't know from the diff (a tooling
+  gotcha, a non-obvious cause, a "looks wrong but isn't").
+- You **rejected** an approach for a reason that isn't visible in the result.
+- You established a **constraint** that's load-bearing — quietly breaking it would be a bug.
+- You're leaving a **directive** for whoever touches this next ("don't reintroduce X here").
+- The change rests on something **that will go stale** (a preview feature, a version-pinned
+  fact) and should be re-checked later.
+
+Skip: typo fixes, renames, formatting, dependency bumps, pure mechanical edits, anything
+where the diff fully explains itself.
+
+## Step 2 — Write the note
+
+**Prose reflection → commit body.** One short paragraph, in plain language. This is what a
+human reviewer reads and what a semantic-matching history bot recalls on. Keep it about
+*this change*; cross-cutting lessons go to a learning skill instead (see Step 4).
+
+**Atomic facts → trailers.** Flat `Key: value`, one line each, in a single contiguous block
+at the very end of the message, no blank lines inside the block (git's trailer parser needs
+this — a stray blank line or an earlier `Foo: bar` line in the body will break extraction).
+
+### Trailer vocabulary
+
+Core — reach for these first; each one changes what a future agent *does*:
+
+| Trailer | Use it for |
+|---|---|
+| `Constraint:` | A load-bearing invariant. Breaking it is a bug. |
+| `Rejected:` | `<approach> \| <why not>` — a dead end already burned, so it isn't re-proposed. |
+| `Directive:` | A message to the next editor of this code, pinned here. |
+| `Learned:` | One-line index to the body reflection (keeps "show me commits that taught us something" a clean `git log` query). |
+
+Situational — only when they genuinely apply:
+
+| Trailer | Use it for |
+|---|---|
+| `Reversibility:` | `clean` / `migration-needed` / `irreversible` — how freely a future agent can experiment here. |
+| `Gaps:` | What was *not* verified — where to be skeptical / add tests. |
+| `Ticket:` | `DOC-NNNN` or a link, so commits thread back to the ticket. |
+| `Recheck:` | An expiry *condition* for a fact that tracks a moving target, e.g. `when AR* commands reach GA`. (Especially for docs.) |
+
+Don't invent fields casually. A field only earns its place if reading it before touching the
+code would change a decision; provenance-only fields ("this came from review") don't.
+
+### Shape
+
+This skill owns the **body and the trailers**, not the subject. Leave the subject in the
+repo's existing convention — `DOC-XXXX <summary>` (the Jira workflow keys off the ticket id),
+or the `RS:` / `DEV:` area prefixes. **Not** Conventional Commits (`type(scope):`); this repo
+doesn't use it.
+
+```
+DOC-XXXX <summary>
+
+<the change in a sentence or two, then the reflection paragraph — the why,
+the surprise, the dead end — in plain prose.>
+
+Learned: <one-line summary of the body reflection>
+Constraint: <invariant that must hold>
+Rejected: <approach> | <reason it was dropped>
+Directive: <warning to the next editor>
+Ticket: DOC-XXXX
+```
+
+`Ticket:` duplicates the subject's ticket id on purpose — it's belt-and-braces, and it keeps
+"thread these commits to their ticket" a clean trailer query even if the subject convention
+ever changes.
+
+## Step 3 — Land it on the commit
+
+- **Not yet committed** → fold the body + trailers into the commit message you're about to
+  write. (Preferred — no rewrite.)
+- **Already committed, not pushed** → `git commit --amend` to add the note.
+- **Already pushed** → do *not* amend (it rewrites shared history). Either carry the note on
+  the next related commit, or leave it for the squash-time distiller to pick up from your
+  working notes. Say which you did.
+
+Verify the trailers parse before finishing:
+
+```
+git log -1 --format='%(trailers:only,unfold)'
+```
+
+If that prints nothing but you wrote trailers, the block isn't contiguous/last — fix the
+blank lines.
+
+## Step 4 — Sort: is this lesson actually location-bound?
+
+The note you just wrote belongs in the commit **only if it's retrievable by location** —
+i.e. a future agent editing *this file/area* is who needs it.
+
+If instead it's **cross-cutting** — it must apply regardless of what's being edited (a user
+preference, a process rule, a standing gotcha like "check the running image, not the client
+version") — a commit can never guarantee it'll be seen. Flag it for promotion to the
+relevant **learning skill** or **memory** instead of (or as well as) the commit. Tell the
+user what you're proposing to promote and where; don't edit a learning skill silently.
+
+## Limits (read honestly)
+
+- This captures *episodic* notes. It does **not** produce the durable record — that's the
+  squash-time distiller's job, and it should run after review, not now.
+- It cannot make a note correct. A confidently-wrong reflection that survives into a durable
+  trailer is worse than none, which is exactly why the durable write is deferred and
+  reviewable.
+- It will not catch cross-cutting lessons by itself — Step 4 is manual judgment, and if it's
+  skipped the learning-skills tier quietly starves.
+- The temptation is to over-capture because schemas are satisfying to fill. Resist it; an
+  empty note is the right output for most commits.

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -93,8 +93,9 @@ promoted. Decide the split here, then carry only the location-bound part into St
   write. (Preferred — no rewrite.)
 - **Already committed, not pushed** → `git commit --amend` to add the note.
 - **Already pushed** → do *not* amend (it rewrites shared history). Either carry the note on
-  the next related commit, or leave it for the squash-time distiller to pick up from your
-  working notes. Say which you did.
+  the next related commit, or **post it as a PR comment** — `/finalize` reads PR comments, so
+  the distiller still sees it. (An *uncommitted* working note is invisible to `/finalize`,
+  which only reads `git log` and PR comments — don't rely on one.) Say which you did.
 
 Verify the trailers parse before finishing:
 

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -98,13 +98,20 @@ promoted. Decide the split here, then carry only the location-bound part into St
   [`../_shared/commit-trailers.md`](../_shared/commit-trailers.md)). An *uncommitted* working
   note is invisible to `/finalize` — don't rely on one. Say which you did.
 
-Verify the trailers parse before finishing:
+Verify the trailers parse — but against the message you actually wrote, not whatever `HEAD`
+happens to be:
 
-```
-git log -1 --format='%(trailers:only,unfold)'
-```
+- **Before committing** (the preferred fold-in path), check the *pending message*, since
+  `git log -1` would read the previous commit and give a false pass:
+  ```
+  git interpret-trailers --parse <message-file>
+  ```
+- **After committing or amending**, check the commit that now carries the note:
+  ```
+  git log -1 --format='%(trailers:only,unfold)'
+  ```
 
-If that prints nothing but you wrote trailers, the block isn't contiguous/last — fix the
+If either prints nothing but you wrote trailers, the block isn't contiguous/last — fix the
 blank lines. (Format and `unfold` rules:
 [`../_shared/commit-trailers.md`](../_shared/commit-trailers.md).)
 

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -93,9 +93,10 @@ promoted. Decide the split here, then carry only the location-bound part into St
   write. (Preferred — no rewrite.)
 - **Already committed, not pushed** → `git commit --amend` to add the note.
 - **Already pushed** → do *not* amend (it rewrites shared history). Either carry the note on
-  the next related commit, or **post it as a PR comment** — `/finalize` reads PR comments, so
-  the distiller still sees it. (An *uncommitted* working note is invisible to `/finalize`,
-  which only reads `git log` and PR comments — don't rely on one.) Say which you did.
+  the next related commit, or **post it as a PR comment prefixed with the `<!-- reflect-note -->`
+  marker** so `/finalize` classifies it as author-side reflection, not reviewer critique (see
+  [`../_shared/commit-trailers.md`](../_shared/commit-trailers.md)). An *uncommitted* working
+  note is invisible to `/finalize` — don't rely on one. Say which you did.
 
 Verify the trailers parse before finishing:
 

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -107,7 +107,24 @@ Ticket: DOC-XXXX
 "thread these commits to their ticket" a clean trailer query even if the subject convention
 ever changes.
 
-## Step 3 — Land it on the commit
+## Step 3 — Sort: where does this note belong? (decide *before* you commit)
+
+The sort picks the destination, so it must run **before** Step 4 lands anything — once a note
+is committed or amended in, you can't honour a "this didn't belong in the commit" decision
+without a rewrite.
+
+- **Location-bound** — a future agent editing *this file/area* is who needs it → it goes in
+  the commit message (Step 4).
+- **Cross-cutting** — it must apply regardless of what's being edited (a user preference, a
+  process rule, a standing gotcha like "check the running image, not the client version") →
+  a commit can never guarantee it'll be seen, so flag it for promotion to the relevant
+  **learning skill** or **memory**. Tell the user what you're proposing to promote and where;
+  don't edit a learning skill silently.
+
+A note can **split**: the location-bound part goes in the commit, the cross-cutting part gets
+promoted. Decide the split here, then carry only the location-bound part into Step 4.
+
+## Step 4 — Land the location-bound part on the commit
 
 - **Not yet committed** → fold the body + trailers into the commit message you're about to
   write. (Preferred — no rewrite.)
@@ -131,17 +148,6 @@ blank lines.
 > raw wrapped form, so a naive reader sees a truncated or oddly-split value. Keep values
 > single-line where you can; pass `unfold` for when you can't.
 
-## Step 4 — Sort: is this lesson actually location-bound?
-
-The note you just wrote belongs in the commit **only if it's retrievable by location** —
-i.e. a future agent editing *this file/area* is who needs it.
-
-If instead it's **cross-cutting** — it must apply regardless of what's being edited (a user
-preference, a process rule, a standing gotcha like "check the running image, not the client
-version") — a commit can never guarantee it'll be seen. Flag it for promotion to the
-relevant **learning skill** or **memory** instead of (or as well as) the commit. Tell the
-user what you're proposing to promote and where; don't edit a learning skill silently.
-
 ## Limits (read honestly)
 
 - This captures *episodic* notes. It does **not** produce the durable record — that's the
@@ -149,7 +155,7 @@ user what you're proposing to promote and where; don't edit a learning skill sil
 - It cannot make a note correct. A confidently-wrong reflection that survives into a durable
   trailer is worse than none, which is exactly why the durable write is deferred and
   reviewable.
-- It will not catch cross-cutting lessons by itself — Step 4 is manual judgment, and if it's
+- It will not catch cross-cutting lessons by itself — Step 3 is manual judgment, and if it's
   skipped the learning-skills tier quietly starves.
 - The temptation is to over-capture because schemas are satisfying to fill. Resist it; an
   empty note is the right output for most commits.

--- a/.claude/skills/reflect/SKILL.md
+++ b/.claude/skills/reflect/SKILL.md
@@ -54,58 +54,21 @@ where the diff fully explains itself.
 
 **Prose reflection → commit body.** One short paragraph, in plain language. This is what a
 human reviewer reads and what a semantic-matching history bot recalls on. Keep it about
-*this change*; cross-cutting lessons go to a learning skill instead (see Step 4).
+*this change*; cross-cutting lessons go to a learning skill instead (see Step 3).
 
 **Atomic facts → trailers.** Flat `Key: value`, one line each, in a single contiguous block
 at the very end of the message, no blank lines inside the block (git's trailer parser needs
 this — a stray blank line or an earlier `Foo: bar` line in the body will break extraction).
 
-### Trailer vocabulary
+### Trailer vocabulary, message shape, and format rules
 
-Core — reach for these first; each one changes what a future agent *does*:
+These are defined once in [`../_shared/commit-trailers.md`](../_shared/commit-trailers.md) so
+they can't drift between this skill and `/finalize`. **Read it now** for the core vocabulary
+(`Constraint` / `Rejected` / `Directive` / `Learned`), the situational fields, the
+`DOC-XXXX` subject convention, and the format rules that keep trailers parseable.
 
-| Trailer | Use it for |
-|---|---|
-| `Constraint:` | A load-bearing invariant. Breaking it is a bug. |
-| `Rejected:` | `<approach> \| <why not>` — a dead end already burned, so it isn't re-proposed. |
-| `Directive:` | A message to the next editor of this code, pinned here. |
-| `Learned:` | One-line index to the body reflection (keeps "show me commits that taught us something" a clean `git log` query). |
-
-Situational — only when they genuinely apply:
-
-| Trailer | Use it for |
-|---|---|
-| `Reversibility:` | `clean` / `migration-needed` / `irreversible` — how freely a future agent can experiment here. |
-| `Gaps:` | What was *not* verified — where to be skeptical / add tests. |
-| `Ticket:` | `DOC-NNNN` or a link, so commits thread back to the ticket. |
-| `Recheck:` | An expiry *condition* for a fact that tracks a moving target, e.g. `when AR* commands reach GA`. (Especially for docs.) |
-
-Don't invent fields casually. A field only earns its place if reading it before touching the
-code would change a decision; provenance-only fields ("this came from review") don't.
-
-### Shape
-
-This skill owns the **body and the trailers**, not the subject. Leave the subject in the
-repo's existing convention — `DOC-XXXX <summary>` (the Jira workflow keys off the ticket id),
-or the `RS:` / `DEV:` area prefixes. **Not** Conventional Commits (`type(scope):`); this repo
-doesn't use it.
-
-```
-DOC-XXXX <summary>
-
-<the change in a sentence or two, then the reflection paragraph — the why,
-the surprise, the dead end — in plain prose.>
-
-Learned: <one-line summary of the body reflection>
-Constraint: <invariant that must hold>
-Rejected: <approach> | <reason it was dropped>
-Directive: <warning to the next editor>
-Ticket: DOC-XXXX
-```
-
-`Ticket:` duplicates the subject's ticket id on purpose — it's belt-and-braces, and it keeps
-"thread these commits to their ticket" a clean trailer query even if the subject convention
-ever changes.
+The one rule worth repeating here: a field only earns its place if reading it before touching
+the code would change a decision. When in doubt, leave it out and let the body prose carry it.
 
 ## Step 3 — Sort: where does this note belong? (decide *before* you commit)
 
@@ -140,13 +103,8 @@ git log -1 --format='%(trailers:only,unfold)'
 ```
 
 If that prints nothing but you wrote trailers, the block isn't contiguous/last — fix the
-blank lines.
-
-> **Pass `unfold` downstream too.** Any consumer that reads these trailers — the squash-time
-> distiller, a dashboard, a `git log` query — should use `%(trailers:...,unfold)`. Without
-> `unfold`, a value folded across multiple lines (RFC-822 continuation) is returned in its
-> raw wrapped form, so a naive reader sees a truncated or oddly-split value. Keep values
-> single-line where you can; pass `unfold` for when you can't.
+blank lines. (Format and `unfold` rules:
+[`../_shared/commit-trailers.md`](../_shared/commit-trailers.md).)
 
 ## Limits (read honestly)
 


### PR DESCRIPTION
Note: even if you think this is looking OK, it's probably best not to start using it yet. I'll test run it on a real doc PR before recommending and documenting it :-) 

## What this is

A skill-based system for recording **agent experience notes** — the lived reasoning behind a
change (what was learned, what was rejected, what a future editor must not break) — in **git
itself** rather than a standalone lessons file. Body prose carries the reflection (for humans
and the semantic history bot); **git trailers** carry atomic, queryable facts.

It chooses our own thin vocabulary over [Lore](https://github.com/Ian-stetsenko/lore-protocol)
(arXiv:2603.15566): Lore's trailer mechanism is sound, but its CLI/vocabulary are young, and
it has no field for *process* lessons — which is our `Learned:` addition.

## The three-tier pipeline

```
/reflect          →  WIP commit messages         [episodic, provisional, disposable]
PR review + bots  →  PR comments                 [external critique]
        ↓  /finalize, just before squash
/finalize         →  squash commit message        [durable, location-reachable]
        ↓  fork
promotion         →  learning skills / memory      [cross-cutting, always-loaded]
```

- **`.claude/skills/reflect/`** — captures a note into a commit message (or a marked PR comment
  if already pushed). A worth-it gate keeps it silent on mechanical commits.
- **`.claude/skills/finalize/`** — reconciles the notes across a PR's commits *and* the review
  feedback into the one commit that survives the squash; proposes promoting cross-cutting
  lessons to learning skills/memory. Prepares the message + `gh pr merge` command; does **not**
  merge.
- **`.claude/skills/_shared/commit-trailers.md`** — the single source of truth for the trailer
  vocabulary, subject convention, format rules, and the author-note marker. Both skills
  reference it so capture and distillation can't drift.

## Design notes for reviewers

- **Capture lands in commit messages, not PR comments** — no PR exists at the first commit, the
  note binds to its diff, and author reflection stays distinct from reviewer critique.
- **Core vocabulary:** `Constraint` / `Rejected` / `Directive` / `Learned`; situational
  `Reversibility` / `Gaps` / `Ticket` / `Recheck`. A field earns a slot only if reading it
  would change a future agent's decision.
- **`/finalize` reconciles to the end state, it doesn't concatenate** — notes the PR later
  overturned are dropped, not frozen onto `main`. It reads the arc oldest-first (`--reverse`).
- **Squash mechanics:** the repo squashes via `COMMIT_MESSAGES`, so `/finalize` overrides the
  body explicitly with `gh pr merge --squash --body-file` rather than relying on the default.

## Dogfooded on its own commits

Every commit here uses the convention on itself; the worth-it gate fired *yes* on the
substantive commits and *no* on a doc tweak. `/finalize` has been dry-run against this PR's
own arc and correctly dropped discharged directives and refined an overturned `Rejected`.
Several commits are Bugbot fixes — notably a chain of cross-skill contract bugs that surfaced
only once both skills existed.

## Not done / follow-ups

- **Not yet exercised on a real content PR** — validated only against this self-referential PR
  about the skills themselves. First non-self test is the next docs change that runs the
  pipeline.
- **No automated merge-time backstop** — `/finalize` is human-triggered by design; an
  optional GitHub Action backstop is possible later (it would also need `--body-file`).
- Long-term, these may move into the `docs:` plugin beside `assess-comments`.

Ticket: DOC-6792

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Claude skill definitions; no application, CI, or merge behavior changes until humans invoke the skills.
> 
> **Overview**
> Adds a **three-tier pipeline** for persisting agent reasoning in git: **`/reflect`** captures provisional notes in WIP commit bodies and trailers; **`/finalize`** reconciles those notes plus PR review into the squash commit and hands off `gh pr merge --squash --body-file` (it does not merge).
> 
> Introduces **`.claude/skills/_shared/commit-trailers.md`** as the single source for trailer vocabulary (`Constraint`, `Rejected`, `Directive`, `Learned`, etc.), `DOC-XXXX` subject rules, parseable trailer blocks, and the `<!-- reflect-note -->` marker so author notes in PR comments are not treated as reviewer critique.
> 
> **`/finalize`** is defined to **reconcile to end state** (oldest-first `git log --reverse`, drop overturned WIP notes) rather than concatenate WIP messages—important because the repo’s squash default is `COMMIT_MESSAGES`. Both skills split **location-bound** notes (commit trailers) from **cross-cutting** lessons (proposed promotion to learning skills/memory).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eeb2ff321074833339639ec43ab0a4a1c3bca8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->