### PR TITLE
RS: Updated remaining mentions of Redis Search's previous names

### DIFF
--- a/content/embeds/rs-8-enabled-modules.md
+++ b/content/embeds/rs-8-enabled-modules.md
@@ -1,7 +1,7 @@
 | Database type | Automatically enabled capabilities |
 |---------------|------------------------------------|
-| RAM-only | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<br />[Time series]({{<relref "/operate/oss_and_stack/stack-with-enterprise/timeseries">}})<br />[Probabilistic]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}})  |
+| RAM-only | [Redis Search]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<br />[Time series]({{<relref "/operate/oss_and_stack/stack-with-enterprise/timeseries">}})<br />[Probabilistic]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}})  |
 | Flash-enabled ([Redis Flex]({{<relref "/operate/rs/databases/flash">}})) | [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}})<br />[Probabilistic]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}}) |
-| [Active-Active]({{<relref "/operate/rs/databases/active-active">}})<sup>[1](#enabled-modules-table-note-1)</sup> | [Search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}) |
+| [Active-Active]({{<relref "/operate/rs/databases/active-active">}})<sup>[1](#enabled-modules-table-note-1)</sup> | [Redis Search]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}})<br />[JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}) |
 
 1. <a name="enabled-modules-table-note-1"></a>Upgrading existing Active-Active databases to Redis version 8 does not automatically enable these capabilities. Only new Active-Active databases created with Redis version 8 enable these capabilities by default.

--- a/content/operate/oss_and_stack/stack-with-enterprise/enterprise-capabilities.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/enterprise-capabilities.md
@@ -19,7 +19,7 @@ The following table shows which Redis Open Source features are supported by Redi
 
 | Feature | Redis<br/>Software | Redis<br/>Cloud |
 |:-------|:-------------------------|:-----------------------|
-| [Search and query]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search" >}}) | &#x2705; Supported | &#x2705; Supported |
+| [Redis Search]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search" >}}) | &#x2705; Supported | &#x2705; Supported |
 | [JSON]({{< relref "/operate/oss_and_stack/stack-with-enterprise/json" >}})   | &#x2705; Supported | &#x2705; Supported |
 | [Time series]({{< relref "/operate/oss_and_stack/stack-with-enterprise/timeseries" >}}) | &#x2705; Supported | &#x2705; Supported |
 | [Probabilistic]({{< relref "/operate/oss_and_stack/stack-with-enterprise/bloom" >}}) | &#x2705; Supported | &#x2705; Supported |
@@ -36,7 +36,7 @@ Version numbers indicate when the feature was first supported.  If you're using 
 
 For details about individual features, see the corresponding documentation.
 
-| Feature name/capability   | [Search and query]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search" >}}) | [JSON]({{< relref "/operate/oss_and_stack/stack-with-enterprise/json" >}})    | 
+| Feature name/capability   | [Redis Search]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search" >}}) | [JSON]({{< relref "/operate/oss_and_stack/stack-with-enterprise/json" >}})    | 
 |---------------------------|:--------------:|:------------:|
 | Active-Active (CRDB)[^5]  | Yes (v2.0)     | Yes (v2.2)   |
 | Backup/Restore            | Yes (v1.4)     | Yes (v1.0)   |
@@ -57,7 +57,7 @@ For details about individual features, see the corresponding documentation.
 
 [^2]: RediSearch version 1.6 supported Replica Of only between databases with the same number of shards.  This limitation was fixed in v2.0. 
 
-[^3]: You cannot use search and query with the [OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}). This limitation was fixed in Redis Software version 8.0.
+[^3]: You cannot use Redis Search with the [OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}). This limitation was fixed in Redis Software version 8.0.
 
 [^4]: You currently cannot combine Auto Tiering with Redis Open Source features in Redis Cloud. 
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/install/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/install/_index.md
@@ -11,7 +11,7 @@ linkTitle: Install and upgrade modules
 weight: 4
 ---
 
