### PR TITLE
RC: Active-Active AZ changes

### DIFF
--- a/content/operate/rc/changelog/july-2026.md
+++ b/content/operate/rc/changelog/july-2026.md
@@ -24,4 +24,4 @@ Redis 8.6 is now generally available for [Redis Cloud Pro databases]({{< relref 
 
 You can now create [Active-Active databases]({{< relref "/operate/rc/databases/active-active" >}}) in regions with fewer than three availability zones. These regions use single-zone replication and provide 99.99% (four-nines) availability instead of 99.999%. When an Active-Active database spans regions with different availability zone counts, the availability of the entire deployment is determined by the least resilient region.
 
-These regions are not available in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the REST API to [create a Pro subscription]({{< relref "/operate/rc/api/examples/manage-subscriptions#create-a-pro-subscription" >}}).
+These regions are not available in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the REST API to [create a Pro subscription]({{< relref "/operate/rc/api/examples/manage-subscriptions#create-a-pro-subscription" >}}). You'll be able to manage these databases using the Redis Cloud console after they're created.

--- a/content/operate/rc/changelog/july-2026.md
+++ b/content/operate/rc/changelog/july-2026.md
@@ -19,3 +19,9 @@ tags:
 ### Redis 8.6 on Redis Cloud Pro
 
 Redis 8.6 is now generally available for [Redis Cloud Pro databases]({{< relref "/operate/rc/databases/create-database/create-pro-database-new" >}}). See the [Redis 8.6 release notes]({{< relref "/operate/rc/changelog/version-release-notes/8-6" >}}) and [What's new in Redis 8.6]({{< relref "/develop/whats-new/8-6" >}}) for more information.
+
+### Active-Active support in regions with fewer than three availability zones
+
+You can now create [Active-Active databases]({{< relref "/operate/rc/databases/active-active" >}}) in regions with fewer than three availability zones. These regions use single-zone replication and provide 99.99% (four-nines) availability instead of 99.999%. When an Active-Active database spans regions with different availability zone counts, the availability of the entire deployment is determined by the least resilient region.
+
+These regions are not available in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the REST API to [create a Pro subscription]({{< relref "/operate/rc/api/examples/manage-subscriptions#create-a-pro-subscription" >}}).

--- a/content/operate/rc/databases/active-active/_index.md
+++ b/content/operate/rc/databases/active-active/_index.md
@@ -71,3 +71,11 @@ However, Active-Active databases do not have a built-in [failover](https://en.wi
 For more information and guidance on which disaster recovery strategy to implement, see [Disaster recovery strategies for Active-Active databases]({{< relref "/operate/rs/databases/active-active/disaster-recovery" >}}).
 
 Data automatically syncs to a recovered cluster when it returns to a healthy state.
+
+## Sizing and memory
+
+Active-Active databases consume more memory than standalone databases. Because Active-Active requires replication, and Active-Active replication doubles memory consumption on top of that, the memory limit impact can be as large as four times (4x) the original data size.
+
+Active-Active databases also begin evicting keys earlier than standalone databases, at 80% of an instance's memory limit, and reserve additional memory for replication backlogs. Account for these factors when you size your database.
+
+For more information, see [Memory limits and sizing]({{< relref "/operate/rc/databases/configuration/sizing#dataset-size" >}}).

--- a/content/operate/rc/databases/active-active/_index.md
+++ b/content/operate/rc/databases/active-active/_index.md
@@ -43,7 +43,7 @@ The availability of each region depends on the number of availability zones it p
 An Active-Active database can combine regions with different availability zone counts. When it does, the availability of the entire deployment is determined by the least resilient region. For example, an Active-Active database that spans a region with three availability zones and a region with fewer than three availability zones provides 99.99% (four-nines) availability overall.
 
 {{< note >}}
-Regions with fewer than three availability zones are not available when you create an Active-Active database in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the [Redis Cloud REST API]({{< relref "/operate/rc/api" >}}). 
+Regions with fewer than three availability zones are not available when you create an Active-Active database in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the [Redis Cloud REST API]({{< relref "/operate/rc/api" >}}). You'll be able to manage these databases using the Redis Cloud console after they're created.
 {{< /note >}}
 
 ### Local latency with unique endpoints

--- a/content/operate/rc/databases/active-active/_index.md
+++ b/content/operate/rc/databases/active-active/_index.md
@@ -35,6 +35,17 @@ Active-Active subscriptions on Redis Cloud are limited to a maximum of 10 region
 
 Geo-distributed replication maintains copies of both primary and replica shards in multiple clusters. These clusters can be spread across multiple availability zones. Active-Active Redis uses zone awareness to spread your primary and replica shards across zones, which helps protect against data loss from regional outages.
 
+The availability of each region depends on the number of availability zones it provides:
+
+- Regions with three or more availability zones use multi-zone replication and provide **99.999%** (five-nines) availability.
+- Regions with fewer than three availability zones use single-zone replication and provide **99.99%** (four-nines) availability.
+
+An Active-Active database can combine regions with different availability zone counts. When it does, the availability of the entire deployment is determined by the least resilient region. For example, an Active-Active database that spans a region with three availability zones and a region with fewer than three availability zones provides 99.99% (four-nines) availability overall.
+
+{{< note >}}
+Regions with fewer than three availability zones are not available when you create an Active-Active database in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the [Redis Cloud REST API]({{< relref "/operate/rc/api" >}}). 
+{{< /note >}}
+
 ### Local latency with unique endpoints
 
 Applications can connect to a specific copy of an Active-Active database using its unique endpoint. For local latency, configure your application to use a database endpoint in the closest region.

--- a/content/operate/rc/databases/active-active/create-active-active-database.md
+++ b/content/operate/rc/databases/active-active/create-active-active-database.md
@@ -99,6 +99,8 @@ In the **Advanced options** section, you can:
 
 {{< note >}}
 Multi-AZ replication is required for all Active-Active databases.
+
+Regions with fewer than three availability zones are not available in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the REST API to [create a Pro subscription]({{< relref "/operate/rc/api/examples/manage-subscriptions#create-a-pro-subscription" >}}). Active-Active databases in these regions use single-zone replication and provide 99.99% (four-nines) availability instead of 99.999%. For more information, see [Active-Active Redis]({{< relref "/operate/rc/databases/active-active#multi-zone" >}}).
 {{< /note >}}
 
 When finished, choose **Continue** to determine your size requirements.

--- a/content/operate/rc/databases/active-active/create-active-active-database.md
+++ b/content/operate/rc/databases/active-active/create-active-active-database.md
@@ -100,7 +100,7 @@ In the **Advanced options** section, you can:
 {{< note >}}
 Multi-AZ replication is required for all Active-Active databases.
 
-Regions with fewer than three availability zones are not available in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the REST API to [create a Pro subscription]({{< relref "/operate/rc/api/examples/manage-subscriptions#create-a-pro-subscription" >}}). Active-Active databases in these regions use single-zone replication and provide 99.99% (four-nines) availability instead of 99.999%. For more information, see [Active-Active Redis]({{< relref "/operate/rc/databases/active-active#multi-zone" >}}).
+Regions with fewer than three availability zones are not available in the Redis Cloud console. To create an Active-Active database that includes one of these regions, use the REST API to [create a Pro subscription]({{< relref "/operate/rc/api/examples/manage-subscriptions#create-a-pro-subscription" >}}). You'll be able to manage these subscriptions and databases using the Redis Cloud console after they're created. Active-Active databases in these regions use single-zone replication and provide 99.99% (four-nines) availability instead of 99.999%. For more information, see [Active-Active Redis]({{< relref "/operate/rc/databases/active-active#multi-zone" >}}).
 {{< /note >}}
 
 When finished, choose **Continue** to determine your size requirements.

--- a/content/operate/rc/databases/configuration/high-availability.md
+++ b/content/operate/rc/databases/configuration/high-availability.md
@@ -25,9 +25,9 @@ Redis Cloud supports three levels of replication:
 
 - _No replication_ means that you will have a single copy of your database.
 
-- _Single-zone replication_ means that your database will have a primary and a replica located in the same cloud zone. If anything happens to the primary, the replica takes over and becomes the new primary.
+- _Single-zone replication_ means that your database will have a primary and a replica located in the same cloud zone. If anything happens to the primary, the replica takes over and becomes the new primary. Regions with fewer than three availability zones can only use single-zone replication.
 
-- _Multi-zone replication_ means that the primary and its replicas are stored in different zones. This means that your database can remain online even if an entire zone becomes unavailable.
+- _Multi-zone replication_ means that the primary and its replicas are stored in different zones. This means that your database can remain online even if an entire zone becomes unavailable. Multi-zone replication requires a region with three or more availability zones.
 
 Your replication options depend on your [subscription plan]({{< relref "/operate/rc/subscriptions/_index.md" >}}):
 

--- a/content/operate/rc/databases/configuration/sizing.md
+++ b/content/operate/rc/databases/configuration/sizing.md
@@ -26,6 +26,12 @@ Here are some general guidelines:
 
 - [Active-Active]({{< relref "/operate/rc/databases/active-active" >}}) also doubles memory consumption and the effect is cumulative with the impact of replication. Since Active-Active requires replication to be turned on, the memory limit impact can be as large as four times (4x) the original data size.
 
+    Active-Active databases also have additional sizing considerations:
+
+    - Active-Active databases begin evicting keys when any one instance reaches 80% of its memory limit, rather than 100%, because eviction must propagate to all participating instances. Size your database so that expected usage stays below this threshold.
+
+    - Each Active-Active instance reserves a replication backlog for shard synchronization and an Active-Active replication backlog for synchronization between instances. By default, each backlog is set to 1% of the database size.
+
 - [Advanced capabilities]({{< relref "/operate/rc/databases/configuration/advanced-capabilities" >}}) also consume memory. For search databases, consider index size when you size your database. See [Search and query sizing]({{< relref "/operate/rc/databases/configuration/advanced-capabilities#search-and-query-sizing" >}}) for more info.
 
 Memory limits in Redis Cloud are subject to the same considerations as Redis Software; to learn more, see [Database memory limits]({{< relref "/operate/rs/databases/memory-performance/memory-limit" >}}).

--- a/content/operate/rc/resilient-apps.md
+++ b/content/operate/rc/resilient-apps.md
@@ -52,7 +52,7 @@ For geographic availability, create [Active-Active databases]({{< relref "/opera
 
 - **Geographic distribution**: Data is replicated across multiple regions and availability zones. Applications can read from and write to the nearest region, reducing latency for users worldwide.
 
-- **99.999% availability**: Higher availability than single-region deployments by protecting against regional outages.
+- **99.999% availability**: Higher availability than single-region deployments by protecting against regional outages. Regions with fewer than three availability zones use single-zone replication and provide 99.99% (four-nines) availability instead. When an Active-Active database spans regions with different availability zone counts, the availability of the entire deployment is determined by the least resilient region.
 
 - **Automatic conflict resolution**: Uses conflict-free replicated data types (CRDTs) to handle concurrent writes across regions.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code, APIs, or infrastructure modifications.
> 
> **Overview**
> Documents **Active-Active support in regions with fewer than three availability zones**, including a July 2026 changelog entry and aligned updates across Redis Cloud operate docs.
> 
> **Availability and replication:** Regions with **3+ AZs** keep multi-zone replication and **99.999%** availability; regions with **&lt;3 AZs** use single-zone replication and **99.99%** availability. Mixed-region Active-Active deployments are capped by the **least resilient** region. **High availability** and **resilient apps** pages now tie single-zone vs multi-zone replication to these AZ limits.
> 
> **Provisioning:** Low-AZ regions are **not selectable in the console**; creation requires the **REST API** (Pro subscription), with console management after creation—called out on the Active-Active overview, create flow, and changelog.
> 
> **Sizing:** Adds Active-Active guidance on the overview and in **sizing**—**80%** eviction threshold (vs 100% for standalone), **4x** memory impact with replication, and default **1%** replication backlogs per instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507d21baa2892fa053c3af1bda870b94595422fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->