### PR TITLE
[codex] Document Cloud RDI DLQ stream inspection

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/rejected-records.md
+++ b/content/integrate/redis-data-integration/data-pipelines/rejected-records.md
@@ -41,6 +41,30 @@ RDI stores rejected records in the RDI database as capped Redis streams. Each DL
 stream corresponds to a source table and tracks the records rejected for that
 table.
 
+DLQ stream names use the `dlq:` prefix followed by the source data stream name.
+In current RDI versions, the stream name is typically:
+
+```text
+dlq:data:{rdi}:<schema_or_database>.<table>
+```
+
+For example, rejected records for the `public.users` table are stored in:
+
+```text
+dlq:data:{rdi}:public.users
+```
+
+For sources that include the source name in the stream qualifier, the final part
+can contain three components:
+
+```text
+dlq:data:{rdi}:<source>.<schema_or_database>.<table>
+```
+
+Some RDI versions or configurations can use a hash-tagged variant such as
+`dlq:{data:rdi:<schema_or_database>.<table>}`. To find all DLQ streams in the
+RDI database, scan for stream keys that start with `dlq:`.
+
 The maximum number of records stored per DLQ stream is controlled by
 `processors.dlq_max_messages`. When the stream reaches the configured limit,
 older entries are evicted as newer entries are added.
@@ -55,15 +79,18 @@ Useful fields include:
 
 - The affected table.
 - The rejection time.
-- The rejected operation, such as create, update, delete, or snapshot read.
+- The rejected operation. RDI stores this as an `opcode` value such as `c`,
+  `u`, `d`, `r`, `t`, or `m`. See [Using the operation code]({{< relref "/integrate/redis-data-integration/data-pipelines/transform-examples/redis-opcode-example" >}})
+  for the operation labels.
 - The rejection reason.
 - The transformation job or operation, when the failure happened during transformation.
 
 {{< note >}}
-Rejected records can contain source data when you inspect them directly with CLI
-or API tools. Treat DLQ contents as sensitive customer data. The Redis Cloud UI
-shows a limited set of troubleshooting metadata and does not show the original
-record payload.
+Rejected records can contain source data when you inspect them directly in the
+RDI database. Treat DLQ contents as sensitive customer data. The Redis Cloud UI
+uses the RDI DLQ API and shows a sanitized set of troubleshooting metadata. It
+does not show the original record payload or every field stored in the
+corresponding DLQ stream.
 {{< /note >}}
 
 ## Resolve rejected records
@@ -83,6 +110,10 @@ for Redis Cloud, or use the appropriate self-managed RDI reset workflow.
 
 For self-managed RDI, use the [`redis-di get-rejected`]({{< relref "/integrate/redis-data-integration/reference/cli/redis-di-get-rejected" >}})
 command to inspect rejected records.
+
+For Redis Cloud RDI, connect to the RDI database and inspect the corresponding
+DLQ streams directly when you need details that are not shown in the Redis Cloud
+UI.
 
 RDI API v2 also includes DLQ inspection endpoints. See the
 [API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}})

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-opcode-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-opcode-example.md
@@ -21,12 +21,14 @@ The opcode is only available in the [full row format]({{< relref "/integrate/red
 
 It has one of the following values:
 
-- r - Read (applies to only snapshots)
-- c - Create
-- u - Update
-- d - Delete
-- t = Truncate (PostgreSQL specific)
-- m = Message (PostgreSQL specific)
+| Opcode | Operation | Notes |
+|--------|-----------|-------|
+| `c` | Create row |  |
+| `u` | Update row |  |
+| `d` | Delete row |  |
+| `r` | Read row (snapshot) | Applies only to snapshots. |
+| `t` | Truncate table | PostgreSQL specific. |
+| `m` | Message event | PostgreSQL specific. |
 
 
 You can add the value of the operation code to the output, and also use it in a conditional expression to modify the behavior of the job. The following examples demonstrate the different use-cases.

--- a/content/operate/rc/rdi/view-edit.md
+++ b/content/operate/rc/rdi/view-edit.md
@@ -97,9 +97,12 @@ The view shows:
 - The number of affected tables.
 - The affected tables and their rejected counts.
 - Rejected record IDs and rejection times.
-- Safe troubleshooting metadata, such as the rejection reason, operation, affected table, and transformation job details when available.
+- Safe troubleshooting metadata, such as the rejection reason, operation, affected table, and transformation job details when available. See [Using the operation code]({{< relref "/integrate/redis-data-integration/data-pipelines/transform-examples/redis-opcode-example" >}}) for the operation labels.
 
-Redis Cloud does not show the original source record payload in this view.
+Redis Cloud uses the RDI DLQ API to show a sanitized view of rejected records. It
+does not show the original source record payload or every field stored in the
+DLQ stream. To inspect the full DLQ entry, connect to the RDI database and read
+the corresponding DLQ stream directly.
 
 For more information about why records are rejected and how RDI stores them, see [Rejected records]({{< relref "/integrate/redis-data-integration/data-pipelines/rejected-records" >}}).
 


### PR DESCRIPTION
## Summary
- clarify that Redis Cloud shows a sanitized DLQ view through the RDI DLQ API
- document when to inspect DLQ streams directly in the RDI database
- add the DLQ stream naming patterns users should scan for

## Validation
- git diff --check origin/main...HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, security, or data-handling code impact.
> 
> **Overview**
> Documentation updates clarify how **Redis Cloud** surfaces rejected records versus what lives in the **RDI database** DLQ streams, and how operators should inspect them.
> 
> **Rejected records** and **View and edit** now state that the Cloud UI uses the RDI DLQ API and shows **sanitized** troubleshooting metadata—not the full payload or every stream field—and point readers to **direct DLQ stream reads** on the RDI database when they need complete entries. **Rejected records** adds concrete **DLQ stream key patterns** (`dlq:data:{rdi}:…`, source-qualified names, hash-tagged variants) and guidance to scan keys prefixed with `dlq:`.
> 
> Inspection guidance now ties rejected **operations** to stored **`opcode`** values (`c`, `u`, `d`, etc.) with a cross-link to the operation-code page. That page reformats the opcode list as a **table** for easier reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6235dde40b9824ab833c0328a04eea7ee3d940c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->