### PR TITLE
RC: Remove A/A upgrades and add 8.6

### DIFF
--- a/content/operate/rc/changelog/july-2026.md
+++ b/content/operate/rc/changelog/july-2026.md
@@ -1,0 +1,21 @@
+---
+Title: Redis Cloud changelog (July 2026)
+alwaysopen: false
+categories:
+- docs
+- operate
+- rc
+description: New features, enhancements, and other changes added to Redis Cloud during
+  July 2026.
+highlights: Redis 8.6 on Redis Cloud Pro
+linktitle: July 2026
+weight: 48
+tags:
+- changelog
+---
+
+## New features
+
+### Redis 8.6 on Redis Cloud Pro
+
+Redis 8.6 is now generally available for [Redis Cloud Pro databases]({{< relref "/operate/rc/databases/create-database/create-pro-database-new" >}}). See the [Redis 8.6 release notes]({{< relref "/operate/rc/changelog/version-release-notes/8-6" >}}) and [What's new in Redis 8.6]({{< relref "/develop/whats-new/8-6" >}}) for more information.

--- a/content/operate/rc/changelog/version-release-notes/8-6.md
+++ b/content/operate/rc/changelog/version-release-notes/8-6.md
@@ -1,0 +1,22 @@
+---
+Title: Redis 8.6 release notes and breaking changes
+alwaysopen: false
+categories:
+- docs
+- operate
+- rc
+description: Release notes and breaking changes for Redis 8.6 on Redis Cloud.
+hideListLinks: true
+linktitle: Redis 8.6
+weight: 2
+tocEmbedHeaders: true
+---
+
+Redis 8.6 builds on the foundation of Redis 8.4 with significant enhancements to stream reliability, memory management, and security features. For more information on the changes in Redis 8.6, see [What's new in Redis 8.6]({{<relref "/develop/whats-new/8-6" >}}) and review the Redis Open Source [8.6 release notes]({{<relref "/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes" >}}).
+
+## Known limitations
+
+When using Redis 8.6, be aware of these current limitations:
+
+- **Redis Search**: During load rebalancing operations (such as atomic slot migration), cursors may miss some results due to data movement between nodes.
+- **Stream idempotency**: Avoid using `XADD` with the new `IDMP` or `IDMPAUTO` options when using `appendonly yes` with `aof-use-rdb-preamble no` (a non-default configuration). This limitation will be removed in the next patch release.

--- a/content/operate/rc/databases/version-management/_index.md
+++ b/content/operate/rc/databases/version-management/_index.md
@@ -43,7 +43,7 @@ When a Redis version reaches **End-of-Life (EOL)**, Redis Cloud will automatical
 
 | Version | Support model | Status | EOL Date | Plans |
 |---------|--------|--------|----------|-------|
-| **Redis 8.6** | STS | Preview | TBD | Essentials |
+| **Redis 8.6** | STS | GA | TBD | Essentials, Pro |
 | **Redis 8.4** | STS | GA | TBD | Essentials, Pro | 
 | **Redis 8.2** | LTS | GA | September 1, 2030 | Essentials, Pro |
 | **Redis 8.0** | STS | Preview | December 1, 2026 | Essentials<sup>[1](#table-note-1)</sup> |

--- a/content/operate/rc/databases/version-management/_index.md
+++ b/content/operate/rc/databases/version-management/_index.md
@@ -44,7 +44,7 @@ When a Redis version reaches **End-of-Life (EOL)**, Redis Cloud will automatical
 | Version | Support model | Status | EOL Date | Plans |
 |---------|--------|--------|----------|-------|
 | **Redis 8.6** | STS | GA | TBD | Essentials, Pro |
-| **Redis 8.4** | STS | GA | TBD | Essentials, Pro | 
+| **Redis 8.4** | STS | GA | January 1, 2027 | Essentials, Pro | 
 | **Redis 8.2** | LTS | GA | September 1, 2030 | Essentials, Pro |
 | **Redis 8.0** | STS | Preview | December 1, 2026 | Essentials<sup>[1](#table-note-1)</sup> |
 | **Redis 7.4** | LTS | GA | December 1, 2029 | Essentials, Pro |

--- a/content/operate/rc/databases/version-management/upgrade-version.md
+++ b/content/operate/rc/databases/version-management/upgrade-version.md
@@ -27,53 +27,35 @@ Please keep in mind the following before upgrading your database version:
     - [Redis 8.0]({{< relref "/operate/rc/changelog/version-release-notes/8-0" >}})
     - [Redis 8.2]({{< relref "/operate/rc/changelog/version-release-notes/8-2" >}})
     - [Redis 8.4]({{< relref "/operate/rc/changelog/version-release-notes/8-4" >}})
+    - [Redis 8.6]({{< relref "/operate/rc/changelog/version-release-notes/8-6" >}})
 
 - You must upgrade the target database in an [Active-Passive]({{< relref "/operate/rc/databases/migrate-databases#sync-using-active-passive" >}}) setup before you upgrade the source database to prevent compatibility issues.
 {{< /note >}}
 
 ## Upgrade database
 
-{{< multitabs id="upgrade-database" 
-tab1="Single-region database"
-tab2="Active-Active database" >}}
-
 To upgrade a single-region Redis Cloud database: 
 
 1. Choose your database from the **Databases** list to open your database page. Select **More actions > Version upgrade**.
 
-    <img src="../../../../../images/rc/databases-more-actions-menu.png" alt="The More Actions menu on the Database page." width=40% >
+    {{< image filename="/images/rc/databases-more-actions-menu.png" alt="The More Actions menu on the Database page." width=40% >}}
     
     You can also select **More actions > Version upgrade** from the database list.
 
 1. Select the target version from the **Select version** list.
 
-    <img src="../../../../../images/rc/database-version-upgrade.png" alt="The Redis version upgrade screen." width=80% >
+    {{< image filename="/images/rc/database-version-upgrade.png" alt="The Redis version upgrade screen." width=80% >}}
 
     If your database has not been backed up before, we recommend that you back up your database. Select **Go to backup** to go to the [backup settings]({{< relref "/operate/rc/databases/back-up-data" >}}).
 
 1. Select **Upgrade Now** to start the upgrade.
 
-    <img src="../../../../../images/rc/button-upgrade-now.png" alt="The upgrade button." width=100px >
+    {{< image filename="/images/rc/button-upgrade-now.png" alt="The upgrade button." width=100px >}}
 
 The database will start upgrading to the selected version immediately. The upgrade may take a few minutes. 
 
 You can continue to use the Redis Cloud console for other tasks during the upgrade.
 
--tab-sep-
-
-To request to upgrade all databases in an [Active-Active]({{< relref "/operate/rc/databases/active-active" >}}) subscription:
-
-1. Choose your Active-Active subscription from the **Subscriptions** list to open your subscription page. Select **Version upgrade**.
-
-    <img src="../../../../../images/rc/button-version-upgrade.png" width=150px alt="Version upgrade button." >
-
-1. Select the version to upgrade your databases from the list and select **Upgrade** to submit the upgrade request.
-
-    <img src="../../../../../images/rc/version-upgrade-request.png" width=80% alt="Version upgrade request list with version 8.2 selected." >
-
-The upgrade will start in 1-3 weeks from your request, according to your subscription's [maintenance windows]({{< relref "/operate/rc/subscriptions/maintenance/set-maintenance-windows" >}}). All databases in the subscription will be upgraded to the same version.
-
-{{< /multitabs >}}
 
 ## Manually revert upgrade
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or infrastructure code; the main product impact is readers no longer seeing Active-Active upgrade steps in docs.
> 
> **Overview**
> Documents **Redis 8.6** as generally available on **Essentials and Pro**, including a July 2026 changelog entry, new **8.6 release notes** (with known Search and stream `XADD` limitations), and updates to the **supported versions** table—**8.6** moves from Preview (Essentials only) to GA on both plans, and **8.4** gets an **EOL date of January 1, 2027**.
> 
> The **upgrade database version** guide now links **8.6** in the pre-upgrade release-notes list, drops the **Active-Active** subscription upgrade tab and workflow entirely, and leaves only **single-region** upgrade steps while switching inline screenshots to the `{{< image >}}` shortcode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit facff3b361d4764547994303c5ead86bca8b01c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->