### PR TITLE
RDSC-5669 Publish RDI Cloud API reference

### DIFF
--- a/.github/workflows/rc_api_sync.yaml
+++ b/.github/workflows/rc_api_sync.yaml
@@ -39,15 +39,19 @@ jobs:
             git checkout -b "${branch}"
           fi
 
-          curl -Ls https://api.redislabs.com/v1/cloud-api-docs \
+          curl -Ls https://api.redislabs.com/v1/cloud-api-docs/capi \
             | jq '(.. | .example? | try select(test("^{"))) |= fromjson' > content/operate/rc/api/api-reference/openapi.json
 
-          spec_is_different=$(git diff content/operate/rc/api/api-reference/openapi.json)
+          curl -Ls https://api.redislabs.com/v1/cloud-api-docs/rdi \
+            | jq '(.. | .example? | try select(test("^{"))) |= fromjson' > content/operate/rc/api/data-integration-api-reference/openapi.json
+
+          spec_is_different=$(git diff content/operate/rc/api/api-reference/openapi.json content/operate/rc/api/data-integration-api-reference/openapi.json)
 
           if [[ ! -z $spec_is_different ]]; then
             spec_change=true
 
             git add "content/operate/rc/api/api-reference/openapi.json"
+            git add "content/operate/rc/api/data-integration-api-reference/openapi.json"
             git config user.email "177626021+redisdocsapp[bot]@users.noreply.github.com"
             git config user.name "redisdocsapp[bot]"
             git commit -m "Update content/operate/rc/api/api-reference/openapi.json"

--- a/content/operate/rc/api/_index.md
+++ b/content/operate/rc/api/_index.md
@@ -41,4 +41,5 @@ You can use the API to:
 
 - Use the [Redis Cloud API]({{< relref "/operate/rc/api/get-started/use-rest-api.md" >}})
 - [Full API Reference]({{< relref "/operate/rc/api/api-reference" >}})
+- [Data Integration API Reference]({{< relref "/operate/rc/api/data-integration-api-reference" >}})
 - Secure [authentication and authorization]({{< relref "/operate/rc/api/get-started" >}})

--- a/content/operate/rc/api/data-integration-api-reference.md
+++ b/content/operate/rc/api/data-integration-api-reference.md
@@ -1,0 +1,8 @@
+---
+Title: Redis Cloud Data Integration API
+linkTitle: Data Integration API reference
+layout: apireference
+type: page
+params:
+  backLink: operate/rc/api
+---

