### PR TITLE
RS: Added data compression section to Active-Active planning doc

### DIFF
--- a/content/operate/rs/databases/active-active/planning.md
+++ b/content/operate/rs/databases/active-active/planning.md
@@ -96,6 +96,26 @@ This is critical to avoid problems with internal cluster communications that can
 
 See [Synchronizing cluster node clocks]({{< relref "/operate/rs/clusters/configure/sync-clocks.md" >}}) for more information.
 
+## Data compression
+
+Active-Active databases replicate data between participating clusters over the network. When clusters are geographically distributed, compressing the replicated data can:
+
+- Reduce network traffic.
+
+- Resolve throughput issues.
+
+- Reduce network traffic costs.
+
+The compression level is an integer between 0 and 6 where:
+
+- `0` turns off compression. This compression level is recommended only when throughput is low, because compression can lead to high lag in such scenarios.
+
+- `6` provides the highest compression but uses the most resources.
+
+- The default compression level is `3`.
+
+To change the compression level, use the `--compression` option when you [create]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/create" >}}) or [update]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/update" >}}) an Active-Active database with [`crdb-cli`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli" >}}).
+
 ## Redis modules {#redis-modules}
 
 Several Redis modules are compatible with Active-Active databases. Find the list of [compatible Redis modules]({{< relref "/operate/oss_and_stack/stack-with-enterprise/enterprise-capabilities" >}}).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no product, API, or runtime behavior modifications.
> 
> **Overview**
> Adds a **Data compression** section to the Active-Active planning doc (`planning.md`), placed after networking and before Redis modules.
> 
> The new content explains why compression matters for geo-distributed replication (lower WAN traffic, throughput, cost), documents levels **0–6** with default **3**, notes that **0** can increase lag at low throughput, and points operators to `crdb-cli` **`--compression`** on **create** and **update**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856fb1f9a5b869cd4fd82d804ea39e547dad8586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->