### PR TITLE
RDSC-5654 Document MongoDB mTLS settings

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/mongodb.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/mongodb.md
@@ -35,6 +35,7 @@ The following table summarizes the considerations to prepare a MongoDB database 
 | Pre/Post Images     | Enable on collections **only if using a custom key**                        |
 | Connection String   | Must include all hosts, replicaSet (if applicable), authSource, credentials |
 | MongoDB Atlas       | **[SSL required](https://debezium.io/documentation/reference/stable/connectors/mongodb.html#mongodb-property-mongodb-ssl-enabled)**, provide root CA as `SOURCE_DB_CACERT` secret in RDI       |
+| MongoDB mTLS        | X.509 authentication requires source TLS secrets and MongoDB SSL properties |
 | Network             | RDI Collector must reach all MongoDB nodes on required ports                |
 
 The following checklist shows the steps to prepare a MongoDB database for RDI,
@@ -48,7 +49,8 @@ complete each step.
 - [ ] [Connection string format](#3-connection-string-format)
 - [ ] [Enable change streams and pre/post images (only if using a custom key)](#4-enable-change-streams-and-prepost-images-only-if-using-a-custom-key)
 - [ ] [MongoDB Atlas specific requirements](#5-mongodb-atlas-specific-requirements)
-- [ ] [Network and security](#6-network-and-security)
+- [ ] [Self-hosted MongoDB mTLS and X.509 authentication](#6-self-hosted-mongodb-mtls-and-x509-authentication)
+- [ ] [Network and security](#7-network-and-security)
 ```
 
 ## 1. Configure oplog size
@@ -128,12 +130,40 @@ Example connection string for Atlas:
 mongodb+srv://${SOURCE_DB_USERNAME}:${SOURCE_DB_PASSWORD}@cluster0.mongodb.net/?authSource=admin
 ```
 
-## 6. Network and security
+## 6. Self-hosted MongoDB mTLS and X.509 authentication
+
+For self-hosted MongoDB deployments that require TLS, set the source CA certificate
+as the `SOURCE_DB_CACERT` secret. For X.509 client certificate authentication, also
+set the `SOURCE_DB_CERT` and `SOURCE_DB_KEY` secrets. See
+[Set secrets]({{< relref "/integrate/redis-data-integration/data-pipelines/deploy#set-secrets" >}})
+for the full list of source database TLS and mTLS secrets.
+
+When you use MongoDB X.509 authentication, include all of the following
+properties in the source `advanced.source` section:
+
+```yaml
+advanced:
+  source:
+    mongodb.ssl.enabled: true
+    mongodb.ssl.keystore: /debezium/certs/source_db_keystore
+    mongodb.ssl.keystore.password: debezium
+```
+
+The RDI Collector builds `/debezium/certs/source_db_keystore` from the source
+database client certificate and private key secrets. Debezium requires the
+`mongodb.ssl.keystore` and `mongodb.ssl.keystore.password` properties to present
+the client certificate to MongoDB.
+
+For X.509 authentication, the MongoDB connection string must also include the
+required authentication options, such as `authMechanism=MONGODB-X509` and
+`authSource=%24external`.
+
+## 7. Network and security
 
 - Ensure the RDI Collector can connect to all MongoDB nodes on the required ports (default: 27017, or as provided by Atlas).
 - If using TLS/SSL, provide the necessary certificates and connection options in the connection string.
 
-## 7. Configuration is complete
+## 8. Configuration is complete
 Once you have followed the steps above, your MongoDB database is ready for Debezium to use.
 
 ## See also


### PR DESCRIPTION
## Summary

- Documents MongoDB X.509/mTLS setup for self-hosted MongoDB sources in RDI.
- Adds the required `advanced.source` properties for Debezium to present the MongoDB client certificate:

```yaml
advanced:
  source:
    mongodb.ssl.enabled: true
    mongodb.ssl.keystore: /debezium/certs/source_db_keystore
    mongodb.ssl.keystore.password: debezium
```

- Points users to the existing source TLS/mTLS secret setup and notes the required X.509 connection string options.

Jira: https://redislabs.atlassian.net/browse/RDSC-5654

## Tests

- `git diff --check`
- `hugo --gc --logLevel warn` fails before this page renders due to an existing issue while rendering `content/commands/acl-dryrun.md`: `layouts/partials/docs-nav.html:10:33`: `can't evaluate field ByWeight in type []interface {}`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the MongoDB prepare guide; no application or pipeline code is modified.
> 
> **Overview**
> Adds documentation for **self-hosted MongoDB** sources that use TLS and **X.509 client certificate authentication** with RDI.
> 
> The prepare-MongoDB summary table and checklist gain an **mTLS** row and a new step **§6 Self-hosted MongoDB mTLS and X.509 authentication**. That section explains which source secrets to set (`SOURCE_DB_CACERT`, and for mTLS `SOURCE_DB_CERT` / `SOURCE_DB_KEY`), links to the deploy **Set secrets** guide, documents required **`advanced.source`** Debezium properties (`mongodb.ssl.enabled`, keystore path/password), notes that the collector builds the keystore from those secrets, and calls out connection-string options such as `authMechanism=MONGODB-X509` and `authSource=%24external`. Later sections are renumbered (**Network and security** → §7, **Configuration is complete** → §8).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 859cbbde0a6e3b3cd16fb4f56ed67689091944a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->