### PR TITLE
DEV: (cmds) update XREAD & XREADGROUP command pages

### DIFF
--- a/content/commands/xread.md
+++ b/content/commands/xread.md
@@ -10,6 +10,18 @@ arguments:
   optional: true
   token: COUNT
   type: integer
+- display_text: maxcount
+  name: maxcount
+  optional: true
+  since: 8.10.0
+  token: MAXCOUNT
+  type: integer
+- display_text: maxsize
+  name: maxsize
+  optional: true
+  since: 8.10.0
+  token: MAXSIZE
+  type: integer
 - display_text: milliseconds
   name: milliseconds
   optional: true
@@ -44,13 +56,17 @@ command_flags:
 - blocking
 - movablekeys
 complexity: 'For each stream mentioned: O(M) with M being the number of elements returned.
-  If M is constant (for example, always asking for the first 10 elements with COUNT), you
-  can consider it O(1). On the other side when XREADGROUP blocks, XADD will pay the
-  O(N) time in order to serve the N clients blocked on the stream getting new data.'
+  If M is constant (for example, always asking for the first 10 elements with COUNT),
+  you can consider it O(1). On the other side when XREADGROUP blocks, XADD will pay
+  the O(N) time in order to serve the N clients blocked on the stream getting new
+  data.'
 description: Returns messages from multiple streams with IDs greater than the ones
   requested. Blocks until a message is available otherwise.
 group: stream
 hidden: false
+history:
+- - 8.10.0
+  - Added the `MAXCOUNT` and `MAXSIZE` options.
 key_specs:
 - RO: true
   access: true
@@ -70,8 +86,8 @@ railroad_diagram: /images/railroad/xread.svg
 since: 5.0.0
 summary: Returns messages from multiple streams with IDs greater than the ones requested.
   Blocks until a message is available otherwise.
-syntax_fmt: "XREAD [COUNT\_count] [BLOCK\_milliseconds] STREAMS\_key [key ...] id\n\
-  \  [id ...]"
+syntax_fmt: "XREAD [COUNT\_count] [MAXCOUNT\_maxcount] [MAXSIZE\_maxsize]\n  [BLOCK\_\
+  milliseconds] STREAMS\_key [key ...] id [id ...]"
 title: XREAD
 ---
 {{< note >}}
@@ -99,6 +115,18 @@ The keys to read from, followed by an ID for each key. For each stream, entries 
 <details open><summary><code>COUNT count</code></summary>
 
 The maximum number of entries to return per stream.