--- a/content/operate/rc/api/data-integration-api-reference/openapi.json
+++ b/content/operate/rc/api/data-integration-api-reference/openapi.json
@@ -1,0 +1,3907 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Data Integration Workspace API",
+    "description": "Data Integration Workspace API",
+    "version": "2.2.2"
+  },
+  "servers": [
+    {
+      "url": "https://api.redislabs.com"
+    }
+  ],
+  "security": [
+    {
+      "x-api-key": [],
+      "x-api-secret-key": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Workspace",
+      "x-order": "1",
+      "x-api-lifecycle": "preview"
+    },
+    {
+      "name": "Tasks",
+      "x-order": "2",
+      "x-api-lifecycle": "preview"
+    },
+    {
+      "name": "Secrets",
+      "x-order": "3",
+      "x-api-lifecycle": "preview"
+    },
+    {
+      "name": "PrivateLink",
+      "x-order": "4",
+      "x-api-lifecycle": "preview"
+    },
+    {
+      "name": "Compose",
+      "x-order": "5",
+      "x-api-lifecycle": "preview"
+    },
+    {
+      "name": "RDI Core",
+      "description": "Data Integration (RDI) endpoints. This surface is independent of the Cloud API and versions through the RDI OpenAPI contract.\n\nRDI Core API version: 1.18.1\n",
+      "externalDocs": {
+        "description": "Redis Data Integration API reference",
+        "url": "https://redis.io/docs/latest/integrate/redis-data-integration/reference/api-reference/"
+      },
+      "x-order": "6",
+      "x-api-lifecycle": "preview",
+      "x-rdi-core-api-version": "1.18.1",
+      "x-rdi-core-api-spec-url": "https://redis.io/docs/latest/integrate/redis-data-integration/reference/api-reference/openapi.json",
+      "x-rdi-core-api-docs-url": "https://redis.io/docs/latest/integrate/redis-data-integration/reference/api-reference/"
+    }
+  ],
+  "paths": {
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace": {
+      "get": {
+        "tags": [
+          "Workspace"
+        ],
+        "operationId": "getWorkspace",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "workspaces",
+        "x-api-lifecycle": "preview"
+      },
+      "post": {
+        "tags": [
+          "Workspace"
+        ],
+        "operationId": "createWorkspace",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTaskResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "workspaces",
+        "x-api-lifecycle": "preview"
+      },
+      "delete": {
+        "tags": [
+          "Workspace"
+        ],
+        "operationId": "deleteWorkspace",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTaskResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "workspaces",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/data-integration-workspaces": {
+      "get": {
+        "tags": [
+          "Workspace"
+        ],
+        "operationId": "listWorkspaces",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspacesResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "workspaces",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/info": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Get RDI API information",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "getRdiV2Info",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "List RDI pipelines",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "listRdiV2Pipelines",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "post": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Create an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "createRdiV2Pipeline",
+        "parameters": [
+          {
+            "name": "dry_run",
+            "in": "query",
+            "description": "Validate the pipeline without deploying it.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "validate_cdc",
+            "in": "query",
+            "description": "Validate change data capture configuration.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Get an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "getRdiV2Pipeline",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "put": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Replace an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "replaceRdiV2Pipeline",
+        "parameters": [
+          {
+            "name": "dry_run",
+            "in": "query",
+            "description": "Validate the pipeline without deploying it.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "validate_cdc",
+            "in": "query",
+            "description": "Validate change data capture configuration.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "delete": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Delete an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "deleteRdiV2Pipeline",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "patch": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Update an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "updateRdiV2Pipeline",
+        "parameters": [
+          {
+            "name": "dry_run",
+            "in": "query",
+            "description": "Validate the pipeline without deploying it.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "validate_cdc",
+            "in": "query",
+            "description": "Validate change data capture configuration.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/status": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Get RDI pipeline status",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "getRdiV2PipelineStatus",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/start": {
+      "post": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Start an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "startRdiV2Pipeline",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/stop": {
+      "post": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Stop an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "stopRdiV2Pipeline",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/reset": {
+      "post": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Reset an RDI pipeline",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "resetRdiV2Pipeline",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/metric-collections": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "List RDI pipeline metric collections",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "listRdiV2MetricCollections",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/metric-collections/{collection_name}": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Get an RDI pipeline metric collection",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "getRdiV2MetricCollection",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "collection_name",
+          "in": "path",
+          "description": "Metric collection name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/secrets": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "List RDI pipeline secrets",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "listRdiV2PipelineSecrets",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "post": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Create an RDI pipeline secret",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "createRdiV2PipelineSecret",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/secrets/{key}": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Get an RDI pipeline secret",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "getRdiV2PipelineSecret",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "put": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Replace an RDI pipeline secret",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "replaceRdiV2PipelineSecret",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "delete": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Delete an RDI pipeline secret",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "deleteRdiV2PipelineSecret",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "key",
+          "in": "path",
+          "description": "Secret key.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/source-schemas/{source_name}": {
+      "get": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Get RDI pipeline source schema",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "getRdiV2SourceSchema",
+        "parameters": [
+          {
+            "name": "schemas",
+            "in": "query",
+            "description": "Comma-separated source schemas to include.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tables",
+            "in": "query",
+            "description": "Comma-separated source tables to include.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "details",
+            "in": "query",
+            "description": "Include detailed source schema metadata.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "source_name",
+          "in": "path",
+          "description": "Source name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines/{name}/flush-target/{target_name}": {
+      "post": {
+        "tags": [
+          "RDI Core"
+        ],
+        "summary": "Flush an RDI pipeline target",
+        "description": "Forwards the request to the RDI API v2 deployment owned by the specified subscription.",
+        "operationId": "flushRdiV2Target",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "rdi",
+        "x-api-lifecycle": "preview"
+      },
+      "parameters": [
+        {
+          "name": "subscriptionId",
+          "in": "path",
+          "description": "Subscription ID.",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "name",
+          "in": "path",
+          "description": "RDI pipeline name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "target_name",
+          "in": "path",
+          "description": "Target name.",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/tasks": {
+      "get": {
+        "tags": [
+          "Tasks"
+        ],
+        "operationId": "listTasks",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTasksResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "tasks",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/tasks/{taskId}": {
+      "get": {
+        "tags": [
+          "Tasks"
+        ],
+        "operationId": "getTask",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "taskId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTaskResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "tasks",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/network/private-link": {
+      "get": {
+        "tags": [
+          "PrivateLink"
+        ],
+        "operationId": "listEndpoints",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateLinkEndpointListResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "privatelink",
+        "x-api-lifecycle": "preview"
+      },
+      "post": {
+        "tags": [
+          "PrivateLink"
+        ],
+        "operationId": "createEndpoint",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePrivateLinkEndpointRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTaskResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "privatelink",
+        "x-speakeasy-name-override": "create-endpoint",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/network/private-link/{endpointId}": {
+      "get": {
+        "tags": [
+          "PrivateLink"
+        ],
+        "operationId": "getEndpoint",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateLinkEndpointResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "privatelink",
+        "x-api-lifecycle": "preview"
+      },
+      "delete": {
+        "tags": [
+          "PrivateLink"
+        ],
+        "operationId": "deleteEndpoint",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTaskResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "privatelink",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/network/private-link/{endpointId}/validate": {
+      "post": {
+        "tags": [
+          "PrivateLink"
+        ],
+        "operationId": "validateEndpoint",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "endpointId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateLinkValidationResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "privatelink",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/network/private-link/validate": {
+      "post": {
+        "tags": [
+          "PrivateLink"
+        ],
+        "operationId": "validatePrivateLink",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PrivateLinkValidationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PrivateLinkValidationResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "privatelink",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/network/suggested-cidrs": {
+      "get": {
+        "tags": [
+          "Workspace"
+        ],
+        "operationId": "getSuggestedCidrs",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "cidr-mask",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 22
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/CidrsInfoResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "workspaces",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/compose": {
+      "get": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "listDrafts",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComposeDraftListResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      },
+      "post": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "createDraft",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComposeDraftUpsertRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComposeDraftCreatedResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/compose/mount-secrets": {
+      "post": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "mountSecretsFromPayload",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComposeDraftUpsertRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/compose/translate": {
+      "post": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "translate",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComposeTranslateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComposeTranslateResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/compose/{draftId}": {
+      "get": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "getDraft",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComposeDraftResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      },
+      "put": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "updateDraft",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComposeDraftUpsertRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComposeDraftResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      },
+      "delete": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "deleteDraft",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/compose/{draftId}/composed": {
+      "get": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "getComposed",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RdiPatchRequest"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/compose/{draftId}/validate": {
+      "post": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "validateDraft",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RdiPipelineResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/compose/{draftId}/mount-secrets": {
+      "post": {
+        "tags": [
+          "Compose"
+        ],
+        "operationId": "mountSecrets",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "draftId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          }
+        },
+        "x-speakeasy-group": "compose",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/secrets/validate": {
+      "post": {
+        "tags": [
+          "Secrets"
+        ],
+        "operationId": "validateSecret",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SecretValidationRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SecretValidationResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "secrets",
+        "x-speakeasy-name-override": "validate",
+        "x-api-lifecycle": "preview"
+      }
+    },
+    "/v1/subscriptions/{subscriptionId}/data-integration-workspace/secrets/validate-single": {
+      "post": {
+        "tags": [
+          "Secrets"
+        ],
+        "operationId": "validateSingleSecret",
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SingleSecretValidationRequestDto"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/SingleSecretValidationResponseDto"
+                }
+              }
+            }
+          }
+        },
+        "x-speakeasy-group": "secrets",
+        "x-api-lifecycle": "preview"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ComposeDraftAdvanced": {
+        "type": "object",
+        "properties": {
+          "processor": {
+            "$ref": "#/components/schemas/Properties"
+          }
+        }
+      },
+      "ComposeDraftSource": {
+        "type": "object",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/PostgresqlSource"
+          },
+          {
+            "$ref": "#/components/schemas/MySqlSource"
+          },
+          {
+            "$ref": "#/components/schemas/MariaDbSource"
+          },
+          {
+            "$ref": "#/components/schemas/OracleSource"
+          },
+          {
+            "$ref": "#/components/schemas/SqlServerSource"
+          },
+          {
+            "$ref": "#/components/schemas/MongodbSource"
+          },
+          {
+            "$ref": "#/components/schemas/SnowflakeSource"
+          }
+        ]
+      },
+      "ComposeDraftSourceBase": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "endpointId": {
+            "type": "string"
+          },
+          "host": {
+            "type": "string"
+          },
+          "databaseType": {
+            "type": "string"
+          },
+          "database": {
+            "type": "string"
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "secretArns": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "sourceAdvanced": {
+            "$ref": "#/components/schemas/Properties"
+          },
+          "sinkAdvanced": {
+            "$ref": "#/components/schemas/Properties"
+          }
+        }
+      },
+      "ComposeDraftTarget": {
+        "type": "object",
+        "properties": {
+          "targetBdbId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ComposeDraftUpsertRequest": {
+        "type": "object",
+        "properties": {
+          "targetDataType": {
+            "type": "string",
+            "enum": [
+              "hash",
+              "json"
+            ]
+          },
+          "source": {
+            "$ref": "#/components/schemas/ComposeDraftSource"
+          },
+          "sourceName": {
+            "type": "string"
+          },
+          "pipelineName": {
+            "type": "string"
+          },
+          "pipelineDescription": {
+            "type": "string"
+          },
+          "target": {
+            "$ref": "#/components/schemas/ComposeDraftTarget"
+          },
+          "advanced": {
+            "$ref": "#/components/schemas/ComposeDraftAdvanced"
+          },
+          "schemas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Schema"
+            }
+          },
+          "jobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Job"
+            }
+          },
+          "clientData": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "Job": {
+        "required": [
+          "file",
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "file": {
+            "type": "string"
+          },
+          "error": {
+            "$ref": "#/components/schemas/WebError"
+          },
+          "rdiJob": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "MariaDbSource": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ComposeDraftSourceBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "endpointId": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "database": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "secretArns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "serverId": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "sourceAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              },
+              "sinkAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              }
+            }
+          }
+        ]
+      },
+      "MongodbSource": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ComposeDraftSourceBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "endpointId": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "database": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "secretArns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "connectionString": {
+                "type": "string"
+              },
+              "sourceAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              },
+              "sinkAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              }
+            }
+          }
+        ]
+      },
+      "MySqlSource": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ComposeDraftSourceBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "endpointId": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "database": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "secretArns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "serverId": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "sourceAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              },
+              "sinkAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              }
+            }
+          }
+        ]
+      },
+      "OracleSource": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ComposeDraftSourceBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "endpointId": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "database": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "secretArns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "pdb": {
+                "type": "string"
+              },
+              "sourceAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              },
+              "sinkAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              }
+            }
+          }
+        ]
+      },
+      "PostgresqlSource": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ComposeDraftSourceBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "endpointId": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "database": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "secretArns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "sourceAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              },
+              "sinkAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              }
+            }
+          }
+        ]
+      },
+      "Properties": {
+        "type": "object"
+      },
+      "Schema": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Table"
+            }
+          }
+        }
+      },
+      "SnowflakeSource": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ComposeDraftSourceBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "endpointId": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "database": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "secretArns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "accountIdentifier": {
+                "type": "string"
+              },
+              "warehouse": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              },
+              "sourceAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              },
+              "sinkAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              }
+            }
+          }
+        ]
+      },
+      "SqlServerSource": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ComposeDraftSourceBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "endpointId": {
+                "type": "string"
+              },
+              "host": {
+                "type": "string"
+              },
+              "databaseType": {
+                "type": "string"
+              },
+              "database": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "secretArns": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "sourceAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              },
+              "sinkAdvanced": {
+                "$ref": "#/components/schemas/Properties"
+              }
+            }
+          }
+        ]
+      },
+      "Table": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TableColumn"
+            }
+          },
+          "snapshot_sql": {
+            "type": "string"
+          }
+        }
+      },
+      "TableColumn": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "uniqueConstraint": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WebError": {
+        "type": "object",
+        "properties": {
+          "timestamp": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "params": {
+            "type": "string"
+          }
+        }
+      },
+      "ComposeDraftResponse": {
+        "type": "object",
+        "properties": {
+          "draftId": {
+            "type": "string"
+          },
+          "targetDataType": {
+            "type": "string",
+            "enum": [
+              "hash",
+              "json"
+            ]
+          },
+          "source": {
+            "$ref": "#/components/schemas/ComposeDraftSource"
+          },
+          "sourceName": {
+            "type": "string"
+          },
+          "pipelineName": {
+            "type": "string"
+          },
+          "pipelineDescription": {
+            "type": "string"
+          },
+          "target": {
+            "$ref": "#/components/schemas/ComposeDraftTarget"
+          },
+          "advanced": {
+            "$ref": "#/components/schemas/ComposeDraftAdvanced"
+          },
+          "schemas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Schema"
+            }
+          },
+          "jobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Job"
+            }
+          },
+          "clientData": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Advanced": {
+        "type": "object",
+        "properties": {
+          "source": {
+            "$ref": "#/components/schemas/Properties"
+          },
+          "sink": {
+            "$ref": "#/components/schemas/Properties"
+          }
+        }
+      },
+      "Aws": {
+        "type": "object",
+        "properties": {
+          "privateLink": {
+            "$ref": "#/components/schemas/PrivateLink"
+          }
+        }
+      },
+      "Endpoint": {
+        "type": "object",
+        "properties": {
+          "vpceId": {
+            "type": "string"
+          }
+        }
+      },
+      "Pipeline": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "deploymentCIDR": {
+            "type": "string"
+          }
+        }
+      },
+      "PipelineInfraDto": {
+        "type": "object",
+        "properties": {
+          "pipeline": {
+            "$ref": "#/components/schemas/Pipeline"
+          },
+          "aws": {
+            "$ref": "#/components/schemas/Aws"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Source"
+          }
+        }
+      },
+      "PrivateLink": {
+        "type": "object",
+        "properties": {
+          "serviceName": {
+            "type": "string"
+          },
+          "endpoint": {
+            "$ref": "#/components/schemas/Endpoint"
+          }
+        }
+      },
+      "Source": {
+        "type": "object",
+        "properties": {
+          "connectivityMode": {
+            "type": "string",
+            "enum": [
+              "privateLink",
+              "publicEndpoint"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "dbType": {
+            "type": "string",
+            "enum": [
+              "mysql",
+              "mariadb",
+              "oracle",
+              "sqlserver",
+              "postgresql",
+              "mongodb",
+              "snowflake"
+            ]
+          },
+          "datasetSizeGB": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dbSecretsARN": {
+            "type": "string"
+          },
+          "dbUseTLS": {
+            "type": "boolean"
+          },
+          "dbUseMTLS": {
+            "type": "boolean"
+          },
+          "dbCaCertARN": {
+            "type": "string"
+          },
+          "dbClientCertARN": {
+            "type": "string"
+          },
+          "dbClientKeyARN": {
+            "type": "string"
+          },
+          "dbClientKeyPasswordARN": {
+            "type": "string"
+          },
+          "dbPort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dbServerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "dbConnectionString": {
+            "type": "string"
+          },
+          "databases": {
+            "type": "string"
+          },
+          "pdb": {
+            "type": "string"
+          },
+          "advanced": {
+            "$ref": "#/components/schemas/Advanced"
+          },
+          "dbHost": {
+            "type": "string"
+          },
+          "dbUser": {
+            "type": "string"
+          },
+          "dbPass": {
+            "type": "string"
+          }
+        }
+      },
+      "PipelineConfigAdvanced": {
+        "type": "object",
+        "properties": {
+          "processor": {
+            "$ref": "#/components/schemas/Properties"
+          }
+        }
+      },
+      "PipelineConfigDto": {
+        "required": [
+          "definitionType",
+          "targetDataType"
+        ],
+        "type": "object",
+        "properties": {
+          "targetDataType": {
+            "type": "string",
+            "enum": [
+              "hash",
+              "json"
+            ]
+          },
+          "definitionType": {
+            "type": "string",
+            "enum": [
+              "predefined",
+              "manual"
+            ]
+          },
+          "schemas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Schema"
+            }
+          },
+          "jobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Job"
+            }
+          },
+          "advanced": {
+            "$ref": "#/components/schemas/PipelineConfigAdvanced"
+          }
+        }
+      },
+      "PipelineConfigJobsResponseDto": {
+        "type": "object",
+        "properties": {
+          "jobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Job"
+            }
+          }
+        }
+      },
+      "EulaAcceptanceResponseDto": {
+        "type": "object",
+        "properties": {
+          "accepted": {
+            "type": "boolean"
+          },
+          "acceptedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "WorkspaceCreateRequest": {
+        "type": "object",
+        "properties": {
+          "cidr": {
+            "type": "string"
+          }
+        }
+      },
+      "TaskLink": {
+        "type": "object",
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "TaskLinks": {
+        "type": "object",
+        "properties": {
+          "task": {
+            "$ref": "#/components/schemas/TaskLink"
+          },
+          "resource": {
+            "$ref": "#/components/schemas/TaskLink"
+          }
+        }
+      },
+      "WorkspaceTaskResponse": {
+        "type": "object",
+        "properties": {
+          "taskId": {
+            "type": "string"
+          },
+          "commandType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "response": {
+            "type": "object"
+          },
+          "_links": {
+            "$ref": "#/components/schemas/TaskLinks"
+          }
+        }
+      },
+      "SecretValidationRequestDto": {
+        "type": "object",
+        "properties": {
+          "credentialsSecretArn": {
+            "type": "string"
+          },
+          "caCertSecretArn": {
+            "type": "string"
+          },
+          "clientCertSecretArn": {
+            "type": "string"
+          },
+          "clientKeySecretArn": {
+            "type": "string"
+          },
+          "clientKeyPassphraseSecretArn": {
+            "type": "string"
+          }
+        }
+      },
+      "SecretError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "SecretValidationResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SecretError"
+            }
+          }
+        }
+      },
+      "SingleSecretValidationRequestDto": {
+        "required": [
+          "purpose",
+          "secretArn"
+        ],
+        "type": "object",
+        "properties": {
+          "secretArn": {
+            "type": "string"
+          },
+          "purpose": {
+            "type": "string",
+            "enum": [
+              "source-credentials",
+              "source-tls-ca",
+              "source-mtls-client-cert",
+              "source-mtls-client-key",
+              "source-mtls-key-password"
+            ]
+          }
+        }
+      },
+      "SingleSecretValidationResponseDto": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "errorCode": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        }
+      },
+      "CreatePrivateLinkEndpointRequest": {
+        "required": [
+          "serviceName"
+        ],
+        "type": "object",
+        "properties": {
+          "serviceName": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateLinkValidationResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "error": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateLinkValidationRequest": {
+        "required": [
+          "serviceName"
+        ],
+        "type": "object",
+        "properties": {
+          "serviceName": {
+            "type": "string"
+          }
+        }
+      },
+      "ComposeDraftCreatedResponse": {
+        "type": "object",
+        "properties": {
+          "draftId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PipelineComponentResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "started",
+              "stopped",
+              "error",
+              "creating",
+              "updating",
+              "deleting",
+              "starting",
+              "stopping",
+              "resetting",
+              "pending",
+              "unknown"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "metricCollections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RdiPipelineError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "RdiPipelineResponse": {
+        "type": "object",
+        "properties": {
+          "errorOtherThanJobValidationError": {
+            "type": "boolean"
+          },
+          "name": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "started",
+              "stopped",
+              "error",
+              "creating",
+              "updating",
+              "deleting",
+              "starting",
+              "stopping",
+              "resetting",
+              "pending",
+              "unknown"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RdiPipelineError"
+            }
+          },
+          "components": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PipelineComponentResponse"
+            }
+          },
+          "current": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ComposeTranslateRequest": {
+        "type": "object",
+        "properties": {
+          "direction": {
+            "type": "string",
+            "enum": [
+              "cloud-to-rdi",
+              "rdi-to-cloud"
+            ]
+          },
+          "cloud": {
+            "$ref": "#/components/schemas/ComposeDraftUpsertRequest"
+          },
+          "rdi": {
+            "$ref": "#/components/schemas/RdiPipelineResponse"
+          }
+        }
+      },
+      "ComposeTranslateResponse": {
+        "type": "object",
+        "properties": {
+          "draft": {
+            "$ref": "#/components/schemas/ComposeDraftUpsertRequest"
+          },
+          "rdi": {
+            "$ref": "#/components/schemas/RdiPatchRequest"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RdiPatchRequest": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "config": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "PipelineCreateRequestDto": {
+        "required": [
+          "targetBdbId"
+        ],
+        "type": "object",
+        "properties": {
+          "targetBdbId": {
+            "minimum": 1,
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "PipelineCreateResponseDto": {
+        "required": [
+          "pipelineId"
+        ],
+        "type": "object",
+        "properties": {
+          "pipelineId": {
+            "type": "string"
+          }
+        }
+      },
+      "ResetPipelineRequestDto": {
+        "type": "object",
+        "properties": {
+          "flush": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DeployPipelineRequestDto": {
+        "type": "object",
+        "properties": {
+          "reset": {
+            "$ref": "#/components/schemas/ResetPipelineRequestDto"
+          }
+        }
+      },
+      "WorkspaceClusterRef": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "WorkspaceDatabaseResponse": {
+        "type": "object",
+        "properties": {
+          "databaseId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "memorySize": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "subscription": {
+            "$ref": "#/components/schemas/WorkspaceSubscriptionRef"
+          },
+          "cluster": {
+            "$ref": "#/components/schemas/WorkspaceClusterRef"
+          },
+          "dnsAddress": {
+            "type": "string"
+          },
+          "publicDnsAddress": {
+            "type": "string"
+          },
+          "sslEnabled": {
+            "type": "boolean"
+          },
+          "throughput": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "defaultUser": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WorkspaceDatabasesResponse": {
+        "type": "object",
+        "properties": {
+          "databases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceDatabaseResponse"
+            }
+          }
+        }
+      },
+      "WorkspaceSubscriptionRef": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "Capabilities": {
+        "type": "object",
+        "properties": {
+          "validateSecrets": {
+            "type": "boolean"
+          },
+          "validatePrivateLink": {
+            "type": "boolean"
+          },
+          "readyForPipeline": {
+            "type": "boolean"
+          }
+        }
+      },
+      "InfrastructureError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "details": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          }
+        }
+      },
+      "InfrastructureIam": {
+        "type": "object",
+        "properties": {
+          "privateLinkAllowedPrincipal": {
+            "type": "string"
+          },
+          "secretsRoleArn": {
+            "type": "string"
+          }
+        }
+      },
+      "InfrastructureResponse": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "NotProvisioned",
+              "Provisioning",
+              "Ready",
+              "Deleting",
+              "Failed"
+            ]
+          },
+          "cidr": {
+            "type": "string"
+          },
+          "timestamps": {
+            "$ref": "#/components/schemas/InfrastructureTimestamps"
+          },
+          "iam": {
+            "$ref": "#/components/schemas/InfrastructureIam"
+          },
+          "networking": {
+            "$ref": "#/components/schemas/NetworkingOutput"
+          },
+          "monitoring": {
+            "$ref": "#/components/schemas/MonitoringOutput"
+          },
+          "error": {
+            "$ref": "#/components/schemas/InfrastructureError"
+          }
+        }
+      },
+      "InfrastructureTimestamps": {
+        "type": "object",
+        "properties": {
+          "startedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MetricsUrls": {
+        "type": "object",
+        "properties": {
+          "rdiProcessorUrl": {
+            "type": "string"
+          },
+          "collectorSourceUrl": {
+            "type": "string"
+          }
+        }
+      },
+      "MonitoringOutput": {
+        "type": "object",
+        "properties": {
+          "metricsUrls": {
+            "$ref": "#/components/schemas/MetricsUrls"
+          }
+        }
+      },
+      "NetworkingOutput": {
+        "type": "object",
+        "properties": {
+          "egressIps": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "availabilityZones": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "WorkspaceResponse": {
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "rcpClusterId": {
+            "type": "string"
+          },
+          "region": {
+            "type": "string"
+          },
+          "vpcId": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "infrastructure": {
+            "$ref": "#/components/schemas/InfrastructureResponse"
+          },
+          "capabilities": {
+            "$ref": "#/components/schemas/Capabilities"
+          }
+        }
+      },
+      "WorkspaceTasksResponse": {
+        "type": "object",
+        "properties": {
+          "tasks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceTaskResponse"
+            }
+          }
+        }
+      },
+      "CidrsInfoResponse": {
+        "type": "object",
+        "properties": {
+          "usedCidrs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "defaultCidr": {
+            "type": "string"
+          },
+          "nextFreeCidr": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateLinkEndpointListResponse": {
+        "type": "object",
+        "properties": {
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PrivateLinkEndpointResponse"
+            }
+          }
+        }
+      },
+      "PrivateLinkEndpointResponse": {
+        "type": "object",
+        "properties": {
+          "endpointId": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "network": {
+            "$ref": "#/components/schemas/PrivateLinkNetwork"
+          },
+          "error": {
+            "$ref": "#/components/schemas/PrivateLinkError"
+          }
+        }
+      },
+      "PrivateLinkError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "PrivateLinkNetwork": {
+        "type": "object",
+        "properties": {
+          "serviceName": {
+            "type": "string"
+          },
+          "vpceId": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "ComposeDraftListResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ComposeDraftSummaryResponse"
+            }
+          }
+        }
+      },
+      "ComposeDraftSourceSummary": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ComposeDraftSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "draftId": {
+            "type": "string"
+          },
+          "targetDataType": {
+            "type": "string",
+            "enum": [
+              "hash",
+              "json"
+            ]
+          },
+          "source": {
+            "$ref": "#/components/schemas/ComposeDraftSourceSummary"
+          }
+        }
+      },
+      "SearchPipeline": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "bdbId": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "SearchPipelinesResponseDto": {
+        "type": "object",
+        "properties": {
+          "pipelines": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchPipeline"
+            }
+          }
+        }
+      },
+      "GetPipelineResponseDto": {
+        "required": [
+          "id",
+          "status"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "pipeline-setup-pending",
+              "pl-initialized",
+              "pl-approval-pending",
+              "pl-failed",
+              "pl-created",
+              "infra-provision-initialized",
+              "infra-provisioned",
+              "infra-provision-failed",
+              "rdi-deploy-initialized",
+              "rdi-deployed",
+              "rdi-deploy-failed",
+              "rdi-healthy",
+              "rdi-health-check-failed",
+              "target-db-connection-test-initialized",
+              "target-db-connection-test-failed",
+              "target-db-connection-test-success",
+              "source-db-connection-test-initialized",
+              "source-db-connection-test-failed",
+              "source-db-connection-test-success",
+              "pipeline-deploy-initialized",
+              "pipeline-deploy-failed",
+              "inactive",
+              "active",
+              "delete-pending",
+              "delete-failed",
+              "delete-success"
+            ]
+          },
+          "error": {
+            "$ref": "#/components/schemas/PipelineError"
+          }
+        }
+      },
+      "PipelineError": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "PipelineRuntimeStatusResponseDto": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "validating",
+              "stopping",
+              "starting",
+              "resetting",
+              "ready",
+              "not-ready",
+              "stopped"
+            ]
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "not-running",
+              "cdc",
+              "initial-sync"
+            ]
+          },
+          "pipelineStatus": {
+            "type": "string",
+            "enum": [
+              "started",
+              "stopped",
+              "error",
+              "creating",
+              "updating",
+              "deleting",
+              "starting",
+              "stopping",
+              "resetting",
+              "pending",
+              "unknown"
+            ]
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PipelineStatusErrorDto"
+            }
+          }
+        }
+      },
+      "PipelineStatusErrorDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "DataStreamDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pending": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "inserted": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "updated": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deleted": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "filtered": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rejected": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deduplicated": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lastArrival": {
+            "type": "string"
+          }
+        }
+      },
+      "PipelineRuntimeStatsResponseDto": {
+        "type": "object",
+        "properties": {
+          "lastRetrieved": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "sourceType": {
+            "type": "string"
+          },
+          "totals": {
+            "$ref": "#/components/schemas/DataStreamDto"
+          },
+          "dataStreams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataStreamDto"
+            }
+          }
+        }
+      },
+      "CidrsInfoDto": {
+        "type": "object",
+        "properties": {
+          "usedCidrs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "defaultCidr": {
+            "type": "string"
+          },
+          "nextFreeCidr": {
+            "type": "string"
+          }
+        }
+      },
+      "GetPipelinePrerequisitesResponseDto": {
+        "type": "object",
+        "properties": {
+          "privateLinkAllowedPrincipal": {
+            "type": "string"
+          },
+          "sourceDbTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TypeResponseDto"
+            }
+          },
+          "targetTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TypeResponseDto"
+            }
+          },
+          "cidrsInfo": {
+            "$ref": "#/components/schemas/CidrsInfoDto"
+          },
+          "pipelineSecretAllowedRole": {
+            "type": "string"
+          }
+        }
+      },
+      "TypeResponseDto": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        }
+      },
+      "PipelineMetricsUrlsResponseDto": {
+        "type": "object",
+        "properties": {
+          "rdiProcessorUrl": {
+            "type": "string"
+          },
+          "collectorSourceUrl": {
+            "type": "string"
+          }
+        }
+      },
+      "SourceSchemasResponseDto": {
+        "type": "object",
+        "properties": {
+          "schemas": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "SchemaDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TableDto"
+            }
+          }
+        }
+      },
+      "SourceMetadataResponseDto": {
+        "type": "object",
+        "properties": {
+          "schemas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SchemaDto"
+            }
+          }
+        }
+      },
+      "TableColumnDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "primaryKey": {
+            "type": "boolean"
+          },
+          "uniqueConstraint": {
+            "type": "boolean"
+          }
+        }
+      },
+      "TableDto": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "cdcReady": {
+            "type": "boolean"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TableColumnDto"
+            }
+          }
+        }
+      },
+      "WorkspacesResponse": {
+        "type": "object",
+        "properties": {
+          "workspaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceResponse"
+            }
+          }
+        }
+      },
+      "BdbPipelinesResponseDto": {
+        "type": "object",
+        "properties": {
+          "pipelineIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "x-api-key": {
+        "type": "apiKey",
+        "name": "x-api-key",
+        "in": "header"
+      },
+      "x-api-secret-key": {
+        "type": "apiKey",
+        "name": "x-api-secret-key",
+        "in": "header"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Redis Cloud Data Integration API reference page backed by the CAPI RDI OpenAPI group
- update the Redis Cloud API sync workflow to fetch explicit capi and rdi grouped specs
- link the new Data Integration API reference from the Redis Cloud REST API landing page

## Jira
https://redislabs.atlassian.net/browse/RDSC-5669

## Validation
- Verified deployed specs from api.redislabs.com: /v1/cloud-api-docs/rdi returns Data Integration Workspace API with 31 paths including /v1/data-integration-workspaces and /v1/subscriptions/{subscriptionId}/data-integration-workspace/rdi/api/v2/pipelines.
- Verified checked-in JSON with jq for title, tags, path count, and key RDI paths.
- Attempted Hugo render with hugo --logLevel warn --gc; it fails on an existing unrelated commands navigation template issue at content/commands/acl-list.md / layouts/commands/single.html.