-Several modules that provide additional Redis capabilities, such as search and query, JSON, time series, and probabilistic data structures, come packaged with [Redis Software]({{< relref "/operate/rs" >}}). As of version 8.0, Redis Software includes multiple feature sets, compatible with different Redis database versions.
+Several modules that provide additional Redis capabilities, such as Redis Search, JSON, time series, and probabilistic data structures, come packaged with [Redis Software]({{< relref "/operate/rs" >}}). As of version 8.0, Redis Software includes multiple feature sets, compatible with different Redis database versions.
 
 However, if you want to use additional modules or upgrade a module to a more recent version, you need to:
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/install/add-module-to-cluster.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/install/add-module-to-cluster.md
@@ -10,7 +10,7 @@ linkTitle: Install on a cluster
 weight: 10
 ---
 
-[Redis Software]({{< relref "/operate/rs" >}}) comes packaged with several modules that provide additional Redis capabilities such as [search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search">}}), [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}), [time series]({{<relref "/operate/oss_and_stack/stack-with-enterprise/timeseries">}}), and [probabilistic data structures]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}}). As of version 8.0, Redis Software includes multiple feature sets, compatible with different Redis database versions. You can view the installed modules, their versions, and their minimum compatible Redis database versions from **Cluster > Modules** in the Cluster Manager UI.
+[Redis Software]({{< relref "/operate/rs" >}}) comes packaged with several modules that provide additional Redis capabilities such as [Redis Search]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search">}}), [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}), [time series]({{<relref "/operate/oss_and_stack/stack-with-enterprise/timeseries">}}), and [probabilistic data structures]({{<relref "/operate/oss_and_stack/stack-with-enterprise/bloom">}}). As of version 8.0, Redis Software includes multiple feature sets, compatible with different Redis database versions. You can view the installed modules, their versions, and their minimum compatible Redis database versions from **Cluster > Modules** in the Cluster Manager UI.
 
 To use other modules or upgrade an existing module to a more recent version, you need to install the new module package on your cluster.
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/install/add-module-to-database.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/install/add-module-to-database.md
@@ -60,7 +60,7 @@ Depending on the [features supported by an enabled module]({{< relref "/operate/
 
 ## Module configuration options
 
-- [RediSearch configuration options]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/config" >}})
+- [Redis Search configuration options]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/config" >}})
 
 - [RedisTimeSeries configuration options]({{< relref "/operate/oss_and_stack/stack-with-enterprise/timeseries/config" >}})
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/modules-lifecycle.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/modules-lifecycle.md
@@ -18,7 +18,7 @@ The lifecycle model for modules changed with Redis 8.0. This page is organized i
 
 ## Redis 8.0 and later
 
-Starting with Redis 8.0, the capabilities that were previously distributed as separate modules—Search and query (RediSearch), JSON (RedisJSON), Time series (RedisTimeSeries), and Probabilistic (RedisBloom)—are built into Redis Open Source. [Redis 8 in Redis Open Source replaces Redis Stack]({{< relref "/operate/oss_and_stack" >}}), so there is no separate module to install or version.
+Starting with Redis 8.0, the capabilities that were previously distributed as separate modules—Redis Search (RediSearch), JSON (RedisJSON), Time series (RedisTimeSeries), and Probabilistic (RedisBloom)—are built into Redis Open Source. [Redis 8 in Redis Open Source replaces Redis Stack]({{< relref "/operate/oss_and_stack" >}}), so there is no separate module to install or version.
 
 As a result:
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/search/_index.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/search/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
 - /stack/search/
-Title: Search and query
+Title: Redis Search
 alwaysopen: false
 categories:
 - docs
@@ -9,7 +9,7 @@ categories:
 - stack
 description: null
 hideListLinks: true
-linkTitle: Search and query
+linkTitle: Redis Search
 weight: 20
 ---
 The [RediSearch 2.x module](https://redis.com/blog/introducing-redisearch-2-0/) is a source-available project that lets you build powerful search queries for open source Redis databases.
@@ -18,7 +18,7 @@ to run geo-replicated queries and full-text searches over efficient in-memory in
 
 ## Index documents
 
-The search and query engine indexes documents, which are objects that represent data as field-value pairs. You can index more than one field per document, and these fields can represent text, numeric, or geospatial data types.
+Redis Search indexes documents, which are objects that represent data as field-value pairs. You can index more than one field per document, and these fields can represent text, numeric, or geospatial data types.
 
 As the documents in your database change, the index automatically processes these changes to keep the search results up to date.
 
@@ -53,7 +53,7 @@ You can also sort by a specific field and limit the results with an offset to pr
 
 Redis Open Source supports [over 15 natural languages]({{< relref "/develop/ai/search-and-query/advanced-concepts/stemming" >}}) for stemming and includes auto-complete engines with specific commands that can provide real-time [interactive search suggestions]({{< relref "/commands/ft.sugadd" >}}).
 
-## Search and query Active-Active databases
+## Redis Search in Active-Active databases
 
 As a result of the new RediSearch architecture and methodology, [RediSearch 2.x supports Active-Active databases]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active" >}}).
 You can now serve your index information from geo-distributed database instances.
@@ -62,17 +62,17 @@ You can now serve your index information from geo-distributed database instances
 
 By moving the index out of the keyspace and structuring the data as hashes, RediSearch 2.x makes it possible to reshard the database.
 When half of the data moves to the new shard, the index related to that data is created synchronously and Redis removes the keys from the index when it detects that the keys were deleted.
-Because the index on the new shard is created synchronously though, it's expected that the resharding process will take longer than resharding of a database without search and query enabled.
+Because the index on the new shard is created synchronously though, it's expected that the resharding process will take longer than resharding of a database without Redis Search enabled.
 
 ## Limitations
 
-- You cannot use search and query capabilities with the [OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}). This limitation was fixed in Redis Software version 8.0.
+- You cannot use Redis Search capabilities with the [OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}). This limitation was fixed in Redis Software version 8.0.
 
 ## More info
 
 - [Getting Started with RediSearch 2.0](https://redis.com/blog/getting-started-with-redisearch-2-0/)
-- [Search and query quick start]({{< relref "/develop/get-started/document-database" >}})
-- [Search and query configuration]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/config" >}})
-- [Search and query commands]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/commands" >}})
-- [Search and query references]({{< relref "/develop/ai/search-and-query/advanced-concepts/" >}})
+- [Redis Search quick start]({{< relref "/develop/get-started/document-database" >}})
+- [Redis Search configuration]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/config" >}})
+- [Redis Search commands]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/commands" >}})
+- [Redis Search references]({{< relref "/develop/ai/search-and-query/advanced-concepts/" >}})
 - [RediSearch source](https://github.com/RediSearch/RediSearch)

--- a/content/operate/oss_and_stack/stack-with-enterprise/search/commands.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/search/commands.md
@@ -1,18 +1,18 @@
 ---
-Title: Search and query commands
+Title: Redis Search commands
 alwaysopen: false
 categories:
 - docs
 - operate
 - stack
-description: Lists search and query commands and provides links to the command reference
+description: Lists Redis Search commands and provides links to the command reference
   pages.
 linkTitle: Commands
 toc: 'false'
 weight: 10
 ---
 
-The following table lists search and query commands. See the command links for more information about each command's syntax, arguments, and examples.
+The following table lists Redis Search commands. See the command links for more information about each command's syntax, arguments, and examples.
 
 | Command | Redis Software | Redis Cloud<br />Flexible & Annual | Redis Cloud<br />Free & Fixed | Description |
 |:--------|:----------------------|:-----------------|:-----------------|:------|
@@ -43,6 +43,6 @@ The following table lists search and query commands. See the command links for m
 | [FT.SYNUPDATE]({{< relref "commands/ft.synupdate" >}}) | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</nobr></span> | Creates or updates a synonym group with additional terms. |
 | [FT.TAGVALS]({{< relref "commands/ft.tagvals" >}}) | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</span> | <span title="Supported">&#x2705; Supported</nobr></span> | Returns all distinct values indexed in a tag field. |
 
-1. <a name="table-note-1" style="display: block; height: 80px; margin-top: -80px;"></a>Use [`rladmin`]({{< relref "/operate/rs/references/cli-utilities/rladmin" >}}) or the [REST API]({{< relref "/operate/rs/references/rest-api" >}}) to change search and query configuration for Redis Software. See [search and query configuration compatibility with Redis Software]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/config" >}}) for more information and examples.
+1. <a name="table-note-1" style="display: block; height: 80px; margin-top: -80px;"></a>Use [`rladmin`]({{< relref "/operate/rs/references/cli-utilities/rladmin" >}}) or the [REST API]({{< relref "/operate/rs/references/rest-api" >}}) to change Redis Search configuration for Redis Software. See [Redis Search configuration compatibility with Redis Software]({{< relref "/operate/oss_and_stack/stack-with-enterprise/search/config" >}}) for more information and examples.
 
 2. <a name="table-note-2" style="display: block; height: 80px; margin-top: -80px;"></a>[Contact support](https://redis.com/company/support/) to view the current configuration values or request configuration changes for Flexible or Annual Redis Cloud subscriptions.

--- a/content/operate/oss_and_stack/stack-with-enterprise/search/config.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/search/config.md
@@ -1,17 +1,17 @@
 ---
-Title: Search and query configuration compatibility with Redis Software
+Title: Redis Search configuration compatibility with Redis Software
 alwaysopen: false
 categories:
 - docs
 - operate
 - stack
-description: Search and query configuration settings supported by Redis Software and Redis Cloud.
+description: Redis Search configuration settings supported by Redis Software and Redis Cloud.
 linkTitle: Configuration
 toc: 'false'
 weight: 15
 ---
 
-To configure RediSearch in [Redis Software]({{< relref "/operate/rs" >}}) or [Redis Cloud]({{< relref "/operate/rc" >}}), use one of the following methods instead of [`FT.CONFIG SET`]({{< relref "commands/ft.config-set" >}}).
+To configure Redis Search in [Redis Software]({{< relref "/operate/rs" >}}) or [Redis Cloud]({{< relref "/operate/rc" >}}), use one of the following methods instead of [`FT.CONFIG SET`]({{< relref "commands/ft.config-set" >}}).
 
 ## Configure search in Redis Cloud
 
@@ -19,7 +19,7 @@ For Redis Cloud:
 
 - _Flexible or Annual [subscriptions]({{< relref "/operate/rc/subscriptions" >}})_: contact [support](https://redis.com/company/support/) to request a configuration change.
     
-- _Free or Fixed subscriptions_: you cannot change RediSearch configuration.
+- _Free or Fixed subscriptions_: you cannot change Redis Search configuration.
 
 ## Configure search in Redis Software
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/search/search-active-active.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/search/search-active-active.md
@@ -9,20 +9,20 @@ description: Search and query Active-Active databases.
 linkTitle: Search Active-Active databases
 weight: 30
 ---
-Starting with RediSearch 2.x, supported in Redis Software (RS) 6.0 and later, you can [enable search and query]({{< relref "/operate/oss_and_stack/stack-with-enterprise/install/add-module-to-database" >}}) for [Active-Active databases]({{< relref "/operate/rs/databases/active-active" >}}) at the time of creation.
+Starting with RediSearch 2.x, supported in Redis Software (RS) 6.0 and later, you can [enable Redis Search]({{< relref "/operate/oss_and_stack/stack-with-enterprise/install/add-module-to-database" >}}) for [Active-Active databases]({{< relref "/operate/rs/databases/active-active" >}}) at the time of creation.
 
 You can run search operations on any instance of an Active-Active database.
 
 ## How it works
 
-1. Create an Active-Active database with RediSearch 2.x enabled. Active-Active databases created with or upgraded to Redis version 8 or later automatically enable search and query.
+1. Create an Active-Active database with RediSearch 2.x enabled. Active-Active databases created with or upgraded to Redis version 8 or later automatically enable Redis Search.
 1. [Create the index]({{< relref "commands/ft.create" >}}) on each instance of the database.
 1. If you are using [synonyms]({{< relref "/develop/ai/search-and-query/advanced-concepts/synonyms" >}}), you need to add them to each replica.
 1. The index is maintained by each instance outside of the database keyspace, so only updates to the hashes in the databases are synchronized.
 
 ## Command compatibility
 
-Active-Active databases do not support the following search and query commands: 
+Active-Active databases do not support the following Redis Search commands: 
 
 - [`FT.DROPINDEX` ]({{< relref "commands/ft.dropindex" >}})
 - [`FT.SUGADD`]({{< relref "commands/ft.sugadd" >}})
@@ -32,13 +32,13 @@ Active-Active databases do not support the following search and query commands:
 
 ## Example
 
-Here's an example to help visualize Active-Active search and query:
+Here's an example to help visualize Active-Active Redis Search:
 
-| Time  | Description | CRDB Instance1 | RediSearch Instance 1 | CRDB Instance 2 | RediSearch Instance 2 |
+| Time  | Description | CRDB Instance1 | Redis Search Instance 1 | CRDB Instance 2 | Redis Search Instance 2 |
 | :---: | :--- | :--- | :--- | :--- | :--- |
 |  t0 | Create the index on each instance |  | FT.CREATE idx .... |  | FT.CREATE idx .... |
-|  t1 | Add doc1 as a hash on instance 1; RediSearch indexes doc1 on instance 1 | HSET doc1 field1 "a" | (Index doc1 field1 "a") |  |  |
-|  t2 | Add doc2 as a hash on instance 2; RediSearch indexes doc2 on instance 2 |  |  | HSET doc1 field2 "b" | (Index doc1 field2 "b") |
+|  t1 | Add doc1 as a hash on instance 1; Redis Search indexes doc1 on instance 1 | HSET doc1 field1 "a" | (Index doc1 field1 "a") |  |  |
+|  t2 | Add doc2 as a hash on instance 2; Redis Search indexes doc2 on instance 2 |  |  | HSET doc1 field2 "b" | (Index doc1 field2 "b") |
 |  t3 | Searching for "a" in each instance only finds the result in instance 1 |  | FT.Search idx "a"<br/>1) 1<br/>2) doc1 |  | FT.Search idx "a"<br/>1) 0 |
 |  t4 | Active-Active synchronization | - Sync - |  | - Sync - |  |
 |  t5 | Both hashes are found in each instance | HGETALL doc1<br/>1) "field2"<br/>2) "b"<br/>3) "field1"<br/>4) "a" |  | HGETALL doc1<br/>1) "field2"<br/>2) "b"<br/>3) "field1"<br/>4) "a" |  |

