### PR TITLE
DOC-6794 Rust Bloom filter data type examples

### DIFF
--- a/content/develop/clients/rust/prob.md
+++ b/content/develop/clients/rust/prob.md
@@ -9,7 +9,7 @@ categories:
 - oss
 - kubernetes
 - clients
-description: Learn how to use HyperLogLog approximate cardinality with redis-rs.
+description: Learn how to use Bloom filter set membership and HyperLogLog approximate cardinality with redis-rs.
 linkTitle: Probabilistic data types
 title: Probabilistic data types
 weight: 45
@@ -19,16 +19,40 @@ Redis supports several
 [probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
 that let you calculate values approximately rather than exactly.
 The `redis-rs` high-level command traits include support for
+[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}})
+set membership and
 [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
 cardinality estimation.
 
 {{< note >}}
-This page covers HyperLogLog because `redis-rs` provides high-level
-`pfadd`, `pfcount`, and `pfmerge` methods. Other probabilistic data types,
-such as Bloom filters, Count-min sketch, t-digest, and Top-K, can still be
+This page covers Bloom filters and HyperLogLog because `redis-rs` provides
+dedicated high-level methods for them. Other probabilistic data types,
+such as Cuckoo filters, Count-min sketch, t-digest, and Top-K, can still be
 called with low-level Redis commands, but they don't currently have dedicated
 high-level `redis-rs` methods.
 {{< /note >}}
+
+## Set membership
+
+A [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}})
+lets you track whether or not a particular item has been added to a set.
+Instead of storing the items themselves, like a
+[set]({{< relref "/develop/data-types/sets" >}}), a Bloom filter records the
+presence or absence of the
+[hash value](https://en.wikipedia.org/wiki/Hash_function) of each item. This
+gives a very compact representation of the set's membership with a fixed memory
+size, regardless of how many items you add. Note that there is an asymmetry
+between presence and absence of items in the set: if an item is reported as
+absent, then it is definitely absent, but if it is reported as present, then
+there is a small chance it may really be absent.
+
+The `redis-rs` command traits provide high-level `bf_add`, `bf_madd`,
+`bf_exists`, and `bf_mexists` methods, among others. The following example adds
+some names to a Bloom filter representing a list of users and then checks for
+the presence or absence of users in the list.
+
+{{< clients-example set="home_prob_dts" step="bloom" lang_filter="Rust-Sync,Rust-Async" description="Set membership: Use Bloom filter to efficiently track item presence with minimal memory overhead" difficulty="beginner" >}}
+{{< /clients-example >}}
 
 ## Set cardinality
 

--- a/data/command-api-mapping/BF.ADD.json
+++ b/data/command-api-mapping/BF.ADD.json
@@ -21,6 +21,48 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_add(key: K, value: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "value",
+            "type": "V",
+            "description": "The item to add to the filter"
+          }
+        ],
+        "returns": {
+          "type": "(bool)",
+          "description": "true if the item was newly added, false if it may have existed previously"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_add(key: K, value: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "value",
+            "type": "V",
+            "description": "The item to add to the filter"
+          }
+        ],
+        "returns": {
+          "type": "(bool)",
+          "description": "true if the item was newly added, false if it may have existed previously"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "boolean bfAdd(String key, String item)",

--- a/data/command-api-mapping/BF.CARD.json
+++ b/data/command-api-mapping/BF.CARD.json
@@ -16,6 +16,38 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_card(key: K)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          }
+        ],
+        "returns": {
+          "type": "(usize)",
+          "description": "The number of items reported as added to the filter"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_card(key: K)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          }
+        ],
+        "returns": {
+          "type": "(usize)",
+          "description": "The number of items reported as added to the filter"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "long bfCard(String key)",

--- a/data/command-api-mapping/BF.EXISTS.json
+++ b/data/command-api-mapping/BF.EXISTS.json
@@ -21,6 +21,48 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_exists(key: K, value: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "value",
+            "type": "V",
+            "description": "The item to check for"
+          }
+        ],
+        "returns": {
+          "type": "(bool)",
+          "description": "true if the item may exist, false if it definitely does not"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_exists(key: K, value: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "value",
+            "type": "V",
+            "description": "The item to check for"
+          }
+        ],
+        "returns": {
+          "type": "(bool)",
+          "description": "true if the item may exist, false if it definitely does not"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "boolean bfExists(String key, String item)",

--- a/data/command-api-mapping/BF.INFO.json
+++ b/data/command-api-mapping/BF.INFO.json
@@ -47,7 +47,7 @@
         ],
         "returns": {
           "type": "(BloomFilterInfoTypeResponse)",
-          "description": "The requested information value (derefs to i64)"
+          "description": "The requested information value (derefs to f64)"
         }
       }
     ],
