### PR TITLE
Fix relrefs for how_to_guides

### DIFF
--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -310,9 +310,18 @@ def move_numbered_user_guides(staging: Path, repo_dir: Path) -> list[str]:
             continue
         dest = how_to / path.name
         shutil.move(str(path), dest)
-        # File moved one level deeper: bump '../' to '../../' in markdown links.
+        # File moved one level deeper into how_to_guides/. Two link fix-ups:
+        #   - bump '../' to '../../' (old top-level relative links now sit one
+        #     directory deeper), and
+        #   - drop the now-redundant 'how_to_guides/' prefix on links that
+        #     reached down into this same subdirectory from the old top-level
+        #     location; those targets are siblings now. The '../' bump runs
+        #     first so a '../how_to_guides/' link becomes '../../how_to_guides/'
+        #     (correct) rather than being mistaken for a same-dir prefix.
         text = dest.read_text(encoding="utf-8")
-        dest.write_text(text.replace("](../", "](../../"), encoding="utf-8")
+        text = text.replace("](../", "](../../")
+        text = text.replace("](how_to_guides/", "](")
+        dest.write_text(text, encoding="utf-8")
         slug = re.sub(r"^[0-9][0-9]_", "", path.name[:-3])
         moved_slugs.append(slug)
     return moved_slugs

--- a/content/develop/ai/redisvl/0.20.0/user_guide/how_to_guides/index_migration.md
+++ b/content/develop/ai/redisvl/0.20.0/user_guide/how_to_guides/index_migration.md
@@ -26,7 +26,7 @@ learn how to:
 
 For conceptual background see
 [Index Migrations]({{< relref "../../concepts/index-migrations" >}}) and the
-[Migrate an Index how-to]({{< relref "how_to_guides/migrate-indexes" >}}).
+[Migrate an Index how-to]({{< relref "migrate-indexes" >}}).
 
 **Prerequisites:** a running Redis 8.0+ (or Redis Stack) at
 `redis://localhost:6379` and `redisvl` installed.
@@ -725,7 +725,7 @@ print("Cleaned up demo indexes, demo keys, backups, and YAML files")
 
 ## Learn more
 
-- [Migrate an Index (how-to)]({{< relref "how_to_guides/migrate-indexes" >}}) -- full CLI
+- [Migrate an Index (how-to)]({{< relref "migrate-indexes" >}}) -- full CLI
   workflow, batch migration, performance tuning, and troubleshooting
 - [Index Migrations (concepts)]({{< relref "../../concepts/index-migrations" >}}) -- modes,
   supported vs blocked changes, backup internals, sync vs async

--- a/content/develop/ai/redisvl/0.20.1/user_guide/how_to_guides/index_migration.md
+++ b/content/develop/ai/redisvl/0.20.1/user_guide/how_to_guides/index_migration.md
@@ -26,7 +26,7 @@ learn how to:
 
 For conceptual background see
 [Index Migrations]({{< relref "../../concepts/index-migrations" >}}) and the
-[Migrate an Index how-to]({{< relref "how_to_guides/migrate-indexes" >}}).
+[Migrate an Index how-to]({{< relref "migrate-indexes" >}}).
 
 **Prerequisites:** a running Redis 8.0+ (or Redis Stack) at
 `redis://localhost:6379` and `redisvl` installed.
@@ -725,7 +725,7 @@ print("Cleaned up demo indexes, demo keys, backups, and YAML files")
 
 ## Learn more
 
-- [Migrate an Index (how-to)]({{< relref "how_to_guides/migrate-indexes" >}}) -- full CLI
+- [Migrate an Index (how-to)]({{< relref "migrate-indexes" >}}) -- full CLI
   workflow, batch migration, performance tuning, and troubleshooting
 - [Index Migrations (concepts)]({{< relref "../../concepts/index-migrations" >}}) -- modes,
   supported vs blocked changes, backup internals, sync vs async

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/index_migration.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/index_migration.md
@@ -27,7 +27,7 @@ learn how to:
 
 For conceptual background see
 [Index Migrations]({{< relref "../../concepts/index-migrations" >}}) and the
-[Migrate an Index how-to]({{< relref "how_to_guides/migrate-indexes" >}}).
+[Migrate an Index how-to]({{< relref "migrate-indexes" >}}).
 
 **Prerequisites:** a running Redis 8.0+ (or Redis Stack) at
 `redis://localhost:6379` and `redisvl` installed.
@@ -726,7 +726,7 @@ print("Cleaned up demo indexes, demo keys, backups, and YAML files")
 
 ## Learn more
 
-- [Migrate an Index (how-to)]({{< relref "how_to_guides/migrate-indexes" >}}) -- full CLI
+- [Migrate an Index (how-to)]({{< relref "migrate-indexes" >}}) -- full CLI
   workflow, batch migration, performance tuning, and troubleshooting
 - [Index Migrations (concepts)]({{< relref "../../concepts/index-migrations" >}}) -- modes,
   supported vs blocked changes, backup internals, sync vs async


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation sync script and markdown link targets only; no runtime or security impact.
> 
> **Overview**
> Fixes broken internal links after numbered RedisVL user guides are moved into `user_guide/how_to_guides/`.
> 
> **`redisvl_docs_sync.py`** — when `move_numbered_user_guides` relocates each `NN_*.md` file, it now applies a second pass on markdown links: strip the redundant `how_to_guides/` prefix on same-subdirectory targets (after the existing `../` → `../../` bump, so parent-relative links are not mishandled).
> 
> **Published docs** — `index_migration.md` Hugo `relref`s to the migrate-indexes how-to are updated from `how_to_guides/migrate-indexes` to sibling slug `migrate-indexes` in the latest tree and `0.20.0` / `0.20.1` copies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1884f219ce865ceed4633e1e432b5234b4b9994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->