--- a/content/operate/rs/databases/active-active/create.md
+++ b/content/operate/rs/databases/active-active/create.md
@@ -136,7 +136,7 @@ for this database. Minimum RAM is 10%. Maximum RAM is 50%.
 
 - [**Capabilities**]({{< relref "/operate/oss_and_stack/stack-with-enterprise" >}}) (previously **Modules**) - When you create a new in-memory database, you can enable additional capabilities in the database. You cannot enable them after database creation.
 
-    Active-Active databases created with or upgraded to Redis version 8 or later automatically enable [search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}}) and [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}), which allows you to index, query, and perform full-text searches of nested JSON documents.
+    Active-Active databases created with or upgraded to Redis version 8 or later automatically enable [Redis Search]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}}) and [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}), which allows you to index, query, and perform full-text searches of nested JSON documents.
 
     For Auto Tiering databases, you can enable capabilities that support Auto Tiering. See [Redis Software and Redis Stack feature compatibility 
 ]({{< relref "/operate/oss_and_stack/stack-with-enterprise/enterprise-capabilities" >}}) for compatibility details.

--- a/content/operate/rs/databases/active-active/planning.md
+++ b/content/operate/rs/databases/active-active/planning.md
@@ -100,7 +100,7 @@ See [Synchronizing cluster node clocks]({{< relref "/operate/rs/clusters/configu
 
 Several Redis modules are compatible with Active-Active databases. Find the list of [compatible Redis modules]({{< relref "/operate/oss_and_stack/stack-with-enterprise/enterprise-capabilities" >}}).
 
-Active-Active databases created with or upgraded to Redis version 8 or later automatically enable [search and query]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}}) and [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}), which allows you to index, query, and perform full-text searches of nested JSON documents.
+Active-Active databases created with or upgraded to Redis version 8 or later automatically enable [Redis Search]({{<relref "/operate/oss_and_stack/stack-with-enterprise/search/search-active-active">}}) and [JSON]({{<relref "/operate/oss_and_stack/stack-with-enterprise/json">}}), which allows you to index, query, and perform full-text searches of nested JSON documents.
 
 
 ## Limitations