@@ -82,7 +82,7 @@
         ],
         "returns": {
           "type": "(BloomFilterInfoTypeResponse)",
-          "description": "The requested information value (derefs to i64)"
+          "description": "The requested information value (derefs to f64)"
         }
       }
     ],

--- a/data/command-api-mapping/BF.INFO.json
+++ b/data/command-api-mapping/BF.INFO.json
@@ -16,6 +16,76 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_info(key: K)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          }
+        ],
+        "returns": {
+          "type": "(HashMap<String, BloomFilterInfoTypeResponse>)",
+          "description": "A map of all available information about the filter"
+        }
+      },
+      {
+        "signature": "bf_info_type(key: K, info_type: BloomFilterInfoType)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "info_type",
+            "type": "BloomFilterInfoType",
+            "description": "The single piece of information to return"
+          }
+        ],
+        "returns": {
+          "type": "(BloomFilterInfoTypeResponse)",
+          "description": "The requested information value (derefs to i64)"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_info(key: K)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          }
+        ],
+        "returns": {
+          "type": "(HashMap<String, BloomFilterInfoTypeResponse>)",
+          "description": "A map of all available information about the filter"
+        }
+      },
+      {
+        "signature": "bf_info_type(key: K, info_type: BloomFilterInfoType)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "info_type",
+            "type": "BloomFilterInfoType",
+            "description": "The single piece of information to return"
+          }
+        ],
+        "returns": {
+          "type": "(BloomFilterInfoTypeResponse)",
+          "description": "The requested information value (derefs to i64)"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "Map<String, Object> bfInfo(String key)",

--- a/data/command-api-mapping/BF.INSERT.json
+++ b/data/command-api-mapping/BF.INSERT.json
@@ -46,6 +46,96 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_insert(key: K, items: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "V",
+            "description": "The items to add to the filter"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if newly added, false if it may have existed previously"
+        }
+      },
+      {
+        "signature": "bf_insert_options(key: K, items: V, options: BloomFilterInsertOptions)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "V",
+            "description": "The items to add to the filter"
+          },
+          {
+            "name": "options",
+            "type": "BloomFilterInsertOptions",
+            "description": "Capacity, error rate, expansion and creation options for the filter"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if newly added, false if it may have existed previously"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_insert(key: K, items: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "V",
+            "description": "The items to add to the filter"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if newly added, false if it may have existed previously"
+        }
+      },
+      {
+        "signature": "bf_insert_options(key: K, items: V, options: BloomFilterInsertOptions)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "V",
+            "description": "The items to add to the filter"
+          },
+          {
+            "name": "options",
+            "type": "BloomFilterInsertOptions",
+            "description": "Capacity, error rate, expansion and creation options for the filter"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if newly added, false if it may have existed previously"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "List<Boolean> bfInsert(String key, String... items)",

--- a/data/command-api-mapping/BF.LOADCHUNK.json
+++ b/data/command-api-mapping/BF.LOADCHUNK.json
@@ -26,6 +26,48 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_loadchunk(key: K, chunk: BloomFilterDumpChunk)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to restore"
+          },
+          {
+            "name": "chunk",
+            "type": "BloomFilterDumpChunk",
+            "description": "A chunk previously produced by bf_scandump"
+          }
+        ],
+        "returns": {
+          "type": "(())",
+          "description": "Unit on success"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_loadchunk(key: K, chunk: BloomFilterDumpChunk)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to restore"
+          },
+          {
+            "name": "chunk",
+            "type": "BloomFilterDumpChunk",
+            "description": "A chunk previously produced by bf_scandump"
+          }
+        ],
+        "returns": {
+          "type": "(())",
+          "description": "Unit on success"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "String bfLoadChunk(String key, long iterator, byte[] data)",

--- a/data/command-api-mapping/BF.MADD.json
+++ b/data/command-api-mapping/BF.MADD.json
@@ -21,6 +21,48 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_madd(key: K, items: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "V",
+            "description": "The items to add to the filter"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if newly added, false if it may have existed previously"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_madd(key: K, items: V)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "V",
+            "description": "The items to add to the filter"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if newly added, false if it may have existed previously"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "List<Boolean> bfMAdd(String key, String... items)",

--- a/data/command-api-mapping/BF.MEXISTS.json
+++ b/data/command-api-mapping/BF.MEXISTS.json
@@ -21,6 +21,48 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_mexists(key: K, items: &[V])",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "&[V]",
+            "description": "The items to check for"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if it may exist, false if it definitely does not"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_mexists(key: K, items: &[V])",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter"
+          },
+          {
+            "name": "items",
+            "type": "&[V]",
+            "description": "The items to check for"
+          }
+        ],
+        "returns": {
+          "type": "(Vec<bool>)",
+          "description": "For each item, true if it may exist, false if it definitely does not"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "List<Boolean> bfMExists(String key, String... items)",

--- a/data/command-api-mapping/BF.RESERVE.json
+++ b/data/command-api-mapping/BF.RESERVE.json
@@ -70,6 +70,116 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_reserve(key: K, err_rate: f64, capacity: usize)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to create"
+          },
+          {
+            "name": "err_rate",
+            "type": "f64",
+            "description": "The desired false positive rate"
+          },
+          {
+            "name": "capacity",
+            "type": "usize",
+            "description": "The number of items expected in the filter"
+          }
+        ],
+        "returns": {
+          "type": "(())",
+          "description": "Unit on success"
+        }
+      },
+      {
+        "signature": "bf_reserve_options(key: K, err_rate: E, capacity: C, options: BloomFilterScalingOptions)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to create"
+          },
+          {
+            "name": "err_rate",
+            "type": "E",
+            "description": "The desired false positive rate"
+          },
+          {
+            "name": "capacity",
+            "type": "C",
+            "description": "The number of items expected in the filter"
+          },
+          {
+            "name": "options",
+            "type": "BloomFilterScalingOptions",
+            "description": "Expansion rate and non-scaling options"
+          }
+        ],
+        "returns": {
+          "type": "(())",
+          "description": "Unit on success"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_reserve(key: K, err_rate: f64, capacity: usize)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to create"
+          },
+          {
+            "name": "err_rate",
+            "type": "f64",
+            "description": "The desired false positive rate"
+          },
+          {
+            "name": "capacity",
+            "type": "usize",
+            "description": "The number of items expected in the filter"
+          }
+        ],
+        "returns": {
+          "type": "(())",
+          "description": "Unit on success"
+        }
+      },
+      {
+        "signature": "bf_reserve_options(key: K, err_rate: E, capacity: C, options: BloomFilterScalingOptions)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to create"
+          },
+          {
+            "name": "err_rate",
+            "type": "E",
+            "description": "The desired false positive rate"
+          },
+          {
+            "name": "capacity",
+            "type": "C",
+            "description": "The number of items expected in the filter"
+          },
+          {
+            "name": "options",
+            "type": "BloomFilterScalingOptions",
+            "description": "Expansion rate and non-scaling options"
+          }
+        ],
+        "returns": {
+          "type": "(())",
+          "description": "Unit on success"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "String bfReserve(String key, double errorRate, long capacity)",

--- a/data/command-api-mapping/BF.SCANDUMP.json
+++ b/data/command-api-mapping/BF.SCANDUMP.json
@@ -21,6 +21,48 @@
         }
       }
     ],
