### PR TITLE
K8s: support error fix

### DIFF
--- a/content/operate/kubernetes/release-notes/8-0-18-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-18-releases/_index.md
@@ -27,8 +27,9 @@ The following table shows supported Kubernetes versions at the time of this rele
 |---|---|
 | 1.35 | Supported |
 | 1.34 | Supported |
-| 1.33 | Deprecated |
-| 1.32 | Removed |
+| 1.33 | Supported |
+| 1.32 | Deprecated |
+| 1.31 | Deprecated |
 
 ## Known limitations
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to release notes; no product code or runtime behavior is affected.
> 
> **Overview**
> Corrects the **Supported distributions** Kubernetes version table on the Redis Enterprise for Kubernetes **8.0.18** release notes page.
> 
> **Kubernetes 1.33** is updated from *Deprecated* to **Supported**. **1.32** changes from *Removed* to **Deprecated**, and **1.31** is added as **Deprecated**, matching the support matrix in the 8.0.18 reference docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 438a54ab8b852fa31a941f964233e44271cb45e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->