### PR TITLE
Minor edits

### DIFF
--- a/content/commands/xcfgset.md
+++ b/content/commands/xcfgset.md
@@ -55,6 +55,8 @@ title: XCFGSET
 ---
 Sets the IDMP (Idempotent Message Processing) configuration parameters for a stream. This command configures how long idempotent IDs are retained and the maximum number of idempotent IDs tracked per producer.
 
+For more details, see [Idempotent message processing](../../develop/data-types/streams/idempotency/).
+
 ## Required arguments
 
 <details open><summary><code>key</code></summary>
@@ -67,7 +69,7 @@ The name of the stream key. The stream must already exist.
 
 <details open><summary><code>IDMP-DURATION idmp-duration</code></summary>
 
-Sets the duration in seconds that each idempotent ID (iid) is kept in the stream's IDMP map. Valid range: 1-86,400 seconds. Default: 100 seconds.
+Sets the duration, in seconds, for which each idempotent ID (iid) is retained in the stream's IDMP map. Valid range: 1-86,400 seconds. Default: 100 seconds.
 
 When an idempotent ID expires, it can be reused for new messages. This provides an operational guarantee that Redis will not forget an idempotency ID before the duration elapses (unless capacity is reached).
 

--- a/content/commands/xidmprecord.md
+++ b/content/commands/xidmprecord.md
@@ -56,7 +56,7 @@ title: XIDMPRECORD
 
  `XIDMPRECORD` is an internal command. Users should not call it directly.
  
-Redis uses it to set IDMP metadata on an existing stream message, which is then replayed during AOF loading.
+Redis uses it to set IDMP metadata, which is then replayed during AOF loading.
 
 ## Required arguments
 

--- a/content/commands/xidmprecord.md
+++ b/content/commands/xidmprecord.md
@@ -54,8 +54,9 @@ syntax_fmt: XIDMPRECORD key pid iid stream-id
 title: XIDMPRECORD
 ---
 
-`XIDMPRECORD` is an internal command for setting IDMP metadata on an existing stream message, which would be replayed during AOF loading.
-Users should not call this command directly.
+ `XIDMPRECORD` is an internal command. Users should not call it directly.
+ 
+Redis uses it to set IDMP metadata on an existing stream message, which is then replayed during AOF loading.
 
 ## Required arguments
 

--- a/content/commands/xsetid.md
+++ b/content/commands/xsetid.md
@@ -65,7 +65,7 @@ summary: An internal command for replicating stream values.
 syntax_fmt: "XSETID key last-id [ENTRIESADDED\_entries-added]\n  [MAXDELETEDID\_max-deleted-id]"
 title: XSETID
 ---
- `XSETID` is an internal command. Users should not call this command directly.
+ `XSETID` is an internal command. Users should not call it directly.
  
 Redis primary shards use it to replicate the last delivered entry ID of the stream.
 

--- a/content/commands/xsetid.md
+++ b/content/commands/xsetid.md
@@ -65,8 +65,9 @@ summary: An internal command for replicating stream values.
 syntax_fmt: "XSETID key last-id [ENTRIESADDED\_entries-added]\n  [MAXDELETEDID\_max-deleted-id]"
 title: XSETID
 ---
-The `XSETID` command is an internal command.
-It is used by a Redis master to replicate the last delivered ID of streams.
+ `XSETID` is an internal command. Users should not call this command directly.
+ 
+Redis primary shards use it to replicate the last delivered entry ID of the stream.
 
 ## Required arguments
 


### PR DESCRIPTION
Clarify usage of the XSETID command in documentation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown documentation only; no runtime or API behavior changes.
> 
> **Overview**
> Documentation-only updates to three stream command pages.
> 
> **`XSETID`** and **`XIDMPRECORD`** intros now follow the same pattern: state they are internal, warn users not to call them directly, then briefly explain what Redis uses them for (`XSETID` on primary shards for replicating the stream’s last delivered entry ID; **`XIDMPRECORD`** for IDMP metadata replayed during AOF load).
> 
> **`XCFGSET`** adds a link to the idempotent message processing developer guide and tightens **`IDMP-DURATION`** wording (“retained” / “in seconds”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee774a46fe4b2f7e04412fa9b4c07d46fd8408fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->