### PR TITLE
DEV: fix link error

### DIFF
--- a/content/develop/reference/eviction/index.md
+++ b/content/develop/reference/eviction/index.md
@@ -15,6 +15,7 @@ title: Key eviction
 aliases:
 - /manual/eviction/
 - /reference/eviction/
+- /develop/reference/eviction/index/
 weight: 6
 ---
 


### PR DESCRIPTION
Fixes #3530.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only alias entry with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds a Hugo front matter **alias** (`/develop/reference/eviction/index/`) on the key eviction reference page so requests to that trailing-slash index URL resolve correctly instead of failing link checks (fixes #3530).
> 
> No changes to page body or eviction policy content—only URL routing for the docs site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31136e235d9c0d80c26f0ad1f3e5c3c408982b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->