### PR TITLE
Support mermaid diagrams in RedisVL docs sync

### DIFF
--- a/.github/workflows/redisvl_docs_sync.yaml
+++ b/.github/workflows/redisvl_docs_sync.yaml
@@ -53,6 +53,7 @@ jobs:
             sphinx_favicon==1.1.0 \
             myst_nb==1.4.0 \
             sphinx_markdown_builder==0.6.8 \
+            sphinxcontrib-mermaid==1.0.0 \
             jupyter==1.1.1
 
       - name: 'Fetch redisvl repo'

--- a/build/redisvl_docs_sync.py
+++ b/build/redisvl_docs_sync.py
@@ -222,6 +222,38 @@ def mark_rst_admonitions(repo_dir: Path) -> None:
             rst_path.write_text("\n".join(out) + "\n", encoding="utf-8")
 
 
+_MYST_FENCE_DIRECTIVE_RE = re.compile(
+    r"^(myst_fence_as_directive\s*=\s*)(\[[^\]]*\])", re.MULTILINE)
+
+
+def preserve_mermaid_fences(repo_dir: Path) -> None:
+    """Keep ```mermaid fences as plain code blocks so they survive into Hugo.
+
+    Upstream conf.py (since v0.21.0) sets `myst_fence_as_directive = ["mermaid"]`,
+    routing ```mermaid blocks to the sphinxcontrib.mermaid directive.
+    sphinx_markdown_builder has no translator for the resulting mermaid node, so
+    it drops it with an "unknown node type: <mermaid>" warning and the diagrams
+    vanish from the generated markdown. The Hugo site renders ```mermaid code
+    fences natively (layouts/_default/_markup/render-codeblock-mermaid.html), so
+    we strip "mermaid" from the directive list and let the fence pass through as
+    an ordinary code block. sphinxcontrib.mermaid stays installed (conf.py still
+    imports it in `extensions`); it is simply no longer invoked for these fences.
+    """
+    conf = repo_dir / "docs/conf.py"
+    if not conf.exists():
+        return
+    text = conf.read_text(encoding="utf-8")
+
+    def repl(m: re.Match) -> str:
+        items = re.findall(r"""["']([^"']+)["']""", m.group(2))
+        kept = [i for i in items if i != "mermaid"]
+        return m.group(1) + "[" + ", ".join(f'"{i}"' for i in kept) + "]"
+
+    new_text = _MYST_FENCE_DIRECTIVE_RE.sub(repl, text)
+    if new_text != text:
+        conf.write_text(new_text, encoding="utf-8")
+
+
 def sphinx_build(repo_dir: Path, build_dir: Path) -> None:
     if build_dir.exists():
         shutil.rmtree(build_dir)
@@ -880,6 +912,7 @@ def sync_version(version: str, *, is_latest: bool, repo_dir: Path,
                   flush=True)
     strip_empty_markdown_cells(repo_dir)
     mark_rst_admonitions(repo_dir)
+    preserve_mermaid_fences(repo_dir)
     sphinx_build(repo_dir, build_dir)
     stage_markdown(repo_dir, build_dir, staging_dir)
     moved_slugs = move_numbered_user_guides(staging_dir, repo_dir)

--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,4 +1,4 @@
-{{ $width := (index .Attributes "width") | default "75%" }}
+{{ $width := (index .Attributes "width") | default "100%" }}
 <div style="width: {{ $width }};">
 <pre class="mermaid" style="background-color: white; padding: 1rem; border-radius: 0.5rem;">
     {{ .Inner | htmlEscape | safeHTML }}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -89,15 +89,30 @@
     {{ partial "search-modal.html" . }}
 
     {{ if .Store.Get "hasMermaid" }}
+    <style>
+      /* Let each diagram fill its container width instead of stopping at
+         mermaid's natural max-width. The SVG scales uniformly (boxes and text
+         together), so nothing overflows. */
+      .mermaid svg { width: 100%; max-width: 100%; height: auto; }
+    </style>
     <script type="module">
       import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+      // Use mermaid's default font. A custom fontFamily (e.g. the wider "Space
+      // Mono") makes label boxes overflow, because sequence diagrams size their
+      // actor/note boxes from font metrics that don't reliably match the
+      // rendered font. The default font's box padding is tuned to fit it.
       mermaid.initialize({
         startOnLoad: true,
         theme: 'base',
         themeVariables: {
-          fontFamily: 'Space Mono',
           primaryColor: '#ffffff',
-          primaryBorderColor: '#ee0000'
+          primaryBorderColor: '#ee0000',
+          // Subgraph "cluster" boxes: pale-yellow fill + olive border, matching
+          // mermaid's default theme (the look the upstream RedisVL docs render
+          // with). The base theme otherwise derives these from primaryColor and
+          // draws them white.
+          clusterBkg: '#ffffde',
+          clusterBorder: '#aaaa33'
         }
       });
     </script>


### PR DESCRIPTION
The RedisVL docs (since upstream v0.21.0) use mermaid diagrams, which were both breaking the sync build and, once building, silently dropped. This wires up end-to-end mermaid support without touching generated markdown (the sync workflow regenerates that).

- workflow: install sphinxcontrib-mermaid so conf.py's extensions import succeeds and sphinx-build no longer aborts.
- redisvl_docs_sync.py: add preserve_mermaid_fences(), run before sphinx_build. It strips "mermaid" from conf.py's myst_fence_as_directive so mermaid fences pass through as plain code blocks instead of being converted to a mermaid node that sphinx_markdown_builder drops.
- layouts: render fenced mermaid client-side at full column width; use mermaid's default font (a custom font mis-sized sequence-diagram boxes and overflowed labels); restore the default pale-yellow subgraph cluster styling to match the upstream docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the RedisVL docs sync pipeline and Hugo mermaid presentation; no auth, data, or core app logic.
> 
> **Overview**
> Fixes RedisVL doc sync for upstream **mermaid** diagrams (v0.21.0+): the workflow now installs **`sphinxcontrib-mermaid`** so Sphinx can import upstream `conf.py`, and **`preserve_mermaid_fences()`** in `redisvl_docs_sync.py` removes `"mermaid"` from `myst_fence_as_directive` before build so fences stay as plain ` ```mermaid ` blocks instead of being dropped by `sphinx_markdown_builder`.
> 
> On the Hugo side, mermaid code blocks default to **full column width**, client rendering uses **mermaid’s default font** (avoids sequence-diagram label overflow), adds **SVG width scaling**, and restores **pale-yellow subgraph cluster** styling to match upstream docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 710a6678d6f9e87b97c24084a4976e79cbe95655. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->