### PR TITLE
DOC-6800 add restructure-diagram skill for docs before/after diagrams

### DIFF
--- a/.claude/skills/restructure-diagram/SKILL.md
+++ b/.claude/skills/restructure-diagram/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: restructure-diagram
+description: "Create a before/after restructuring diagram for a docs section. Use when planning how to reorganise a folder under content/ — produces a draw.io-editable .drawio.svg with two identical columns (current structure left, a copy on the right) joined by arrows, so you can drag the right-hand boxes into their proposed new layout. Reads Hugo weight/linkTitle frontmatter."
+---
+
+# Docs restructuring diagram
+
+Generate a planning diagram that mirrors a docs section's folder/page tree as
+two identical columns — **before** (left) and **after** (right) — with an arrow
+joining each item to its copy. The after column starts as an exact duplicate;
+the human then opens the file in [diagrams.net](https://app.diagrams.net) and
+drags the after boxes into the proposed new structure, the arrows tracking
+where each page moved.
+
+This is the tool that drew the NRedisStack client-docs migration diagram and the
+RDI `redis-data-integration` restructure. The output is an *editable* SVG: it
+renders as an image anywhere, and opening it in draw.io gives back real boxes
+and arrows because the model is embedded in the SVG `content` attribute.
+
+## When to use
+
+- Planning a reorganisation of any folder under `content/` (moving pages
+  between sections, splitting/merging sections, reordering).
+- Sharing a "here's the current shape, here's the proposed shape" picture with
+  reviewers before doing the actual file moves.
+
+## How it reads the docs
+
+The generator (`build_diagram.py`) walks the section folder and builds the tree
+automatically. It does **not** guess — it reads the source:
+
+- **Order** follows each file's Hugo `weight` frontmatter (ties broken
+  alphabetically by label), matching the live left-hand nav.
+- **Box text** is the `linkTitle` frontmatter (falls back to `title`, then the
+  filename) — generally more compact than the full title.
+- **Folders/sections** (anything with an `_index.md`) are shaded yellow;
+  individual pages are white.
+- **Asset folders** with no `_index.md` (e.g. ones holding only `openapi.json`
+  or dashboard JSON) are skipped — they aren't navigable doc sections.
+
+## Workflow
+
+1. **Pick the section root** — the folder to diagram, e.g.
+   `content/integrate/redis-data-integration`.
+
+2. **Decide which folders to collapse.** Some sections contain many similar
+   child pages that aren't individually interesting for a restructure (a long
+   list of CLI commands, per-database setup pages, every release note). Collapse
+   those: the folder shows as one yellow box with a single indented `...`
+   sub-box, instead of dozens of rows. Pass them via `--collapse` as paths
+   **relative to the root**. Everything not collapsed is expanded in full.
+
+3. **Run the generator** (from the repo root):
+   ```bash
+   python3 .claude/skills/restructure-diagram/build_diagram.py \
+     content/integrate/redis-data-integration \
+     --out RDI-docs-restructure.drawio.svg \
+     --collapse data-pipelines/prepare-dbs data-pipelines/transform-examples \
+                reference/cli reference/data-transformation release-notes
+   ```
+   It writes the `.drawio.svg`, validates that both the SVG and the embedded
+   model parse, and prints the row count and the tree it produced. Read the
+   printed tree back to the user to confirm it's what they expected.
+
+   **zsh gotcha:** pass each `--collapse` path as its own literal token (as
+   above). zsh does *not* word-split an unquoted variable, so
+   `--collapse $PATHS` sends all the paths as one string that matches nothing
+   and silently collapses nothing (you'll see a much larger row count). If the
+   row count looks too big, this is the cause.
+
+4. **Confirm placement.** The default output filename is
+   `<section>-restructure.drawio.svg` in the current directory. These are
+   planning artifacts — write them to the repo root (or wherever the user asks),
+   **not** into `content/`, so they aren't published. Mention where you put it.
+
+5. **Hand off.** Tell the user the after column is currently identical and is
+   theirs to rearrange in draw.io.
+
+## Arrow routing (`--edge-style`)
+
+The arrows join each before box to its after copy. Default is `straight`.
+
+- `straight` *(default)* — point-to-point diagonals. Each line has its own
+  slope, so once after-column boxes are moved the lines cross but never stack.
+  This is the routing that actually keeps a busy diagram legible.
+- `curved` — draw.io's "Curved" preset (smooth orthogonal S-bends). Looks
+  softer, but still routes through the shared central channel, so heavily-moved
+  lines can still overlay. Use for aesthetics, not to fix overlap.
+- `orthogonal` — right-angle rectilinear (draw.io's default). Tidy at rest;
+  overlays badly after a rearrange.
+
+Note: a true point-to-point *bezier* isn't offered — draw.io only curves edges
+that have bends (orthogonal routing) or fixed waypoints, and baked-in waypoints
+would break as soon as the user drags a box. `straight` is the closest thing to
+"clean independent lines". The edge style can always be changed afterwards in
+draw.io's Format panel.
+
+## Cross-branch pages (`--add`)
+
+The walk only sees the working tree. If a page exists on another branch (e.g. an
+in-progress page on a feature branch you're not on) and should appear in the
+diagram, inject it manually:
+
+```
+--add "data-pipelines/supported-types.md::Supported data types::80"
+```
+
+Format is `REL_PATH::LABEL::WEIGHT` (path relative to root). The page is placed
+among its siblings in `weight` order, just as if it were on disk. Repeatable.
+Prefer regenerating from the branch that has the page if you can; use `--add`
+only when you can't.
+
+## Guardrails
+
+- **Check the branch first.** The diagram reflects the current working tree.
+  Note the branch in your summary — a page missing from the diagram is usually a
+  page that lives on a different branch, not an error. (This is easy to misread
+  as data loss.)
+- **Don't hand-edit the XML** for structural changes — change the inputs and
+  rerun, so the diagram stays reproducible.
+- The script needs no network and only reads the docs tree; it's safe to run in
+  the sandbox.
+
+## Files
+
+- `build_diagram.py` — the generator. `--help` lists all options. Layout
+  constants (box size, indent, colours, font) are near the top if you need to
+  tweak the look; the default style matches the existing migration diagrams
+  (Space Grotesk, yellow `#fff2cc` sections).

--- a/.claude/skills/restructure-diagram/build_diagram.py
+++ b/.claude/skills/restructure-diagram/build_diagram.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Build a "before/after" restructuring diagram for a docs section.
+
+Walks a Hugo docs folder, renders its page/section tree as two identical
+columns (before = left, after = right) joined by arrows, and writes a
+draw.io-editable SVG. The "after" column is a starting point: open the file in
+diagrams.net and drag the after-column boxes into their new positions.
+
+Conventions baked in:
+  * Order follows the Hugo `weight` frontmatter (ties broken by label).
+  * Box text is the `linkTitle` frontmatter (falls back to `title`, then name).
+  * Folders/sections (anything with an `_index.md`) are shaded yellow;
+    individual pages are white.
+  * Asset folders (no `_index.md`, e.g. holding only JSON) are skipped.
+  * `--collapse` folders are shown as a single box with one indented "..."
+    sub-box, hiding their many similar children.
+
+See SKILL.md for usage guidance.
+"""
+
+import argparse
+import html
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+FONT = "Space Grotesk"
+W, H_BOX, PITCH = 190, 24, 32
+INDENT = 30
+START_Y = 30
+LBASE = 40
+GAP = 130  # constant horizontal gap between the two columns
+
+YELLOW_FILL, YELLOW_STROKE = "#fff2cc", "#d6b656"
+
+# Edge routing presets. Every arrow exits the right side of the left box and
+# enters the left side of the right box.
+#
+#   straight    point-to-point diagonal (edgeStyle=none). Each line has its own
+#               slope, so they cross but never stack. This is what actually
+#               cures the overlap once after-column boxes are moved -> default.
+#   curved      draw.io's "Curved" preset (orthogonalEdgeStyle + curved=1):
+#               smooth S-bends. Prettier, but still routes through the shared
+#               central channel, so heavily-moved lines can still overlay.
+#   orthogonal  right-angle rectilinear routing (the draw.io default); tidy at
+#               rest but overlays badly after a rearrange.
+#
+# A genuine point-to-point bezier isn't available without per-edge waypoints,
+# which would break when the user drags boxes around -- so it's deliberately
+# not offered.
+_EXIT_ENTRY = ("exitX=1;exitY=0.5;exitDx=0;exitDy=0;"
+               "entryX=0;entryY=0.5;entryDx=0;entryDy=0;")
+EDGE_STYLES = {
+    "straight": "edgeStyle=none;rounded=0;" + _EXIT_ENTRY,
+    "curved": ("edgeStyle=orthogonalEdgeStyle;curved=1;orthogonalLoop=1;"
+               "jettySize=auto;") + _EXIT_ENTRY,
+    "orthogonal": ("edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;"
+                   "jettySize=auto;") + _EXIT_ENTRY,
+}
+
+
+def front(path):
+    """Parse the YAML/TOML frontmatter of a markdown file into a flat dict."""
+    try:
+        txt = open(path, encoding="utf-8").read()
+    except OSError:
+        return {}
+    m = (re.match(r'^﻿?---\n(.*?)\n---', txt, re.S)
+         or re.match(r'^﻿?\+\+\+\n(.*?)\n\+\+\+', txt, re.S))
+    if not m:
+        return {}
+    fm = {}
+    for line in m.group(1).splitlines():
+        mm = re.match(r'\s*([A-Za-z_]+)\s*[:=]\s*(.*)', line)
+        if mm:
+            fm[mm.group(1).lower()] = mm.group(2).strip().strip('"').strip("'")
+    return fm
+
+
+def weight(fm):
+    try:
+        return int(fm.get("weight", "999999"))
+    except ValueError:
+        return 999999
+
+
+def label(fm, fallback):
+    return fm.get("linktitle") or fm.get("title") or fallback
+
+
+def walk(d, depth, root, collapse, virtual):
+    """Return [(depth, label, kind)] rows for directory `d`.
+
+    kind is "folder", "page", or "ellipsis". `virtual` maps an absolute
+    directory path to extra (weight, label) page entries to merge in (used for
+    pages that exist on another branch but not the working tree).
+    """
+    entries = []
+    for name in os.listdir(d):
+        p = os.path.join(d, name)
+        rel = os.path.relpath(p, root)
+        if os.path.isdir(p):
+            idx = os.path.join(p, "_index.md")
+            if not os.path.exists(idx):
+                continue  # asset folder, not a Hugo section
+            fm = front(idx)
+            entries.append((weight(fm), label(fm, name), p, True, rel))
+        elif name.endswith(".md") and name != "_index.md":
+            fm = front(p)
+            entries.append((weight(fm), label(fm, name[:-3]), p, False, rel))
+    for w, lab in virtual.get(os.path.abspath(d), []):
+        entries.append((w, lab, None, False, None))
+    entries.sort(key=lambda e: (e[0], e[1].lower()))
+
+    rows = []
+    for w, lab, p, isdir, rel in entries:
+        rows.append((depth, lab, "folder" if isdir else "page"))
+        if isdir:
+            if rel in collapse:
+                rows.append((depth + 1, "...", "ellipsis"))
+            else:
+                rows.extend(walk(p, depth + 1, root, collapse, virtual))
+    return rows
+
+
+def fill_for(kind):
+    if kind in ("root", "folder"):
+        return YELLOW_FILL, YELLOW_STROKE
+    return None, None
+
+
+def esc(s):
+    return html.escape(s, quote=True)
+
+
+def build_rows(root, collapse, adds):
+    virtual = {}
+    for rel, lab, w in adds:
+        parent = os.path.abspath(os.path.join(root, os.path.dirname(rel)))
+        virtual.setdefault(parent, []).append((w, lab))
+    rootfm = front(os.path.join(root, "_index.md"))
+    rows = [(0, label(rootfm, os.path.basename(os.path.normpath(root))), "root")]
+    rows.extend(walk(root, 1, root, set(collapse), virtual))
+    return rows
+
+
+def build_svg(rows, edge_style="straight"):
+    max_depth = max(d for d, _, _ in rows)
+    page_w = LBASE + W + GAP + max_depth * INDENT + W + 40
+    rbase = LBASE + W + GAP
+    page_h = START_Y + len(rows) * PITCH + 20
+
+    cells = []
+
+    def vcell(cid, value, x, y, fill, stroke, bold):
+        style = "rounded=1;whiteSpace=wrap;html=1;fontFamily=%s;" % FONT
+        if bold:
+            style += "fontStyle=1;"
+        if fill:
+            style += "fillColor=%s;strokeColor=%s;" % (fill, stroke)
+        cells.append(
+            '<mxCell id="%s" value="%s" style="%s" vertex="1" parent="1">'
+            '<mxGeometry x="%d" y="%d" width="%d" height="%d" as="geometry"/>'
+            '</mxCell>' % (cid, esc(value), style, x, y, W, H_BOX))
+
+    edge_base = EDGE_STYLES[edge_style]
+
+    def ecell(cid, src, tgt):
+        style = "%shtml=1;strokeColor=#999999;fontFamily=%s;" % (edge_base, FONT)
+        cells.append(
+            '<mxCell id="%s" style="%s" edge="1" parent="1" source="%s" '
+            'target="%s"><mxGeometry relative="1" as="geometry"/></mxCell>'
+            % (cid, style, src, tgt))
+
+    geom = []
+    for i, (depth, lab, kind) in enumerate(rows):
+        y = START_Y + i * PITCH
+        lx = LBASE + depth * INDENT
+        rx = rbase + depth * INDENT
+        fill, stroke = fill_for(kind)
+        vcell("L%d" % i, lab, lx, y, fill, stroke, kind == "root")
+        vcell("R%d" % i, lab, rx, y, fill, stroke, kind == "root")
+        if kind not in ("root", "ellipsis"):
+            ecell("e%d" % i, "L%d" % i, "R%d" % i)
+        geom.append((lx, rx, y, lab, kind))
+
+    model = (
+        '<mxGraphModel dx="960" dy="640" grid="1" gridSize="10" guides="1" '
+        'tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" '
+        'pageWidth="%d" pageHeight="%d" math="0" shadow="0">\n'
+        '      <root>\n'
+        '        <mxCell id="0"/>\n'
+        '        <mxCell id="1" parent="0"/>\n'
+        '        %s\n'
+        '      </root>\n'
+        '    </mxGraphModel>' % (page_w, page_h, "\n        ".join(cells)))
+
+    mxfile = (
+        '<mxfile host="app.diagrams.net" agent="Claude Code" '
+        'version="27.0.8" scale="1" border="0">\n'
+        '  <diagram name="Page-1" id="docs-restructure">\n'
+        '    %s\n  </diagram>\n</mxfile>' % model)
+
+    svg = ['<?xml version="1.0" encoding="UTF-8"?>']
+    svg.append(
+        '<svg xmlns="http://www.w3.org/2000/svg" '
+        'xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" '
+        'width="%dpx" height="%dpx" viewBox="-0.5 -0.5 %d %d" content="%s">'
+        % (page_w, page_h, page_w, page_h, esc(mxfile)))
+    svg.append('<rect x="0" y="0" width="%d" height="%d" fill="#ffffff"/>'
+               % (page_w, page_h))
+
+    def box(x, y, lab, kind):
+        f, s = fill_for(kind)
+        svg.append('<rect x="%d" y="%d" width="%d" height="%d" rx="5" ry="5" '
+                   'fill="%s" stroke="%s"/>'
+                   % (x, y, W, H_BOX, f or "#ffffff", s or "#000000"))
+        fw = 'font-weight:bold;' if kind == "root" else ''
+        svg.append('<text x="%.1f" y="%.1f" text-anchor="middle" '
+                   'dominant-baseline="middle" style="font-family:%s;'
+                   'font-size:11px;fill:#000000;%s">%s</text>'
+                   % (x + W / 2, y + H_BOX / 2, FONT, fw, html.escape(lab)))
+
+    def arrow(x1, y, x2):
+        svg.append('<path d="M %d %d L %d %d" stroke="#999999" fill="none"/>'
+                   % (x1, y, x2 - 8, y))
+        svg.append('<path d="M %d %d L %d %d L %d %d Z" fill="#999999" '
+                   'stroke="#999999"/>'
+                   % (x2, y, x2 - 9, y - 4, x2 - 9, y + 4))
+
+    for lx, rx, y, lab, kind in geom:
+        if kind not in ("root", "ellipsis"):
+            arrow(lx + W, y + H_BOX / 2, rx)
+        box(lx, y, lab, kind)
+        box(rx, y, lab, kind)
+    svg.append('</svg>')
+    return "\n".join(svg), page_w, page_h
+
+
+def parse_add(spec):
+    parts = spec.split("::")
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError(
+            "--add must be REL_PATH::LABEL::WEIGHT, got %r" % spec)
+    rel, lab, w = parts
+    return (rel, lab, int(w))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("root", help="docs section folder (the diagram root)")
+    ap.add_argument("--out", help="output .drawio.svg path "
+                    "(default: <section>-restructure.drawio.svg)")
+    ap.add_argument("--collapse", nargs="*", default=[], metavar="REL",
+                    help="folder paths (relative to root) to show collapsed "
+                    "as a single box with a '...' sub-box")
+    ap.add_argument("--add", action="append", default=[], type=parse_add,
+                    metavar="REL::LABEL::WEIGHT",
+                    help="manually inject a page that is not in the working "
+                    "tree (e.g. exists only on another branch); repeatable")
+    ap.add_argument("--edge-style", choices=sorted(EDGE_STYLES),
+                    default="straight",
+                    help="arrow routing (default: straight). 'straight' = "
+                    "point-to-point diagonals (best for avoiding overlap when "
+                    "boxes move); 'curved' = smooth orthogonal S-bends "
+                    "(prettier but still centre-routed); 'orthogonal' = "
+                    "right-angle rectilinear.")
+    args = ap.parse_args()
+
+    root = os.path.abspath(args.root)
+    if not os.path.isdir(root):
+        sys.exit("error: not a directory: %s" % root)
+    out = args.out or (os.path.basename(os.path.normpath(root))
+                       + "-restructure.drawio.svg")
+
+    rows = build_rows(root, args.collapse, args.add)
+    svg, pw, ph = build_svg(rows, args.edge_style)
+    print("Edge style: %s" % args.edge_style)
+    open(out, "w", encoding="utf-8").write(svg)
+
+    # Validate: both the outer SVG and the embedded editable model must parse.
+    r = ET.fromstring(svg)
+    model = ET.fromstring(r.get("content"))
+    nv = sum(1 for c in model.iter("mxCell") if c.get("vertex") == "1")
+    ne = sum(1 for c in model.iter("mxCell") if c.get("edge") == "1")
+
+    print("Wrote %s  (%dx%d, %d rows, %d boxes, %d arrows)"
+          % (out, pw, ph, len(rows), nv, ne))
+    print("\nTree (before == after):")
+    for depth, lab, kind in rows:
+        print("  " * depth + lab + ("/" if kind in ("root", "folder") else ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/restructure-diagram/build_diagram.py
+++ b/.claude/skills/restructure-diagram/build_diagram.py
@@ -99,7 +99,10 @@ def walk(d, depth, root, collapse, virtual):
     entries = []
     for name in os.listdir(d):
         p = os.path.join(d, name)
-        rel = os.path.relpath(p, root)
+        # Normalise to forward slashes: os.path.relpath uses "\" on Windows,
+        # but --collapse args (and the SKILL examples) use "/", so an un-
+        # normalised compare in `rel in collapse` would never match there.
+        rel = os.path.relpath(p, root).replace(os.sep, "/")
         if os.path.isdir(p):
             idx = os.path.join(p, "_index.md")
             if not os.path.exists(idx):
@@ -137,6 +140,14 @@ def esc(s):
 def build_rows(root, collapse, adds):
     virtual = {}
     for rel, lab, w in adds:
+        # --add injects pages that aren't in the working tree. If the file is
+        # actually present, walk() will already emit it -- skip the virtual
+        # copy so it doesn't appear twice, and say so.
+        if os.path.exists(os.path.join(root, rel)):
+            print("note: --add %r is already in the working tree; "
+                  "using the on-disk page (not duplicating)" % rel,
+                  file=sys.stderr)
+            continue
         parent = os.path.abspath(os.path.join(root, os.path.dirname(rel)))
         virtual.setdefault(parent, []).append((w, lab))
     rootfm = front(os.path.join(root, "_index.md"))

--- a/.claude/skills/restructure-diagram/build_diagram.py
+++ b/.claude/skills/restructure-diagram/build_diagram.py
@@ -89,13 +89,16 @@ def label(fm, fallback):
     return fm.get("linktitle") or fm.get("title") or fallback
 
 
-def walk(d, depth, root, collapse, virtual):
+def walk(d, depth, root, collapse, virtual, expanded):
     """Return [(depth, label, kind)] rows for directory `d`.
 
     kind is "folder", "page", or "ellipsis". `virtual` maps an absolute
     directory path to extra (weight, label) page entries to merge in (used for
-    pages that exist on another branch but not the working tree).
+    pages that exist on another branch but not the working tree). `expanded`
+    is a set this records each visited dir into, so build_rows can tell which
+    `virtual` entries actually got merged vs silently dropped.
     """
+    expanded.add(os.path.abspath(d))
     entries = []
     for name in os.listdir(d):
         p = os.path.join(d, name)
@@ -123,7 +126,8 @@ def walk(d, depth, root, collapse, virtual):
             if rel in collapse:
                 rows.append((depth + 1, "...", "ellipsis"))
             else:
-                rows.extend(walk(p, depth + 1, root, collapse, virtual))
+                rows.extend(walk(p, depth + 1, root, collapse, virtual,
+                                 expanded))
     return rows
 
 
@@ -137,42 +141,42 @@ def esc(s):
     return html.escape(s, quote=True)
 
 
-def _under_collapse(parent_rel, collapse):
-    """True if parent_rel is, or is nested under, any collapsed folder."""
-    return any(parent_rel == c or parent_rel.startswith(c + "/")
-               for c in collapse)
-
-
 def build_rows(root, collapse, adds):
     collapse = set(collapse)
+    # Queue every --add as a virtual page keyed on its parent dir. We do NOT try
+    # to predict whether walk() will render it -- a virtual page shows up iff
+    # walk() expands its parent dir, and the conditions for that (dir exists, has
+    # an _index.md, is in-tree, isn't collapsed) are exactly walk()'s own logic.
+    # Re-deriving them here is what kept leaking edge cases. Instead, let walk
+    # record the dirs it expanded and reconcile against that ground truth below.
+    # The one thing we still check up front is the on-disk case: there walk emits
+    # the page itself, so a virtual copy would duplicate rather than drop.
     virtual = {}
-    # Resolve every --add in one place: a virtual page only renders if walk()
-    # actually descends into its parent folder. That fails three ways -- the
-    # file is really on disk (walk emits it anyway -> would duplicate), the
-    # parent folder doesn't exist (typo), or the parent is collapsed (walk stops
-    # at the "..." box and never merges siblings). In every case warn rather
-    # than silently dropping or duplicating the page.
+    queued = []  # (parent_abs, rel) for post-walk reconciliation
     for rel, lab, w in adds:
-        rel_norm = rel.replace(os.sep, "/")
-        parent_rel = rel_norm.rsplit("/", 1)[0] if "/" in rel_norm else ""
-        parent_abs = os.path.abspath(os.path.join(root, parent_rel))
         if os.path.exists(os.path.join(root, rel)):
             print("note: --add %r is already in the working tree; using the "
                   "on-disk page (not duplicating)" % rel, file=sys.stderr)
             continue
-        if not os.path.isdir(parent_abs):
-            print("warning: --add %r skipped: folder %r does not exist"
-                  % (rel, parent_rel or "."), file=sys.stderr)
-            continue
-        if _under_collapse(parent_rel, collapse):
-            print("warning: --add %r skipped: its folder is collapsed via "
-                  "--collapse, so injected pages would not be shown" % rel,
-                  file=sys.stderr)
-            continue
+        rel_norm = rel.replace(os.sep, "/")
+        parent_rel = rel_norm.rsplit("/", 1)[0] if "/" in rel_norm else ""
+        parent_abs = os.path.abspath(os.path.join(root, parent_rel))
         virtual.setdefault(parent_abs, []).append((w, lab))
+        queued.append((parent_abs, rel))
+
     rootfm = front(os.path.join(root, "_index.md"))
     rows = [(0, label(rootfm, os.path.basename(os.path.normpath(root))), "root")]
-    rows.extend(walk(root, 1, root, set(collapse), virtual))
+    expanded = set()
+    rows.extend(walk(root, 1, root, collapse, virtual, expanded))
+
+    # Reconcile: warn for any --add whose parent walk never expanded -- one check
+    # that covers missing, collapsed, asset-folder, and out-of-tree parents.
+    for parent_abs, rel in queued:
+        if parent_abs not in expanded:
+            print("warning: --add %r not shown: its folder %r is not an "
+                  "expanded section (missing, collapsed, an asset folder "
+                  "without _index.md, or outside the tree)"
+                  % (rel, os.path.relpath(parent_abs, root)), file=sys.stderr)
     return rows
 
 

--- a/.claude/skills/restructure-diagram/build_diagram.py
+++ b/.claude/skills/restructure-diagram/build_diagram.py
@@ -137,19 +137,39 @@ def esc(s):
     return html.escape(s, quote=True)
 
 
+def _under_collapse(parent_rel, collapse):
+    """True if parent_rel is, or is nested under, any collapsed folder."""
+    return any(parent_rel == c or parent_rel.startswith(c + "/")
+               for c in collapse)
+
+
 def build_rows(root, collapse, adds):
+    collapse = set(collapse)
     virtual = {}
+    # Resolve every --add in one place: a virtual page only renders if walk()
+    # actually descends into its parent folder. That fails three ways -- the
+    # file is really on disk (walk emits it anyway -> would duplicate), the
+    # parent folder doesn't exist (typo), or the parent is collapsed (walk stops
+    # at the "..." box and never merges siblings). In every case warn rather
+    # than silently dropping or duplicating the page.
     for rel, lab, w in adds:
-        # --add injects pages that aren't in the working tree. If the file is
-        # actually present, walk() will already emit it -- skip the virtual
-        # copy so it doesn't appear twice, and say so.
+        rel_norm = rel.replace(os.sep, "/")
+        parent_rel = rel_norm.rsplit("/", 1)[0] if "/" in rel_norm else ""
+        parent_abs = os.path.abspath(os.path.join(root, parent_rel))
         if os.path.exists(os.path.join(root, rel)):
-            print("note: --add %r is already in the working tree; "
-                  "using the on-disk page (not duplicating)" % rel,
+            print("note: --add %r is already in the working tree; using the "
+                  "on-disk page (not duplicating)" % rel, file=sys.stderr)
+            continue
+        if not os.path.isdir(parent_abs):
+            print("warning: --add %r skipped: folder %r does not exist"
+                  % (rel, parent_rel or "."), file=sys.stderr)
+            continue
+        if _under_collapse(parent_rel, collapse):
+            print("warning: --add %r skipped: its folder is collapsed via "
+                  "--collapse, so injected pages would not be shown" % rel,
                   file=sys.stderr)
             continue
-        parent = os.path.abspath(os.path.join(root, os.path.dirname(rel)))
-        virtual.setdefault(parent, []).append((w, lab))
+        virtual.setdefault(parent_abs, []).append((w, lab))
     rootfm = front(os.path.join(root, "_index.md"))
     rows = [(0, label(rootfm, os.path.basename(os.path.normpath(root))), "root")]
     rows.extend(walk(root, 1, root, set(collapse), virtual))
@@ -289,13 +309,16 @@ def main():
     rows = build_rows(root, args.collapse, args.add)
     svg, pw, ph = build_svg(rows, args.edge_style)
     print("Edge style: %s" % args.edge_style)
-    open(out, "w", encoding="utf-8").write(svg)
 
-    # Validate: both the outer SVG and the embedded editable model must parse.
+    # Validate *before* writing, so a parse failure never leaves an invalid
+    # file at --out (the skill promises validated output): both the outer SVG
+    # and the embedded editable model must parse.
     r = ET.fromstring(svg)
     model = ET.fromstring(r.get("content"))
     nv = sum(1 for c in model.iter("mxCell") if c.get("vertex") == "1")
     ne = sum(1 for c in model.iter("mxCell") if c.get("edge") == "1")
+
+    open(out, "w", encoding="utf-8").write(svg)
 
     print("Wrote %s  (%dx%d, %d rows, %d boxes, %d arrows)"
           % (out, pw, ph, len(rows), nv, ne))

--- a/.claude/state/assess-comments.coverage.md
+++ b/.claude/state/assess-comments.coverage.md
@@ -31,18 +31,18 @@ whether to commit the change.
 | Multi-source collection (inline + top-level + reviews) | 🟢 corroborated | 7 | 2026-06-30 | #3415, #3507, #3510, #3374, #3536, #3543, #3573 |
 | GraphQL thread-resolution pull (`isResolved`/`isOutdated`) | 🟢 corroborated | 5 | 2026-06-30 | #3510 (12/12 resolved), #3374 (15/15), #3536 (2/2 open), #3543 (1/1 open), #3573 (2/2 open) |
 | Source-role tagging (bugbot/security/history/summary/ci/human) | 🟢 corroborated | 6 | 2026-06-30 | #3415, #3507, #3374, #3536, #3543, #3573 |
-| Open/resolved split | 🟢 corroborated | 5 | 2026-06-30 | #3510, #3374, #3536, #3543, #3573 (2 open / 0 resolved) |
-| Fix-quality spot-check (genuinely fixed vs silenced) | 🟢 corroborated | 2 | 2026-06-23 | #3510 (term removals landed), #3374 (`num_docs`, dropIndex landed) |
+| Open/resolved split | 🟢 corroborated | 5 | 2026-06-30 | #3510, #3374, #3536, #3543, #3573 (r1: 2 open/0 resolved; r2: 2 resolved/2 open — mixed-state PR) |
+| Fix-quality spot-check (genuinely fixed vs silenced) | 🟢 corroborated | 3 | 2026-06-30 | #3510 (term removals landed), #3374 (`num_docs`, dropIndex landed), #3573 (r1 fixes genuinely landed: relpath `.replace(os.sep,"/")` L105, --add dedup guard L146-150) |
 | "Resolved ≠ fixed" flag — **legitimate deferral** variant | 🟡 seen once | 1 | 2026-06-23 | #3510 (TS.BGET:122 left pending eng) |
 | "Resolved ≠ fixed" flag — **still-broken** variant | ❓ untested | 0 | — | never confirmed a resolved thread that was actually still broken |
 | Cross-tool **agreement** | 🟡 seen once | 1 | 2026-06-23 | #3374 (Claude + bugbot independently on `num_docs`) |
 | **Contradiction** detection | 🟡 seen once | 1 | 2026-06-23 | #3415 (approval vs open bugbot finding). *(#3507 bugbot-vs-author was an off-branch manual demo — illustrative, not counted toward encounters.)* |
-| **Ping-pong loop** detection | ❓ untested | 0 | 2026-06-23 | still no real loop across 4 bugbot rounds on #3536. Rounds 2 & 4 each raised new post-fix findings but none was a reopened concern or A↔B cycle — correctly judged NOT a loop both times. Round 4 instead revealed *subsystem churn* (next row) |
-| **Subsystem churn** detection (repeated findings on one patched area) | 🟡 seen (1 PR, 3 instances) | 3 | 2026-06-23 | #3536 — (a) 429/862/874 on `$ARGUMENTS` filter + review handling; (b) r5 442/449 on the *churn feature*; (c) r6 3461052859 on the *cap ↔ report contract* — i.e. (b)'s consolidation was too narrow. Pattern is robust on this PR; needs a 2nd PR for 🟢. Worked examples below |
-| Approval-over-open-finding cross-check | 🟢 corroborated | 3 | 2026-06-23 | #3415 (dwdougherty), #3374 (dwdougherty low-confidence over open HIGH), #3536 (dwdougherty high-confidence — tested — over 2 open Mediums: benign variant) |
+| **Ping-pong loop** detection | ❓ untested | 0 | 2026-06-30 | still no real loop. #3536 (4 rounds) and now #3573 (r2): r1 findings reached a fixed point (both resolved), r2 raised new *independent* findings — correctly judged NOT a loop. Confirmed my r1 dedup patch did **not** cause the r2 collapse-drop finding (pre-existing gap), so not an A→fix→B cycle either |
+| **Subsystem churn** detection (repeated findings on one patched area) | 🟢 corroborated | 2 PRs | 2026-06-30 | #3536 (review-handling, 3 instances) **and** #3573 (the `--add` virtual-merge mechanism: r1 #3499137529 dup-vs-disk → I patched build_rows → r2 #3499226329 dropped-under-collapse, same mechanism, adjacent gap my patch didn't cover). 2nd distinct PR → corroborated. Worked examples below |
+| Approval-over-open-finding cross-check | 🟢 corroborated | 4 | 2026-06-30 | #3415 (dwdougherty), #3374 (dwdougherty low-confidence over open HIGH), #3536 (dwdougherty high-confidence over 2 open Mediums: benign), #3573 (dwdougherty "Sure, why not?" APPROVED 13:41 over open findings; 2 more bot findings landed 13:49 after the approval) |
 | Depth cap / prioritisation under load | 🟡 seen once | 1 | 2026-06-23 | #3374 (19 candidate findings → 4 deep-verified). *(#3573 had only 2 findings — under cap, not a load test)* |
 | Mandatory deep-verify of resolved+not-outdated HIGH | ❓ untested | 0 | — | rule added 2026-06-23; not yet fired on a fresh run |
-| Bot calibration (fixed-vs-dismissed ratio) | 🟢 corroborated | 4 | 2026-06-30 | #3374 (bugbot signal mostly accepted); #3536 (bugbot 5/5 findings valid across 2 rounds — high trust); #3543 (bugbot 1/1 valid — lifespan asymmetry real; Jit 0 findings); #3573 (bugbot 2/2 valid — both real latent bugs; Jit 0 findings) |
+| Bot calibration (fixed-vs-dismissed ratio) | 🟢 corroborated | 4 | 2026-06-30 | #3374 (bugbot signal mostly accepted); #3536 (bugbot 5/5 findings valid across 2 rounds — high trust); #3543 (bugbot 1/1 valid — lifespan asymmetry real; Jit 0 findings); #3573 (bugbot 4/4 valid across 2 rounds — all real; Jit 0 findings — high trust) |
 | Codex second-opinion availability gate | 🟢 corroborated | 4 | 2026-06-30 | #3415, #3374 (CLI on PATH; #3374 had a real Codex review); #3543 (codex on PATH); #3573 (codex on PATH) |
 
 ## Worked examples library
@@ -102,6 +102,21 @@ present in the code)*
   marking deferred ones unverified. Meta-lesson: when round N+1 finds another gap
   in an area you *just* "consolidated", your consolidation boundary was wrong —
   widen it to the true subsystem, don't re-patch the edge.
+
+- **#3573 `--add` virtual-merge, 2026-06-30 (2nd PR → corroborates the pattern).**
+  Round 1 bugbot #3499137529 flagged `--add` duplicating a page that's also on
+  disk; fixed by an existence-check in `build_rows`. Round-2 re-scan then raised
+  #3499226329: `--add` into a `--collapse`d folder is silently dropped (virtual
+  entries merge only when `walk` recurses, which collapsed folders skip). *New,
+  independent finding* (not ping-pong) but the **same under-specified subsystem**
+  — how `--add` virtual entries reconcile with the on-disk walk and collapse
+  state. Signature again: each point-patch exposed the next adjacent gap.
+  Consolidation that would end it: resolve all `--add` entries against the final
+  tree in one place — validate the parent is a real, non-collapsed, walked dir
+  and **warn instead of silently dropping**, and dedupe vs disk there too —
+  rather than threading a `virtual` dict through the recursion. Borderline
+  (only 2 instances, niche feature), but the cross-round, same-mechanism shape
+  is the early churn signal.
 
 ### Cross-tool agreement
 - **#3374 `num_docs`** — Claude (Critical #2, top-level review) and bugbot

--- a/.claude/state/assess-comments.coverage.md
+++ b/.claude/state/assess-comments.coverage.md
@@ -27,11 +27,11 @@ whether to commit the change.
 
 | Capability | Confidence | Real encounters | Last verified | Evidence |
 |---|---|---|---|---|
-| Branch/PR identification + arg handling | 🟢 corroborated | 5 | 2026-06-25 | #3415, #3507, #3374, #3536, #3543 |
-| Multi-source collection (inline + top-level + reviews) | 🟢 corroborated | 6 | 2026-06-25 | #3415, #3507, #3510, #3374, #3536, #3543 |
-| GraphQL thread-resolution pull (`isResolved`/`isOutdated`) | 🟢 corroborated | 4 | 2026-06-25 | #3510 (12/12 resolved), #3374 (15/15), #3536 (2/2 open), #3543 (1/1 open) |
-| Source-role tagging (bugbot/security/history/summary/ci/human) | 🟢 corroborated | 5 | 2026-06-25 | #3415, #3507, #3374, #3536, #3543 |
-| Open/resolved split | 🟢 corroborated | 4 | 2026-06-25 | #3510, #3374, #3536, #3543 (1 open / 0 resolved) |
+| Branch/PR identification + arg handling | 🟢 corroborated | 6 | 2026-06-30 | #3415, #3507, #3374, #3536, #3543, #3573 |
+| Multi-source collection (inline + top-level + reviews) | 🟢 corroborated | 7 | 2026-06-30 | #3415, #3507, #3510, #3374, #3536, #3543, #3573 |
+| GraphQL thread-resolution pull (`isResolved`/`isOutdated`) | 🟢 corroborated | 5 | 2026-06-30 | #3510 (12/12 resolved), #3374 (15/15), #3536 (2/2 open), #3543 (1/1 open), #3573 (2/2 open) |
+| Source-role tagging (bugbot/security/history/summary/ci/human) | 🟢 corroborated | 6 | 2026-06-30 | #3415, #3507, #3374, #3536, #3543, #3573 |
+| Open/resolved split | 🟢 corroborated | 5 | 2026-06-30 | #3510, #3374, #3536, #3543, #3573 (2 open / 0 resolved) |
 | Fix-quality spot-check (genuinely fixed vs silenced) | 🟢 corroborated | 2 | 2026-06-23 | #3510 (term removals landed), #3374 (`num_docs`, dropIndex landed) |
 | "Resolved ≠ fixed" flag — **legitimate deferral** variant | 🟡 seen once | 1 | 2026-06-23 | #3510 (TS.BGET:122 left pending eng) |
 | "Resolved ≠ fixed" flag — **still-broken** variant | ❓ untested | 0 | — | never confirmed a resolved thread that was actually still broken |
@@ -40,10 +40,10 @@ whether to commit the change.
 | **Ping-pong loop** detection | ❓ untested | 0 | 2026-06-23 | still no real loop across 4 bugbot rounds on #3536. Rounds 2 & 4 each raised new post-fix findings but none was a reopened concern or A↔B cycle — correctly judged NOT a loop both times. Round 4 instead revealed *subsystem churn* (next row) |
 | **Subsystem churn** detection (repeated findings on one patched area) | 🟡 seen (1 PR, 3 instances) | 3 | 2026-06-23 | #3536 — (a) 429/862/874 on `$ARGUMENTS` filter + review handling; (b) r5 442/449 on the *churn feature*; (c) r6 3461052859 on the *cap ↔ report contract* — i.e. (b)'s consolidation was too narrow. Pattern is robust on this PR; needs a 2nd PR for 🟢. Worked examples below |
 | Approval-over-open-finding cross-check | 🟢 corroborated | 3 | 2026-06-23 | #3415 (dwdougherty), #3374 (dwdougherty low-confidence over open HIGH), #3536 (dwdougherty high-confidence — tested — over 2 open Mediums: benign variant) |
-| Depth cap / prioritisation under load | 🟡 seen once | 1 | 2026-06-23 | #3374 (19 candidate findings → 4 deep-verified) |
+| Depth cap / prioritisation under load | 🟡 seen once | 1 | 2026-06-23 | #3374 (19 candidate findings → 4 deep-verified). *(#3573 had only 2 findings — under cap, not a load test)* |
 | Mandatory deep-verify of resolved+not-outdated HIGH | ❓ untested | 0 | — | rule added 2026-06-23; not yet fired on a fresh run |
-| Bot calibration (fixed-vs-dismissed ratio) | 🟢 corroborated | 3 | 2026-06-25 | #3374 (bugbot signal mostly accepted); #3536 (bugbot 5/5 findings valid across 2 rounds — high trust); #3543 (bugbot 1/1 valid — lifespan asymmetry real; Jit 0 findings) |
-| Codex second-opinion availability gate | 🟢 corroborated | 3 | 2026-06-25 | #3415, #3374 (CLI on PATH; #3374 had a real Codex review); #3543 (codex on PATH) |
+| Bot calibration (fixed-vs-dismissed ratio) | 🟢 corroborated | 4 | 2026-06-30 | #3374 (bugbot signal mostly accepted); #3536 (bugbot 5/5 findings valid across 2 rounds — high trust); #3543 (bugbot 1/1 valid — lifespan asymmetry real; Jit 0 findings); #3573 (bugbot 2/2 valid — both real latent bugs; Jit 0 findings) |
+| Codex second-opinion availability gate | 🟢 corroborated | 4 | 2026-06-30 | #3415, #3374 (CLI on PATH; #3374 had a real Codex review); #3543 (codex on PATH); #3573 (codex on PATH) |
 
 ## Worked examples library
 


### PR DESCRIPTION
## What

Adds a `restructure-diagram` skill that generates a **before/after restructuring diagram** for any docs section under `content/`. The output is a draw.io-editable `.drawio.svg`: two identical columns (current structure left, a copy on the right) joined by arrows, so you can drag the right-hand boxes into a proposed new layout and see where each page moved.

It reads the docs straight from source rather than guessing:
- **Order** follows each page's Hugo `weight` frontmatter (ties broken by label).
- **Box text** is the `linkTitle` (falling back to `title`, then filename).
- **Folders/sections** (anything with an `_index.md`) are shaded yellow; pages are white.
- **Asset folders** (no `_index.md`, e.g. holding only JSON) are skipped.
- `--collapse` shows a folder as a single box with one `...` sub-box, for sections with many similar children (CLI commands, per-database setup pages, release notes).
- `--add` injects a page that exists only on another branch.
- `--edge-style` picks arrow routing; default `straight` (point-to-point diagonals) keeps a busy, rearranged diagram legible.

## Files

- `.claude/skills/restructure-diagram/SKILL.md` — when/how to use, guardrails.
- `.claude/skills/restructure-diagram/build_diagram.py` — the generator (`--help` for options); self-validates the SVG and embedded model and prints the tree.

## Notes

- This is tooling only — no docs content changes. The diagrams it produces are planning artifacts written to the repo root (or wherever specified), **not** into `content/`, so they aren't published.
- The skill won't appear in the `/` list until Claude Code reloads the skills directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and internal Claude state only; no Hugo content, auth, or runtime docs changes.
> 
> **Overview**
> Introduces the **`restructure-diagram`** Claude skill and a **`build_diagram.py`** generator that walks a Hugo section under `content/`, builds a nav-aligned tree from `weight` / `linkTitle`, and writes a **draw.io-editable** `.drawio.svg` with mirrored **before** and **after** columns linked by arrows for planning moves in diagrams.net.
> 
> The script supports **`--collapse`** (summarize noisy subtrees), **`--add`** (inject pages from other branches with dedup and warnings when parents are missing or collapsed), **`--edge-style`** (default straight diagonals), path normalization for **`--collapse`** on Windows, and **XML validation** before writing output. **`SKILL.md`** documents workflow, zsh **`--collapse`** pitfalls, and guardrails (planning artifacts outside `content/`).
> 
> Also updates **`.claude/state/assess-comments.coverage.md`** with **#3573** encounter counts and a worked **subsystem churn** example around `--add` virtual-merge—internal assess-comments telemetry only, no published docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c998e8f09759f363ae039a3e4c8226bd3b462d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->