### PR TITLE
Add styled landing page intros to AI and context engine docs

### DIFF
--- a/content/develop/ai/_index.md
+++ b/content/develop/ai/_index.md
@@ -46,7 +46,7 @@ Redis is an in-memory data platform purpose-built for the speed and structure th
   <div class="p-5 border border-redis-pen-300 rounded-lg">
     <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
     <ul class="space-y-1 text-redis-pen-600">
-      <li>Python, JavaScript, Java, Go, and .NET client libraries</li>
+      <li>Redis Search available in Python, JavaScript, Java, Go, .NET, and PHP client libraries</li>
       <li>Managed Context Engine services — no infrastructure to build or maintain</li>
       <li>Works with LangChain, LlamaIndex, LangGraph, and other AI frameworks</li>
       <li>From local development to Redis Cloud with the same API</li>

--- a/content/develop/ai/_index.md
+++ b/content/develop/ai/_index.md
@@ -19,6 +19,41 @@ Redis stores and indexes vector embeddings that semantically represent unstructu
   {{< image-card image="images/ai-brain.svg" alt="AI Redis icon" title="Give AI agents the context engine they need with Redis Iris." url="/develop/ai/context-engine/" >}}
 </div>
 
+## What is Redis for AI and search?
+
+Redis is an in-memory data platform purpose-built for the speed and structure that AI applications demand. It stores and indexes vector embeddings alongside structured metadata, enabling semantic search, real-time retrieval, and agent memory at millisecond latency — at any scale.
+
+<ul class="my-4 space-y-2">
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Vector search</strong> — Store and query vector embeddings using KNN and range queries with metadata filters, across hashes and JSON documents</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Semantic caching</strong> — Reduce LLM API costs by reusing cached responses for semantically similar prompts with LangCache</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Agent memory</strong> — Give agents short-term session memory and long-term persistent memory that survives across interactions</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Structured data access</strong> — Turn your business data into governed tools agents can reliably query with Context Retriever</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Live data sync</strong> — Stream changes from relational databases into Redis in near real time so agents always work with current information</span></li>
+</ul>
+
+## Why use Redis for AI and search?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-6">
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For AI applications</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Sub-millisecond vector search at production scale</li>
+      <li>Agents that remember context across sessions and users</li>
+      <li>Lower LLM costs through semantic caching of repeated queries</li>
+      <li>Reliable access to fresh, structured business data for every agent step</li>
+    </ul>
+  </div>
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Python, JavaScript, Java, Go, and .NET client libraries</li>
+      <li>Managed Context Engine services — no infrastructure to build or maintain</li>
+      <li>Works with LangChain, LlamaIndex, LangGraph, and other AI frameworks</li>
+      <li>From local development to Redis Cloud with the same API</li>
+    </ul>
+  </div>
+</div>
+
 ## Redis Feature Form
 
 Use [Redis Feature Form]({{< relref "/develop/ai/featureform/" >}}) to define, manage, and serve machine learning features on top of your existing data systems. The Feature Form docs cover the Python SDK workflow from provider registration through feature serving.

--- a/content/develop/ai/context-engine/_index.md
+++ b/content/develop/ai/context-engine/_index.md
@@ -4,12 +4,80 @@ categories:
 - docs
 - develop
 - ai
-description: Redis Iris is a suite of fully-managed services that give AI agents the context engine they need to reliably act on business data.
+description: Redis Iris is a suite of fully-managed services.
 hideListLinks: true
 linktitle: Redis Iris context engine
 title: Redis Iris context engine
 weight: 30
 ---
