### PR TITLE
RS: Copied NFS is not supported for persistent storage warning from k8s to RS

### DIFF
--- a/content/operate/rs/7.22/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
+++ b/content/operate/rs/7.22/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
@@ -31,7 +31,8 @@ options for a database.
     
 The persistent volume must be a storage area network (SAN)
 using an EXT4 or XFS file system and be connected as an external storage volume.
-    
+NFS, NFS-like, and multi-read-write/shared storage options are not supported. These types of storage are often slow and can cause locking behaviors that are incompatible with the requirements of database storage.
+
 When using append-only file (AOF) persistence, use flash-based storage
 for the persistent volume.
 

--- a/content/operate/rs/7.4/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
+++ b/content/operate/rs/7.4/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
@@ -31,7 +31,8 @@ options for a database.
     
 The persistent volume must be a storage area network (SAN)
 using an EXT4 or XFS file system and be connected as an external storage volume.
-    
+NFS, NFS-like, and multi-read-write/shared storage options are not supported. These types of storage are often slow and can cause locking behaviors that are incompatible with the requirements of database storage.
+
 When using append-only file (AOF) persistence, use flash-based storage
 for the persistent volume.
 

--- a/content/operate/rs/7.8/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
+++ b/content/operate/rs/7.8/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
@@ -31,7 +31,8 @@ options for a database.
     
 The persistent volume must be a storage area network (SAN)
 using an EXT4 or XFS file system and be connected as an external storage volume.
-    
+NFS, NFS-like, and multi-read-write/shared storage options are not supported. These types of storage are often slow and can cause locking behaviors that are incompatible with the requirements of database storage.
+
 When using append-only file (AOF) persistence, use flash-based storage
 for the persistent volume.
 

--- a/content/operate/rs/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
+++ b/content/operate/rs/installing-upgrading/install/plan-deployment/persistent-ephemeral-storage.md
@@ -30,7 +30,8 @@ options for a database.
     
 The persistent volume must be a storage area network (SAN)
 using an EXT4 or XFS file system and be connected as an external storage volume.
-    
+NFS, NFS-like, and multi-read-write/shared storage options are not supported. These types of storage are often slow and can cause locking behaviors that are incompatible with the requirements of database storage.
+
 When using append-only file (AOF) persistence, use flash-based storage
 for the persistent volume.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no code, config, or deployment logic changes.
> 
> **Overview**
> Adds an explicit **unsupported storage** note to Redis Software (RS) **persistent node storage** planning docs, aligned with the existing Kubernetes persistent-volumes warning.
> 
> In the **Persistent storage** section of `persistent-ephemeral-storage.md` (unversioned RS plus **7.4**, **7.8**, and **7.22**), a new paragraph states that **NFS**, **NFS-like**, and **multi-read-write/shared** options are not supported, with brief rationale (performance and locking vs. database storage requirements). No other sections or behavior are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c496e58fa9ed33d649b3b15591387b95813d1ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->