### PR TITLE
OP: fix K8s link warnings

### DIFF
--- a/content/operate/kubernetes/7.8.4/architecture/_index.md
+++ b/content/operate/kubernetes/7.8.4/architecture/_index.md
@@ -17,11 +17,11 @@ Redis Enterprise for Kubernetes gives you the speed and durability of [Redis Ent
 
 ## Lifecycle
 
-Kubernetes is a rapidly evolving platform with a short release cycle (around 4 months). This frequent influx of new features, enhancements and bug fixes means Kubernetes distributions move in and out of support quickly. Redis Enterprise is also a fast-moving product, and is compatible and tested only on distributions listed as [supported distributions.]({{<relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions">}})
+Kubernetes is a rapidly evolving platform with a short release cycle (around 4 months). This frequent influx of new features, enhancements and bug fixes means Kubernetes distributions move in and out of support quickly. Redis Enterprise is also a fast-moving product, and is compatible and tested only on distributions listed as [supported distributions.]({{<relref "/operate/kubernetes/7.8.4/reference">}})
 
-Each version of Redis Enterprise for Kubernetes is tested to ensure the version of Redis Enterprise works with the [supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions">}}) at the time. Both the Kubernetes version and the Redis Enterprise version must be supported for the operator to function correctly. We encourage you to upgrade Redis Enterprise for Kubernetes frequently, not only to get the benefit of enhancements and bug fixes, but to keep your software supported.
+Each version of Redis Enterprise for Kubernetes is tested to ensure the version of Redis Enterprise works with the [supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference">}}) at the time. Both the Kubernetes version and the Redis Enterprise version must be supported for the operator to function correctly. We encourage you to upgrade Redis Enterprise for Kubernetes frequently, not only to get the benefit of enhancements and bug fixes, but to keep your software supported.
 
-Supported platforms are listed in the [release notes]({{<relref "/operate/kubernetes/release-notes">}}) and in the [supported platforms reference.]({{<relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions">}})
+Supported platforms are listed in the [release notes]({{<relref "/operate/kubernetes/release-notes">}}) and in the [supported platforms reference.]({{<relref "/operate/kubernetes/7.8.4/reference">}})
 
 ## Architecture
 

--- a/content/operate/kubernetes/7.8.4/deployment/_index.md
+++ b/content/operate/kubernetes/7.8.4/deployment/_index.md
@@ -19,6 +19,6 @@ This section lists the different ways to set up and run Redis Enterprise for Kub
 
 ## Compatibility
 
-Before installing, check [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions" >}}) to see which Redis Enterprise operator version supports your Kubernetes distribution.
+Before installing, check [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference" >}}) to see which Redis Enterprise operator version supports your Kubernetes distribution.
 
 

--- a/content/operate/kubernetes/7.8.4/deployment/openshift/_index.md
+++ b/content/operate/kubernetes/7.8.4/deployment/openshift/_index.md
@@ -40,4 +40,4 @@ To [create a database on an OpenShift cluster via the CLI]({{< relref "/operate/
 
 ## Version compatibility
 
-To see which version of Redis Enterprise for Kubernetes supports your OpenShift version, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions" >}}).
+To see which version of Redis Enterprise for Kubernetes supports your OpenShift version, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference" >}}).

--- a/content/operate/kubernetes/7.8.4/deployment/openshift/openshift-cli.md
+++ b/content/operate/kubernetes/7.8.4/deployment/openshift/openshift-cli.md
@@ -18,7 +18,7 @@ Use these steps to set up a Redis Enterprise Software cluster with OpenShift.
 - [OpenShift cluster](https://docs.openshift.com/container-platform/4.8/installing/index.html) with at least 3 nodes (each meeting the [minimum requirements for a development installation]({{< relref "/operate/rs/installing-upgrading/install/plan-deployment/hardware-requirements" >}}))
 - [OpenShift CLI](https://docs.openshift.com/container-platform/latest/cli_reference/openshift_cli/getting-started-cli.html)
 
-To see which version of Redis Enterprise for Kubernetes supports your OpenShift version, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions" >}}).
+To see which version of Redis Enterprise for Kubernetes supports your OpenShift version, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference" >}}).
 
 ## Deploy the operator
 

--- a/content/operate/kubernetes/7.8.4/deployment/openshift/openshift-operatorhub.md
+++ b/content/operate/kubernetes/7.8.4/deployment/openshift/openshift-operatorhub.md
@@ -14,7 +14,7 @@ url: '/operate/kubernetes/7.8.4/deployment/openshift/openshift-operatorhub/'
 
 You can deploy Redis Enterprise for Kubernetes from the Red Hat OpenShift CLI. You can also use a UI, [OperatorHub](https://docs.openshift.com/container-platform/4.11/operators/index.html) (Red Hat) to install operators and create custom resources.
 
-To see which version of Redis Enterprise for Kubernetes supports your OpenShift version, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions" >}}).
+To see which version of Redis Enterprise for Kubernetes supports your OpenShift version, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/7.8.4/reference" >}}).
 
 ## Install the Redis Enterprise operator
 

--- a/content/operate/kubernetes/7.8.4/deployment/quick-start.md
+++ b/content/operate/kubernetes/7.8.4/deployment/quick-start.md
@@ -18,13 +18,13 @@ To deploy Redis Enterprise Software for Kubernetes and start your Redis Enterpri
 - Apply the operator bundle and verify it's running.
 - Create a Redis Enterprise cluster (REC).
 
-This guide works with most supported Kubernetes distributions. If you're using OpenShift, see [Redis Enterprise on OpenShift]({{< relref "/operate/kubernetes/7.8.4/deployment/openshift" >}}). For details on what is currently supported, see [supported distributions]({{< relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions.md" >}}).
+This guide works with most supported Kubernetes distributions. If you're using OpenShift, see [Redis Enterprise on OpenShift]({{< relref "/operate/kubernetes/7.8.4/deployment/openshift" >}}). For details on what is currently supported, see [supported distributions]({{< relref "/operate/kubernetes/7.8.4/reference" >}}).
 
 ## Prerequisites
 
 To deploy Redis Enterprise for Kubernetes, you'll need:
 
-- Kubernetes cluster in a [supported distribution]({{< relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions.md" >}})
+- Kubernetes cluster in a [supported distribution]({{< relref "/operate/kubernetes/7.8.4/reference" >}})
 - minimum of three worker nodes
 - Kubernetes client (kubectl)
 - access to DockerHub, RedHat Container Catalog, or a private repository that can hold the required images.

--- a/content/operate/kubernetes/7.8.4/upgrade/_index.md
+++ b/content/operate/kubernetes/7.8.4/upgrade/_index.md
@@ -26,7 +26,7 @@ For all other Kubernetes distributions, see [Upgrade Redis Enterprise for Kubern
 
 When upgrading, both your Kubernetes version and Redis operator version need to be supported at all times.
 
-{{<warning>}}If your current Kubernetes distribution is not [supported]({{<relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions.md">}}), upgrade to a supported distribution before upgrading. {{</warning>}}
+{{<warning>}}If your current Kubernetes distribution is not [supported]({{<relref "/operate/kubernetes/7.8.4/reference">}}), upgrade to a supported distribution before upgrading. {{</warning>}}
 
 ## RHEL9-based image
 

--- a/content/operate/kubernetes/7.8.4/upgrade/openshift-cli.md
+++ b/content/operate/kubernetes/7.8.4/upgrade/openshift-cli.md
@@ -26,7 +26,7 @@ See the [troubleshooting](#troubleshooting) section for details on recovering a 
 
 #### Kubernetes version
 
-Check [Supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions" >}}) to make sure your Kubernetes distribution is supported. If not, upgrade your Kubernetes distribution before upgrading the Redis operator.
+Check [Supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference" >}}) to make sure your Kubernetes distribution is supported. If not, upgrade your Kubernetes distribution before upgrading the Redis operator.
 
 #### Redis operator version
 

--- a/content/operate/kubernetes/7.8.4/upgrade/upgrade-olm.md
+++ b/content/operate/kubernetes/7.8.4/upgrade/upgrade-olm.md
@@ -26,7 +26,7 @@ See the [troubleshooting](#troubleshooting) section for details on recovering a 
 
 #### Kubernetes version
 
-Check [Supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions" >}}) to make sure your Kubernetes distribution is supported. If not, upgrade your Kubernetes distribution before upgrading the Redis operator.
+Check [Supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference" >}}) to make sure your Kubernetes distribution is supported. If not, upgrade your Kubernetes distribution before upgrading the Redis operator.
 
 #### Redis operator version
 

--- a/content/operate/kubernetes/7.8.4/upgrade/upgrade-redis-cluster.md
+++ b/content/operate/kubernetes/7.8.4/upgrade/upgrade-redis-cluster.md
@@ -29,7 +29,7 @@ See the [troubleshooting](#troubleshooting) section for details on recovering a 
 
 ### Kubernetes version
 
-Check [Supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference/supported_k8s_distributions" >}}) to make sure your Kubernetes distribution is supported by 7.8.2-6. If not, upgrade your Kubernetes distribution before upgrading the Redis operator.
+Check [Supported Kubernetes distributions]({{<relref "/operate/kubernetes/7.8.4/reference" >}}) to make sure your Kubernetes distribution is supported by 7.8.2-6. If not, upgrade your Kubernetes distribution before upgrading the Redis operator.
 
 ### Redis operator version
 


### PR DESCRIPTION
Hi @kaitlynmichael. This PR attempts to fix the 13 lingering link warnings related to the K8s content. I had CC investigate and this is the result. I remember somebody saying that we'd have to live with these warnings (for the rest of our lives...), so I'm not sure if these changes are the way forward or not. That said, the warnings are no longer present with these changes. Let me know.

This was CC's assessment:

> **The fix**
> 
> Two options:
> 
> Option A (recommended, low-risk): Repoint the ~13 relrefs in 7.8.4 from .../reference/supported_k8s_distributions to .../reference/ — which is exactly where the alias already redirects users today. This makes relref resolve, clears every warning, and changes nothing about where the link actually lands. It just makes the link honest about its real target.
> 
> Option B (more faithful): Restore a real supported_k8s_distributions.md in 7.8.4 (adapted from 7.8.6's version-appropriate table) and drop the alias. This is closer to "correct" if that page genuinely should exist for 7.8.4, but it edits an old/superseded version's content and requires the right distribution list for that release.
> 
> I'd go with A — it matches the intent already shipped in #1870 and touches only link text, not archived content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only internal link updates with no product or deployment behavior changes.
> 
> **Overview**
> Updates **13 Hugo `relref` links** across Redis Enterprise for Kubernetes **7.8.4** docs (architecture, deployment, OpenShift, quick-start, and upgrade guides) so “Supported Kubernetes distributions” / “supported platforms” no longer target `.../reference/supported_k8s_distributions` (or `.md` variants) and instead point to **`/operate/kubernetes/7.8.4/reference`**.
> 
> This is a **link-target-only** change intended to clear lingering **link checker warnings**; anchor text and surrounding guidance are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f81daa0202b0033fd3c550f4fe38cb667f1e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->