+
+Give your AI agents the context layer they need to reliably act on business data.
+
+Redis Iris eliminates the infrastructure burden of building context-aware AI agents — persistent memory, semantic caching, governed data access, and live data sync, all on Redis Cloud.
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
+  {{< image-card image="images/ai-brain.svg" alt="Agent Memory icon" title="Agent Memory — Persistent short-term and long-term memory across agent interactions" url="/develop/ai/context-engine/agent-memory" >}}
+  {{< image-card image="images/ai-LLM-memory.svg" alt="LangCache icon" title="LangCache — Semantic caching to reduce LLM costs and improve response times" url="/develop/ai/context-engine/langcache" >}}
+  {{< image-card image="images/ai-cube.svg" alt="Context Retriever icon" title="Context Retriever — Governed, schema-first data access tools for agents" url="/develop/ai/context-engine/context-retriever" >}}
+</div>
+
+## What is Redis Iris?
+
+Redis Iris is a production-ready context engine for AI agents that:
+
+<ul class="my-4 space-y-2">
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Reduces LLM costs</strong> — Semantic caching returns cached responses for similar queries in milliseconds</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Adds persistent memory</strong> — Agents remember past interactions and user preferences across sessions</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Structures business data access</strong> — Context Retriever generates governed tools agents can safely call at runtime</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Keeps data fresh</strong> — Data Integration streams live changes from relational databases into Redis within seconds</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Requires no database management</strong> — All four services are fully managed on Redis Cloud via REST API</span></li>
+</ul>
+
+## Why use Redis Iris?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-6">
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For AI applications</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Agents that remember context across sessions and users</li>
+      <li>Faster responses and lower costs through semantic caching</li>
+      <li>Reliable, structured access to live business data</li>
+      <li>No stale data — near real-time sync from your source databases</li>
+    </ul>
+  </div>
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Four fully-managed services — no infrastructure to build or maintain</li>
+      <li>REST API and Python/JS SDKs for all services</li>
+      <li>Define your data model once, reuse it across all agents</li>
+      <li>Available on Redis Cloud with no database setup required</li>
+    </ul>
+  </div>
+</div>
+
+## Quick example
+
+Search LangCache before calling your LLM — return a cached response in milliseconds if a semantically similar prompt has been seen before:
+
+```json
+POST /v1/caches/{cacheId}/entries/search
+{
+    "prompt": "What are the features of Product A?"
+}
+```
+
+If the response is empty (cache miss), call your LLM and store the result:
+
+```json
+POST /v1/caches/{cacheId}/entries
+{
+    "prompt": "What are the features of Product A?",
+    "response": "Product A includes X, Y, and Z features..."
+}
+```
+
+See [LangCache API examples]({{< relref "/develop/ai/context-engine/langcache/api-examples" >}}) and [Agent Memory API examples]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) for more.
 
 Redis Iris context engine includes four services:
 

--- a/content/develop/ai/context-engine/agent-memory/_index.md
+++ b/content/develop/ai/context-engine/agent-memory/_index.md
@@ -13,18 +13,101 @@ bannerText: Redis Agent Memory is currently available in preview. Features and b
 bannerChildren: true
 ---
 
-Redis Agent Memory is a memory service for AI Agents available as a REST API and client libraries. It provides the persistent, structured memory layer that intelligent agents need to store, retrieve, and manage contextual data across interactions. Rather than requiring developers to build custom memory infrastructure from scratch, Redis Agent Memory offers a turnkey solution with dedicated endpoints, secure API key management, configurable memory schemas, and automatic TTL-based lifecycle management.
+Give your AI agents persistent memory and context that gets smarter over time.
 