+    "redis_rs_sync": [
+      {
+        "signature": "bf_scandump(key: K, iterator: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to dump"
+          },
+          {
+            "name": "iterator",
+            "type": "i64",
+            "description": "Iterator value; 0 to start, then the value returned by the previous call"
+          }
+        ],
+        "returns": {
+          "type": "(BloomFilterDumpChunk)",
+          "description": "The next chunk of the filter; an empty chunk signals completion"
+        }
+      }
+    ],
+    "redis_rs_async": [
+      {
+        "signature": "bf_scandump(key: K, iterator: i64)",
+        "params": [
+          {
+            "name": "key",
+            "type": "K",
+            "description": "The name of the Bloom filter to dump"
+          },
+          {
+            "name": "iterator",
+            "type": "i64",
+            "description": "Iterator value; 0 to start, then the value returned by the previous call"
+          }
+        ],
+        "returns": {
+          "type": "(BloomFilterDumpChunk)",
+          "description": "The next chunk of the filter; an empty chunk signals completion"
+        }
+      }
+    ],
     "jedis": [
       {
         "signature": "Map.Entry<Long, byte[]> bfScanDump(String key, long iterator)",

--- a/local_examples/client-specific/rust-async/home_prob_dts.rs
+++ b/local_examples/client-specific/rust-async/home_prob_dts.rs
@@ -19,6 +19,37 @@ mod home_prob_dts_tests {
             }
         };
 
+        // STEP_START bloom
+        // REMOVE_START
+        let _: Result<i32, _> = r.del("recorded_users").await;
+        // REMOVE_END
+        let res1: Vec<bool> = r
+            .bf_madd(
+                "recorded_users",
+                &["andy", "cameron", "david", "michelle"],
+            )
+            .await
+            .expect("Failed to add users to Bloom filter");
+        println!("{res1:?}"); // >>> [true, true, true, true]
+
+        let res2: bool = r
+            .bf_exists("recorded_users", "cameron")
+            .await
+            .expect("Failed to check Bloom filter");
+        println!("{res2}"); // >>> true
+
+        let res3: bool = r
+            .bf_exists("recorded_users", "kaitlyn")
+            .await
+            .expect("Failed to check Bloom filter");
+        println!("{res3}"); // >>> false
+        // STEP_END
+        // REMOVE_START
+        assert_eq!(res1, vec![true, true, true, true]);
+        assert!(res2);
+        assert!(!res3);
+        // REMOVE_END
+
         // STEP_START hyperloglog
         // REMOVE_START
         let _: Result<i32, _> = r.del(&["group:1", "group:2", "both_groups"]).await;

--- a/local_examples/client-specific/rust-sync/home_prob_dts.rs
+++ b/local_examples/client-specific/rust-sync/home_prob_dts.rs
@@ -19,6 +19,34 @@ mod home_prob_dts_tests {
             }
         };
 
