### PR TITLE
K8s: wisconsin maint 11

### DIFF
--- a/content/operate/kubernetes/kubernetes-archive.md
+++ b/content/operate/kubernetes/kubernetes-archive.md
@@ -16,7 +16,7 @@ The Redis Enterprise for Kubernetes documentation is versioned. You are looking 
 - View the [8.0.18 docs](https://redis.io/docs/latest/operate/kubernetes/8.0.18/) for Redis Enterprise for Kubernetes versions 8.0.18-11 and 8.0.20-21.
 - View the [8.0 docs](https://redis.io/docs/latest/operate/kubernetes/8.0/) for Redis Enterprise for Kubernetes versions 8.0.2-2 through 8.0.10-23.
 - View the [7.22 docs](https://redis.io/docs/latest/operate/kubernetes/7.22/) for Redis Enterprise for Kubernetes versions 7.22.0-7 through 7.22.2-40.
-- View the [7.8.6 docs](https://redis.io/docs/latest/operate/kubernetes/7.8.6/) for Redis Enterprise for Kubernetes versions 7.8.6-1 through 7.8.6-15.
+- View the [7.8.6 docs](https://redis.io/docs/latest/operate/kubernetes/7.8.6/) for Redis Enterprise for Kubernetes versions 7.8.6-1 through 7.8.6-16.
 - View the [7.8.4 docs](https://redis.io/docs/latest/operate/kubernetes/7.8.4/) for Redis Enterprise for Kubernetes versions 7.8.2-6, 7.8.4-8, and 7.8.4-9.
 - View the [7.4.6 docs](https://redis.io/docs/latest/operate/kubernetes/7.4.6/) for Redis Enterprise for Kubernetes versions 7.4.6-2 and 7.4.6-6.
 

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-16-july2026.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-16-july2026.md
@@ -1,0 +1,36 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: A maintenance release that includes support for Redis Software 7.8.6-286.
+hideListLinks: true
+linkTitle: 7.8.6-16 (July 2026)
+title: Redis Enterprise for Kubernetes 7.8.6-16 (July 2026) release notes
+weight: 16
+---
+
+Redis Enterprise for Kubernetes 7.8.6-16 (July 2026) is a maintenance release that includes support for [Redis Software 7.8.6-286]({{<relref "/operate/rs/release-notes/rs-7-8-releases/" >}}).
+
+For supported distributions, known limitations, and API changes, see [Redis Enterprise for Kubernetes 7.8.6-1 March 2025 release notes]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-march2025" >}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:7.8.6-286`
+- **Operator**: `redislabs/operator:7.8.6-16`
+- **Services Rigger**: `redislabs/k8s-controller:7.8.6-16`
+
+### OpenShift images
+
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.8.6-286`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.8.6-16`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.8.6-16`
+
+### OLM bundle
+
+**Redis Enterprise operator bundle**: `v7.8.6-16.0`
+
+## Known limitations
+
+See [7.8.6 releases]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases" >}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.8.6 release notes
 weight: 92
 ---
 
-Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-15 with support for Redis Enterprise Software version 7.8.6-263.
+Redis Enterprise for Kubernetes 7.8.6 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.8.6-16 with support for Redis Enterprise Software version 7.8.6-286.
 
 ## Detailed release notes
 


### PR DESCRIPTION
DOC-6813

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no application, API, or infrastructure code changes.
> 
> **Overview**
> Documents the **7.8.6-16 (July 2026)** maintenance release for Redis Enterprise for Kubernetes, including Redis Software **7.8.6-286** and download tags for Redis Enterprise, operator, services rigger, OpenShift images, and OLM bundle **v7.8.6-16.0**.
> 
> The **7.8.6 releases** index now lists **7.8.6-16** as the latest (was 7.8.6-15). The **Archive** page extends the 7.8.6 doc version range through **7.8.6-16**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4831bd93481b586c992fb61b635e875ba7926757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->