-[Get started](#get-started) with Redis Agent Memory on Redis Cloud, join the private preview, or set up your own Redis Agent Memory instance.
+Transform your AI agents from simple chatbots into intelligent assistants with Redis-powered memory that automatically learns, organizes, and recalls information across conversations and sessions.
 
-## Redis Agent Memory overview
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
+  {{< image-card image="images/ai-brain.svg" alt="Quick start icon" title="Quick Start — Get up and running in 5 minutes with our step-by-step Cloud setup guide" url="/operate/rc/context-engine/agent-memory/create-service" >}}
+  {{< image-card image="images/ai-LLM-memory.svg" alt="Use cases icon" title="API and SDK Examples — See real-world usage patterns with session events and long-term memory" url="/develop/ai/context-engine/agent-memory/api-examples" >}}
+  {{< image-card image="images/ai-brain-2.svg" alt="Python SDK icon" title="Python SDK — Easy integration with tool abstractions for OpenAI and Anthropic" url="/develop/ai/context-engine/agent-memory/api-examples" >}}
+</div>
+
+## What is Redis Agent Memory?
+
+Redis Agent Memory is a production-ready memory system for AI agents and applications that:
+
+<ul class="my-4 space-y-2">
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Remembers everything</strong> — Stores conversation history, user preferences, and important facts across sessions</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Finds relevant context</strong> — Uses semantic, keyword, and hybrid search to surface the right information at the right time</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Gets smarter over time</strong> — Automatically extracts, organizes, and deduplicates memories from interactions</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Works with any AI model</strong> — REST API and MCP interfaces compatible with OpenAI, Anthropic, and others</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Multi-provider support</strong> — Use 100+ LLM providers via LiteLLM (OpenAI, Anthropic, AWS Bedrock, Ollama, Azure, Gemini, and more)</span></li>
+</ul>
+
+## Why use Redis Agent Memory?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-6">
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For AI applications</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Never lose conversation context across sessions</li>
+      <li>Provide personalized responses based on user history</li>
+      <li>Build agents that learn and improve from interactions</li>
+      <li>Scale from prototypes to production with authentication and multi-tenancy</li>
+    </ul>
+  </div>
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Drop-in REST API — no custom infrastructure to build or maintain</li>
+      <li>Python SDK with tool abstractions for OpenAI and Anthropic</li>
+      <li>Automatic memory extraction and promotion in the background</li>
+      <li>Flexible deployment: Redis Cloud, Redis Software, or self-hosted</li>
+    </ul>
+  </div>
+</div>
+
+## Quick example
+
+Add a session event to short-term memory:
+
+```json
+POST /v1/stores/{storeId}/session-memory/events
+{
+    "sessionId": "abcd-efgh",
+    "actorId": "user-name",
+    "role": "USER",
+    "content": [
+        {
+            "text": "I'm planning a trip to Japan next month."
+        }
+    ],
+    "createdAt": "2026-05-02T18:15:06Z",
+    "metadata": {
+        "browser": "Chrome",
+        "source": "web-chat"
+    }
+}
+```
+
+Add long-term memories directly:
+
+```json
+POST /v1/stores/{storeId}/long-term-memory
+{
+    "memories": [
+        {
+            "id": "cofIXpuMmg",
+            "text": "The user prefers vegetarian food.",
+            "memoryType": "episodic",
+            "sessionId": "abcd-efgh",
+            "ownerId": "user-name"
+        }
+    ]
+}
+```
+
+See the full [API and SDK examples]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) for more.
+
+## Two-tier memory model
 
 Redis Agent Memory uses a two-tier memory model:
 
 - **Session memory** (also known as **Short-term memory** or **Working memory**) maintains the current conversation state, session history, and session-specific metadata. You can set a custom time-to-live (TTL) for session memory to control how long session data is retained.
 - **Long-term memory** stores information extracted from past sessions, including user preferences, learned patterns, and other relevant data.
 
-The promotion from short term memory to long-term memory is automatic. When you store a conversation event in session memory, the Agent Memory Server asynchronously extracts important information using the configured extraction strategy (discrete, summary, preferences, or custom). These extracted memories are then stored as long-term memory entries with vector embeddings and metadata.
+The promotion from short term memory to long-term memory is automatic. When you store a conversation event in session memory, the Agent Memory service asynchronously extracts important information using the configured extraction strategy (discrete, summary, preferences, or custom). These extracted memories are then stored as long-term memory entries with vector embeddings and metadata.
 
 This process is non-blocking: the extraction and promotion happen in the background using a task worker, so the main agent interaction remains responsive. Users do not need to explicitly trigger promotion; it happens as a natural byproduct of storing conversation events in working memory.
 Users can also create long-term memories directly using the API. This is useful for bulk memory creation or for importing knowledge from external sources.

--- a/content/develop/ai/context-engine/agent-memory/_index.md
+++ b/content/develop/ai/context-engine/agent-memory/_index.md
@@ -20,7 +20,7 @@ Transform your AI agents from simple chatbots into intelligent assistants with R
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
   {{< image-card image="images/ai-brain.svg" alt="Quick start icon" title="Quick Start — Get up and running in 5 minutes with our step-by-step Cloud setup guide" url="/operate/rc/context-engine/agent-memory/create-service" >}}
   {{< image-card image="images/ai-LLM-memory.svg" alt="Use cases icon" title="API and SDK Examples — See real-world usage patterns with session events and long-term memory" url="/develop/ai/context-engine/agent-memory/api-examples" >}}
-  {{< image-card image="images/ai-brain-2.svg" alt="Python SDK icon" title="Python SDK — Easy integration with tool abstractions for OpenAI and Anthropic" url="/develop/ai/context-engine/agent-memory/api-examples" >}}
+  {{< image-card image="images/ai-brain-2.svg" alt="Python SDK icon" title="Python SDK — Install the redis-agent-memory package from PyPI" url="https://pypi.org/project/redis-agent-memory/" >}}
 </div>
 
 ## What is Redis Agent Memory?
