### PR TITLE
DOC-6803 RDI: clarify redis.lookup is not a supported denormalization mechanism

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/data-denormalization.md
+++ b/content/integrate/redis-data-integration/data-pipelines/data-denormalization.md
@@ -25,6 +25,21 @@ at the expense of speed.
 A Redis cache, on the other hand, is focused on making *read* queries fast, so RDI provides data
 *denormalization* to help with this.
 
+The supported denormalization techniques are joining
+[one-to-one relationships](#joining-one-to-one-relationships) (using `merge`) and
+joining [one-to-many relationships](#joining-one-to-many-relationships) (using nesting),
+both described below.
+
+{{< note >}}
+The [`redis.lookup`]({{< relref "/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example" >}})
+transformation is *not* a supported way to denormalize data that RDI ingests. RDI
+can't guarantee that a key written by one job is present or up to date when another
+job looks it up, so lookups against pipeline-populated data can miss or return stale
+values. Use the techniques on this page instead. See
+[Reading Redis data with redis.lookup]({{< relref "/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example" >}})
+for details.
+{{< /note >}}
+
 ## Joining one-to-one relationships
 
 You can join one-to-one relationships by making more than one job to write to the same Redis key.

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example.md
@@ -1,5 +1,5 @@
 ---
-Title: Denormalization with redis.lookup
+Title: Reading Redis data with redis.lookup
 alwaysopen: false
 categories:
 - docs
@@ -8,7 +8,7 @@ categories:
 - rdi
 description: null
 group: di
-linkTitle: Denormalization with redis.lookup
+linkTitle: Reading Redis data with redis.lookup
 summary: Redis Data Integration keeps Redis in sync with a primary database in near
   real time.
 type: integration
@@ -18,18 +18,41 @@ weight: 40
 You can use the
 [`redis.lookup`]({{< relref "/integrate/redis-data-integration/reference/data-transformation/lookup" >}})
 transformation to read existing data from Redis during the `transform` stage of a
-job. This is useful when you want to denormalize incoming change data by enriching
-a record with values that RDI has already written to Redis from another table
-(see [Data denormalization]({{< relref "/integrate/redis-data-integration/data-pipelines/data-denormalization" >}}) for more information about this technique).
+job. This lets you enrich an incoming record with values that are already present
+in the target database.
 
-For example, a pipeline for the Chinook database might write `artist` records to
-Redis, then use `redis.lookup` in
-an `album` table job to add selected artist details
-to each album record before writing it to the target database. This lets you
-design the structure of your Redis data to fit the read patterns of your
-application while still keeping the source database normalized.
+For example, a pipeline for the Chinook database might read an `artist` record
+that is already stored in Redis and use `redis.lookup` in an `album` table job to
+add selected artist details to each album record before writing it to the target
+database.
 
-## Denormalizing a hash
+{{< warning >}}
+Do not rely on `redis.lookup` to *denormalize* data that RDI writes from another
+table in the **same pipeline**. RDI can't guarantee that the looked-up data will be
+present or up to date when the lookup runs, for the following reasons:
+
+- **Snapshot order isn't guaranteed.** During the initial snapshot, RDI can't
+  guarantee that the table you look up is ingested before the table that depends
+  on it. If a dependent job runs before the referenced key has been written, the
+  lookup misses.
+- **Change (CDC) order isn't guaranteed.** If a parent and child record are
+  inserted or updated at around the same time, RDI has no way to order these
+  events, so the lookup can still miss.
+- **Parent updates don't refresh existing keys.** Even if the lookup succeeds,
+  updating the source record later does *not* update the keys that already copied
+  its values. The denormalized data becomes stale.
+
+The only case where `redis.lookup` is safe for enrichment is when you can guarantee
+that the looked-up data is present in the target database *independently* of the
+RDI pipeline (for example, a reference table that is loaded and maintained
+separately).
+
+To denormalize data that RDI ingests, use a supported technique instead. See
+[Data denormalization]({{< relref "/integrate/redis-data-integration/data-pipelines/data-denormalization" >}})
+for one-to-one joins (using `merge`) and one-to-many joins (using nesting).
+{{< /warning >}}
+
+## Reading a hash field
 
 The `redis.lookup` transformation works by executing a Redis command and adding the
 result to the record. You specify the command and its arguments in the
@@ -68,7 +91,7 @@ output:
         language: jmespath
 ```
 
-Without denormalization, the album hash object contains only the `artistid` field to
+Before the lookup runs, the album hash object contains only the `artistid` field to
 reference the artist:
 
 ```bash
@@ -96,10 +119,10 @@ extra `artist` field obtained by looking up the artist with the `artistid`:
 8) "AC/DC"
 ```
 
-## Denormalizing a JSON document
+## Embedding a JSON document
 
 If you are using [JSON]({{< relref "/develop/data-types/json" >}}) objects,
-you can denormalize to include the whole of one object
+you can read the whole of one object and embed it
 as a field of another. The following example shows how to do this using a temporary field
 to hold the result of the `redis.lookup` command. It then uses
 [`add_field`]({{< relref "/integrate/redis-data-integration/reference/data-transformation/add_field" >}})

--- a/content/integrate/redis-data-integration/reference/data-transformation/lookup.md
+++ b/content/integrate/redis-data-integration/reference/data-transformation/lookup.md
@@ -49,7 +49,7 @@ weight: 10
 **Additional Properties:** not allowed
 **Example**
 
-Denormalize a hash:
+Read a hash field:
 
 ```yaml
 source:


### PR DESCRIPTION
## What

Clarifies that `redis.lookup` is **not** a supported way to denormalize data that RDI ingests, resolving [DOC-6803](https://redislabs.atlassian.net/browse/DOC-6803).

The [lookup example page](https://redis.io/docs/latest/integrate/redis-data-integration/data-pipelines/transform-examples/redis-lookup-example/) was framed as a denormalization solution. Per RDI engineering (Zdravko Donev, via the ticket's Slack thread) that's incorrect, because when the looked-up data is populated by the *same* pipeline:

1. **Snapshot order isn't guaranteed** — a dependent job can run before the referenced table is ingested, so the lookup misses.
2. **CDC event order isn't guaranteed** — near-simultaneous parent/child changes can still miss.
3. **Parent updates don't refresh existing keys** — already-copied values go stale.

Lookup enrichment is only safe when the looked-up data is present in the target database **independently of the RDI pipeline**.

## Changes

- **`redis-lookup-example.md`** — retitled to *"Reading Redis data with redis.lookup"*; reframed around reading/enriching from existing target data; added a warning box covering the three failure modes and the one viable condition; renamed the section headings and reworked the prose. Filename/slug kept unchanged so existing support links still resolve.
- **`data-denormalization.md`** — added a note that `redis.lookup` is not a supported denormalization mechanism, steering readers to the supported `merge` (one-to-one) and nesting (one-to-many) techniques.
- **`reference/data-transformation/lookup.md`** — changed the example caption from "Denormalize a hash:" to "Read a hash field:".

No roadmap/Flink-processor references added. Hugo build confirmed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6803]: https://redislabs.atlassian.net/browse/DOC-6803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and cross-links; no product or runtime behavior changes.
> 
> **Overview**
> Documentation now states that **`redis.lookup` must not be used to denormalize data another job in the same RDI pipeline wrote to Redis**, and points readers to supported **`merge`** and **nesting** patterns on the data denormalization page.
> 
> The **redis.lookup** example page is retitled to *Reading Redis data with redis.lookup* and reframed around enriching from data already in the target. A **warning** explains snapshot ordering, CDC ordering, and stale copies after parent updates, and notes lookup is only safe when referenced keys exist **outside** the pipeline.
> 
> **data-denormalization.md** adds a note cross-linking that guidance; the reference **lookup** example caption is renamed from “Denormalize a hash” to “Read a hash field.” The page slug is unchanged so existing links keep working.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fbad3b2e8f1ec381dd39a4c8dc5803a05fef453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->