--- a/content/operate/rs/references/rest-api/objects/bdb/_index.md
+++ b/content/operate/rs/references/rest-api/objects/bdb/_index.md
@@ -147,7 +147,7 @@ An API object that represents a managed database in the cluster.
 | resp3 | boolean (default:&nbsp;true); Enables or deactivates RESP3 support |
 | roles_permissions | {{<code>}}[{<br />  "role_uid": integer,<br />  "redis_acl_uid": integer<br />}, ...]{{</code>}} |
 | sched_policy | Controls how server-side connections are used when forwarding traffic to shards.<br />Values:<br />**cmp**: Closest to max_pipelined policy. Pick the connection with the most pipelined commands that has not reached the max_pipelined limit.<br />**mru**: Try to use most recently used connections.<br />**spread**: Try to use all connections.<br />**mnp**: Minimal pipeline policy. Pick the connection with the least pipelined commands. |
-| search | [complex object]({{< relref "/operate/rs/references/rest-api/objects/bdb/search" >}}); Configuration fields for search and query. |
+| search | [complex object]({{< relref "/operate/rs/references/rest-api/objects/bdb/search" >}}); Configuration fields for Redis Search. |
 | search_on_bigstore | boolean (default: false); Include search module in Redis on flash v2 (Flex databases) |
 | shard_block_crossslot_keys | boolean (default:&nbsp;false); In Lua scripts, prevent use of keys from different hash slots within the range owned by the current shard |
 | shard_block_foreign_keys | boolean (default:&nbsp;true); In Lua scripts, `foreign_keys` prevent use of keys which could reside in a different shard (foreign keys) |