@@ -31,8 +31,7 @@ Redis Agent Memory is a production-ready memory system for AI agents and applica
   <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Remembers everything</strong> — Stores conversation history, user preferences, and important facts across sessions</span></li>
   <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Finds relevant context</strong> — Uses semantic, keyword, and hybrid search to surface the right information at the right time</span></li>
   <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Gets smarter over time</strong> — Automatically extracts, organizes, and deduplicates memories from interactions</span></li>
-  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Works with any AI model</strong> — REST API and MCP interfaces compatible with OpenAI, Anthropic, and others</span></li>
-  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Multi-provider support</strong> — Use 100+ LLM providers via LiteLLM (OpenAI, Anthropic, AWS Bedrock, Ollama, Azure, Gemini, and more)</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Works with any AI model</strong> — REST API and Python SDK compatible with any agent framework or LLM provider</span></li>
 </ul>
 
 ## Why use Redis Agent Memory?

--- a/content/develop/ai/context-engine/context-retriever/_index.md
+++ b/content/develop/ai/context-engine/context-retriever/_index.md
@@ -13,6 +13,68 @@ bannerText: Redis Context Retriever is currently available in preview. Features 
 bannerChildren: true
 ---
 
+Give your agents structured, governed access to business data — without building custom tools for every project.
+
+Context Retriever lets you define your data model once. It automatically generates the retrieval tools agents call at runtime, so agents always work with accurate, live data through a controlled interface rather than guessing at SQL or calling databases directly.
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
+  {{< image-card image="images/ai-cube.svg" alt="Quick start icon" title="Quick Start — Create a Context Retriever service on Redis Cloud" url="/operate/rc/context-engine/context-retriever/create-service" >}}
+  {{< image-card image="images/ai-lib.svg" alt="Python SDK icon" title="Python SDK and CLI — Model entities and deploy tools with the redis-context-retriever package" url="https://pypi.org/project/redis-context-retriever/" >}}
+  {{< image-card image="images/ai-brain.svg" alt="Admin keys icon" title="Manage Access — Create and manage agent keys to control what each agent can access" url="/operate/rc/context-engine/context-retriever/view-admin-keys" >}}
+</div>
+
+## What is Context Retriever?
+
+Redis Context Retriever is a schema-first context layer for AI agents that:
+
+<ul class="my-4 space-y-2">
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Defines business context once</strong> — Model your entities, fields, and relationships in one place, reused across all agents</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Auto-generates retrieval tools</strong> — Tools are created from your data model, not hand-coded per agent</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Keeps agents out of your database</strong> — Agents call generated tools; the system handles data access safely</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Governs access by design</strong> — Each agent key has access tags that automatically filter what data it can see</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Exposes tools via MCP</strong> — Agents call tools through a standard MCP interface at runtime</span></li>
+</ul>
+
+## Why use Context Retriever?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-6">
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For AI applications</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Agents reliably follow defined data paths instead of guessing at SQL</li>
+      <li>Live, structured context from your business data at every agent step</li>
+      <li>No tool zoo sprawl — one model definition, consistent tool surface</li>
+      <li>Access control built in — agents only see what they're allowed to see</li>
+    </ul>
+  </div>
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Python client and <code>ctxctl</code> CLI for modeling and deploying</li>
+      <li>UI-based setup available in Redis Cloud console</li>
+      <li>No per-agent tool engineering — the platform handles tool generation</li>
+      <li>Fully managed on Redis Cloud, no infrastructure required</li>
+    </ul>
+  </div>
+</div>
+
+## Quick example
+
+Install the Python client and CLI:
+
+```bash
+pip install redis-context-retriever
+```
+
+Connect to your service and define an entity:
+
+```bash
+ctxctl connect --url https://your-service-url --key your-admin-key
+ctxctl entity add customer --fields id,name,email,tier
+```
+
+Context Retriever automatically generates a retrieval tool for the `customer` entity that agents can call through the MCP interface. Agents never access your database directly — they call the tool and receive structured, filtered results.
+
 Redis Context Retriever helps teams expose operational context to AI agents through schema-first retrieval. It models the entities, fields, keys, and relationships that matter to an agent workflow, then presents that context through a governed tool surface the agent can call at runtime. Context Retriever helps an AI Agent understand what business objects exist, how they connect, and which paths are safe to use.
 
 ## Overview

