### PR TITLE
[codex] RDSC-5568 Update RDI collector property links

### DIFF
--- a/content/operate/rc/rdi/define.md
+++ b/content/operate/rc/rdi/define.md
@@ -127,7 +127,7 @@ Under **Collector properties**, Select **Edit advanced properties** to configure
 
 {{<image filename="images/rc/rdi/rdi-advanced-properties.png" alt="The advanced properties section." width=80% >}}
 
-You can add any [Debezium source property](https://debezium.io/documentation/reference/stable/connectors/) for your source database type in the **Collector source properties** section and any [Redis server Debezium sink property](https://debezium.io/documentation/reference/stable/operations/debezium-server.html#_redis_stream) in the **Collector sink properties** section. Select **Save properties** to return to Source configuration.
+You can add collector source properties in the **Collector source properties** section and collector sink properties in the **Collector sink properties** section. See the RDI configuration file reference for all available [collector source properties]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#sourcesadvancedsource" >}}) and [collector sink properties]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#sourcesadvancedsink" >}}). Select **Save properties** to return to Source configuration.
 
 ## Dataset
 

--- a/content/operate/rc/rdi/view-edit.md
+++ b/content/operate/rc/rdi/view-edit.md
@@ -101,7 +101,7 @@ From the **Configuration** tab of your pipeline, select **Edit collector propert
 
 {{<image filename="images/rc/rdi/rdi-advanced-properties.png" alt="The advanced properties section." width=80% >}}
 
-You can add any [Debezium source property](https://debezium.io/documentation/reference/stable/connectors/) for your source database type in the **Collector source properties** section and any [Redis server Debezium sink property](https://debezium.io/documentation/reference/stable/operations/debezium-server.html#_redis_stream) in the **Collector sink properties** section. Select **Save properties** to save the collector properties.
+You can add collector source properties in the **Collector source properties** section and collector sink properties in the **Collector sink properties** section. See the RDI configuration file reference for all available [collector source properties]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#sourcesadvancedsource" >}}) and [collector sink properties]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#sourcesadvancedsink" >}}). Select **Save properties** to save the collector properties.
 
 ## Dataset
 


### PR DESCRIPTION
## Summary

- Updates the Redis Cloud RDI collector properties copy on the view/edit page to link to Redis's RDI configuration reference instead of external Debezium configuration pages.
- Applies the same wording to the matching collector properties section in the define/create-flow page so the Cloud RDI docs stay consistent.

Jira: https://redislabs.atlassian.net/browse/RDSC-5568

## Validation

- `git diff --check`
- Verified the referenced `#sourcesadvancedsource` and `#sourcesadvancedsink` anchors exist in `content/integrate/redis-data-integration/reference/config-yaml-reference.md`.
- Verified the two updated Cloud RDI pages no longer link directly to the Debezium source or Redis Stream sink docs from this sentence.
- Attempted `hugo --logLevel debug --gc`; it currently fails in an existing command-page render path: `layouts/partials/docs-nav.html` while rendering `content/commands/acl-load.md` (`can't evaluate field ByWeight in type []interface {}`).