--- a/content/operate/rs/references/rest-api/objects/bdb/search.md
+++ b/content/operate/rs/references/rest-api/objects/bdb/search.md
@@ -1,21 +1,21 @@
 ---
-Title: Search and query configuration object
+Title: Redis Search configuration object
 alwaysopen: false
 categories:
 - docs
 - operate
 - rs
-description: Configuration object for search and query.
+description: Configuration object for Redis Search.
 linkTitle: search
 weight: $weight
 ---
 
-Configuration fields for search and query.
+Configuration fields for Redis Search.
 
 | Field | Type/Value | Description |
 |-------|------------|-------------|
 | search-timeout | integer (range: 1-9223372036854775807) (default: 500) | The maximum amount of time in milliseconds that a search query is allowed to run. |
-| search-ext-load | string  | If present, RediSearch will try to load an extension dynamic library from its specified file path. Requires a database restart to take effect. |
+| search-ext-load | string  | If present, Redis Search will try to load an extension dynamic library from its specified file path. Requires a database restart to take effect. |
 | search-max-doctablesize | integer (range: 1-18446744073709551615) (default: 1000000) | The maximum size of the internal hash table used for storing the documents. Requires a database restart to take effect. |
 | search-friso-ini | string  | If present, load the custom Chinese dictionary from the specified path. Requires a database restart to take effect. |
 | search-cursor-max-idle | integer (range: 1-9223372036854775807) (default: 300000) | The maximum idle time in milliseconds that can be set to the cursor api. |