--- a/content/develop/ai/context-engine/context-retriever/_index.md
+++ b/content/develop/ai/context-engine/context-retriever/_index.md
@@ -60,20 +60,15 @@ Redis Context Retriever is a schema-first context layer for AI agents that:
 
 ## Quick example
 
-Install the Python client and CLI:
+Install the Python client, which also includes the `ctxctl` CLI:
 
 ```bash
 pip install redis-context-retriever
 ```
 
-Connect to your service and define an entity:
+Use the `ctxctl` CLI, the Python client, or the Redis Cloud UI to model your entities and relationships. Context Retriever uses that model to automatically generate retrieval tools that agents call at runtime through its MCP interface — agents never access your database directly.
 
-```bash
-ctxctl connect --url https://your-service-url --key your-admin-key
-ctxctl entity add customer --fields id,name,email,tier
-```
-
-Context Retriever automatically generates a retrieval tool for the `customer` entity that agents can call through the MCP interface. Agents never access your database directly — they call the tool and receive structured, filtered results.
+See the [Redis Cloud setup guide]({{< relref "/operate/rc/context-engine/context-retriever/create-service" >}}) to create your first Context Retriever service.
 
 Redis Context Retriever helps teams expose operational context to AI agents through schema-first retrieval. It models the entities, fields, keys, and relationships that matter to an agent workflow, then presents that context through a governed tool surface the agent can call at runtime. Context Retriever helps an AI Agent understand what business objects exist, how they connect, and which paths are safe to use.
 

--- a/content/develop/ai/context-engine/data-integration/_index.md
+++ b/content/develop/ai/context-engine/data-integration/_index.md
@@ -13,7 +13,7 @@ weight: 40
 
 Stream live business data into Redis so agents always work with accurate, up-to-date information.
 
