### PR TITLE
DEV: (cmds) add new set command pages

### DIFF
--- a/content/commands/sdiff.md
+++ b/content/commands/sdiff.md
@@ -106,3 +106,7 @@ SDIFF key1 key2
 [Set reply](../../develop/reference/protocol-spec#sets): a set with the members of the resulting set.
 
 {{< /multitabs >}}
+
+## See also
+
+[`SDIFFCARD`]({{< relref "commands/sdiffcard/" >}}) | [`SDIFFSTORE`]({{< relref "commands/sdiffstore" >}})

--- a/content/commands/sdiffcard.md
+++ b/content/commands/sdiffcard.md
@@ -128,7 +128,7 @@ When provided with the optional `LIMIT` argument (which defaults to `0`, meaning
 
 ## See also
 
-[`SDIFF`]({{< relref "commands/sdiff/" >}}) | [`SDIFFSTORE`]({{< relref "commands/sdiffstore/" >}}) | [`SINTERCARD`]({{< relref "commands/sintercard/" >}}) | [`SUNIONCARD`]({{< relref "commands/sunioncard/" >}})
+[`SDIFF`]({{< relref "commands/sdiff/" >}}) | [`SDIFFSTORE`]({{< relref "commands/sdiffstore/" >}})
 
 ## Related topics
 

--- a/content/commands/sdiffcard.md
+++ b/content/commands/sdiffcard.md
@@ -1,0 +1,137 @@
+---
+acl_categories:
+- '@read'
+- '@set'
+- '@slow'
+arguments:
+- display_text: numkeys
+  name: numkeys
+  type: integer
+- display_text: key
+  key_spec_index: 0
+  multiple: true
+  name: key
+  type: key
+- display_text: limit
+  name: limit
+  optional: true
+  token: LIMIT
+  type: integer
+arity: -3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+- movablekeys
+complexity: O(N) where N is the total number of elements in all given sets.
+description: Returns the number of members of the difference between the first set
+  and all successive sets.
+group: set
+hidden: false
+key_specs:
+- RO: true
+  access: true
+  begin_search:
+    spec:
+      index: 1
+    type: index
+  find_keys:
+    spec:
+      firstkey: 1
+      keynumidx: 0
+      keystep: 1
+    type: keynum
+linkTitle: SDIFFCARD
+railroad_diagram: /images/railroad/sdiffcard.svg
+since: 8.10.0
+summary: Returns the number of members of the difference between the first set and
+  all successive sets.
+syntax_fmt: "SDIFFCARD numkeys key [key ...] [LIMIT\_limit]"
+title: SDIFFCARD
+---
+{{< note >}}
+This command's behavior varies in clustered Redis environments. See the [multi-key operations]({{< relref "/develop/using-commands/multi-key-operations" >}}) page for more information.
+{{< /note >}}
+
+
+Returns the cardinality of the difference between the first set and all the successive sets. This is the count-only counterpart of [`SDIFF`]({{< relref "/commands/sdiff" >}}): it returns just the number of elements in the difference, not the members themselves.
+
+## Required arguments
+
+<details open><summary><code>numkeys</code></summary>
+
+The number of keys that follow.
+
+</details>
+
+<details open><summary><code>key [key ...]</code></summary>
+
+One or more set keys. The result counts the members of the first set that are not present in any of the subsequent sets.
+
+</details>
+
+## Optional arguments
+
+<details open><summary><code>LIMIT limit</code></summary>
+
+Stop counting once the cardinality reaches `limit`. `0` (the default) means no limit.
+
+</details>
+
+## Examples
+
+{{% redis-cli %}}
+SADD key1 "a"
+SADD key1 "b"
+SADD key1 "c"
+SADD key2 "c"
+SADD key2 "d"
+SADD key2 "e"
+SDIFF key1 key2
+SDIFFCARD 2 key1 key2
+SDIFFCARD 2 key1 key2 LIMIT 1
+{{% /redis-cli %}}
+
+## Details
+
+Keys that do not exist are considered to be empty sets.
+
+When provided with the optional `LIMIT` argument (which defaults to `0`, meaning unlimited), if the difference cardinality reaches `limit` partway through the computation, the command stops and returns `limit` as the cardinality. This ensures a significant speedup for queries where the limit is lower than the actual difference cardinality.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="sdiffcard-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the resulting difference.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the resulting difference.
+
+{{< /multitabs >}}
+
+## See also
+
+[`SDIFF`]({{< relref "commands/sdiff/" >}}) | [`SDIFFSTORE`]({{< relref "commands/sdiffstore/" >}}) | [`SINTERCARD`]({{< relref "commands/sintercard/" >}}) | [`SUNIONCARD`]({{< relref "commands/sunioncard/" >}})
+
+## Related topics
+
+- [Redis sets]({{< relref "/develop/data-types/sets" >}})
+- [Multi-key operations]({{< relref "/develop/using-commands/multi-key-operations" >}})
+

--- a/content/commands/sdiffstore.md
+++ b/content/commands/sdiffstore.md
@@ -119,3 +119,7 @@ SMEMBERS key
 [Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the resulting set.
 
 {{< /multitabs >}}
+
+## See also
+
+[`SDIFF`]({{< relref "commands/sdiff" >}}) | [`SDIFFCARD`]({{< relref "commands/sdiffcard/" >}})

--- a/content/commands/sinter.md
+++ b/content/commands/sinter.md
@@ -109,3 +109,7 @@ SINTER key1 key2
 [Set reply](../../develop/reference/protocol-spec#sets): a set with the members of the resulting set.
 
 {{< /multitabs >}}
+
+## See also
+
+[`SINTERCARD`]({{< relref "commands/sintercard" >}}) | [`SINTERSTORE`]({{< relref "commands/sinterstore" >}})

--- a/content/commands/sintercard.md
+++ b/content/commands/sintercard.md
@@ -127,3 +127,7 @@ SINTERCARD 2 key1 key2 LIMIT 1
 [Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the resulting intersection.
 
 {{< /multitabs >}}
+
+## See also
+
+[`SINTER`]({{< relref "commands/sinter" >}}) | [`SINTERSTORE`]({{< relref "commands/sinterstore" >}})

--- a/content/commands/sinterstore.md
+++ b/content/commands/sinterstore.md
@@ -120,3 +120,7 @@ SMEMBERS key
 [Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the result set.
 
 {{< /multitabs >}}
+
+## See also
+
+[`SINTER`]({{< relref "commands/sinter" >}}) | [`SINTERCARD`]({{< relref "commands/sintercard" >}})

--- a/content/commands/sunion.md
+++ b/content/commands/sunion.md
@@ -105,3 +105,7 @@ SUNION key1 key2
 [Set reply](../../develop/reference/protocol-spec#sets): a set with the members of the resulting set.
 
 {{< /multitabs >}}
+
+## See also
+
+[`SUNIONCARD`]({{< relref "commands/sunioncard/" >}}) | [`SUNIONSTORE`]({{< relref "commands/sunionstore/" >}})

--- a/content/commands/sunioncard.md
+++ b/content/commands/sunioncard.md
@@ -1,0 +1,150 @@
+---
+acl_categories:
+- '@read'
+- '@set'
+- '@slow'
+arguments:
+- display_text: numkeys
+  name: numkeys
+  type: integer
+- display_text: key
+  key_spec_index: 0
+  multiple: true
+  name: key
+  type: key
+- display_text: approx
+  name: approx
+  optional: true
+  token: APPROX
+  type: pure-token
+- display_text: limit
+  name: limit
+  optional: true
+  token: LIMIT
+  type: integer
+arity: -3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+- movablekeys
+complexity: O(N) where N is the total number of elements in all given sets.
+description: Returns the number of members of the union of multiple sets.
+group: set
+hidden: false
+key_specs:
+- RO: true
+  access: true
+  begin_search:
+    spec:
+      index: 1
+    type: index
+  find_keys:
+    spec:
+      firstkey: 1
+      keynumidx: 0
+      keystep: 1
+    type: keynum
+linkTitle: SUNIONCARD
+railroad_diagram: /images/railroad/sunioncard.svg
+since: 8.10.0
+summary: Returns the number of members of the union of multiple sets.
+syntax_fmt: "SUNIONCARD numkeys key [key ...] [APPROX] [LIMIT\_limit]"
+title: SUNIONCARD
+---
+{{< note >}}
+This command's behavior varies in clustered Redis environments. See the [multi-key operations]({{< relref "/develop/using-commands/multi-key-operations" >}}) page for more information.
+{{< /note >}}
+
+
+Returns the cardinality of the union of the given sets. This is the count-only counterpart of [`SUNION`]({{< relref "/commands/sunion" >}}): it returns just the number of distinct elements in the union, not the members themselves.
+
+## Required arguments
+
+<details open><summary><code>numkeys</code></summary>
+
+The number of keys that follow.
+
+</details>
+
+<details open><summary><code>key [key ...]</code></summary>
+
+One or more set keys to union.
+
+</details>
+
+## Optional arguments
+
+<details open><summary><code>APPROX</code></summary>
+
+Return an approximate cardinality instead of an exact count.
+
+</details>
+
+<details open><summary><code>LIMIT limit</code></summary>
+
+Stop counting once the cardinality reaches `limit`. `0` (the default) means no limit.
+
+</details>
+
+## Examples
+
+{{% redis-cli %}}
+SADD key1 "a"
+SADD key1 "b"
+SADD key1 "c"
+SADD key2 "c"
+SADD key2 "d"
+SADD key2 "e"
+SUNION key1 key2
+SUNIONCARD 2 key1 key2
+SUNIONCARD 2 key1 key2 LIMIT 3
+{{% /redis-cli %}}
+
+## Details
+
+Keys that do not exist are considered to be empty sets.
+
+When provided with the optional `LIMIT` argument (which defaults to `0`, meaning unlimited), if the union cardinality reaches `limit` partway through the computation, the command stops and returns `limit` as the cardinality. This ensures a significant speedup for queries where the limit is lower than the actual union cardinality. `LIMIT` works in both exact and approximate modes.
+
+### Approximate cardinality
+
+By default, `SUNIONCARD` returns the exact union cardinality. With the `APPROX` option, it instead uses [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}}) to estimate the cardinality with a standard error of about 0.81%, without materializing the full union. This is useful for very large unions, where computing an exact count is expensive in both time and memory.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="sunioncard-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the resulting union.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): the number of elements in the resulting union.
+
+{{< /multitabs >}}
+
+## See also
+
+[`SUNION`]({{< relref "commands/sunion/" >}}) | [`SUNIONSTORE`]({{< relref "commands/sunionstore/" >}}) | [`SINTERCARD`]({{< relref "commands/sintercard/" >}}) | [`SDIFFCARD`]({{< relref "commands/sdiffcard/" >}})
+
+## Related topics
+
+- [Redis sets]({{< relref "/develop/data-types/sets" >}})
+- [Multi-key operations]({{< relref "/develop/using-commands/multi-key-operations" >}})
+

--- a/content/commands/sunioncard.md
+++ b/content/commands/sunioncard.md
@@ -117,7 +117,7 @@ When provided with the optional `LIMIT` argument (which defaults to `0`, meaning
 
 ### Approximate cardinality
 
-By default, `SUNIONCARD` returns the exact union cardinality. With the `APPROX` option, it instead uses [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}}) to estimate the cardinality with a standard error of about 0.81%, without materializing the full union. This is useful for very large unions, where computing an exact count is expensive in both time and memory.
+By default, `SUNIONCARD` returns the exact union cardinality. With the `APPROX` option, it instead uses [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}}) internally to estimate the cardinality with a standard error of about 0.81%, without materializing the full union. This is useful for very large unions, where computing an exact count is expensive in both time and memory.
 
 ## Redis Software and Redis Cloud compatibility
 
@@ -141,7 +141,7 @@ By default, `SUNIONCARD` returns the exact union cardinality. With the `APPROX` 
 
 ## See also
 
-[`SUNION`]({{< relref "commands/sunion/" >}}) | [`SUNIONSTORE`]({{< relref "commands/sunionstore/" >}}) | [`SINTERCARD`]({{< relref "commands/sintercard/" >}}) | [`SDIFFCARD`]({{< relref "commands/sdiffcard/" >}})
+[`SUNION`]({{< relref "commands/sunion/" >}}) | [`SUNIONSTORE`]({{< relref "commands/sunionstore/" >}})
 
 ## Related topics
 

--- a/content/commands/sunionstore.md
+++ b/content/commands/sunionstore.md
@@ -119,3 +119,7 @@ SMEMBERS key
 [Integer reply](../../develop/reference/protocol-spec#integers): Number of the elements in the resulting set.
 
 {{< /multitabs >}}
+
+## See also
+
+[`SUNION`]({{< relref "commands/sunion/" >}}) | [`SUNIONCARD`]({{< relref "commands/sunioncard/" >}})

--- a/static/images/railroad/sdiffcard.svg
+++ b/static/images/railroad/sdiffcard.svg
@@ -1,0 +1,57 @@
+<svg class="railroad-diagram" height="80" viewBox="0 0 576.5 80" width="576.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M526.5 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M146.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="50.0" y="29"></rect><text x="98.25" y="44">SDIFFCARD</text></g><path d="M146.5 40h10"></path><path d="M156.5 40h10"></path><g class="non-terminal ">
+<path d="M166.5 40h0.0"></path><path d="M246.0 40h0.0"></path><rect height="22" width="79.5" x="166.5" y="29"></rect><text x="206.25" y="44">numkeys</text></g><path d="M246.0 40h10"></path><path d="M256.0 40h10"></path><g>
+<path d="M266.0 40h0.0"></path><path d="M331.5 40h0.0"></path><path d="M266.0 40h10"></path><g class="non-terminal ">
+<path d="M276.0 40h0.0"></path><path d="M321.5 40h0.0"></path><rect height="22" width="45.5" x="276.0" y="29"></rect><text x="298.75" y="44">key</text></g><path d="M321.5 40h10"></path><path d="M276.0 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M276.0 60h45.5"></path></g><path d="M321.5 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M331.5 40h10"></path><g>
+<path d="M341.5 40h0.0"></path><path d="M526.5 40h0.0"></path><path d="M341.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M361.5 20h145.0"></path></g><path d="M506.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M341.5 40h20"></path><g>
+<path d="M361.5 40h0.0"></path><path d="M506.5 40h0.0"></path><g class="terminal ">
+<path d="M361.5 40h0.0"></path><path d="M424.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="361.5" y="29"></rect><text x="392.75" y="44">LIMIT</text></g><path d="M424.0 40h10"></path><path d="M434.0 40h10"></path><g class="non-terminal ">
+<path d="M444.0 40h0.0"></path><path d="M506.5 40h0.0"></path><rect height="22" width="62.5" x="444.0" y="29"></rect><text x="475.25" y="44">limit</text></g></g><path d="M506.5 40h20"></path></g></g><path d="M526.5 40h10"></path><path d="M 536.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/sunioncard.svg
+++ b/static/images/railroad/sunioncard.svg
@@ -1,0 +1,60 @@
+<svg class="railroad-diagram" height="80" viewBox="0 0 696.0 80" width="696.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M646.0 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M155.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="50.0" y="29"></rect><text x="102.5" y="44">SUNIONCARD</text></g><path d="M155.0 40h10"></path><path d="M165.0 40h10"></path><g class="non-terminal ">
+<path d="M175.0 40h0.0"></path><path d="M254.5 40h0.0"></path><rect height="22" width="79.5" x="175.0" y="29"></rect><text x="214.75" y="44">numkeys</text></g><path d="M254.5 40h10"></path><path d="M264.5 40h10"></path><g>
+<path d="M274.5 40h0.0"></path><path d="M340.0 40h0.0"></path><path d="M274.5 40h10"></path><g class="non-terminal ">
+<path d="M284.5 40h0.0"></path><path d="M330.0 40h0.0"></path><rect height="22" width="45.5" x="284.5" y="29"></rect><text x="307.25" y="44">key</text></g><path d="M330.0 40h10"></path><path d="M284.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M284.5 60h45.5"></path></g><path d="M330.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M340.0 40h10"></path><g>
+<path d="M350.0 40h0.0"></path><path d="M461.0 40h0.0"></path><path d="M350.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M370.0 20h71.0"></path></g><path d="M441.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M350.0 40h20"></path><g class="terminal ">
+<path d="M370.0 40h0.0"></path><path d="M441.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="370.0" y="29"></rect><text x="405.5" y="44">APPROX</text></g><path d="M441.0 40h20"></path></g><g>
+<path d="M461.0 40h0.0"></path><path d="M646.0 40h0.0"></path><path d="M461.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M481.0 20h145.0"></path></g><path d="M626.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M461.0 40h20"></path><g>
+<path d="M481.0 40h0.0"></path><path d="M626.0 40h0.0"></path><g class="terminal ">
+<path d="M481.0 40h0.0"></path><path d="M543.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="481.0" y="29"></rect><text x="512.25" y="44">LIMIT</text></g><path d="M543.5 40h10"></path><path d="M553.5 40h10"></path><g class="non-terminal ">
+<path d="M563.5 40h0.0"></path><path d="M626.0 40h0.0"></path><rect height="22" width="62.5" x="563.5" y="29"></rect><text x="594.75" y="44">limit</text></g></g><path d="M626.0 40h20"></path></g></g><path d="M646.0 40h10"></path><path d="M 656.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (markdown and SVG assets) with no runtime or application code impact.
> 
> **Overview**
> Documents **Redis 8.10** set cardinality commands and ties them into the existing set-command docs.
> 
> **New command pages:** `SDIFFCARD` (count-only `SDIFF` with optional `LIMIT`) and `SUNIONCARD` (count-only `SUNION` with optional `LIMIT` and `APPROX` HyperLogLog mode), each with front matter, examples, compatibility tables, and railroad diagrams.
> 
> **Cross-linking:** **See also** sections were added on `SDIFF` / `SDIFFSTORE`, `SUNION` / `SUNIONSTORE`, and the `SINTER*` family so cardinality and member-returning variants reference each other.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483e13740f90e6a2085cb0ecdbd42cfbe4a763bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->