@@ -23,12 +23,12 @@ Configuration fields for search and query.
 | search-gc-scan-size | integer (range: 1-9223372036854775807) (default: 100) | The bulk size of the internal GC used for cleaning up indexes. Requires a database restart to take effect. |
 | search-no-gc | boolean (default: false) | If set, Garbage Collection is deactivated for all indexes. Requires a database restart to take effect. |
 | search-fork-gc-run-interval | integer (range: 1-9223372036854775807) (default: 30) | Interval in seconds between two consecutive fork GC runs. |
-| search-fork-gc-retry-interval | integer (range: 1-9223372036854775807) (default: 5) | Interval in seconds in which RediSearch will retry to run fork GC in case of a failure. |
+| search-fork-gc-retry-interval | integer (range: 1-9223372036854775807) (default: 5) | Interval in seconds in which Redis Search will retry to run fork GC in case of a failure. |
 | search-fork-gc-clean-threshold | integer (range: 1-9223372036854775807) (default: 100) | The fork GC will only start to clean when the number of not cleaned documents exceeds this threshold; otherwise, it will skip this run. |
 | search-vss-max-resize | integer (range: 0-4294967295) (default: 0) | The maximum memory resize for vector similarity indexes in bytes. |
 | search-union-iterator-heap | integer (range: 1-9223372036854775807) (default: 20) | The minimum number of iterators in a union from which the iterator will switch to heap-based implementation. |
 | search-min-phonetic-term-len | integer (range: 1-9223372036854775807) (default: 3) | Minimum length of term to be considered for phonetic matching. |
