### PR TITLE
Document Pub/Sub ACL risk on Sentinel-monitored nodes

### DIFF
--- a/content/operate/oss_and_stack/management/sentinel.md
+++ b/content/operate/oss_and_stack/management/sentinel.md
@@ -817,24 +817,29 @@ following directives:
 
 Where `<username>` and `<password>` are the username and password for accessing the group's instances. These credentials should be provisioned on all of the group's Redis instances with the minimal control permissions. For example:
 
-    127.0.0.1:6379> ACL SETUSER sentinel-user ON >somepassword allchannels +multi +slaveof +ping +exec +subscribe +config|rewrite +role +publish +info +client|setname +client|kill +script|kill
+    127.0.0.1:6379> ACL SETUSER sentinel-user ON >somepassword resetchannels &__sentinel__:hello +multi +slaveof +ping +exec +subscribe +config|rewrite +role +publish +info +client|setname +client|kill +script|kill
+
+The only Pub/Sub channel that Sentinel uses on a monitored node is `__sentinel__:hello`, so
+this user is granted access to that channel only (`resetchannels &__sentinel__:hello`) rather
+than to all channels (`allchannels`, equivalently `&*`).
 
 {{< warning >}}
 Sentinel discovery relies on the reserved `__sentinel__:hello` Pub/Sub channel on each
 monitored master and replica. Sentinels periodically publish their presence there and
-subscribe to it to discover other Sentinels and learn the current topology. The messages
+subscribe to it to discover other Sentinels and learn the current topology. These messages
 carry no authentication and are trusted by receiving Sentinels, so any client that can
 publish to this channel on a monitored node can inject forged topology information and
 trigger spurious failovers or a denial of service.
 
 Because of this, do not grant broad Pub/Sub access on Sentinel-monitored Redis nodes:
 
-* Avoid `allchannels` (equivalently `&*`) for any user other than the Sentinel `auth-user`
-  itself. Since Redis 7.0 the default `acl-pubsub-default` is `resetchannels`, so new ACL
-  users have no channel access unless you explicitly grant it. Be especially careful with
-  the legacy `default` user, which may retain broad access.
-* Treat the `__sentinel__:` channel prefix as reserved. Grant access to it only to the
-  Sentinel `auth-user`, and only where Sentinel functionality requires it.
+* No user needs access to all channels (`allchannels` / `&*`). The Sentinel `auth-user`
+  needs access only to the `__sentinel__:hello` channel (`&__sentinel__:hello`), and no
+  other user should be able to publish to or subscribe to it. Since Redis 7.0 the default
+  value of `acl-pubsub-default` is `resetchannels`, so newly created ACL users have no
+  channel access unless you grant it explicitly. Be especially careful with the legacy
+  `default` user, which may still have broad access.
+* Treat the `__sentinel__:` channel prefix as reserved for Sentinel's internal use.
 {{< /warning >}}
 
 ### Redis password-only authentication

--- a/content/operate/oss_and_stack/management/sentinel.md
+++ b/content/operate/oss_and_stack/management/sentinel.md
@@ -819,6 +819,24 @@ Where `<username>` and `<password>` are the username and password for accessing 
 
     127.0.0.1:6379> ACL SETUSER sentinel-user ON >somepassword allchannels +multi +slaveof +ping +exec +subscribe +config|rewrite +role +publish +info +client|setname +client|kill +script|kill
 
+{{< warning >}}
+Sentinel discovery relies on the reserved `__sentinel__:hello` Pub/Sub channel on each
+monitored master and replica. Sentinels periodically publish their presence there and
+subscribe to it to discover other Sentinels and learn the current topology. The messages
+carry no authentication and are trusted by receiving Sentinels, so any client that can
+publish to this channel on a monitored node can inject forged topology information and
+trigger spurious failovers or a denial of service.
+
+Because of this, do not grant broad Pub/Sub access on Sentinel-monitored Redis nodes:
+
+* Avoid `allchannels` (equivalently `&*`) for any user other than the Sentinel `auth-user`
+  itself. Since Redis 7.0 the default `acl-pubsub-default` is `resetchannels`, so new ACL
+  users have no channel access unless you explicitly grant it. Be especially careful with
+  the legacy `default` user, which may retain broad access.
+* Treat the `__sentinel__:` channel prefix as reserved. Grant access to it only to the
+  Sentinel `auth-user`, and only where Sentinel functionality requires it.
+{{< /warning >}}
+
 ### Redis password-only authentication
 
 Until Redis 6, authentication is achieved using the following configuration directives:

--- a/content/operate/oss_and_stack/management/sentinel.md
+++ b/content/operate/oss_and_stack/management/sentinel.md
@@ -835,7 +835,7 @@ Because of this, do not grant broad Pub/Sub access on Sentinel-monitored Redis n
 
 * No user needs access to all channels (`allchannels` / `&*`). The Sentinel `auth-user`
   needs access only to the `__sentinel__:hello` channel (`&__sentinel__:hello`), and no
-  other user should be able to publish to or subscribe to it. Since Redis 7.0 the default
+  other user should be able to publish to or subscribe to it. Since Redis 7.0, the default
   value of `acl-pubsub-default` is `resetchannels`, so newly created ACL users have no
   channel access unless you grant it explicitly. Be especially careful with the legacy
   `default` user, which may still have broad access.


### PR DESCRIPTION
## Description

Adds a security note to the Sentinel management page warning against granting broad Pub/Sub channel access (`allchannels` / `&*`) on Sentinel-monitored Redis nodes.

Sentinel discovery relies on the reserved `__sentinel__:hello` Pub/Sub channel on each monitored master/replica. Those messages carry no authentication and are trusted wholesale by receiving Sentinels, so any client able to publish to that channel on a monitored node can inject forged topology information and trigger spurious failovers or a denial of service.

The note advises:
- Avoiding `allchannels` / `&*` for any user other than the Sentinel `auth-user` (with a reminder about the Redis 7.0 `resetchannels` default and the legacy `default` user).
- Treating the `__sentinel__:` channel prefix as reserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior changes.
> 
> **Overview**
> Updates the Sentinel ACL example for monitored Redis nodes to grant Pub/Sub on **`__sentinel__:hello` only** (`resetchannels &__sentinel__:hello`) instead of **`allchannels`**, with a short note explaining that Sentinel only needs that channel.
> 
> Adds a **warning** that discovery traffic on `__sentinel__:hello` is unauthenticated and trusted, so publishers on monitored masters/replicas can forge topology and cause spurious failovers or DoS. It advises against `allchannels` / `&*` for any user, limiting the Sentinel `auth-user` to `&__sentinel__:hello`, noting Redis 7.0’s `acl-pubsub-default` of `resetchannels`, and treating the `__sentinel__:` prefix as reserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42d065dd3128c09d0038d1729fdf2ef671eb3076. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->