### PR TITLE
RS: Custom group should match user's primary group during custom install

### DIFF
--- a/content/operate/rs/7.22/installing-upgrading/install/customize-user-and-group.md
+++ b/content/operate/rs/7.22/installing-upgrading/install/customize-user-and-group.md
@@ -27,6 +27,8 @@ During installation, you can specify the user and group that own all Redis Enter
 
 - If you specify the user only, then installation is run with the primary group that the user belongs to.
 
+- The custom group must be the user's primary group. If the user's primary group differs from the custom group, database backups can fail because the installation user cannot change backup file ownership to a different group.
+
 ## Install with custom user or group
 
 To customize the user or group during [installation]({{< relref "/operate/rs/7.22/installing-upgrading/install/install-on-linux" >}}), include the `--os-user` or `--os-group` [command-line options]({{< relref "/operate/rs/7.22/installing-upgrading/install/install-script" >}}) when you run the `install.sh` script.

--- a/content/operate/rs/7.4/installing-upgrading/install/customize-user-and-group.md
+++ b/content/operate/rs/7.4/installing-upgrading/install/customize-user-and-group.md
@@ -22,6 +22,7 @@ If you specify the user only, then installation is run with the primary group th
 - When you install with custom directories, the installation does not run as an RPM file.
 - You must create the user and group before attempting to install Redis Software.
 - You can specify an LDAP user as the installation user.
+- The custom group must be the user's primary group. If the user's primary group differs from the custom group, database backups can fail because the installation user cannot change backup file ownership to a different group.
 {{< /note >}}
 
 To customize the user or group during [installation]({{< relref "/operate/rs/7.4/installing-upgrading/install/install-on-linux" >}}), include the `--os-user` or `--os-group` [command-line options]({{< relref "/operate/rs/7.4/installing-upgrading/install/install-script" >}}) when you run the `install.sh` script. For example:

--- a/content/operate/rs/7.8/installing-upgrading/install/customize-user-and-group.md
+++ b/content/operate/rs/7.8/installing-upgrading/install/customize-user-and-group.md
@@ -22,6 +22,7 @@ If you specify the user only, then installation is run with the primary group th
 - When you install with custom directories, the installation does not run as an RPM file.
 - You must create the user and group before attempting to install Redis Software.
 - You can specify an LDAP user as the installation user.
+- The custom group must be the user's primary group. If the user's primary group differs from the custom group, database backups can fail because the installation user cannot change backup file ownership to a different group.
 {{< /note >}}
 
 To customize the user or group during [installation]({{< relref "/operate/rs/7.8/installing-upgrading/install/install-on-linux" >}}), include the `--os-user` or `--os-group` [command-line options]({{< relref "/operate/rs/7.8/installing-upgrading/install/install-script" >}}) when you run the `install.sh` script. For example:

--- a/content/operate/rs/installing-upgrading/install/customize-user-and-group.md
+++ b/content/operate/rs/installing-upgrading/install/customize-user-and-group.md
@@ -26,6 +26,8 @@ During installation, you can specify the user and group that own all Redis Softw
 
 - If you specify the user only, then installation is run with the primary group that the user belongs to.
 
+- The custom group must be the user's primary group. If the user's primary group differs from the custom group, database backups can fail because the installation user cannot change backup file ownership to a different group.
+
 ## Install with custom user or group
 
 To customize the user or group during [installation]({{< relref "/operate/rs/installing-upgrading/install/install-on-linux" >}}), include the `--os-user` or `--os-group` [command-line options]({{< relref "/operate/rs/installing-upgrading/install/install-script" >}}) when you run the `install.sh` script.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no product or install-script behavior changes.
> 
> **Overview**
> Documents a **custom `--os-group` constraint** across the RS **Customize user and group** install pages (unversioned `operate/rs` plus **7.4**, **7.8**, and **7.22**).
> 
> Adds the same consideration everywhere: the group passed to `install.sh` must be the installation user's **primary group**. If it is not, **database backups can fail** because the install user cannot reassign backup file ownership to a non-primary group.
> 
> On **7.22** and the unversioned page the bullet sits in **Considerations**; on **7.4** and **7.8** it is added inside the existing `{{< note >}}` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1da76a82a381f5776c94aefd1f8f62a1d8b0de05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->