+        // STEP_START bloom
+        // REMOVE_START
+        let _: Result<i32, _> = r.del("recorded_users");
+        // REMOVE_END
+        let res1: Vec<bool> = r
+            .bf_madd(
+                "recorded_users",
+                &["andy", "cameron", "david", "michelle"],
+            )
+            .expect("Failed to add users to Bloom filter");
+        println!("{res1:?}"); // >>> [true, true, true, true]
+
+        let res2: bool = r
+            .bf_exists("recorded_users", "cameron")
+            .expect("Failed to check Bloom filter");
+        println!("{res2}"); // >>> true
+
+        let res3: bool = r
+            .bf_exists("recorded_users", "kaitlyn")
+            .expect("Failed to check Bloom filter");
+        println!("{res3}"); // >>> false
+        // STEP_END
+        // REMOVE_START
+        assert_eq!(res1, vec![true, true, true, true]);
+        assert!(res2);
+        assert!(!res3);
+        // REMOVE_END
+
         // STEP_START hyperloglog
         // REMOVE_START
         let _: Result<i32, _> = r.del(&["group:1", "group:2", "both_groups"]);

--- a/local_examples/rust-async/dt-bloom.rs
+++ b/local_examples/rust-async/dt-bloom.rs
@@ -1,0 +1,77 @@
+// EXAMPLE: bf_tutorial
+#[cfg(test)]
+mod bloom_tests {
+    use redis::AsyncCommands;
+
+    #[tokio::test]
+    async fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_multiplexed_async_connection().await {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // REMOVE_START
+        let _: Result<i32, _> = r.del("bikes:models").await;
+        // REMOVE_END
+        // STEP_START bloom
+        let _: () = r
+            .bf_reserve("bikes:models", 0.001, 1_000_000)
+            .await
+            .expect("Failed to reserve Bloom filter");
+        println!("OK"); // >>> OK
+
+        let res1: bool = r
+            .bf_add("bikes:models", "Smoky Mountain Striker")
+            .await
+            .expect("Failed to add item to Bloom filter");
+        println!("{res1}"); // >>> true
+
+        let res2: bool = r
+            .bf_exists("bikes:models", "Smoky Mountain Striker")
+            .await
+            .expect("Failed to check item in Bloom filter");
+        println!("{res2}"); // >>> true
+
+        let res3: Vec<bool> = r
+            .bf_madd(
+                "bikes:models",
+                &[
+                    "Rocky Mountain Racer",
+                    "Cloudy City Cruiser",
+                    "Windy City Wippet",
+                ],
+            )
+            .await
+            .expect("Failed to add items to Bloom filter");
+        println!("{res3:?}"); // >>> [true, true, true]
+
+        let res4: Vec<bool> = r
+            .bf_mexists(
+                "bikes:models",
+                &[
+                    "Rocky Mountain Racer",
+                    "Cloudy City Cruiser",
+                    "Windy City Wippet",
+                ],
+            )
+            .await
+            .expect("Failed to check items in Bloom filter");
+        println!("{res4:?}"); // >>> [true, true, true]
+        // STEP_END
+        // REMOVE_START
+        assert!(res1);
+        assert!(res2);
+        assert_eq!(res3, vec![true, true, true]);
+        assert_eq!(res4, vec![true, true, true]);
+        // REMOVE_END
+    }
+}