-Redis Data Integration (RDI) keeps your Redis Cloud database in sync with your existing relational databases using change data capture. Agents query Redis at full speed without ever touching your production databases directly.
+Redis Data Integration (RDI) keeps your Redis Cloud database in sync with your existing relational databases using [Change data capture](https://en.wikipedia.org/wiki/Change_data_capture) (CDC). Agents query Redis at full speed without ever querying your production databases directly.
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
   {{< image-card image="images/ai-model.svg" alt="Quick start icon" title="Quick Start — Get a PostgreSQL pipeline running on Redis Cloud in minutes" url="/operate/rc/rdi/quick-start" >}}
@@ -58,37 +58,9 @@ Redis Data Integration (RDI) is a fully-managed pipeline service that:
 
 ## Quick example
 
-Define a pipeline to sync a PostgreSQL `users` table into Redis:
+RDI pipelines are defined through configuration — you specify which source database tables to sync, how to map each row to a Redis key, and what transformations to apply. No custom code is required.
 
-```yaml
-sources:
-  my_pg:
-    type: postgresql
-    host: my-db.example.com
-    database: myapp
-    username: rdi_user
-
-targets:
-  my_redis:
-    type: redis
-
-jobs:
-  sync-users:
-    source:
-      server-name: my_pg
-      schema: public
-      table: users
-    target:
-      key:
-        expression: "user:{{ id }}"
-        language: jmespath
-```
-
-RDI performs an initial full sync, then captures every subsequent `INSERT`, `UPDATE`, and `DELETE` and applies them to Redis within seconds. See the [RDI quick start]({{< relref "/operate/rc/rdi/quick-start" >}}) to get up and running with a live PostgreSQL source.
-
-Redis Data Integration (RDI) is a fully-managed data pipeline service that keeps your Redis Cloud database in sync with your existing relational databases in near real time. By streaming live data from your primary databases into Redis, RDI ensures that AI agents always have access to accurate, up-to-date business data without querying slow source databases directly.
-
-[Get started](#get-started) with RDI on [Redis Cloud]({{< relref "/operate/rc/rdi" >}}) or explore the full [Redis Data Integration documentation]({{< relref "/integrate/redis-data-integration" >}}).
+See the [RDI quick start]({{< relref "/operate/rc/rdi/quick-start" >}}) for a step-by-step walkthrough syncing a live PostgreSQL source to Redis Cloud.
 
 ## Redis Data Integration overview
 

--- a/content/develop/ai/context-engine/data-integration/_index.md
+++ b/content/develop/ai/context-engine/data-integration/_index.md
@@ -11,6 +11,81 @@ hideListLinks: true
 weight: 40
 ---
 
+Stream live business data into Redis so agents always work with accurate, up-to-date information.
+
+Redis Data Integration (RDI) keeps your Redis Cloud database in sync with your existing relational databases using change data capture. Agents query Redis at full speed without ever touching your production databases directly.
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
+  {{< image-card image="images/ai-model.svg" alt="Quick start icon" title="Quick Start — Get a PostgreSQL pipeline running on Redis Cloud in minutes" url="/operate/rc/rdi/quick-start" >}}
+  {{< image-card image="images/ai-cube.svg" alt="Pipeline setup icon" title="Define Your Pipeline — Configure which tables to sync and how to map them to Redis" url="/operate/rc/rdi/define" >}}
+  {{< image-card image="images/ai-brain-2.svg" alt="RDI docs icon" title="Full RDI Documentation — Installation, configuration, and advanced pipeline options" url="/integrate/redis-data-integration" >}}
+</div>
+
+## What is Redis Data Integration?
+
+Redis Data Integration (RDI) is a fully-managed pipeline service that:
+
+<ul class="my-4 space-y-2">
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Syncs data in near real time</strong> — Changes in your source database propagate to Redis within seconds using CDC</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Keeps agents away from source databases</strong> — Agents query Redis at full speed, preserving performance and security</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Requires no coding</strong> — Define pipelines through configuration; transformations are handled automatically</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Handles initial and streaming sync</strong> — Full snapshot on first run, then continuous change capture from that point on</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Supports major relational databases</strong> — Oracle, MySQL, PostgreSQL, MariaDB, SQL Server, and AWS Aurora</span></li>
+</ul>
+
+## Why use Redis Data Integration?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-6">
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For AI applications</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Eliminate stale data — agents always see current business state</li>
+      <li>Millisecond query performance from Redis instead of slow source DB calls</li>
+      <li>No cache invalidation logic to write or maintain</li>
+      <li>Combine with Context Retriever for governed, always-fresh agent tools</li>
+    </ul>
+  </div>
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Configuration-driven — no custom ETL code required</li>
+      <li>Fully managed on Redis Cloud, no infrastructure to provision</li>
+      <li>~10,000 records per second per core for initial snapshots and streaming</li>
+      <li>At-least-once delivery guaranteed for every change in the defined dataset</li>
+    </ul>
+  </div>
+</div>
+
+## Quick example
+
+Define a pipeline to sync a PostgreSQL `users` table into Redis:
+
+```yaml
+sources:
+  my_pg:
+    type: postgresql
+    host: my-db.example.com
+    database: myapp
+    username: rdi_user
+
+targets:
+  my_redis:
+    type: redis
+
+jobs:
+  sync-users:
+    source:
+      server-name: my_pg
+      schema: public
+      table: users
+    target:
+      key:
+        expression: "user:{{ id }}"
+        language: jmespath
+```
+
+RDI performs an initial full sync, then captures every subsequent `INSERT`, `UPDATE`, and `DELETE` and applies them to Redis within seconds. See the [RDI quick start]({{< relref "/operate/rc/rdi/quick-start" >}}) to get up and running with a live PostgreSQL source.
+
 Redis Data Integration (RDI) is a fully-managed data pipeline service that keeps your Redis Cloud database in sync with your existing relational databases in near real time. By streaming live data from your primary databases into Redis, RDI ensures that AI agents always have access to accurate, up-to-date business data without querying slow source databases directly.
 
 [Get started](#get-started) with RDI on [Redis Cloud]({{< relref "/operate/rc/rdi" >}}) or explore the full [Redis Data Integration documentation]({{< relref "/integrate/redis-data-integration" >}}).

--- a/content/develop/ai/context-engine/langcache/_index.md
+++ b/content/develop/ai/context-engine/langcache/_index.md
@@ -15,7 +15,75 @@ aliases:
 - /develop/ai/langcache
 ---
 
-Redis LangCache is a fully-managed semantic caching service that reduces large language model (LLM) costs and improves response times for AI applications. 
+Cut LLM costs and improve response times with semantic caching.
+
+LangCache checks whether a semantically similar prompt has been answered before and returns the cached response instantly — no LLM call required. When there's no match, your app calls the LLM as usual and stores the result for future use.
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
+  {{< image-card image="images/ai-LLM-memory.svg" alt="Quick start icon" title="Quick Start — Create a LangCache service on Redis Cloud and make your first API call" url="/operate/rc/context-engine/langcache/create-service" >}}
+  {{< image-card image="images/ai-search.svg" alt="API examples icon" title="API and SDK Examples — Search, store, and manage cache entries with REST, Python, or JS" url="/develop/ai/context-engine/langcache/api-examples" >}}
+  {{< image-card image="images/ai-brain-2.svg" alt="Monitor icon" title="Monitor Cache — Track hit rates, usage, and performance in Redis Cloud" url="/operate/rc/context-engine/langcache/monitor-cache" >}}
+</div>
+
+## What is LangCache?
+
+LangCache is a fully-managed semantic caching service that:
+
+<ul class="my-4 space-y-2">
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Reduces LLM costs</strong> — Avoids redundant API calls for semantically equivalent queries</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Improves response times</strong> — Returns cached answers in milliseconds instead of waiting for an LLM</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Handles embeddings automatically</strong> — No embedding model to manage; LangCache generates them for you</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Gives you cache control</strong> — Configure similarity thresholds, TTLs, and eviction policies</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Works with any LLM workflow</strong> — REST API and Python/JS SDKs drop into existing applications</span></li>
+</ul>
+
+## Why use LangCache?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-6">
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For AI applications</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Dramatically lower LLM API spend for apps with repetitive queries</li>
+      <li>Faster responses for AI assistants, chatbots, and RAG pipelines</li>
+      <li>Cache intermediate results in multi-step agent workflows</li>
+      <li>Centralize caching across multiple apps via an AI gateway</li>
+    </ul>
+  </div>
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Two API calls to integrate — search before LLM, store after LLM</li>
+      <li>Python and JavaScript SDKs available on PyPI and npm</li>
+      <li>No database to provision — fully managed on Redis Cloud</li>
+      <li>Monitor hit rates and cost savings from the Redis Cloud console</li>
+    </ul>
+  </div>
+</div>
+
+## Quick example
+
+Before calling your LLM, search for a cached response:
+
+```json
+POST /v1/caches/{cacheId}/entries/search
+{
+    "prompt": "What are the features of Product A?"
+}
+```
+
+On a cache miss, call your LLM, then store the result:
+
+```json
+POST /v1/caches/{cacheId}/entries
+{
+    "prompt": "What are the features of Product A?",
+    "response": "Product A includes real-time analytics, automatic scaling, and sub-millisecond latency."
+}
+```
+
+See the full [LangCache API and SDK examples]({{< relref "/develop/ai/context-engine/langcache/api-examples" >}}) for more.
+
+Redis LangCache is a fully-managed semantic caching service that reduces large language model (LLM) costs and improves response times for AI applications.
 
 [Get started](#get-started) with LangCache on [Redis Cloud]({{< relref "/operate/rc/context-engine/langcache" >}}) or join the [private preview](https://redis.io/langcache/).
 

--- a/content/develop/ai/context-engine/langcache/_index.md
+++ b/content/develop/ai/context-engine/langcache/_index.md
@@ -83,10 +83,6 @@ POST /v1/caches/{cacheId}/entries
 
 See the full [LangCache API and SDK examples]({{< relref "/develop/ai/context-engine/langcache/api-examples" >}}) for more.
 
-Redis LangCache is a fully-managed semantic caching service that reduces large language model (LLM) costs and improves response times for AI applications.
-
-[Get started](#get-started) with LangCache on [Redis Cloud]({{< relref "/operate/rc/context-engine/langcache" >}}) or join the [private preview](https://redis.io/langcache/).
-
 ## LangCache overview
 
 LangCache uses semantic caching to store and reuse previous LLM responses for repeated queries. Instead of calling the LLM for every request, LangCache checks if a similar response has already been generated and is stored in the cache. If a match is found, LangCache returns the cached response instantly, saving time and resources. 

--- a/content/develop/ai/featureform/_index.md
+++ b/content/develop/ai/featureform/_index.md
@@ -12,6 +12,51 @@ bannerText: Redis Feature Form is currently in preview and subject to change. Fe
 bannerChildren: true
 ---
 
+Define, manage, and serve machine learning features on top of your existing data systems — without replacing them.
+
+Redis Feature Form lets you register your data providers, define features as Python transformations, materialize them on a schedule, and serve them at low latency from Redis. Your existing databases stay in place; Feature Form coordinates the pipeline.
+
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
+  {{< image-card image="images/ai-brain.svg" alt="Quickstart icon" title="Quickstart — Register a provider, define a feature, materialize it, and serve it end to end" url="/develop/ai/featureform/quickstart" >}}
+  {{< image-card image="images/ai-lib.svg" alt="Overview icon" title="Overview — Learn the onboarding path: workspace, providers, definitions, apply, and serving" url="/develop/ai/featureform/overview" >}}
+  {{< image-card image="images/ai-cube.svg" alt="Deploy icon" title="Deploy — Installation and authentication instructions for running Feature Form" url="/operate/featureform" >}}
+</div>
+
+## What is Redis Feature Form?
+
+Redis Feature Form is a feature platform for machine learning teams that:
+
+<ul class="my-4 space-y-2">
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Works with your existing data</strong> — Register your databases, data warehouses, and streams as providers; no migration required</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Defines features as code</strong> — Write transformations in Python and version them alongside your model code</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Materializes on demand</strong> — Push computed features to Redis for sub-millisecond online serving</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Serves training and inference from the same definitions</strong> — Training sets and online feature views share one source of truth</span></li>
+  <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Supports streaming features</strong> — Ingest real-time events and serve up-to-the-second feature values</span></li>
+</ul>
+
+## Why use Redis Feature Form?
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-6">
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For ML teams</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Consistent features between training and serving — no training-serving skew</li>
+      <li>Version and audit feature definitions alongside model code</li>
+      <li>Reuse features across multiple models and teams</li>
+      <li>Streaming support for time-sensitive predictions</li>
+    </ul>
+  </div>
+  <div class="p-5 border border-redis-pen-300 rounded-lg">
+    <h3 class="text-redis-ink-900 font-semibold mb-3">For developers</h3>
+    <ul class="space-y-1 text-redis-pen-600">
+      <li>Python SDK for defining features, labels, training sets, and providers</li>
+      <li>Redis as the online store — sub-millisecond feature serving at scale</li>
+      <li>No need to replace existing data systems — register them as providers</li>
+      <li>Refer to <a href="/operate/featureform">Deploy</a> for installation and license key setup</li>
+    </ul>
+  </div>
+</div>
+
 Redis Feature Form helps teams define, manage, materialize, and serve machine learning features while keeping existing data systems in place. In the documented workflow, Redis acts as the low-latency online store for feature serving.
 
 This documentation describes platform setup, workspace access, provider and secret registration, definitions-file authoring, apply, and serving. Refer to [Deploy]({{< relref "/operate/featureform" >}}) for installation and authentication instructions.

--- a/content/develop/ai/featureform/_index.md
+++ b/content/develop/ai/featureform/_index.md
@@ -52,7 +52,6 @@ Redis Feature Form is a feature platform for machine learning teams that:
       <li>Python SDK for defining features, labels, training sets, and providers</li>
       <li>Redis as the online store — sub-millisecond feature serving at scale</li>
       <li>No need to replace existing data systems — register them as providers</li>
-      <li>Refer to <a href="/operate/featureform">Deploy</a> for installation and license key setup</li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Adds tagline, three clickable cards, "What is X?" and "Why use X?" sections with Redis-palette styling to the Redis for AI, Context Engine, Agent Memory, LangCache, Context Retriever, Data Integration, and Feature Form index pages. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Hugo markdown and marketing copy on index pages; no runtime, security, or API behavior changes.
> 
> **Overview**
> Adds a shared **landing-page pattern** to seven Hugo index pages under `develop/ai`: opening taglines, **What is / Why use** sections with Redis palette styling (`text-redis-*`, bordered two-column grids), red bullet lists, and **three `image-card` navigation grids** per page (where the page already had cards, new cards are added for Context Engine services).
> 
> **Redis for AI and search** gains capability bullets (vector search, LangCache, agent memory, Context Retriever, live sync) plus audience split boxes before the existing Feature Form and agents sections.
> 
> **Context Engine (Redis Iris)** is restructured with Iris positioning, service cards, LangCache search/store **Quick example** JSON, and a shortened front-matter `description`.
> 
> **LangCache, Agent Memory, Context Retriever, Data Integration, and Feature Form** each replace or supplement terse intros with the same template, service-specific quick starts (REST JSON, `pip install`, or config pointers), and deep links to operate/quick-start docs. **Agent Memory** renames the overview heading to **Two-tier memory model** and refers to the **Agent Memory service** instead of “Agent Memory Server.”
> 
> No application code, APIs, or build logic change—only markdown content and layout classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4820f8c8badb7f455fbd50e3a799400a719f2b1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->