-| search-multi-text-slop | integer (range: 1-4294967295) (default: 100) | Set RediSearch delta used to increase positional offsets between array slots for multi-text values. Requires a database restart to take effect. |
+| search-multi-text-slop | integer (range: 1-4294967295) (default: 100) | Set Redis Search delta used to increase positional offsets between array slots for multi-text values. Requires a database restart to take effect. |
 | search-raw-docid-encoding | boolean (default: false) | Turn off compression for DocID inverted index. Boost CPU performance. Requires a database restart to take effect. |
 | search-_print-profile-clock | boolean (default: true) | Turn off print of time for ft.profile. For testing only. |
 | search-_free-resource-on-thread | boolean (default: true) | Determine whether some index resources are free on a second thread |
@@ -36,7 +36,7 @@ Configuration fields for search and query.
 | search-bg-index-sleep-gap | integer (range: 1-4294967295) (default: 100) | The number of iterations to run while performing background indexing before we call usleep(1) (sleep for 1 micro-second) and make sure that we allow Redis to process other commands. Requires a database restart to take effect. |
 | search-_numeric-ranges-parents | integer (range: 0-2) (default: 0) | Keep numeric ranges in numeric tree parent nodes of leaves for `x` |
 | search-fork-gc-sleep-before-exit | integer (range: 0-9223372036854775807) (default: 0) | Set the number of seconds for the fork GC to sleep before exists, should always be set to 0 (other then on tests). |
