### PR TITLE
DOC-6829 Add preemptive Spring Data Redis JSON docs [PARKED]

### DIFF
--- a/content/integrate/spring-framework-cache/_index.md
+++ b/content/integrate/spring-framework-cache/_index.md
@@ -26,3 +26,4 @@ The pages in this section describe recipes for using Redis from Spring Data Redi
 
 - [Use Redis with the Spring cache abstraction]({{< relref "/integrate/spring-framework-cache/cache" >}}) shows how to use Redis as the storage for Spring's cache abstraction.
 - [Client-side geographic failover]({{< relref "/integrate/spring-framework-cache/geo-failover" >}}) shows how to configure resilient connections that automatically fail over between Redis endpoints.
+- [Use JSON documents with Spring Data Redis]({{< relref "/integrate/spring-framework-cache/json" >}}) shows how to store, retrieve, and update JSON documents with the template-based JSON API.

--- a/content/integrate/spring-framework-cache/json.md
+++ b/content/integrate/spring-framework-cache/json.md
@@ -1,0 +1,200 @@
+---
+LinkTitle: JSON support
+Title: Use JSON documents with Spring Data Redis
+alwaysopen: false
+categories:
+- docs
+- integrate
+- stack
+- oss
+- rs
+- rc
+- oss
+- client
+description: Store, retrieve, and update JSON documents from a Spring Data Redis
+  application.
+group: framework
+summary: Spring Data Redis provides a template-based, fluent API for working with
+  Redis JSON documents, including path-based updates and type-specific operations.
+type: integration
+weight: 30
+bannerText: JSON support in Spring Data Redis is not yet released and the API is subject to change. This page is based on the in-progress pull request [spring-data-redis#3390](https://github.com/spring-projects/spring-data-redis/pull/3390) and will be updated when the feature ships.
+relatedPages:
+- /develop/data-types/json
+- /develop/data-types/json/path
+- /develop/clients/lettuce
+- /develop/clients/jedis
+---
+
+Spring Data Redis lets you work with
+[JSON]({{< relref "/develop/data-types/json" >}}) documents through a
+template-based, fluent API. This builds on the underlying
+[Lettuce]({{< relref "/develop/clients/lettuce" >}}) and
+[Jedis]({{< relref "/develop/clients/jedis" >}}) clients, so your Spring
+application can store, retrieve, and update JSON documents without dropping
+down to the low-level command API.
+
+The JSON API serializes your own Java objects to and from JSON using a
+dedicated serializer, and supports [JSON path]({{< relref "/develop/data-types/json/path" >}})
+expressions so you can read and update parts of a document without
+transferring the whole thing.
+
+## Requirements
+
+To use the JSON support, you need:
+
+- A Redis server with the JSON capability, such as
+  [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}}) 8 or later,
+  or [Redis Stack]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}).
+- The Lettuce or Jedis client on your classpath (Spring Data Redis works with
+  either).
+- A JSON library. The examples below use
+  [Jackson](https://github.com/FasterXML/jackson), which Spring Data Redis
+  uses by default for JSON serialization.
+
+## Set up
+
+Add Spring Data Redis to your build. For Maven, edit your `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>org.springframework.data</groupId>
+    <artifactId>spring-data-redis</artifactId>
+    <!-- Use the first release that includes JSON support. -->
+    <version>{version}</version>
+</dependency>
+```
+
+For Gradle, add the following to your `build.gradle`:
+
+```groovy
+implementation 'org.springframework.data:spring-data-redis:{version}'
+```
+
+Configure a `RedisJsonTemplate` bean, backed by your existing connection
+factory and a `JacksonRedisJsonSerializer` for the document values. Use
+`StringRedisJsonTemplate` if you want `String` keys and values without any
+extra configuration:
+
+```java
+@Configuration
+public class RedisJsonConfig {
+
+    @Bean
+    public RedisJsonTemplate<String, User> redisJsonTemplate(
+            RedisConnectionFactory connectionFactory) {
+
+        RedisJsonTemplate<String, User> template = new RedisJsonTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(RedisSerializer.string());
+        template.setJsonSerializer(new JacksonRedisJsonSerializer<>(User.class));
+        template.afterPropertiesSet();
+        return template;
+    }
+}
+```
+
+The examples below use a simple `User` type:
+
+```java
+public class User {
+    private String name;
+    private int age;
+    private String city;
+    private List<String> interests;
+
+    // Constructors, getters, and setters omitted.
+}
+```
+
+## Store and retrieve a document
+
+Use the `value()` spec to work with a whole document. Call `set()` to store an
+object as a JSON document, and `get()` to read it back:
+
+```java
+User user = new User("Paul", 42, "London", List.of("golf", "coding"));
+
+// Store the object as a JSON document at the key "user:1".
+jsonTemplate.value("user:1").set(user);
+
+// Read the whole document back as a User object.
+JsonResult<User> result = jsonTemplate.value("user:1").get();
+User stored = result.getValue();
+```
+
+## Work with JSON paths
+
+Pass a [JSON path]({{< relref "/develop/data-types/json/path" >}}) to `path()`
+to target part of a document instead of the whole thing. This lets you read or
+update a single field without rewriting the entire object.
+
+```java
+// Update just the "city" field.
+jsonTemplate.value("user:1").path("$.city").set("Manchester");
+
+// Set a field only if it does not already exist.
+jsonTemplate.value("user:1").path("$.nickname").setIfAbsent("Paulie");
+
+// Read a specific path.
+JsonResult<String> city = jsonTemplate.value("user:1").paths("$.city");
+```
+
+## Update arrays
+
+Use the `array()` spec for array fields. You can append elements, read the
+current length, trim the array to a range, or find the index of a value:
+
+```java
+// Append a value to the "interests" array.
+jsonTemplate.array("user:1").path("$.interests").append("cycling");
+
+// Get the length of the array.
+List<Long> lengths = jsonTemplate.array("user:1").path("$.interests").length();
+
+// Find the index of a value.
+List<Long> index = jsonTemplate.array("user:1").path("$.interests").indexOf("golf");
+
+// Keep only the first two elements.
+jsonTemplate.array("user:1").path("$.interests").trim(0, 1);
+```
+
+## Update strings
+
+Use the `string()` spec to append to string fields and read their length:
+
+```java
+// Append to a string field.
+jsonTemplate.string("user:1").path("$.name").append(" Jones");
+
+// Get the length of the string.
+List<Long> nameLength = jsonTemplate.string("user:1").path("$.name").length();
+```
+
+## Toggle booleans
+
+Use the `bool()` spec to flip boolean fields between `true` and `false`:
+
+```java
+// Flip the "active" flag.
+List<Boolean> newValues = jsonTemplate.bool("user:1").path("$.active").toggle();
+```
+
+## Merge into a document
+
+Use `mergeWith()` to merge new data into an existing document, following the
+[JSON merge]({{< relref "/commands/json.merge" >}}) semantics. Fields in the
+supplied object are added or overwritten, and setting a field to `null`
+removes it:
+
+```java
+// Merge in a partial object to update several fields at once.
+Map<String, Object> changes = Map.of("city", "Leeds", "age", 43);
+jsonTemplate.value("user:1").mergeWith(changes);
+```
+
+## Further reading
+
+- [Redis JSON data type]({{< relref "/develop/data-types/json" >}})
+- [JSON path syntax]({{< relref "/develop/data-types/json/path" >}})
+- [Spring Data Redis reference documentation](https://docs.spring.io/spring-data/redis/reference/)

--- a/content/integrate/spring-framework-cache/json.md
+++ b/content/integrate/spring-framework-cache/json.md
@@ -18,7 +18,7 @@ summary: Spring Data Redis provides a template-based, fluent API for working wit
   Redis JSON documents, including path-based updates and type-specific operations.
 type: integration
 weight: 30
-bannerText: JSON support in Spring Data Redis is not yet released and the API is subject to change. This page is based on the in-progress pull request [spring-data-redis#3390](https://github.com/spring-projects/spring-data-redis/pull/3390) and will be updated when the feature ships.
+bannerText: JSON support in Spring Data Redis is currently available only in the `4.2.0-M1` milestone release, and the API may still change before `4.2.0` becomes generally available. This page will be updated when `4.2.0` ships.
 relatedPages:
 - /develop/data-types/json
 - /develop/data-types/json/path
@@ -71,28 +71,29 @@ For Gradle, add the following to your `build.gradle`:
 implementation 'org.springframework.data:spring-data-redis:{version}'
 ```
 
-Configure a `RedisJsonTemplate` bean, backed by your existing connection
-factory and a `JacksonRedisJsonSerializer` for the document values. Use
-`StringRedisJsonTemplate` if you want `String` keys and values without any
-extra configuration:
+Configure a `RedisJsonTemplate` bean. The template takes its connection
+factory, a key serializer, and a JSON serializer as constructor arguments.
+Its single type parameter is the *key* type, not the document type:
 
 ```java
 @Configuration
 public class RedisJsonConfig {
 
     @Bean
-    public RedisJsonTemplate<String, User> redisJsonTemplate(
+    public RedisJsonTemplate<String> redisJsonTemplate(
             RedisConnectionFactory connectionFactory) {
 
-        RedisJsonTemplate<String, User> template = new RedisJsonTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(RedisSerializer.string());
-        template.setJsonSerializer(new JacksonRedisJsonSerializer<>(User.class));
-        template.afterPropertiesSet();
-        return template;
+        return new RedisJsonTemplate<>(connectionFactory,
+                RedisSerializer.string(),
+                GenericJacksonJsonRedisSerializer.builder().build());
     }
 }
 ```
+
+The JSON serializer is not bound to a document type. Pass
+`GenericJacksonJsonRedisSerializer` for Jackson 3 or
+`GenericJackson2JsonRedisSerializer` for Jackson 2; you choose the Java type
+when you read a value back.
 
 The examples below use a simple `User` type:
 
@@ -119,8 +120,8 @@ User user = new User("Paul", 42, "London", List.of("golf", "coding"));
 jsonTemplate.value("user:1").set(user);
 
 // Read the whole document back as a User object.
-JsonResult<User> result = jsonTemplate.value("user:1").get();
-User stored = result.getValue();
+JsonResult result = jsonTemplate.value("user:1").get();
+User stored = result.as(User.class);
 ```
 
 ## Work with JSON paths
@@ -136,8 +137,12 @@ jsonTemplate.value("user:1").path("$.city").set("Manchester");
 // Set a field only if it does not already exist.
 jsonTemplate.value("user:1").path("$.nickname").setIfAbsent("Paulie");
 
-// Read a specific path.
-JsonResult<String> city = jsonTemplate.value("user:1").paths("$.city");
+// Set a field only if it already exists.
+jsonTemplate.value("user:1").path("$.city").setIfPresent("Bristol");
+
+// Read a specific path. paths() is called on the template, not on a spec.
+JsonResult city = jsonTemplate.paths("user:1", "$.city");
+String cityName = city.asString();
 ```
 
 ## Update arrays


### PR DESCRIPTION
## Summary

Preemptively documents the new template-layer JSON API in Spring Data Redis (DOC-6829), ahead of its upstream release. Adds a new recipe page under the Spring Data Redis section and links it from the section index.

- New page: `content/integrate/spring-framework-cache/json.md`
- Index entry: `content/integrate/spring-framework-cache/_index.md`

> [!WARNING]
> **This PR is parked — do not merge.** The docs are written against an unreleased, still-under-review upstream PR ([spring-data-redis#3390](https://github.com/spring-projects/spring-data-redis/pull/3390)). Merge only after the feature ships and the manifest below has been reconciled (see `/unpark`).

<!-- park-manifest -->
<!--
  Machine-and-human-readable unpark contract. When this feature ships, re-fetch
  each source, diff against the snapshot, work the checklist, then reconcile and
  merge. This block is the single source of truth for picking the PR back up.
-->
## Park manifest

**Ticket:** DOC-6829
**Parked at:** 2026-07-10
**Trigger to pick up:** the JSON API is present in a **released** `spring-data-redis` version — testably, `gh api "repos/spring-projects/spring-data-redis/contents/src/main/java/org/springframework/data/redis/core/RedisJsonTemplate.java?ref=<tag>"` returns 200 at a release tag newer than `4.1.0`. The expected first such release is **`4.2.0-M1`**. **✅ FIRED 2026-08-21** — `4.2.0-M1` shipped and contains the API (see the 2026-08-25 update below). The remaining blocker is no longer upstream at all: it was the **milestone-vs-GA decision** in the checklist below — **DECIDED 2026-08-26: hold for `4.2.0` GA.** New trigger: a non-prerelease `4.2.0` tag containing `core/RedisJsonTemplate.java`. The page is now API-correct against `4.2.0-M1` and stays parked purely for the GA gate.
**Labels:** `parked`, `do not merge yet`

### Pinned sources (state observed at park time)

| Source | URL | Snapshot at park |
| :-- | :-- | :-- |
| SDR JSON support PR | https://github.com/spring-projects/spring-data-redis/pull/3390 | state: **open**, merged: **false**, head SHA `e35714beca1c1ac46f0cb8a325ac95b9e6199d0f`, base `main`, milestone: **none (no target version)**, updated 2026-07-08 |

To diff on unpark: re-read `JsonOperations.java` and `RedisJsonTemplate.java` at the released tag. **Do not gate on the PR's `merged` flag** — see the correction below.

> #### ⚠️ Trigger test CORRECTED — 2026-08-13 (`/pr-scan-review`)
>
> **The original trigger test could never fire.** It said to compare `merged` / `head.sha` against the
> snapshot. Spring Data projects **rebase and close** rather than merging, so #3390 reads
> `state: closed, merged: false, merged_at: null` **permanently**, and its head SHA
> (`a7239457`, moved from the park-time `e35714be`) never becomes a merge commit. A future `/unpark 3611`
> following the manifest literally would have concluded "still open, hold" — and been wrong.
>
> **The code is on `main` and has been since before this scan.** Verified three ways, not inferred from the
> PR state:
>
> | Check | Result @ 2026-08-13 |
> |---|---|
> | `main` commit | `8927add1` *"Add support for Redis JSON"* (also `cf7878ec` "Polishing" 2026-08-12) |
> | `core/RedisJsonTemplate.java` @ `main` | blob `0d79685d2e77eaaa40d08db41196954324e30e18`, 23849 bytes |
> | `core/JsonOperations.java` @ `main` | blob `b15772310a9cecccf4d193d52c213e135fe9019f`, 22416 bytes |
> | #3390 milestone | **`4.2.0-M1 (2026.1.0)`** (was *none* at park time) |
> | `main` HEAD | `bc6fa4ab` *"Enter rampdown phase for 4.2.0-M1."* (2026-08-13) — the M1 release is imminent |
> | Latest releases | `4.1.0` (2026-06-09), `3.5.13` (2026-06-24) → **no released version contains JSON yet** |
>
> So the blocker is now **only the release**, not the merge. Also on `main`: the 3.x→4.x migration guide
> (#3403, commit `4d7f8038`) — likewise `closed, merged: false`. Checked: this repo has **no** Redis-side SDR
> migration docs (only `content/integrate/spring-framework-cache/{_index,cache,geo-failover}.md`), so there is
> nothing to align with it. Don't re-derive that at unpark.
>
> Re-fetch: `gh api "repos/spring-projects/spring-data-redis/contents/src/main/java/org/springframework/data/redis/core/RedisJsonTemplate.java?ref=<tag>" --jq '{sha,size}'` and
> `gh api repos/spring-projects/spring-data-redis/releases --jq '.[0:5][] | {tag:.tag_name,published:.published_at}'`

> #### ✅ Trigger FIRED — 2026-08-21, verified 2026-08-25 (`/pr-scan-review`)
>
> **`4.2.0-M1` was released on 2026-08-21 and contains the JSON API.** The 2026-08-13 row saying "no
> released version contains JSON yet" is now stale. Supersedes it:
>
> | Check | Result @ 2026-08-25 |
> |---|---|
> | `4.2.0-M1` (2026-08-21, `prerelease: true`) | **contains** `RedisJsonTemplate.java` and `JsonOperations.java` |
> | `4.1.1` (2026-08-21, GA) | `RedisJsonTemplate.java` → **HTTP 404** — no JSON API |
> | `4.0.7` (2026-08-21, GA) | `RedisJsonTemplate.java` → **HTTP 404** — no JSON API |
> | Newest GA on the 4.2 line | **none yet** — `4.2.0` GA has not shipped |
>
> **Signature check is DISCHARGED — do not redo it.** Both blobs are *byte-identical* at the `4.2.0-M1`
> tag to the 2026-08-13 `main` snapshot:
>
> | File @ `4.2.0-M1` | Blob | Size | vs `main` 08-13 |
> |---|---|---|---|
> | `core/RedisJsonTemplate.java` | `0d79685d` | 23849 | **unchanged** |
> | `core/JsonOperations.java` | `b1577231` | 22416 | **unchanged** |
>
> Per the checklist rule "if those are unchanged at the tag, no signature can have moved": **no signature
> moved.** The four confirmed defects in the 2026-08-13 reconciliation note are therefore still exactly
> the work required — no more, and nothing new has drifted underneath them.
>
> **What this leaves.** Upstream is no longer the blocker; the open question is entirely ours, and it is
> the checklist's "Version" item: *is a milestone build enough to publish against?* Note both GA releases
> cut on the same day (2026-08-21) deliberately omit the API, so "wait for GA" means waiting for `4.2.0`
> proper, not for a patch on 4.1.x/4.0.x.

> #### 🔴 Signature reconciliation — four CONFIRMED defects, 2026-08-13 (`/pr-scan-review`)
>
> Because the API is now on `main` at fixed blob SHAs, the "LOW confidence" section below stopped being
> speculative and became **checkable** — so it was checked. Four of the page's claims are wrong and one
> snippet would not compile. Each was verified by reading the files/directory listings at `main`, not by code
> search alone (search `total_count: 0` is not evidence on its own).
>
> | Page claims | Reality @ `main` |
> |---|---|
> | `new JacksonRedisJsonSerializer<>(User.class)` | **No such class.** The interface is `RedisJsonSerializer extends RedisSerializer<Object>`; the Jackson impls in `serializer/` are `JacksonJsonRedisSerializer`, `GenericJacksonJsonRedisSerializer` (plus the `Jackson2` pair) |
> | "Use `StringRedisJsonTemplate` if you want `String` keys…" | **No such class.** `core/` contains only `JsonOperations.java`, `RedisJsonOperations.java`, `RedisJsonTemplate.java` |
> | `RedisJsonTemplate<String, User>` + no-arg `new` + `setKeySerializer()` / `setJsonSerializer()` | `public class RedisJsonTemplate<K> implements RedisJsonOperations<K>` — **one** type parameter, **constructor**-injected: `RedisJsonTemplate(RedisConnectionFactory, RedisSerializer<K> keySerializer, …)`. No matching setters |
> | `JsonResult<User>` / `JsonResult<String>` | `interface JsonResult extends JsonValue` — **not generic**. Values come out via `as(Class)` / `asString()`. Note a separate `JsonResults extends Streamable<JsonResult>` exists for the multi-key form |
>
> **Resolved cleanly in the page's favour — do not re-check these:**
> - `mergeWith(Object)` **kept its name** (checklist item "may ship as `merge`" → resolved, it did not).
> - `setIfAbsent` exists (a `default` delegating to `conditional(JsonSetSpec::ifAbsent).set(value)`); `setIfPresent` also exists and the page does not yet mention it.
> - The `get(K key)` vs fluent `value(key).get()` disagreement was **both readings being right**: `get(K)` is a `default` method delegating to `value(key).get()`. Same for `paths(key, String...)` (on `JsonOperations`) vs `path(String)` (on `PathSpec`) — both exist.
> - `array().length()`, `array().trim(int,int)`, `array().indexOf(Object)`, `string().length()` → `List<@Nullable Long>`; `bool().toggle()` → `List<@Nullable Boolean>`. All match the page exactly.
> - **`opsForJson()` was NOT added** — absent from both `RedisOperations` and `RedisTemplate`. The checklist item "if added before release, lead the page with it" resolves as *no restructure needed*; `RedisJsonTemplate` stays the entry point.
>
> The damage is therefore confined to the **bean-wiring block and the result types** — the fluent operation
> surface the page spends most of its length on is correct.

> #### 🟢 Reconciled against released `4.2.0-M1` — 2026-08-26 (`/unpark 3611`)
>
> **The page is now API-correct. Commit `363dd624`.** Decision taken: **hold for `4.2.0` GA**, because `4.2.0-M1`
> is a milestone and Spring does not freeze API at M1. Labels stay on; `bannerText` stays (rewritten — it still
> described #3390 as an in-progress PR).
>
> Re-pinned first, not trusted: both blobs are **still** `0d79685d`/23849 and `b1577231`/22416 at `4.2.0-M1`,
> and no release has shipped since 2026-08-21. So the 08-25 signature discharge holds.
>
> **⚠️ Two corrections TO THIS MANIFEST.** The notes above were not fully reliable:
>
> 1. **The bean-wiring fix prescribed above would not have compiled.** It listed `JacksonJsonRedisSerializer`
>    and `GenericJacksonJsonRedisSerializer` as the replacements for the non-existent `JacksonRedisJsonSerializer`.
>    Only the `Generic*` pair implements `RedisJsonSerializer`, which is what the constructor demands:
>
>    | Class @ `4.2.0-M1` | Implements | Usable as 3rd ctor arg |
>    |---|---|---|
>    | `JacksonJsonRedisSerializer<T>` | `RedisSerializer<T>` | **no** |
>    | `Jackson2JsonRedisSerializer<T>` | `RedisSerializer<T>` | **no** |
>    | `GenericJacksonJsonRedisSerializer` | `RedisJsonSerializer` | yes (Jackson 3) |
>    | `GenericJackson2JsonRedisSerializer` | `RedisJsonSerializer` | yes (Jackson 2) |
>
>    Neither `Generic*` class has a no-arg constructor — use `builder().build()`, `create(…)`, or `(ObjectMapper)`.
>    The blob-identity discharge could never have caught this: **these classes live in files this manifest never
>    pinned.** A discharge is only as wide as its pins.
>
> 2. **"The fluent surface is correct as written" was wrong.** Two of the six defects were in that surface:
>    - `result.getValue()` **does not exist** on `JsonResult` (`as(Class)` / `as(ParameterizedTypeReference)` /
>      `asString()` / `map()` / `isNull()`). Not in the 08-13 four-defect table.
>    - `value(key).paths(…)` **exists on nothing.** `paths` is top-level on `JsonOperations`; the specs carry only
>      `path(String)` via `PathSpec`. The 08-13 note said "both `paths(key,…)` and `path(String)` exist" — true, but
>      it masked that the page used a *third* form belonging to neither.
>
>    A signature diff proves nothing *moved*. It does not prove the page ever *matched*.
>
> **Verified correct, do not re-check:** `array()` (`append`/`length`/`trim`/`indexOf` → `List<@Nullable Long>`),
> `string()` (`append`/`length`), `bool().toggle()` → `List<@Nullable Boolean>`, `mergeWith(Object)`, `set`,
> `setIfAbsent`, `setIfPresent`, `value().get()`, `path()`, `RedisSerializer.string()`.
> **Jedis/Lettuce parity CONFIRMED** at the tag — both ship `*JsonCommands` *and* `*ClusterJsonCommands`.
> All 7 relref targets resolve.

> #### ⚠️ Forward risk noted — 2026-09-08 (`/pr-scan-review`)
>
> **Open PR [spring-data-redis#3433](https://github.com/spring-projects/spring-data-redis/pull/3433)**
> ("Refactor Redis JSON API", not yet merged, `state: open`, head `12cc5baf4999b17273aea6f1f4f3b321455c4f11`,
> base `main`, updated 2026-09-08T06:36:07Z) touches the exact files this manifest already reconciled the
> page against — `JsonOperations.java`, `RedisJsonTemplate.java`, `GenericJackson2JsonRedisSerializer.java`,
> `GenericJacksonJsonRedisSerializer.java`, `RedisJsonSerializer.java` — and is a breaking change to the API
> this page documents. Confirmed by reading `gh pr diff 3433`, not assumed:
>
> - `JsonOperations.paths(K, Collection<String>)` changes return type from `JsonResult` to a new
>   `JsonPathResult` interface; `JsonResult` no longer extends `JsonValue`. This page's
>   `content/integrate/spring-framework-cache/json.md` line 144 —
>   `JsonResult city = jsonTemplate.paths("user:1", "$.city");` — assigns the old return type and
>   **will not compile** once this PR's shape lands and ships.
> - `JsonResult` gains `matches()` and `exists()`; `isNull()` semantics change (true only for JSON
>   `null`, no longer for an absent value — that's `exists()` now). The page doesn't call `isNull()`,
>   `matches()`, or `exists()` today, so these are new material to consider covering, not yet a defect.
> - `value(key).get()` (line 123) is unaffected — `DefaultJsonSpec.get()` still returns `JsonResult`.
>
> Does **not** change the pick-up trigger above (still a non-prerelease `4.2.0` tag). Adds a second
> re-check beyond the version at unpark: re-diff `JsonOperations.java` / `RedisJsonTemplate.java` against
> blobs `0d79685d` / `b1577231` — if they've moved, the `paths()` snippet (line 144) needs rewriting to
> `JsonPathResult`, not just re-verifying, before trusting the 2026-08-26 reconciliation note above.
> Re-fetch: `gh api repos/spring-projects/spring-data-redis/pulls/3433 --jq '{state,merged,head_sha:.head.sha,updated_at}'`

> #### 🔴 Forward risk CONFIRMED LANDED on `main` — 2026-09-09 (`/pr-scan-review`)
>
> **#3433 is no longer just open — its shape is on `main`.** Today's PR scan reports it "merged,
> 4.2.0-M2", but per the 2026-08-13 correction above this repo rebases-and-closes: `gh api
> repos/spring-projects/spring-data-redis/pulls/3433` reads `state: closed, merged: false,
> merge_commit_sha: ad078395fb2b0c5692a7966d4ef11a0d489d5500`. Verified on `main` directly, not
> inferred from the PR's `merged` flag:
>
> | Check | Result @ 2026-09-09 |
> |---|---|
> | `core/RedisJsonTemplate.java` @ `main` | blob `0f4acc56`, 28457 bytes — **moved** from the discharged `0d79685d`/23849 |
> | `core/JsonOperations.java` @ `main` | blob `7b7ec52a`, 27173 bytes — **moved** from the discharged `b1577231`/22416 |
> | `JsonPathResult` | confirmed as a nested interface **inside `JsonOperations`** (`JsonOperations.java:651`), not a separate top-level file; `paths(K, Collection<String>)` now declares it as the return type (`JsonOperations.java:150`) |
> | `4.2.0-M2` tag/release | **does not exist yet** — milestone is assigned on the (closed) PR, nothing published |
>
> This makes the 2026-09-08 prediction a confirmed fact, not a risk: `content/integrate/spring-framework-cache/json.md`
> line 144 (`JsonResult city = jsonTemplate.paths("user:1", "$.city");`) **will not compile** against
> `main` today, let alone whatever tag ships this.
>
> **Consequence for this manifest's discharge logic.** The 2026-08-25/08-26 notes said "if
> `0d79685d`/`b1577231` are unchanged at the tag, no signature can have moved" and relied on that to
> mark method signatures DONE. Both blobs have now moved on `main`. That discharge is still valid
> *as of `4.2.0-M1`* (the tag it was pinned to) — but do not assume it carries forward to whatever tag
> eventually satisfies the pick-up trigger. **Still does not change the pick-up trigger** (a
> non-prerelease `4.2.0` tag) — `4.2.0-M2`, if it ships before `4.2.0` GA, would itself be a
> prerelease and would not fire pickup either.
>
> **New unpark step, additive to the checklist below:** before trusting the "Method signatures — DONE"
> and "fluent surface" checklist rows, re-diff `RedisJsonTemplate.java` / `JsonOperations.java` against
> these new blobs (not the `4.2.0-M1` ones), rewrite json.md line 144 to assign `JsonPathResult` instead
> of `JsonResult`, and decide whether to cover the new `matches()`/`exists()` accessors.
> Re-fetch: `gh api "repos/spring-projects/spring-data-redis/contents/src/main/java/org/springframework/data/redis/core/JsonOperations.java?ref=main" --jq '{sha,size}'`

### Observed API shape the page assumes (LOW confidence at park time — superseded by the 2026-08-13 reconciliation note above)

- Fluent, spec-based entry points on `RedisJsonTemplate`: `value(key)`, `array(key)`, `string(key)`, `bool(key)`.
- `.path("$.jsonpath")` chaining; `set` / `setIfAbsent` / `get` / `paths`.
- Array: `append`, `length`, `indexOf`, `trim`. String: `append`, `length`. Boolean: `toggle`. Document: `mergeWith`.
- Bean wiring: `RedisJsonTemplate` + `JacksonRedisJsonSerializer(Type.class)` over the existing `RedisConnectionFactory`.
- Access is client-agnostic: identical API over Jedis and Lettuce (clients diverge only in internal converters/path types; full parity in the PR).

### Re-check checklist (work these on unpark)

- [x] **(highest risk) Rewrite the bean-wiring block — DONE 2026-08-26** (`363dd624`). Now `RedisJsonTemplate<String>` (one type param) built via the 3-arg constructor with `GenericJacksonJsonRedisSerializer.builder().build()`. **Read correction 1 in the 08-26 note before touching this** — the fix originally prescribed here would not have compiled. Original text: `RedisJsonTemplate<K>` is single-parameter and constructor-injected, and both `JacksonRedisJsonSerializer` and `StringRedisJsonTemplate` do not exist. The snippet as written **will not compile**. See the 2026-08-13 reconciliation table.
- [x] **Fix the result types — DONE 2026-08-26** (`363dd624`). `JsonResult` de-genericised; `getValue()` (which does not exist) replaced with `as(User.class)`; `value(key).paths(…)` replaced with the top-level `paths(key, …)` + `asString()`. Original text: `JsonResult` is not generic; replace `JsonResult<User>` / `JsonResult<String>` with `JsonResult` + `as(Class)` / `asString()`.
- [x] **Method signatures — DONE 2026-08-25.** Diffed at the released `4.2.0-M1` tag: both blobs are byte-identical to the 2026-08-13 `main` snapshot (`0d79685d`/23849, `b1577231`/22416), so by this item's own rule no signature can have moved. Re-open only if unparking against a *different* tag than `4.2.0-M1`. **⚠️ This item also claimed "the fluent surface is correct as written" — that was WRONG, corrected 2026-08-26:** `getValue()` and `value(key).paths(…)` were both bogus. A signature diff proves nothing moved; it does not prove the page ever matched.
- [x] **`opsForJson()` — DONE 2026-08-25.** Re-checked at the released `4.2.0-M1` tag: **absent** from both `RedisOperations.java` and `RedisTemplate.java` (0 occurrences each, against a positive control of `opsForHash` = 1, so this is a real absence and not a broken check). `RedisJsonTemplate` stays the entry point; **no page restructure needed.** Item closed — do not re-derive.
- [ ] **(SOLE REMAINING BLOCKER) Version — decision taken 2026-08-26: hold for `4.2.0` GA.** The `{version}` placeholder stays until a non-prerelease `4.2.0` ships; then replace it and re-diff both blobs at that tag. Rationale: M1 is not API-frozen, and the same-day GA releases (`4.1.1`, `4.0.7`) deliberately omit the API, so there is no GA option short of `4.2.0`. Original text: replace the `{version}` placeholder in the Maven/Gradle snippets with the first release that includes JSON support. As of 2026-08-25 that is **`4.2.0-M1`, a milestone/pre-release**; the GA releases cut the same day (`4.1.1`, `4.0.7`) deliberately omit the API, so there is no GA option short of `4.2.0` itself. **Decide explicitly whether a milestone build is enough to publish against** — if yes, the page must say the API is milestone-only and name the milestone repository; if no, hold for `4.2.0` GA and re-run the blob diff at that tag.
- [x] **`BoundJsonOperations` — DID NOT LAND, closed 2026-08-26.** Absent from `core/` at `4.2.0-M1` (directory listing shows only `JsonOperations`, `RedisJsonOperations`, `RedisJsonTemplate`; code search 0 hits). No bound-operations section needed. Do not re-derive. Original text: explicitly deferred in the PR. If it lands before GA, add a bound-operations section.
- [x] **`setIfPresent` — DONE 2026-08-26.** Now covered on the page alongside `setIfAbsent`. Original text: exists on `main` and the page doesn't mention it. Decide whether to cover it alongside `setIfAbsent`.
- [ ] **Runnable examples** — convert inline `java` blocks to tested TCE (`clients-example`) doctests once the feature reaches the client example repos.
- [x] **Jedis/Lettuce parity — CONFIRMED 2026-08-26** at the `4.2.0-M1` tag: both `jedis/` and `lettuce/` ship `*JsonCommands` and `*ClusterJsonCommands`. Re-confirm at the GA tag. Original text: re-confirm the "works with either" claim; the two clients could ship support on different timelines.
- [ ] **Staleness** — rebase/merge `main`; re-run link checks. **Partially done 2026-08-26:** all 7 `relref` targets re-verified as resolving, and `bannerText` was rewritten (it still described #3390 as in-progress). The branch has *not* been rebased onto `main` — deliberately deferred, to keep this parked branch free of merge noise until the GA unpark.

### On unpark, then

Update the docs to reconcile, remove the `bannerText` warning, drop the `parked` / `do not merge yet` labels, run `/reflect` (record what actually changed vs predicted) and `/finalize` (the durable squash — deferred until now on purpose so these re-check notes survive).
<!-- /park-manifest -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact; publishing still depends on the milestone-vs-GA version decision noted in the PR.
> 
> **Overview**
> Adds documentation for Spring Data Redis’s template-based JSON API (DOC-6829): a new recipe under **Spring Data Redis** and a bullet on the section index linking to it.
> 
> The **`json.md`** page covers requirements (Redis JSON, Lettuce/Jedis, Jackson), Maven/Gradle setup with a `{version}` placeholder, **`RedisJsonTemplate`** bean wiring, and fluent examples for whole-document **`value()`** ops, JSON path updates (**`setIfAbsent`** / **`setIfPresent`**), **`array()`** / **`string()`** / **`bool()`** helpers, and **`mergeWith()`**. It includes a **`bannerText`** warning that JSON support is only in the **`4.2.0-M1`** milestone until GA, plus **`relatedPages`** to Redis JSON and client docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 363dd62427bddfc8848868043da070d72b578edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