+
+</details>
+
+<details open><summary><code>MAXCOUNT maxcount</code></summary>
+
+Added in Redis 8.10. The maximum number of entries to return in total across all streams named in the command. Unlike `COUNT`, which limits entries on a per-stream basis, `MAXCOUNT` applies a single cumulative budget for the whole command. It must be a positive integer, and it must be greater than or equal to `COUNT` when both are given. When `COUNT` is omitted, `MAXCOUNT` alone bounds the total. See [The MAXCOUNT and MAXSIZE options](#the-maxcount-and-maxsize-options) for details.
+
+</details>
+
+<details open><summary><code>MAXSIZE maxsize</code></summary>
+
+Added in Redis 8.10. The maximum size, in bytes, of the reply across all streams named in the command. It must be a positive integer. At least one entry is always returned, so a single entry larger than `MAXSIZE` is still returned rather than yielding an empty reply. See [The MAXCOUNT and MAXSIZE options](#the-maxcount-and-maxsize-options) for details.
 
 </details>
 
@@ -130,7 +158,7 @@ For example, if I have two streams `mystream` and `writers`, and I want to
 read data from both the streams starting from the first element they contain,
 I could call `XREAD` like in the following example.
 
-Note: we use the **COUNT** option in the example, so that for each stream
+Note: we use the `COUNT` option in the example, so that for each stream
 the call will return at maximum two elements per stream.
 
 ```
@@ -302,8 +330,58 @@ This requests the last available entry in a stream. For example:
 > XREAD STREAMS streamA streamB streamC streamD + + + +
 ```
 
-Note that when using this special ID for a stream, the **COUNT** option will
+Note that when using this special ID for a stream, the `COUNT` option will
 be ignored (for the specific stream) since only the last entry can be returned.
+
+### The MAXCOUNT and MAXSIZE options
+
+Added in Redis 8.10, the `MAXCOUNT` and `MAXSIZE` options cap the *cumulative*
+reply across all streams named in a single command. This is different from
+`COUNT`, which limits the number of entries returned on a *per-stream* basis.
+Because `XREAD` accepts multiple streams in one call, a read over N streams with
+`COUNT C` can return up to `N * C` entries, and the total reply size is otherwise
+unbounded. `MAXCOUNT` and `MAXSIZE` give clients a reliable way to bound the
+work and memory of a single multi-stream read.
+
+* `MAXCOUNT` caps the total number of entries returned across all streams. It
+  must be a positive integer, and it must be greater than or equal to `COUNT`
+  when both are given (since it is a cumulative cap over a per-stream limit).
+  When `COUNT` is omitted, `MAXCOUNT` alone bounds the total, filling from
+  the first stream onward.
+* `MAXSIZE` caps the total reply size in bytes. It must be a positive integer.
+* At least one entry is always returned. The byte budget is never enforced
+  until at least one entry has been emitted across the whole reply, so a single
+  entry larger than `MAXSIZE` is still returned rather than yielding an empty
+  reply.
+* When both options are given, whichever bound is reached first wins.
+
+Given three streams, each with 100 entries:
+
+```
+> XREAD COUNT 50 STREAMS s1 s2 s3 0 0 0
+# returns 150 entries total (50 per stream)
+
+> XREAD COUNT 50 MAXCOUNT 80 STREAMS s1 s2 s3 0 0 0
+# returns 80 entries total — capped across all streams
+
+> XREAD MAXCOUNT 7 STREAMS s1 s2 s3 0 0 0
+# returns 7 entries total, all from s1
+
+> XREAD MAXCOUNT 5 MAXSIZE 100000 STREAMS s1 s2 s3 0 0 0
+# returns 5 entries (MAXCOUNT is the tighter bound)
+```
+
+A single oversized entry is always returned, even when it exceeds `MAXSIZE`:
+
+```
+> XADD bigstream 1-1 f <5000-byte value>
+> XREAD MAXSIZE 50 STREAMS bigstream 0
+1) 1) "bigstream"
+   2) 1) 1) "1-1"
+         2) 1) "f"
+            2) "<5000-byte value>"
+# the single entry exceeds MAXSIZE but is still returned
+```
 
 ### How multiple clients blocked on a single stream are served
 

--- a/content/commands/xreadgroup.md
+++ b/content/commands/xreadgroup.md
@@ -20,6 +20,18 @@ arguments:
   optional: true
   token: COUNT
   type: integer
+- display_text: maxcount
+  name: maxcount
+  optional: true
+  since: 8.10.0
+  token: MAXCOUNT
+  type: integer
+- display_text: maxsize
+  name: maxsize
+  optional: true
+  since: 8.10.0
+  token: MAXSIZE
+  type: integer
 - display_text: milliseconds
   name: milliseconds
   optional: true
@@ -28,6 +40,7 @@ arguments:
 - display_text: min-idle-time
   name: min-idle-time
   optional: true
+  since: 8.4.0
   token: CLAIM
   type: integer
 - display_text: noack
@@ -71,6 +84,11 @@ description: Returns new or historical messages from a stream for a consumer in 
   group. Blocks until a message is available otherwise.
 group: stream
 hidden: false
+history:
+- - 8.4.0
+  - Added the `CLAIM` option.
+- - 8.10.0
+  - Added the `MAXCOUNT` and `MAXSIZE` options.
 key_specs:
 - RO: true
   access: true
@@ -90,8 +108,9 @@ railroad_diagram: /images/railroad/xreadgroup.svg
 since: 5.0.0
 summary: Returns new or historical messages from a stream for a consumer in a group.
   Blocks until a message is available otherwise.
-syntax_fmt: "XREADGROUP GROUP\_group consumer [COUNT\_count] [BLOCK\_milliseconds]\n\
-  \  [CLAIM\_min-idle-time] [NOACK] STREAMS\_key [key ...] id [id ...]"
+syntax_fmt: "XREADGROUP GROUP\_group consumer [COUNT\_count] [MAXCOUNT\_maxcount]\n\
+  \  [MAXSIZE\_maxsize] [BLOCK\_milliseconds] [CLAIM\_min-idle-time]\n  [NOACK] STREAMS\_\
+  key [key ...] id [id ...]"
 title: XREADGROUP
 ---
 {{< note >}}
@@ -126,6 +145,18 @@ The keys to read from, followed by an ID for each key. Use `>` to read messages 
 <details open><summary><code>COUNT count</code></summary>
 
 The maximum number of entries to return per stream.
+
+</details>
+
+<details open><summary><code>MAXCOUNT maxcount</code></summary>
+
+Added in Redis 8.10. The maximum number of entries to return in total across all streams named in the command. Unlike `COUNT`, which limits entries on a per-stream basis, `MAXCOUNT` applies a single cumulative budget for the whole command. It must be a positive integer, and it must be greater than or equal to `COUNT` when both are given. When `COUNT` is omitted, `MAXCOUNT` alone bounds the total. It works for both new (`>`) reads and history/pending entries list (PEL) reads. See [The MAXCOUNT and MAXSIZE options](#the-maxcount-and-maxsize-options) for details.
+
+</details>
+
+<details open><summary><code>MAXSIZE maxsize</code></summary>
+
+Added in Redis 8.10. The maximum size, in bytes, of the reply across all streams named in the command. It must be a positive integer. At least one entry is always returned, so a single entry larger than `MAXSIZE` is still returned rather than yielding an empty reply. For `MAXSIZE`, the limit is checked before delivering the next new or PEL entry, so a skipped entry is neither sent nor added to the consumer's PEL. See [The MAXCOUNT and MAXSIZE options](#the-maxcount-and-maxsize-options) for details.
 
 </details>
 
@@ -237,6 +268,47 @@ When using `CLAIM`, the following ordering guarantees apply per stream:
 For example, if there are 20 idle pending entries and 200 incoming entries (in all the specified streams together):
 - When calling `XREADGROUP ... CLAIM ...`, you would retrieve 220 entries in the reply
 - When calling `XREADGROUP ... COUNT 100 ... CLAIM ...`, you would retrieve the 20 idle pending entries + 80 incoming entries in the reply
+
+### The MAXCOUNT and MAXSIZE options
+
+Added in Redis 8.10, the `MAXCOUNT` and `MAXSIZE` options cap the *cumulative*
+reply across all streams named in a single command. This is different from
+`COUNT`, which limits the number of entries returned on a *per-stream* basis.
+Because `XREADGROUP` accepts multiple streams in one call, a read over N streams
+with `COUNT C` can return up to `N * C` entries, and the total reply size is
+otherwise unbounded. `MAXCOUNT` and `MAXSIZE` give clients a reliable way to
+bound the work and memory of a single multi-stream read.
+
+* `MAXCOUNT` caps the total number of entries returned across all streams. It
+  must be a positive integer, and it must be greater than or equal to `COUNT`
+  when both are given (since it is a cumulative cap over a per-stream limit).
+  When `COUNT` is omitted, `MAXCOUNT` alone bounds the total, filling from
+  the first stream onward.
+* `MAXSIZE` caps the total reply size in bytes. It must be a positive integer.
+* At least one entry is always returned. The byte budget is never enforced
+  until at least one entry has been emitted across the whole reply, so a single
+  entry larger than `MAXSIZE` is still returned rather than yielding an empty
+  reply.
+* When both options are given, whichever bound is reached first wins.
+
+Both caps apply to new (`>`) reads and to history/PEL reads, and they are honored
+after a blocking client is unblocked. For `MAXSIZE`, the limit is checked
+*before* delivering the next new or PEL entry, so a skipped entry is neither sent
+nor added to the consumer's PEL.
+
+Given three streams, each with 100 entries that the consumer reads as new
+messages:
+
+```
+> XREADGROUP GROUP g c COUNT 50 STREAMS s1 s2 s3 > > >
+# returns 150 entries total (50 per stream)
+
+> XREADGROUP GROUP g c COUNT 50 MAXCOUNT 80 STREAMS s1 s2 s3 > > >
+# returns 80 entries total — capped across all streams
+
+> XREADGROUP GROUP g c MAXCOUNT 5 MAXSIZE 100000 STREAMS s1 s2 s3 > > >
+# returns 5 entries (MAXCOUNT is the tighter bound)
+```
 
 ### What happens when a message is delivered to a consumer?
 

--- a/static/images/railroad/xread.svg
+++ b/static/images/railroad/xread.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="80" viewBox="0 0 854.0 80" width="854.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="80" viewBox="0 0 1309.0 80" width="1309.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,23 +44,33 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
-<path d="M50 40h0.0"></path><path d="M804.0 40h0.0"></path><g class="terminal ">
+<path d="M50 40h0.0"></path><path d="M1259.0 40h0.0"></path><g class="terminal ">
 <path d="M50.0 40h0.0"></path><path d="M112.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="50.0" y="29"></rect><text x="81.25" y="44">XREAD</text></g><path d="M112.5 40h10"></path><g>
 <path d="M122.5 40h0.0"></path><path d="M307.5 40h0.0"></path><path d="M122.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
 <path d="M142.5 20h145.0"></path></g><path d="M287.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M122.5 40h20"></path><g>
 <path d="M142.5 40h0.0"></path><path d="M287.5 40h0.0"></path><g class="terminal ">
 <path d="M142.5 40h0.0"></path><path d="M205.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="142.5" y="29"></rect><text x="173.75" y="44">COUNT</text></g><path d="M205.0 40h10"></path><path d="M215.0 40h10"></path><g class="non-terminal ">
 <path d="M225.0 40h0.0"></path><path d="M287.5 40h0.0"></path><rect height="22" width="62.5" x="225.0" y="29"></rect><text x="256.25" y="44">count</text></g></g><path d="M287.5 40h20"></path></g><g>
-<path d="M307.5 40h0.0"></path><path d="M552.0 40h0.0"></path><path d="M307.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M327.5 20h204.5"></path></g><path d="M532.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M307.5 40h20"></path><g>
-<path d="M327.5 40h0.0"></path><path d="M532.0 40h0.0"></path><g class="terminal ">
-<path d="M327.5 40h0.0"></path><path d="M390.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="327.5" y="29"></rect><text x="358.75" y="44">BLOCK</text></g><path d="M390.0 40h10"></path><path d="M400.0 40h10"></path><g class="non-terminal ">
-<path d="M410.0 40h0.0"></path><path d="M532.0 40h0.0"></path><rect height="22" width="122.0" x="410.0" y="29"></rect><text x="471.0" y="44">milliseconds</text></g></g><path d="M532.0 40h20"></path></g><path d="M552.0 40h10"></path><g>
-<path d="M562.0 40h0.0"></path><path d="M804.0 40h0.0"></path><g class="terminal ">
-<path d="M562.0 40h0.0"></path><path d="M641.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="562.0" y="29"></rect><text x="601.75" y="44">STREAMS</text></g><path d="M641.5 40h10"></path><path d="M651.5 40h10"></path><g>
-<path d="M661.5 40h0.0"></path><path d="M727.0 40h0.0"></path><path d="M661.5 40h10"></path><g class="non-terminal ">
-<path d="M671.5 40h0.0"></path><path d="M717.0 40h0.0"></path><rect height="22" width="45.5" x="671.5" y="29"></rect><text x="694.25" y="44">key</text></g><path d="M717.0 40h10"></path><path d="M671.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M671.5 60h45.5"></path></g><path d="M717.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M727.0 40h10"></path><path d="M737.0 40h10"></path><g>
-<path d="M747.0 40h0.0"></path><path d="M804.0 40h0.0"></path><path d="M747.0 40h10"></path><g class="non-terminal ">
-<path d="M757.0 40h0.0"></path><path d="M794.0 40h0.0"></path><rect height="22" width="37.0" x="757.0" y="29"></rect><text x="775.5" y="44">id</text></g><path d="M794.0 40h10"></path><path d="M757.0 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M757.0 60h37.0"></path></g><path d="M794.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g></g><path d="M804.0 40h10"></path><path d="M 814.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M307.5 40h0.0"></path><path d="M543.5 40h0.0"></path><path d="M307.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M327.5 20h196.0"></path></g><path d="M523.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M307.5 40h20"></path><g>
+<path d="M327.5 40h0.0"></path><path d="M523.5 40h0.0"></path><g class="terminal ">
+<path d="M327.5 40h0.0"></path><path d="M415.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="327.5" y="29"></rect><text x="371.5" y="44">MAXCOUNT</text></g><path d="M415.5 40h10"></path><path d="M425.5 40h10"></path><g class="non-terminal ">
+<path d="M435.5 40h0.0"></path><path d="M523.5 40h0.0"></path><rect height="22" width="88.0" x="435.5" y="29"></rect><text x="479.5" y="44">maxcount</text></g></g><path d="M523.5 40h20"></path></g><g>
+<path d="M543.5 40h0.0"></path><path d="M762.5 40h0.0"></path><path d="M543.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M563.5 20h179.0"></path></g><path d="M742.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M543.5 40h20"></path><g>
+<path d="M563.5 40h0.0"></path><path d="M742.5 40h0.0"></path><g class="terminal ">
+<path d="M563.5 40h0.0"></path><path d="M643.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="563.5" y="29"></rect><text x="603.25" y="44">MAXSIZE</text></g><path d="M643.0 40h10"></path><path d="M653.0 40h10"></path><g class="non-terminal ">
+<path d="M663.0 40h0.0"></path><path d="M742.5 40h0.0"></path><rect height="22" width="79.5" x="663.0" y="29"></rect><text x="702.75" y="44">maxsize</text></g></g><path d="M742.5 40h20"></path></g><g>
+<path d="M762.5 40h0.0"></path><path d="M1007.0 40h0.0"></path><path d="M762.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M782.5 20h204.5"></path></g><path d="M987.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M762.5 40h20"></path><g>
+<path d="M782.5 40h0.0"></path><path d="M987.0 40h0.0"></path><g class="terminal ">
+<path d="M782.5 40h0.0"></path><path d="M845.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="782.5" y="29"></rect><text x="813.75" y="44">BLOCK</text></g><path d="M845.0 40h10"></path><path d="M855.0 40h10"></path><g class="non-terminal ">
+<path d="M865.0 40h0.0"></path><path d="M987.0 40h0.0"></path><rect height="22" width="122.0" x="865.0" y="29"></rect><text x="926.0" y="44">milliseconds</text></g></g><path d="M987.0 40h20"></path></g><path d="M1007.0 40h10"></path><g>
+<path d="M1017.0 40h0.0"></path><path d="M1259.0 40h0.0"></path><g class="terminal ">
+<path d="M1017.0 40h0.0"></path><path d="M1096.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="1017.0" y="29"></rect><text x="1056.75" y="44">STREAMS</text></g><path d="M1096.5 40h10"></path><path d="M1106.5 40h10"></path><g>
+<path d="M1116.5 40h0.0"></path><path d="M1182.0 40h0.0"></path><path d="M1116.5 40h10"></path><g class="non-terminal ">
+<path d="M1126.5 40h0.0"></path><path d="M1172.0 40h0.0"></path><rect height="22" width="45.5" x="1126.5" y="29"></rect><text x="1149.25" y="44">key</text></g><path d="M1172.0 40h10"></path><path d="M1126.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M1126.5 60h45.5"></path></g><path d="M1172.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M1182.0 40h10"></path><path d="M1192.0 40h10"></path><g>
+<path d="M1202.0 40h0.0"></path><path d="M1259.0 40h0.0"></path><path d="M1202.0 40h10"></path><g class="non-terminal ">
+<path d="M1212.0 40h0.0"></path><path d="M1249.0 40h0.0"></path><rect height="22" width="37.0" x="1212.0" y="29"></rect><text x="1230.5" y="44">id</text></g><path d="M1249.0 40h10"></path><path d="M1212.0 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M1212.0 60h37.0"></path></g><path d="M1249.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g></g><path d="M1259.0 40h10"></path><path d="M 1269.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/xreadgroup.svg
+++ b/static/images/railroad/xreadgroup.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="80" viewBox="0 0 1525.0 80" width="1525.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="80" viewBox="0 0 1980.0 80" width="1980.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,7 +44,7 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
-<path d="M50 40h0.0"></path><path d="M1475.0 40h0.0"></path><g class="terminal ">
+<path d="M50 40h0.0"></path><path d="M1930.0 40h0.0"></path><g class="terminal ">
 <path d="M50.0 40h0.0"></path><path d="M155.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="105.0" x="50.0" y="29"></rect><text x="102.5" y="44">XREADGROUP</text></g><path d="M155.0 40h10"></path><path d="M165.0 40h10"></path><g>
 <path d="M175.0 40h0.0"></path><path d="M428.0 40h0.0"></path><g class="terminal ">
 <path d="M175.0 40h0.0"></path><path d="M237.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="175.0" y="29"></rect><text x="206.25" y="44">GROUP</text></g><path d="M237.5 40h10"></path><path d="M247.5 40h10"></path><g class="non-terminal ">
@@ -55,24 +55,34 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 <path d="M458.0 40h0.0"></path><path d="M603.0 40h0.0"></path><g class="terminal ">
 <path d="M458.0 40h0.0"></path><path d="M520.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="458.0" y="29"></rect><text x="489.25" y="44">COUNT</text></g><path d="M520.5 40h10"></path><path d="M530.5 40h10"></path><g class="non-terminal ">
 <path d="M540.5 40h0.0"></path><path d="M603.0 40h0.0"></path><rect height="22" width="62.5" x="540.5" y="29"></rect><text x="571.75" y="44">count</text></g></g><path d="M603.0 40h20"></path></g><g>
-<path d="M623.0 40h0.0"></path><path d="M867.5 40h0.0"></path><path d="M623.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M643.0 20h204.5"></path></g><path d="M847.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M623.0 40h20"></path><g>
-<path d="M643.0 40h0.0"></path><path d="M847.5 40h0.0"></path><g class="terminal ">
-<path d="M643.0 40h0.0"></path><path d="M705.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="643.0" y="29"></rect><text x="674.25" y="44">BLOCK</text></g><path d="M705.5 40h10"></path><path d="M715.5 40h10"></path><g class="non-terminal ">
-<path d="M725.5 40h0.0"></path><path d="M847.5 40h0.0"></path><rect height="22" width="122.0" x="725.5" y="29"></rect><text x="786.5" y="44">milliseconds</text></g></g><path d="M847.5 40h20"></path></g><g>
-<path d="M867.5 40h0.0"></path><path d="M1120.5 40h0.0"></path><path d="M867.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M887.5 20h213.0"></path></g><path d="M1100.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M867.5 40h20"></path><g>
-<path d="M887.5 40h0.0"></path><path d="M1100.5 40h0.0"></path><g class="terminal ">
-<path d="M887.5 40h0.0"></path><path d="M950.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="887.5" y="29"></rect><text x="918.75" y="44">CLAIM</text></g><path d="M950.0 40h10"></path><path d="M960.0 40h10"></path><g class="non-terminal ">
-<path d="M970.0 40h0.0"></path><path d="M1100.5 40h0.0"></path><rect height="22" width="130.5" x="970.0" y="29"></rect><text x="1035.25" y="44">min-idle-time</text></g></g><path d="M1100.5 40h20"></path></g><g>
-<path d="M1120.5 40h0.0"></path><path d="M1223.0 40h0.0"></path><path d="M1120.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1140.5 20h62.5"></path></g><path d="M1203.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1120.5 40h20"></path><g class="terminal ">
-<path d="M1140.5 40h0.0"></path><path d="M1203.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1140.5" y="29"></rect><text x="1171.75" y="44">NOACK</text></g><path d="M1203.0 40h20"></path></g><path d="M1223.0 40h10"></path><g>
-<path d="M1233.0 40h0.0"></path><path d="M1475.0 40h0.0"></path><g class="terminal ">
-<path d="M1233.0 40h0.0"></path><path d="M1312.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="1233.0" y="29"></rect><text x="1272.75" y="44">STREAMS</text></g><path d="M1312.5 40h10"></path><path d="M1322.5 40h10"></path><g>
-<path d="M1332.5 40h0.0"></path><path d="M1398.0 40h0.0"></path><path d="M1332.5 40h10"></path><g class="non-terminal ">
-<path d="M1342.5 40h0.0"></path><path d="M1388.0 40h0.0"></path><rect height="22" width="45.5" x="1342.5" y="29"></rect><text x="1365.25" y="44">key</text></g><path d="M1388.0 40h10"></path><path d="M1342.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M1342.5 60h45.5"></path></g><path d="M1388.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M1398.0 40h10"></path><path d="M1408.0 40h10"></path><g>
-<path d="M1418.0 40h0.0"></path><path d="M1475.0 40h0.0"></path><path d="M1418.0 40h10"></path><g class="non-terminal ">
-<path d="M1428.0 40h0.0"></path><path d="M1465.0 40h0.0"></path><rect height="22" width="37.0" x="1428.0" y="29"></rect><text x="1446.5" y="44">id</text></g><path d="M1465.0 40h10"></path><path d="M1428.0 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M1428.0 60h37.0"></path></g><path d="M1465.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g></g><path d="M1475.0 40h10"></path><path d="M 1485.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M623.0 40h0.0"></path><path d="M859.0 40h0.0"></path><path d="M623.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M643.0 20h196.0"></path></g><path d="M839.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M623.0 40h20"></path><g>
+<path d="M643.0 40h0.0"></path><path d="M839.0 40h0.0"></path><g class="terminal ">
+<path d="M643.0 40h0.0"></path><path d="M731.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="643.0" y="29"></rect><text x="687.0" y="44">MAXCOUNT</text></g><path d="M731.0 40h10"></path><path d="M741.0 40h10"></path><g class="non-terminal ">
+<path d="M751.0 40h0.0"></path><path d="M839.0 40h0.0"></path><rect height="22" width="88.0" x="751.0" y="29"></rect><text x="795.0" y="44">maxcount</text></g></g><path d="M839.0 40h20"></path></g><g>
+<path d="M859.0 40h0.0"></path><path d="M1078.0 40h0.0"></path><path d="M859.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M879.0 20h179.0"></path></g><path d="M1058.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M859.0 40h20"></path><g>
+<path d="M879.0 40h0.0"></path><path d="M1058.0 40h0.0"></path><g class="terminal ">
+<path d="M879.0 40h0.0"></path><path d="M958.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="879.0" y="29"></rect><text x="918.75" y="44">MAXSIZE</text></g><path d="M958.5 40h10"></path><path d="M968.5 40h10"></path><g class="non-terminal ">
+<path d="M978.5 40h0.0"></path><path d="M1058.0 40h0.0"></path><rect height="22" width="79.5" x="978.5" y="29"></rect><text x="1018.25" y="44">maxsize</text></g></g><path d="M1058.0 40h20"></path></g><g>
+<path d="M1078.0 40h0.0"></path><path d="M1322.5 40h0.0"></path><path d="M1078.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1098.0 20h204.5"></path></g><path d="M1302.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1078.0 40h20"></path><g>
+<path d="M1098.0 40h0.0"></path><path d="M1302.5 40h0.0"></path><g class="terminal ">
+<path d="M1098.0 40h0.0"></path><path d="M1160.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1098.0" y="29"></rect><text x="1129.25" y="44">BLOCK</text></g><path d="M1160.5 40h10"></path><path d="M1170.5 40h10"></path><g class="non-terminal ">
+<path d="M1180.5 40h0.0"></path><path d="M1302.5 40h0.0"></path><rect height="22" width="122.0" x="1180.5" y="29"></rect><text x="1241.5" y="44">milliseconds</text></g></g><path d="M1302.5 40h20"></path></g><g>
+<path d="M1322.5 40h0.0"></path><path d="M1575.5 40h0.0"></path><path d="M1322.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1342.5 20h213.0"></path></g><path d="M1555.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1322.5 40h20"></path><g>
+<path d="M1342.5 40h0.0"></path><path d="M1555.5 40h0.0"></path><g class="terminal ">
+<path d="M1342.5 40h0.0"></path><path d="M1405.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1342.5" y="29"></rect><text x="1373.75" y="44">CLAIM</text></g><path d="M1405.0 40h10"></path><path d="M1415.0 40h10"></path><g class="non-terminal ">
+<path d="M1425.0 40h0.0"></path><path d="M1555.5 40h0.0"></path><rect height="22" width="130.5" x="1425.0" y="29"></rect><text x="1490.25" y="44">min-idle-time</text></g></g><path d="M1555.5 40h20"></path></g><g>
+<path d="M1575.5 40h0.0"></path><path d="M1678.0 40h0.0"></path><path d="M1575.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1595.5 20h62.5"></path></g><path d="M1658.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1575.5 40h20"></path><g class="terminal ">
+<path d="M1595.5 40h0.0"></path><path d="M1658.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1595.5" y="29"></rect><text x="1626.75" y="44">NOACK</text></g><path d="M1658.0 40h20"></path></g><path d="M1678.0 40h10"></path><g>
+<path d="M1688.0 40h0.0"></path><path d="M1930.0 40h0.0"></path><g class="terminal ">
+<path d="M1688.0 40h0.0"></path><path d="M1767.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="1688.0" y="29"></rect><text x="1727.75" y="44">STREAMS</text></g><path d="M1767.5 40h10"></path><path d="M1777.5 40h10"></path><g>
+<path d="M1787.5 40h0.0"></path><path d="M1853.0 40h0.0"></path><path d="M1787.5 40h10"></path><g class="non-terminal ">
+<path d="M1797.5 40h0.0"></path><path d="M1843.0 40h0.0"></path><rect height="22" width="45.5" x="1797.5" y="29"></rect><text x="1820.25" y="44">key</text></g><path d="M1843.0 40h10"></path><path d="M1797.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M1797.5 60h45.5"></path></g><path d="M1843.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g><path d="M1853.0 40h10"></path><path d="M1863.0 40h10"></path><g>
+<path d="M1873.0 40h0.0"></path><path d="M1930.0 40h0.0"></path><path d="M1873.0 40h10"></path><g class="non-terminal ">
+<path d="M1883.0 40h0.0"></path><path d="M1920.0 40h0.0"></path><rect height="22" width="37.0" x="1883.0" y="29"></rect><text x="1901.5" y="44">id</text></g><path d="M1920.0 40h10"></path><path d="M1883.0 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M1883.0 60h37.0"></path></g><path d="M1920.0 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g></g><path d="M1930.0 40h10"></path><path d="M 1940.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

Add the `MAXCOUNT` and `MAXSIZE` optional arguments to the `XREAD` and `XREADGROUP` command pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static SVG updates only; no runtime or application code changes.
> 
> **Overview**
> Documents **Redis 8.10** optional **`MAXCOUNT`** and **`MAXSIZE`** on **`XREAD`** and **`XREADGROUP`**, including front matter (`arguments`, `syntax_fmt`, `history`), optional-argument sections, and new **“The MAXCOUNT and MAXSIZE options”** prose with examples (cumulative caps vs per-stream **`COUNT`**, interaction when both are set, minimum one entry, oversized-entry behavior).
> 
> **`XREADGROUP`** also records **`CLAIM`** in **`history`** with **`since: 8.4.0`** on that argument. Railroad SVGs for both commands are widened to show the new optional tokens. Minor formatting tweaks (e.g. **`COUNT`** in backticks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643679a87e5c8d3c25d06fa553a1082cc4595304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->