--- a/local_examples/rust-sync/dt-bloom.rs
+++ b/local_examples/rust-sync/dt-bloom.rs
@@ -1,0 +1,72 @@
+// EXAMPLE: bf_tutorial
+#[cfg(test)]
+mod bloom_tests {
+    use redis::Commands;
+
+    #[test]
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        // REMOVE_START
+        let _: Result<i32, _> = r.del("bikes:models");
+        // REMOVE_END
+        // STEP_START bloom
+        let _: () = r
+            .bf_reserve("bikes:models", 0.001, 1_000_000)
+            .expect("Failed to reserve Bloom filter");
+        println!("OK"); // >>> OK
+
+        let res1: bool = r
+            .bf_add("bikes:models", "Smoky Mountain Striker")
+            .expect("Failed to add item to Bloom filter");
+        println!("{res1}"); // >>> true
+
+        let res2: bool = r
+            .bf_exists("bikes:models", "Smoky Mountain Striker")
+            .expect("Failed to check item in Bloom filter");
+        println!("{res2}"); // >>> true
+
+        let res3: Vec<bool> = r
+            .bf_madd(
+                "bikes:models",
+                &[
+                    "Rocky Mountain Racer",
+                    "Cloudy City Cruiser",
+                    "Windy City Wippet",
+                ],
+            )
+            .expect("Failed to add items to Bloom filter");
+        println!("{res3:?}"); // >>> [true, true, true]
+
+        let res4: Vec<bool> = r
+            .bf_mexists(
+                "bikes:models",
+                &[
+                    "Rocky Mountain Racer",
+                    "Cloudy City Cruiser",
+                    "Windy City Wippet",
+                ],
+            )
+            .expect("Failed to check items in Bloom filter");
+        println!("{res4:?}"); // >>> [true, true, true]
+        // STEP_END
+        // REMOVE_START
+        assert!(res1);
+        assert!(res2);
+        assert_eq!(res3, vec![true, true, true]);
+        assert_eq!(res4, vec![true, true, true]);
+        // REMOVE_END
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example metadata only; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds **Rust client coverage** for Redis Bloom filter (`BF.*`) commands in the command API mapping data, for both **`redis_rs_sync`** and **`redis_rs_async`**, including the aggregated `command-api-mapping.json` and per-command files (`BF.ADD`, `BF.CARD`, `BF.EXISTS`, `BF.INFO`, `BF.INSERT`, `BF.LOADCHUNK`, `BF.MADD`, `BF.MEXISTS`, `BF.RESERVE`, `BF.SCANDUMP`). Signatures document typed Rust returns (e.g. `bool`, `Vec<bool>`, `BloomFilterDumpChunk`) and option helpers where applicable (`bf_reserve_options`, `bf_insert_options`, `bf_info_type`).
> 
> Introduces **`local_examples/rust-sync/dt-bloom.rs`** and **`local_examples/rust-async/dt-bloom.rs`** as the `bf_tutorial` / `bloom` step examples, mirroring the existing bike-models reserve/add/exists/madd/mexists flow for published docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57edf3cf92b82251398a3beeb9769a7172ec6fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->