-| search-no-mem-pools | boolean (default: false) | Set RediSearch to run without memory pools. Requires a database restart to take effect. |
+| search-no-mem-pools | boolean (default: false) | Set Redis Search to run without memory pools. Requires a database restart to take effect. |
 | search-_prioritize-intersect-union-children | boolean (default: false) | Intersection iterator orders the children iterators by their relative estimated number of results in ascending order. If the first iterators have a lower count of results, skips a larger number of results, which translates into faster iteration. If this flag is set, we use this optimization in a way where union iterators are being factorized by the number of their own children, so that we sort by the number of children times the overall estimated number of results instead. |
 | search-conn-per-shard | integer (range: 0-9223372036854775807) (default: 0) | Number of connections to each shard in the cluster. Default to 0. If 0, the number of connections is set to `WORKERS` + 1. |
 | search-cursor-reply-threshold | integer (range: 1-9223372036854775807) (default: 1) | Maximum number of replies to accumulate before triggering `_FT.CURSOR READ` on the shards |

--- a/content/operate/rs/references/rest-api/requests/usage_report/_index.md
+++ b/content/operate/rs/references/rest-api/requests/usage_report/_index.md
@@ -63,7 +63,7 @@ Returns Newline Delimited JSON (NDJSON), which represents the usage report for e
 | replication | boolean | Indicates if replication is enabled |
 | software_version | string | The Redis Software version |
 | used_memory | number | Used memory in bytes |
-| <span class="break-all">using_redis_search</span> | boolean | Indicates if RediSearch is in use |
+| <span class="break-all">using_redis_search</span> | boolean | Indicates if Redis Search is in use |
 | <span class="break-all">master_shards_count</span> | number | Amount of primary shards |
 | license | object | License information for the cluster<br />{{<code>}} "license": {<br />    "activation_date": string,<br />    "expiration_date": string,<br />    "ram_shards_in_use": integer,<br />    "ram_shards_limit": integer,<br />    "flash_shards_in_use": integer,<br />    "flash_shards_limit": integer,<br />    "shards_limit": integer<br />}{{</code>}}<br />**activation_date**: License activation date and time<br />**expiration_date**: License expiration date and time<br />**ram_shards_in_use**: Amount of RAM shards in use<br />**ram_shards_limit**: Amount of RAM shards allowed<br />**flash_shards_in_use**: Amount of flash shards in use<br />**flash_shards_limit**: Amount of flash shards allowed<br />**shards_limit**: Total shards limit |
 

--- a/content/operate/rs/security/access-control/redis-acl-overview.md
+++ b/content/operate/rs/security/access-control/redis-acl-overview.md
@@ -46,7 +46,7 @@ For database versions earlier than Redis 8.2, module commands have several ACL l
 
 - You have to include individual module commands in a Redis ACL rule to allow them.
 
-    For example, the following Redis ACL rule allows read-only commands and the RediSearch commands `FT.INFO` and `FT.SEARCH`:
+    For example, the following Redis ACL rule allows read-only commands and the Redis Search commands `FT.INFO` and `FT.SEARCH`:
 
     ```sh
     +@read +FT.INFO +FT.SEARCH


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording and title changes with no runtime, security, or configuration logic affected.
> 
> **Overview**
> This PR **standardizes product naming** in Redis Software / Stack enterprise docs by replacing **"Search and query"** with **"Redis Search"** wherever that capability is named (tables, titles, link text, footnotes, and prose).
> 
> Updates span **enabled-modules embeds**, **enterprise feature compatibility**, **module install/lifecycle** pages, the **search** section hub (`Title`/`linkTitle` → Redis Search), **commands/config** pages, **Active-Active search** guidance, **RS database create/planning**, **REST API** `bdb.search` / usage report field descriptions, and **ACL** examples. **RediSearch** is still used where it refers to the module or version (e.g. RediSearch 2.x).
> 
> No behavioral or API changes—terminology and navigation labels only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46596f0b30be42c0d307474988c1abf7815e74e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->