### PR TITLE
DEV: (cmds) add EXCLUDEEMPTY flag to TS.[M|MREV]RANGE commands

### DIFF
--- a/content/commands/ts.mrange.md
+++ b/content/commands/ts.mrange.md
@@ -101,6 +101,11 @@ arguments:
   name: groupby
   optional: true
   type: block
+- name: EXCLUDEEMPTY
+  optional: true
+  since: 8.10.0
+  token: EXCLUDEEMPTY
+  type: pure-token
 categories:
 - docs
 - develop
@@ -125,13 +130,13 @@ summary: Query a range across multiple time series by filters in forward directi
 syntax: "TS.MRANGE fromTimestamp toTimestamp\n  [LATEST]\n  [FILTER_BY_TS ts...]\n\
   \  [FILTER_BY_VALUE min max]\n  [WITHLABELS | <SELECTED_LABELS label...>]\n  [COUNT\
   \ count]\n  [[ALIGN align] AGGREGATION aggregators bucketDuration [BUCKETTIMESTAMP\
-  \ bt] [EMPTY]]\n  FILTER filterExpr...\n  [GROUPBY label REDUCE reducer]\n"
+  \ bt] [EMPTY]]\n  FILTER filterExpr...\n  [GROUPBY label REDUCE reducer]\n  [EXCLUDEEMPTY]\n"
 syntax_fmt: "TS.MRANGE fromTimestamp toTimestamp [LATEST] [FILTER_BY_TS\_Timestamp\n\
   \  [Timestamp ...]] [FILTER_BY_VALUE min max] [WITHLABELS |\n  SELECTED_LABELS label1\
   \ [label1 ...]] [COUNT\_count] [[ALIGN\_value]\n  AGGREGATION\ aggregators bucketDuration\
   \ [BUCKETTIMESTAMP]\n  [EMPTY]] FILTER\_<l=v | l!=v | l= | l!= | l=(v1,v2,...) |\n\
   \  l!=(v1,v2,...) [l=v | l!=v | l= | l!= | l=(v1,v2,...) |\n  l!=(v1,v2,...) ...]>\
-  \ [GROUPBY label REDUCE reducer]"
+  \ [GROUPBY label REDUCE reducer] [EXCLUDEEMPTY]"
 title: TS.MRANGE
 ---
 {{< note >}}
@@ -347,6 +352,16 @@ When combined with `AGGREGATION` the `GROUPBY`/`REDUCE` is applied post aggregat
 
 </details>
 
+<details open>
+<summary><code>EXCLUDEEMPTY</code> (since Redis 8.10)</summary>
+
+excludes from the reply any time series that has no samples in the requested range. By default, every time series that passes `FILTER filterExpr...` is reported, even those with no samples in the range (reported with an empty samples list).
+
+A time series whose only samples in the range are NaN is not considered empty and is still reported.
+
+`EXCLUDEEMPTY` cannot be used together with `GROUPBY label REDUCE reducer`; combining them replies with an error.
+</details>
+
 <note><b>Note:</b> An `MRANGE` command cannot be part of a transaction when running on a Redis cluster.</note>
 
 ## Examples
@@ -540,6 +555,73 @@ Query all time series with the metric label equal to `cpu`, but only return the 
          2) "SF"
    3) 1) 1) (integer) 1548149180000
          2) 99
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Exclude empty time series from the reply</b></summary>
+
+Create three time series that share the label `s=1`, then add samples so that only two of them have data in the `- 500` range.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE s LABELS s 1 t 1
+OK
+127.0.0.1:6379> TS.CREATE t LABELS s 1 t 1
+OK
+127.0.0.1:6379> TS.CREATE u LABELS s 1 t 1
+OK
+127.0.0.1:6379> TS.MADD s 100 100 t 100 100 s 200 200 t 300 300 s 400 400 t 400 400 u 2000 2000
+1) (integer) 100
+2) (integer) 100
+3) (integer) 200
+4) (integer) 300
+5) (integer) 400
+6) (integer) 400
+7) (integer) 2000
+{{< / highlight >}}
+
+Query the `- 500` range with `EXCLUDEEMPTY`. Time series `u`, whose only sample is at timestamp `2000`, has no samples in the range and is omitted from the reply.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MRANGE - 500 WITHLABELS EXCLUDEEMPTY FILTER s=1
+1) 1) "s"
+   2) 1) 1) "s"
+         2) "1"
+      2) 1) "t"
+         2) "1"
+   3) 1) 1) (integer) 100
+         2) 100
+      2) 1) (integer) 200
+         2) 200
+      3) 1) (integer) 400
+         2) 400
+2) 1) "t"
+   2) 1) 1) "s"
+         2) "1"
+      2) 1) "t"
+         2) "1"
+   3) 1) 1) (integer) 100
+         2) 100
+      2) 1) (integer) 300
+         2) 300
+      3) 1) (integer) 400
+         2) 400
+{{< / highlight >}}
+
+Without `EXCLUDEEMPTY`, `u` is also reported, with an empty samples list.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MRANGE - 500 WITHLABELS FILTER s=1
+1) 1) "s"
+   ...
+2) 1) "t"
+   ...
+3) 1) "u"
+   2) 1) 1) "s"
+         2) "1"
+      2) 1) "t"
+         2) "1"
+   3) (empty array)
 {{< / highlight >}}
 </details>
 

--- a/content/commands/ts.mrevrange.md
+++ b/content/commands/ts.mrevrange.md
@@ -101,6 +101,11 @@ arguments:
   name: groupby
   optional: true
   type: block
+- name: EXCLUDEEMPTY
+  optional: true
+  since: 8.10.0
+  token: EXCLUDEEMPTY
+  type: pure-token
 categories:
 - docs
 - develop
@@ -125,13 +130,13 @@ summary: Query a range across multiple time-series by filters in reverse directi
 syntax: "TS.MREVRANGE fromTimestamp toTimestamp\n  [LATEST]\n  [FILTER_BY_TS ts...]\n\
   \  [FILTER_BY_VALUE min max]\n  [WITHLABELS | <SELECTED_LABELS label...>]\n  [COUNT\
   \ count]\n  [[ALIGN align] AGGREGATION aggregators bucketDuration [BUCKETTIMESTAMP\
-  \ bt] [EMPTY]]\n  FILTER filterExpr...\n  [GROUPBY label REDUCE reducer]\n"
+  \ bt] [EMPTY]]\n  FILTER filterExpr...\n  [GROUPBY label REDUCE reducer]\n  [EXCLUDEEMPTY]\n"
 syntax_fmt: "TS.MREVRANGE fromTimestamp toTimestamp [LATEST]\n  [FILTER_BY_TS\_Timestamp\
   \ [Timestamp ...]] [FILTER_BY_VALUE min max]\n  [WITHLABELS | SELECTED_LABELS label1\
   \ [label1 ...]] [COUNT\_count]\n  [[ALIGN\_value] AGGREGATION\ aggregators bucketDuration\n\
   \  [BUCKETTIMESTAMP] [EMPTY]] FILTER\_<l=v | l!=v | l= | l!= |\n  l=(v1,v2,...)\
   \ | l!=(v1,v2,...) [l=v | l!=v | l= | l!= |\n  l=(v1,v2,...) | l!=(v1,v2,...) ...]>\
-  \ [GROUPBY label REDUCE\n  reducer]"
+  \ [GROUPBY label REDUCE\n  reducer] [EXCLUDEEMPTY]"
 title: TS.MREVRANGE
 ---
 {{< note >}}
@@ -346,6 +351,16 @@ When combined with `AGGREGATION` the `GROUPBY`/`REDUCE` is applied post aggregat
 </note>
 </details>
 
+<details open>
+<summary><code>EXCLUDEEMPTY</code> (since Redis 8.10)</summary>
+
+excludes from the reply any time series that has no samples in the requested range. By default, every time series that passes `FILTER filterExpr...` is reported, even those with no samples in the range (reported with an empty samples list).
+
+A time series whose only samples in the range are NaN is not considered empty and is still reported.
+
+`EXCLUDEEMPTY` cannot be used together with `GROUPBY label REDUCE reducer`; combining them replies with an error.
+</details>
+
 <note><b>Note:</b> An `MREVRANGE` command cannot be part of a transaction when running on a Redis cluster.</note>
 
 ## Examples
@@ -539,6 +554,73 @@ Query all time series with the metric label equal to `cpu`, but only return the 
          2) (nil)
    3) 1) 1) (integer) 1548149180000
          2) 99
+{{< / highlight >}}
+</details>
+
+<details open>
+<summary><b>Exclude empty time series from the reply</b></summary>
+
+Create three time series that share the label `s=1`, then add samples so that only two of them have data in the `- 500` range.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.CREATE s LABELS s 1 t 1
+OK
+127.0.0.1:6379> TS.CREATE t LABELS s 1 t 1
+OK
+127.0.0.1:6379> TS.CREATE u LABELS s 1 t 1
+OK
+127.0.0.1:6379> TS.MADD s 100 100 t 100 100 s 200 200 t 300 300 s 400 400 t 400 400 u 2000 2000
+1) (integer) 100
+2) (integer) 100
+3) (integer) 200
+4) (integer) 300
+5) (integer) 400
+6) (integer) 400
+7) (integer) 2000
+{{< / highlight >}}
+
+Query the `- 500` range with `EXCLUDEEMPTY`. Time series `u`, whose only sample is at timestamp `2000`, has no samples in the range and is omitted from the reply.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MREVRANGE - 500 WITHLABELS EXCLUDEEMPTY FILTER s=1
+1) 1) "s"
+   2) 1) 1) "s"
+         2) "1"
+      2) 1) "t"
+         2) "1"
+   3) 1) 1) (integer) 400
+         2) 400
+      2) 1) (integer) 200
+         2) 200
+      3) 1) (integer) 100
+         2) 100
+2) 1) "t"
+   2) 1) 1) "s"
+         2) "1"
+      2) 1) "t"
+         2) "1"
+   3) 1) 1) (integer) 400
+         2) 400
+      2) 1) (integer) 300
+         2) 300
+      3) 1) (integer) 100
+         2) 100
+{{< / highlight >}}
+
+Without `EXCLUDEEMPTY`, `u` is also reported, with an empty samples list.
+
+{{< highlight bash >}}
+127.0.0.1:6379> TS.MREVRANGE - 500 WITHLABELS FILTER s=1
+1) 1) "s"
+   ...
+2) 1) "t"
+   ...
+3) 1) "u"
+   2) 1) 1) "s"
+         2) "1"
+      2) 1) "t"
+         2) "1"
+   3) (empty array)
 {{< / highlight >}}
 </details>
 

--- a/static/images/railroad/ts.mrange.svg
+++ b/static/images/railroad/ts.mrange.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="237" viewBox="0 0 3685.5 237" width="3685.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="499" viewBox="0 0 3670.0 499" width="3670.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,85 +44,97 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 38v20m10 -20v20m-10 -10h20"></path></g><path d="M40 48h10"></path><g>
-<path d="M50 48h0.0"></path><path d="M3635.5 48h0.0"></path><g class="terminal ">
+<path d="M50 48h0.0"></path><path d="M3620.0 48h0.0"></path><g class="terminal ">
 <path d="M50.0 48h0.0"></path><path d="M146.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="50.0" y="37"></rect><text x="98.25" y="52">TS.MRANGE</text></g><path d="M146.5 48h10"></path><path d="M156.5 48h10"></path><g class="non-terminal ">
 <path d="M166.5 48h0.0"></path><path d="M297.0 48h0.0"></path><rect height="22" width="130.5" x="166.5" y="37"></rect><text x="231.75" y="52">fromTimestamp</text></g><path d="M297.0 48h10"></path><path d="M307.0 48h10"></path><g class="non-terminal ">
 <path d="M317.0 48h0.0"></path><path d="M430.5 48h0.0"></path><rect height="22" width="113.5" x="317.0" y="37"></rect><text x="373.75" y="52">toTimestamp</text></g><path d="M430.5 48h10"></path><g>
 <path d="M440.5 48h0.0"></path><path d="M551.5 48h0.0"></path><path d="M440.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M460.5 28h71.0"></path></g><path d="M531.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M440.5 48h20"></path><g class="non-terminal ">
-<path d="M460.5 48h0.0"></path><path d="M531.5 48h0.0"></path><rect height="22" width="71.0" x="460.5" y="37"></rect><text x="496.0" y="52">LATEST</text></g><path d="M531.5 48h20"></path></g><g>
-<path d="M551.5 48h0.0"></path><path d="M850.0 48h0.0"></path><path d="M551.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M571.5 28h258.5"></path></g><path d="M830.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M551.5 48h20"></path><g>
-<path d="M571.5 48h0.0"></path><path d="M830.0 48h0.0"></path><g class="terminal ">
-<path d="M571.5 48h0.0"></path><path d="M693.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="571.5" y="37"></rect><text x="632.5" y="52">FILTER&#95;BY&#95;TS</text></g><path d="M693.5 48h10"></path><path d="M703.5 48h10"></path><g>
-<path d="M713.5 48h0.0"></path><path d="M830.0 48h0.0"></path><path d="M713.5 48h10"></path><g class="non-terminal ">
-<path d="M723.5 48h0.0"></path><path d="M820.0 48h0.0"></path><rect height="22" width="96.5" x="723.5" y="37"></rect><text x="771.75" y="52">Timestamp</text></g><path d="M820.0 48h10"></path><path d="M723.5 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M723.5 68h96.5"></path></g><path d="M820.0 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M830.0 48h20"></path></g><g>
-<path d="M850.0 48h0.0"></path><path d="M1168.5 48h0.0"></path><path d="M850.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M870.0 28h278.5"></path></g><path d="M1148.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M850.0 48h20"></path><g>
-<path d="M870.0 48h0.0"></path><path d="M1148.5 48h0.0"></path><g class="terminal ">
-<path d="M870.0 48h0.0"></path><path d="M1017.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="870.0" y="37"></rect><text x="943.75" y="52">FILTER&#95;BY&#95;VALUE</text></g><path d="M1017.5 48h10"></path><path d="M1027.5 48h10"></path><g class="non-terminal ">
-<path d="M1037.5 48h0.0"></path><path d="M1083.0 48h0.0"></path><rect height="22" width="45.5" x="1037.5" y="37"></rect><text x="1060.25" y="52">min</text></g><path d="M1083.0 48h10"></path><path d="M1093.0 48h10"></path><g class="non-terminal ">
-<path d="M1103.0 48h0.0"></path><path d="M1148.5 48h0.0"></path><rect height="22" width="45.5" x="1103.0" y="37"></rect><text x="1125.75" y="52">max</text></g></g><path d="M1148.5 48h20"></path></g><g>
-<path d="M1168.5 48h0.0"></path><path d="M1507.0 48h0.0"></path><path d="M1168.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1188.5 28h298.5"></path></g><path d="M1487.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1168.5 48h20"></path><g>
-<path d="M1188.5 48h0.0"></path><path d="M1487.0 48h0.0"></path><path d="M1188.5 48h20"></path><g class="terminal ">
-<path d="M1208.5 48h76.75"></path><path d="M1390.25 48h76.75"></path><rect height="22" rx="10" ry="10" width="105.0" x="1285.25" y="37"></rect><text x="1337.75" y="52">WITHLABELS</text></g><path d="M1467.0 48h20"></path><path d="M1188.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
-<path d="M1208.5 78h0.0"></path><path d="M1467.0 78h0.0"></path><g class="terminal ">
-<path d="M1208.5 78h0.0"></path><path d="M1356.0 78h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="1208.5" y="67"></rect><text x="1282.25" y="82">SELECTED&#95;LABELS</text></g><path d="M1356.0 78h10"></path><path d="M1366.0 78h10"></path><g>
-<path d="M1376.0 78h0.0"></path><path d="M1467.0 78h0.0"></path><path d="M1376.0 78h10"></path><g class="non-terminal ">
-<path d="M1386.0 78h0.0"></path><path d="M1457.0 78h0.0"></path><rect height="22" width="71.0" x="1386.0" y="67"></rect><text x="1421.5" y="82">label1</text></g><path d="M1457.0 78h10"></path><path d="M1386.0 78a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M1386.0 98h71.0"></path></g><path d="M1457.0 98a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M1467.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><path d="M1487.0 48h20"></path></g><g>
-<path d="M1507.0 48h0.0"></path><path d="M1692.0 48h0.0"></path><path d="M1507.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1527.0 28h145.0"></path></g><path d="M1672.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1507.0 48h20"></path><g>
-<path d="M1527.0 48h0.0"></path><path d="M1672.0 48h0.0"></path><g class="terminal ">
-<path d="M1527.0 48h0.0"></path><path d="M1589.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1527.0" y="37"></rect><text x="1558.25" y="52">COUNT</text></g><path d="M1589.5 48h10"></path><path d="M1599.5 48h10"></path><g class="non-terminal ">
-<path d="M1609.5 48h0.0"></path><path d="M1672.0 48h0.0"></path><rect height="22" width="62.5" x="1609.5" y="37"></rect><text x="1640.75" y="52">count</text></g></g><path d="M1672.0 48h20"></path></g><g>
-<path d="M1692.0 48h0.0"></path><path d="M2633.0 48h0.0"></path><path d="M1692.0 48a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path><g>
-<path d="M1712.0 20h901.0"></path></g><path d="M2613.0 20a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path><path d="M1692.0 48h20"></path><g>
-<path d="M1712.0 48h0.0"></path><path d="M2613.0 48h0.0"></path><g>
-<path d="M1712.0 48h0.0"></path><path d="M1897.0 48h0.0"></path><path d="M1712.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1732.0 28h145.0"></path></g><path d="M1877.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1712.0 48h20"></path><g>
-<path d="M1732.0 48h0.0"></path><path d="M1877.0 48h0.0"></path><g class="terminal ">
-<path d="M1732.0 48h0.0"></path><path d="M1794.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1732.0" y="37"></rect><text x="1763.25" y="52">ALIGN</text></g><path d="M1794.5 48h10"></path><path d="M1804.5 48h10"></path><g class="non-terminal ">
-<path d="M1814.5 48h0.0"></path><path d="M1877.0 48h0.0"></path><rect height="22" width="62.5" x="1814.5" y="37"></rect><text x="1845.75" y="52">value</text></g></g><path d="M1877.0 48h20"></path></g><path d="M1897.0 48h10"></path><g>
-<path d="M1907.0 48h0.0"></path><path d="M2154.0 48h0.0"></path><g class="terminal ">
-<path d="M1907.0 48h0.0"></path><path d="M2020.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="1907.0" y="37"></rect><text x="1963.75" y="52">AGGREGATION</text></g><path d="M2020.5 48h10"></path><path d="M2030.5 48h10"></path><g class="non-terminal ">
-<path d="M2040.5 48h0.0"></path><path d="M2154.0 48h0.0"></path><rect height="22" width="113.5" x="2040.5" y="37"></rect><text x="2097.25" y="52">aggregators</text></g></g><path d="M2154.0 48h10"></path><path d="M2164.0 48h10"></path><g class="non-terminal ">
-<path d="M2174.0 48h0.0"></path><path d="M2313.0 48h0.0"></path><rect height="22" width="139.0" x="2174.0" y="37"></rect><text x="2243.5" y="52">bucketDuration</text></g><path d="M2313.0 48h10"></path><g>
-<path d="M2323.0 48h0.0"></path><path d="M2510.5 48h0.0"></path><path d="M2323.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M2343.0 28h147.5"></path></g><path d="M2490.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2323.0 48h20"></path><g class="terminal ">
-<path d="M2343.0 48h0.0"></path><path d="M2490.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="2343.0" y="37"></rect><text x="2416.75" y="52">BUCKETTIMESTAMP</text></g><path d="M2490.5 48h20"></path></g><g>
-<path d="M2510.5 48h0.0"></path><path d="M2613.0 48h0.0"></path><path d="M2510.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M2530.5 28h62.5"></path></g><path d="M2593.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2510.5 48h20"></path><g class="terminal ">
-<path d="M2530.5 48h0.0"></path><path d="M2593.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2530.5" y="37"></rect><text x="2561.75" y="52">EMPTY</text></g><path d="M2593.0 48h20"></path></g></g><path d="M2613.0 48h20"></path></g><path d="M2633.0 48h10"></path><g>
-<path d="M2643.0 48h0.0"></path><path d="M3233.0 48h0.0"></path><g>
-<path d="M2643.0 48h0.0"></path><path d="M2903.0 48h0.0"></path><g class="terminal ">
-<path d="M2643.0 48h0.0"></path><path d="M2714.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="2643.0" y="37"></rect><text x="2678.5" y="52">FILTER</text></g><path d="M2714.0 48h10"></path><g>
-<path d="M2724.0 48h0.0"></path><path d="M2903.0 48h0.0"></path><path d="M2724.0 48h20"></path><g class="non-terminal ">
-<path d="M2744.0 48h46.75"></path><path d="M2836.25 48h46.75"></path><rect height="22" width="45.5" x="2790.75" y="37"></rect><text x="2813.5" y="52">l=v</text></g><path d="M2883.0 48h20"></path><path d="M2724.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2744.0 78h42.5"></path><path d="M2840.5 78h42.5"></path><rect height="22" width="54.0" x="2786.5" y="67"></rect><text x="2813.5" y="82">l!=v</text></g><path d="M2883.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M2724.0 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2744.0 108h51.0"></path><path d="M2832.0 108h51.0"></path><rect height="22" width="37.0" x="2795.0" y="97"></rect><text x="2813.5" y="112">l=</text></g><path d="M2883.0 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M2724.0 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2744.0 138h46.75"></path><path d="M2836.25 138h46.75"></path><rect height="22" width="45.5" x="2790.75" y="127"></rect><text x="2813.5" y="142">l!=</text></g><path d="M2883.0 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M2724.0 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2744.0 168h4.25"></path><path d="M2878.75 168h4.25"></path><rect height="22" width="130.5" x="2748.25" y="157"></rect><text x="2813.5" y="172">l=(v1,v2,...)</text></g><path d="M2883.0 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M2724.0 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2744.0 198h0.0"></path><path d="M2883.0 198h0.0"></path><rect height="22" width="139.0" x="2744.0" y="187"></rect><text x="2813.5" y="202">l!=(v1,v2,...)</text></g><path d="M2883.0 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M2903.0 48h10"></path><g>
-<path d="M2913.0 48h0.0"></path><path d="M3233.0 48h0.0"></path><path d="M2913.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M2933.0 28h280.0"></path></g><path d="M3213.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2913.0 48h20"></path><g>
-<path d="M2933.0 48h0.0"></path><path d="M3213.0 48h0.0"></path><path d="M2933.0 48h10"></path><g>
-<path d="M2943.0 48h0.0"></path><path d="M3203.0 48h0.0"></path><g class="terminal ">
-<path d="M2943.0 48h0.0"></path><path d="M3014.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="2943.0" y="37"></rect><text x="2978.5" y="52">FILTER</text></g><path d="M3014.0 48h10"></path><g>
-<path d="M3024.0 48h0.0"></path><path d="M3203.0 48h0.0"></path><path d="M3024.0 48h20"></path><g class="non-terminal ">
-<path d="M3044.0 48h46.75"></path><path d="M3136.25 48h46.75"></path><rect height="22" width="45.5" x="3090.75" y="37"></rect><text x="3113.5" y="52">l=v</text></g><path d="M3183.0 48h20"></path><path d="M3024.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3044.0 78h42.5"></path><path d="M3140.5 78h42.5"></path><rect height="22" width="54.0" x="3086.5" y="67"></rect><text x="3113.5" y="82">l!=v</text></g><path d="M3183.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M3024.0 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3044.0 108h51.0"></path><path d="M3132.0 108h51.0"></path><rect height="22" width="37.0" x="3095.0" y="97"></rect><text x="3113.5" y="112">l=</text></g><path d="M3183.0 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M3024.0 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3044.0 138h46.75"></path><path d="M3136.25 138h46.75"></path><rect height="22" width="45.5" x="3090.75" y="127"></rect><text x="3113.5" y="142">l!=</text></g><path d="M3183.0 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M3024.0 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3044.0 168h4.25"></path><path d="M3178.75 168h4.25"></path><rect height="22" width="130.5" x="3048.25" y="157"></rect><text x="3113.5" y="172">l=(v1,v2,...)</text></g><path d="M3183.0 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M3024.0 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3044.0 198h0.0"></path><path d="M3183.0 198h0.0"></path><rect height="22" width="139.0" x="3044.0" y="187"></rect><text x="3113.5" y="202">l!=(v1,v2,...)</text></g><path d="M3183.0 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M3203.0 48h10"></path><path d="M2943.0 48a10 10 0 0 0 -10 10v149a10 10 0 0 0 10 10"></path><g>
-<path d="M2943.0 217h260.0"></path></g><path d="M3203.0 217a10 10 0 0 0 10 -10v-149a10 10 0 0 0 -10 -10"></path></g><path d="M3213.0 48h20"></path></g></g><path d="M3233.0 48h10"></path><g>
-<path d="M3243.0 48h0.0"></path><path d="M3635.5 48h0.0"></path><path d="M3243.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M3263.0 28h352.5"></path></g><path d="M3615.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M3243.0 48h20"></path><g>
-<path d="M3263.0 48h0.0"></path><path d="M3615.5 48h0.0"></path><g class="terminal ">
-<path d="M3263.0 48h0.0"></path><path d="M3342.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="3263.0" y="37"></rect><text x="3302.75" y="52">GROUPBY</text></g><path d="M3342.5 48h10"></path><path d="M3352.5 48h10"></path><g class="non-terminal ">
-<path d="M3362.5 48h0.0"></path><path d="M3425.0 48h0.0"></path><rect height="22" width="62.5" x="3362.5" y="37"></rect><text x="3393.75" y="52">label</text></g><path d="M3425.0 48h10"></path><path d="M3435.0 48h10"></path><g class="non-terminal ">
-<path d="M3445.0 48h0.0"></path><path d="M3516.0 48h0.0"></path><rect height="22" width="71.0" x="3445.0" y="37"></rect><text x="3480.5" y="52">REDUCE</text></g><path d="M3516.0 48h10"></path><path d="M3526.0 48h10"></path><g class="non-terminal ">
-<path d="M3536.0 48h0.0"></path><path d="M3615.5 48h0.0"></path><rect height="22" width="79.5" x="3536.0" y="37"></rect><text x="3575.75" y="52">reducer</text></g></g><path d="M3615.5 48h20"></path></g></g><path d="M3635.5 48h10"></path><path d="M 3645.5 48 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M460.5 28h71.0"></path></g><path d="M531.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M440.5 48h20"></path><g class="terminal ">
+<path d="M460.5 48h0.0"></path><path d="M531.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="460.5" y="37"></rect><text x="496.0" y="52">LATEST</text></g><path d="M531.5 48h20"></path></g><g>
+<path d="M551.5 48h0.0"></path><path d="M870.0 48h0.0"></path><path d="M551.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M571.5 28h278.5"></path></g><path d="M850.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M551.5 48h20"></path><g>
+<path d="M571.5 48h0.0"></path><path d="M850.0 48h0.0"></path><path d="M571.5 48h10"></path><g>
+<path d="M581.5 48h0.0"></path><path d="M840.0 48h0.0"></path><g class="terminal ">
+<path d="M581.5 48h0.0"></path><path d="M703.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="581.5" y="37"></rect><text x="642.5" y="52">FILTER&#95;BY&#95;TS</text></g><path d="M703.5 48h10"></path><path d="M713.5 48h10"></path><g>
+<path d="M723.5 48h0.0"></path><path d="M840.0 48h0.0"></path><path d="M723.5 48h10"></path><g class="non-terminal ">
+<path d="M733.5 48h0.0"></path><path d="M830.0 48h0.0"></path><rect height="22" width="96.5" x="733.5" y="37"></rect><text x="781.75" y="52">timestamp</text></g><path d="M830.0 48h10"></path><path d="M733.5 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M733.5 68h96.5"></path></g><path d="M830.0 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M840.0 48h10"></path><path d="M581.5 48a10 10 0 0 0 -10 10v8a10 10 0 0 0 10 10"></path><g>
+<path d="M581.5 76h258.5"></path></g><path d="M840.0 76a10 10 0 0 0 10 -10v-8a10 10 0 0 0 -10 -10"></path></g><path d="M850.0 48h20"></path></g><g>
+<path d="M870.0 48h0.0"></path><path d="M1188.5 48h0.0"></path><path d="M870.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M890.0 28h278.5"></path></g><path d="M1168.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M870.0 48h20"></path><g>
+<path d="M890.0 48h0.0"></path><path d="M1168.5 48h0.0"></path><g class="terminal ">
+<path d="M890.0 48h0.0"></path><path d="M1037.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="890.0" y="37"></rect><text x="963.75" y="52">FILTER&#95;BY&#95;VALUE</text></g><path d="M1037.5 48h10"></path><path d="M1047.5 48h10"></path><g class="non-terminal ">
+<path d="M1057.5 48h0.0"></path><path d="M1103.0 48h0.0"></path><rect height="22" width="45.5" x="1057.5" y="37"></rect><text x="1080.25" y="52">min</text></g><path d="M1103.0 48h10"></path><path d="M1113.0 48h10"></path><g class="non-terminal ">
+<path d="M1123.0 48h0.0"></path><path d="M1168.5 48h0.0"></path><rect height="22" width="45.5" x="1123.0" y="37"></rect><text x="1145.75" y="52">max</text></g></g><path d="M1168.5 48h20"></path></g><g>
+<path d="M1188.5 48h0.0"></path><path d="M1518.5 48h0.0"></path><path d="M1188.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1208.5 28h290.0"></path></g><path d="M1498.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1188.5 48h20"></path><g>
+<path d="M1208.5 48h0.0"></path><path d="M1498.5 48h0.0"></path><path d="M1208.5 48h20"></path><g class="terminal ">
+<path d="M1228.5 48h72.5"></path><path d="M1406.0 48h72.5"></path><rect height="22" rx="10" ry="10" width="105.0" x="1301.0" y="37"></rect><text x="1353.5" y="52">WITHLABELS</text></g><path d="M1478.5 48h20"></path><path d="M1208.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M1228.5 78h0.0"></path><path d="M1478.5 78h0.0"></path><g class="terminal ">
+<path d="M1228.5 78h0.0"></path><path d="M1376.0 78h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="1228.5" y="67"></rect><text x="1302.25" y="82">SELECTED&#95;LABELS</text></g><path d="M1376.0 78h10"></path><path d="M1386.0 78h10"></path><g>
+<path d="M1396.0 78h0.0"></path><path d="M1478.5 78h0.0"></path><path d="M1396.0 78h10"></path><g class="non-terminal ">
+<path d="M1406.0 78h0.0"></path><path d="M1468.5 78h0.0"></path><rect height="22" width="62.5" x="1406.0" y="67"></rect><text x="1437.25" y="82">label</text></g><path d="M1468.5 78h10"></path><path d="M1406.0 78a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M1406.0 98h62.5"></path></g><path d="M1468.5 98a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M1478.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><path d="M1498.5 48h20"></path></g><g>
+<path d="M1518.5 48h0.0"></path><path d="M1703.5 48h0.0"></path><path d="M1518.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1538.5 28h145.0"></path></g><path d="M1683.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1518.5 48h20"></path><g>
+<path d="M1538.5 48h0.0"></path><path d="M1683.5 48h0.0"></path><g>
+<path d="M1538.5 48h0.0"></path><path d="M1683.5 48h0.0"></path><g class="terminal ">
+<path d="M1538.5 48h0.0"></path><path d="M1601.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1538.5" y="37"></rect><text x="1569.75" y="52">COUNT</text></g><path d="M1601.0 48h10"></path><path d="M1611.0 48h10"></path><g class="non-terminal ">
+<path d="M1621.0 48h0.0"></path><path d="M1683.5 48h0.0"></path><rect height="22" width="62.5" x="1621.0" y="37"></rect><text x="1652.25" y="52">count</text></g></g></g><path d="M1683.5 48h20"></path></g><g>
+<path d="M1703.5 48h0.0"></path><path d="M2791.0 48h0.0"></path><path d="M1703.5 48a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path><g>
+<path d="M1723.5 20h1047.5"></path></g><path d="M2771.0 20a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path><path d="M1703.5 48h20"></path><g>
+<path d="M1723.5 48h0.0"></path><path d="M2771.0 48h0.0"></path><g>
+<path d="M1723.5 48h0.0"></path><path d="M1942.5 48h0.0"></path><path d="M1723.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1743.5 28h179.0"></path></g><path d="M1922.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1723.5 48h20"></path><g>
+<path d="M1743.5 48h0.0"></path><path d="M1922.5 48h0.0"></path><g>
+<path d="M1743.5 48h0.0"></path><path d="M1922.5 48h0.0"></path><g class="terminal ">
+<path d="M1743.5 48h0.0"></path><path d="M1806.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1743.5" y="37"></rect><text x="1774.75" y="52">ALIGN</text></g><path d="M1806.0 48h10"></path><path d="M1816.0 48h10"></path><g class="non-terminal ">
+<path d="M1826.0 48h0.0"></path><path d="M1922.5 48h0.0"></path><rect height="22" width="96.5" x="1826.0" y="37"></rect><text x="1874.25" y="52">alignment</text></g></g></g><path d="M1922.5 48h20"></path></g><path d="M1942.5 48h10"></path><g>
+<path d="M1952.5 48h0.0"></path><path d="M2771.0 48h0.0"></path><g class="terminal ">
+<path d="M1952.5 48h0.0"></path><path d="M2066.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="1952.5" y="37"></rect><text x="2009.25" y="52">AGGREGATION</text></g><path d="M2066.0 48h10"></path><path d="M2076.0 48h10"></path><g class="non-terminal ">
+<path d="M2086.0 48h0.0"></path><path d="M2199.5 48h0.0"></path><rect height="22" width="113.5" x="2086.0" y="37"></rect><text x="2142.75" y="52">aggregators</text></g><path d="M2199.5 48h10"></path><path d="M2209.5 48h10"></path><g class="non-terminal ">
+<path d="M2219.5 48h0.0"></path><path d="M2358.5 48h0.0"></path><rect height="22" width="139.0" x="2219.5" y="37"></rect><text x="2289.0" y="52">bucketDuration</text></g><path d="M2358.5 48h10"></path><g>
+<path d="M2368.5 48h0.0"></path><path d="M2668.5 48h0.0"></path><path d="M2368.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2388.5 28h260.0"></path></g><path d="M2648.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2368.5 48h20"></path><g>
+<path d="M2388.5 48h0.0"></path><path d="M2648.5 48h0.0"></path><g class="terminal ">
+<path d="M2388.5 48h0.0"></path><path d="M2536.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="2388.5" y="37"></rect><text x="2462.25" y="52">BUCKETTIMESTAMP</text></g><path d="M2536.0 48h10"></path><g>
+<path d="M2546.0 48h0.0"></path><path d="M2648.5 48h0.0"></path><path d="M2546.0 48h20"></path><g class="terminal ">
+<path d="M2566.0 48h8.5"></path><path d="M2620.0 48h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2574.5" y="37"></rect><text x="2597.25" y="52">mid</text></g><path d="M2628.5 48h20"></path><path d="M2546.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2566.0 78h0.0"></path><path d="M2628.5 78h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2566.0" y="67"></rect><text x="2597.25" y="82">start</text></g><path d="M2628.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M2546.0 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2566.0 108h8.5"></path><path d="M2620.0 108h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2574.5" y="97"></rect><text x="2597.25" y="112">end</text></g><path d="M2628.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M2546.0 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2566.0 138h17.0"></path><path d="M2611.5 138h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2583.0" y="127"></rect><text x="2597.25" y="142">+</text></g><path d="M2628.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M2546.0 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2566.0 168h17.0"></path><path d="M2611.5 168h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2583.0" y="157"></rect><text x="2597.25" y="172">-</text></g><path d="M2628.5 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M2546.0 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2566.0 198h17.0"></path><path d="M2611.5 198h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2583.0" y="187"></rect><text x="2597.25" y="202">~</text></g><path d="M2628.5 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M2648.5 48h20"></path></g><g>
+<path d="M2668.5 48h0.0"></path><path d="M2771.0 48h0.0"></path><path d="M2668.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2688.5 28h62.5"></path></g><path d="M2751.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2668.5 48h20"></path><g class="terminal ">
+<path d="M2688.5 48h0.0"></path><path d="M2751.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2688.5" y="37"></rect><text x="2719.75" y="52">EMPTY</text></g><path d="M2751.0 48h20"></path></g></g></g><path d="M2771.0 48h20"></path></g><path d="M2791.0 48h10"></path><g>
+<path d="M2801.0 48h0.0"></path><path d="M3017.0 48h0.0"></path><g class="terminal ">
+<path d="M2801.0 48h0.0"></path><path d="M2872.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="2801.0" y="37"></rect><text x="2836.5" y="52">FILTER</text></g><path d="M2872.0 48h10"></path><path d="M2882.0 48h10"></path><g>
+<path d="M2892.0 48h0.0"></path><path d="M3017.0 48h0.0"></path><path d="M2892.0 48h10"></path><g class="non-terminal ">
+<path d="M2902.0 48h0.0"></path><path d="M3007.0 48h0.0"></path><rect height="22" width="105.0" x="2902.0" y="37"></rect><text x="2954.5" y="52">filterExpr</text></g><path d="M3007.0 48h10"></path><path d="M2902.0 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M2902.0 68h105.0"></path></g><path d="M3007.0 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M3017.0 48h10"></path><g>
+<path d="M3027.0 48h0.0"></path><path d="M3458.0 48h0.0"></path><path d="M3027.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M3047.0 28h391.0"></path></g><path d="M3438.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M3027.0 48h20"></path><g>
+<path d="M3047.0 48h0.0"></path><path d="M3438.0 48h0.0"></path><g class="terminal ">
+<path d="M3047.0 48h0.0"></path><path d="M3126.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="3047.0" y="37"></rect><text x="3086.75" y="52">GROUPBY</text></g><path d="M3126.5 48h10"></path><path d="M3136.5 48h10"></path><g class="non-terminal ">
+<path d="M3146.5 48h0.0"></path><path d="M3209.0 48h0.0"></path><rect height="22" width="62.5" x="3146.5" y="37"></rect><text x="3177.75" y="52">label</text></g><path d="M3209.0 48h10"></path><path d="M3219.0 48h10"></path><g class="terminal ">
+<path d="M3229.0 48h0.0"></path><path d="M3300.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="3229.0" y="37"></rect><text x="3264.5" y="52">REDUCE</text></g><path d="M3300.0 48h10"></path><g>
+<path d="M3310.0 48h0.0"></path><path d="M3438.0 48h0.0"></path><path d="M3310.0 48h20"></path><g class="terminal ">
+<path d="M3330.0 48h21.25"></path><path d="M3396.75 48h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3351.25" y="37"></rect><text x="3374.0" y="52">avg</text></g><path d="M3418.0 48h20"></path><path d="M3310.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 78h21.25"></path><path d="M3396.75 78h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3351.25" y="67"></rect><text x="3374.0" y="82">sum</text></g><path d="M3418.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 108h21.25"></path><path d="M3396.75 108h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3351.25" y="97"></rect><text x="3374.0" y="112">min</text></g><path d="M3418.0 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 138h21.25"></path><path d="M3396.75 138h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3351.25" y="127"></rect><text x="3374.0" y="142">max</text></g><path d="M3418.0 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 168h12.75"></path><path d="M3405.25 168h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3342.75" y="157"></rect><text x="3374.0" y="172">range</text></g><path d="M3418.0 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 198h12.75"></path><path d="M3405.25 198h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3342.75" y="187"></rect><text x="3374.0" y="202">count</text></g><path d="M3418.0 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v160a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 228h12.75"></path><path d="M3405.25 228h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3342.75" y="217"></rect><text x="3374.0" y="232">first</text></g><path d="M3418.0 228a10 10 0 0 0 10 -10v-160a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v190a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 258h17.0"></path><path d="M3401.0 258h17.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="3347.0" y="247"></rect><text x="3374.0" y="262">last</text></g><path d="M3418.0 258a10 10 0 0 0 10 -10v-190a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v220a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 288h12.75"></path><path d="M3405.25 288h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3342.75" y="277"></rect><text x="3374.0" y="292">std.p</text></g><path d="M3418.0 288a10 10 0 0 0 10 -10v-220a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v250a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 318h12.75"></path><path d="M3405.25 318h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3342.75" y="307"></rect><text x="3374.0" y="322">std.s</text></g><path d="M3418.0 318a10 10 0 0 0 10 -10v-250a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v280a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 348h12.75"></path><path d="M3405.25 348h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3342.75" y="337"></rect><text x="3374.0" y="352">var.p</text></g><path d="M3418.0 348a10 10 0 0 0 10 -10v-280a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v310a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 378h12.75"></path><path d="M3405.25 378h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3342.75" y="367"></rect><text x="3374.0" y="382">var.s</text></g><path d="M3418.0 378a10 10 0 0 0 10 -10v-310a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v340a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 408h21.25"></path><path d="M3396.75 408h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3351.25" y="397"></rect><text x="3374.0" y="412">twa</text></g><path d="M3418.0 408a10 10 0 0 0 10 -10v-340a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v370a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 438h0.0"></path><path d="M3418.0 438h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="3330.0" y="427"></rect><text x="3374.0" y="442">countnan</text></g><path d="M3418.0 438a10 10 0 0 0 10 -10v-370a10 10 0 0 1 10 -10"></path><path d="M3310.0 48a10 10 0 0 1 10 10v400a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3330.0 468h0.0"></path><path d="M3418.0 468h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="3330.0" y="457"></rect><text x="3374.0" y="472">countall</text></g><path d="M3418.0 468a10 10 0 0 0 10 -10v-400a10 10 0 0 1 10 -10"></path></g></g><path d="M3438.0 48h20"></path></g><g>
+<path d="M3458.0 48h0.0"></path><path d="M3620.0 48h0.0"></path><path d="M3458.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M3478.0 28h122.0"></path></g><path d="M3600.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M3458.0 48h20"></path><g class="terminal ">
+<path d="M3478.0 48h0.0"></path><path d="M3600.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="3478.0" y="37"></rect><text x="3539.0" y="52">EXCLUDEEMPTY</text></g><path d="M3600.0 48h20"></path></g></g><path d="M3620.0 48h10"></path><path d="M 3630.0 48 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/ts.mrevrange.svg
+++ b/static/images/railroad/ts.mrevrange.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="237" viewBox="0 0 3711.0 237" width="3711.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="499" viewBox="0 0 3695.5 499" width="3695.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -44,85 +44,97 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 /* ]]> */
 </style><g>
 <path d="M20 38v20m10 -20v20m-10 -10h20"></path></g><path d="M40 48h10"></path><g>
-<path d="M50 48h0.0"></path><path d="M3661.0 48h0.0"></path><g class="terminal ">
+<path d="M50 48h0.0"></path><path d="M3645.5 48h0.0"></path><g class="terminal ">
 <path d="M50.0 48h0.0"></path><path d="M172.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="50.0" y="37"></rect><text x="111.0" y="52">TS.MREVRANGE</text></g><path d="M172.0 48h10"></path><path d="M182.0 48h10"></path><g class="non-terminal ">
 <path d="M192.0 48h0.0"></path><path d="M322.5 48h0.0"></path><rect height="22" width="130.5" x="192.0" y="37"></rect><text x="257.25" y="52">fromTimestamp</text></g><path d="M322.5 48h10"></path><path d="M332.5 48h10"></path><g class="non-terminal ">
 <path d="M342.5 48h0.0"></path><path d="M456.0 48h0.0"></path><rect height="22" width="113.5" x="342.5" y="37"></rect><text x="399.25" y="52">toTimestamp</text></g><path d="M456.0 48h10"></path><g>
 <path d="M466.0 48h0.0"></path><path d="M577.0 48h0.0"></path><path d="M466.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
 <path d="M486.0 28h71.0"></path></g><path d="M557.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M466.0 48h20"></path><g class="terminal ">
 <path d="M486.0 48h0.0"></path><path d="M557.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="486.0" y="37"></rect><text x="521.5" y="52">LATEST</text></g><path d="M557.0 48h20"></path></g><g>
-<path d="M577.0 48h0.0"></path><path d="M875.5 48h0.0"></path><path d="M577.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M597.0 28h258.5"></path></g><path d="M855.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M577.0 48h20"></path><g>
-<path d="M597.0 48h0.0"></path><path d="M855.5 48h0.0"></path><g class="terminal ">
-<path d="M597.0 48h0.0"></path><path d="M719.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="597.0" y="37"></rect><text x="658.0" y="52">FILTER&#95;BY&#95;TS</text></g><path d="M719.0 48h10"></path><path d="M729.0 48h10"></path><g>
-<path d="M739.0 48h0.0"></path><path d="M855.5 48h0.0"></path><path d="M739.0 48h10"></path><g class="non-terminal ">
-<path d="M749.0 48h0.0"></path><path d="M845.5 48h0.0"></path><rect height="22" width="96.5" x="749.0" y="37"></rect><text x="797.25" y="52">Timestamp</text></g><path d="M845.5 48h10"></path><path d="M749.0 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M749.0 68h96.5"></path></g><path d="M845.5 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M855.5 48h20"></path></g><g>
-<path d="M875.5 48h0.0"></path><path d="M1194.0 48h0.0"></path><path d="M875.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M895.5 28h278.5"></path></g><path d="M1174.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M875.5 48h20"></path><g>
-<path d="M895.5 48h0.0"></path><path d="M1174.0 48h0.0"></path><g class="terminal ">
-<path d="M895.5 48h0.0"></path><path d="M1043.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="895.5" y="37"></rect><text x="969.25" y="52">FILTER&#95;BY&#95;VALUE</text></g><path d="M1043.0 48h10"></path><path d="M1053.0 48h10"></path><g class="non-terminal ">
-<path d="M1063.0 48h0.0"></path><path d="M1108.5 48h0.0"></path><rect height="22" width="45.5" x="1063.0" y="37"></rect><text x="1085.75" y="52">min</text></g><path d="M1108.5 48h10"></path><path d="M1118.5 48h10"></path><g class="non-terminal ">
-<path d="M1128.5 48h0.0"></path><path d="M1174.0 48h0.0"></path><rect height="22" width="45.5" x="1128.5" y="37"></rect><text x="1151.25" y="52">max</text></g></g><path d="M1174.0 48h20"></path></g><g>
-<path d="M1194.0 48h0.0"></path><path d="M1532.5 48h0.0"></path><path d="M1194.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1214.0 28h298.5"></path></g><path d="M1512.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1194.0 48h20"></path><g>
-<path d="M1214.0 48h0.0"></path><path d="M1512.5 48h0.0"></path><path d="M1214.0 48h20"></path><g class="terminal ">
-<path d="M1234.0 48h76.75"></path><path d="M1415.75 48h76.75"></path><rect height="22" rx="10" ry="10" width="105.0" x="1310.75" y="37"></rect><text x="1363.25" y="52">WITHLABELS</text></g><path d="M1492.5 48h20"></path><path d="M1214.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
-<path d="M1234.0 78h0.0"></path><path d="M1492.5 78h0.0"></path><g class="terminal ">
-<path d="M1234.0 78h0.0"></path><path d="M1381.5 78h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="1234.0" y="67"></rect><text x="1307.75" y="82">SELECTED&#95;LABELS</text></g><path d="M1381.5 78h10"></path><path d="M1391.5 78h10"></path><g>
-<path d="M1401.5 78h0.0"></path><path d="M1492.5 78h0.0"></path><path d="M1401.5 78h10"></path><g class="non-terminal ">
-<path d="M1411.5 78h0.0"></path><path d="M1482.5 78h0.0"></path><rect height="22" width="71.0" x="1411.5" y="67"></rect><text x="1447.0" y="82">label1</text></g><path d="M1482.5 78h10"></path><path d="M1411.5 78a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
-<path d="M1411.5 98h71.0"></path></g><path d="M1482.5 98a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M1492.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><path d="M1512.5 48h20"></path></g><g>
-<path d="M1532.5 48h0.0"></path><path d="M1717.5 48h0.0"></path><path d="M1532.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1552.5 28h145.0"></path></g><path d="M1697.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1532.5 48h20"></path><g>
-<path d="M1552.5 48h0.0"></path><path d="M1697.5 48h0.0"></path><g class="terminal ">
-<path d="M1552.5 48h0.0"></path><path d="M1615.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1552.5" y="37"></rect><text x="1583.75" y="52">COUNT</text></g><path d="M1615.0 48h10"></path><path d="M1625.0 48h10"></path><g class="non-terminal ">
-<path d="M1635.0 48h0.0"></path><path d="M1697.5 48h0.0"></path><rect height="22" width="62.5" x="1635.0" y="37"></rect><text x="1666.25" y="52">count</text></g></g><path d="M1697.5 48h20"></path></g><g>
-<path d="M1717.5 48h0.0"></path><path d="M2658.5 48h0.0"></path><path d="M1717.5 48a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path><g>
-<path d="M1737.5 20h901.0"></path></g><path d="M2638.5 20a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path><path d="M1717.5 48h20"></path><g>
-<path d="M1737.5 48h0.0"></path><path d="M2638.5 48h0.0"></path><g>
-<path d="M1737.5 48h0.0"></path><path d="M1922.5 48h0.0"></path><path d="M1737.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M1757.5 28h145.0"></path></g><path d="M1902.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1737.5 48h20"></path><g>
-<path d="M1757.5 48h0.0"></path><path d="M1902.5 48h0.0"></path><g class="terminal ">
-<path d="M1757.5 48h0.0"></path><path d="M1820.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1757.5" y="37"></rect><text x="1788.75" y="52">ALIGN</text></g><path d="M1820.0 48h10"></path><path d="M1830.0 48h10"></path><g class="non-terminal ">
-<path d="M1840.0 48h0.0"></path><path d="M1902.5 48h0.0"></path><rect height="22" width="62.5" x="1840.0" y="37"></rect><text x="1871.25" y="52">value</text></g></g><path d="M1902.5 48h20"></path></g><path d="M1922.5 48h10"></path><g>
-<path d="M1932.5 48h0.0"></path><path d="M2179.5 48h0.0"></path><g class="terminal ">
-<path d="M1932.5 48h0.0"></path><path d="M2046.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="1932.5" y="37"></rect><text x="1989.25" y="52">AGGREGATION</text></g><path d="M2046.0 48h10"></path><path d="M2056.0 48h10"></path><g class="non-terminal ">
-<path d="M2066.0 48h0.0"></path><path d="M2179.5 48h0.0"></path><rect height="22" width="113.5" x="2066.0" y="37"></rect><text x="2122.75" y="52">aggregators</text></g></g><path d="M2179.5 48h10"></path><path d="M2189.5 48h10"></path><g class="non-terminal ">
-<path d="M2199.5 48h0.0"></path><path d="M2338.5 48h0.0"></path><rect height="22" width="139.0" x="2199.5" y="37"></rect><text x="2269.0" y="52">bucketDuration</text></g><path d="M2338.5 48h10"></path><g>
-<path d="M2348.5 48h0.0"></path><path d="M2536.0 48h0.0"></path><path d="M2348.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M2368.5 28h147.5"></path></g><path d="M2516.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2348.5 48h20"></path><g class="terminal ">
-<path d="M2368.5 48h0.0"></path><path d="M2516.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="2368.5" y="37"></rect><text x="2442.25" y="52">BUCKETTIMESTAMP</text></g><path d="M2516.0 48h20"></path></g><g>
-<path d="M2536.0 48h0.0"></path><path d="M2638.5 48h0.0"></path><path d="M2536.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M2556.0 28h62.5"></path></g><path d="M2618.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2536.0 48h20"></path><g class="terminal ">
-<path d="M2556.0 48h0.0"></path><path d="M2618.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2556.0" y="37"></rect><text x="2587.25" y="52">EMPTY</text></g><path d="M2618.5 48h20"></path></g></g><path d="M2638.5 48h20"></path></g><path d="M2658.5 48h10"></path><g>
-<path d="M2668.5 48h0.0"></path><path d="M3258.5 48h0.0"></path><g>
-<path d="M2668.5 48h0.0"></path><path d="M2928.5 48h0.0"></path><g class="terminal ">
-<path d="M2668.5 48h0.0"></path><path d="M2739.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="2668.5" y="37"></rect><text x="2704.0" y="52">FILTER</text></g><path d="M2739.5 48h10"></path><g>
-<path d="M2749.5 48h0.0"></path><path d="M2928.5 48h0.0"></path><path d="M2749.5 48h20"></path><g class="non-terminal ">
-<path d="M2769.5 48h46.75"></path><path d="M2861.75 48h46.75"></path><rect height="22" width="45.5" x="2816.25" y="37"></rect><text x="2839.0" y="52">l=v</text></g><path d="M2908.5 48h20"></path><path d="M2749.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2769.5 78h42.5"></path><path d="M2866.0 78h42.5"></path><rect height="22" width="54.0" x="2812.0" y="67"></rect><text x="2839.0" y="82">l!=v</text></g><path d="M2908.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M2749.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2769.5 108h51.0"></path><path d="M2857.5 108h51.0"></path><rect height="22" width="37.0" x="2820.5" y="97"></rect><text x="2839.0" y="112">l=</text></g><path d="M2908.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M2749.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2769.5 138h46.75"></path><path d="M2861.75 138h46.75"></path><rect height="22" width="45.5" x="2816.25" y="127"></rect><text x="2839.0" y="142">l!=</text></g><path d="M2908.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M2749.5 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2769.5 168h4.25"></path><path d="M2904.25 168h4.25"></path><rect height="22" width="130.5" x="2773.75" y="157"></rect><text x="2839.0" y="172">l=(v1,v2,...)</text></g><path d="M2908.5 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M2749.5 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M2769.5 198h0.0"></path><path d="M2908.5 198h0.0"></path><rect height="22" width="139.0" x="2769.5" y="187"></rect><text x="2839.0" y="202">l!=(v1,v2,...)</text></g><path d="M2908.5 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M2928.5 48h10"></path><g>
-<path d="M2938.5 48h0.0"></path><path d="M3258.5 48h0.0"></path><path d="M2938.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M2958.5 28h280.0"></path></g><path d="M3238.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2938.5 48h20"></path><g>
-<path d="M2958.5 48h0.0"></path><path d="M3238.5 48h0.0"></path><path d="M2958.5 48h10"></path><g>
-<path d="M2968.5 48h0.0"></path><path d="M3228.5 48h0.0"></path><g class="terminal ">
-<path d="M2968.5 48h0.0"></path><path d="M3039.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="2968.5" y="37"></rect><text x="3004.0" y="52">FILTER</text></g><path d="M3039.5 48h10"></path><g>
-<path d="M3049.5 48h0.0"></path><path d="M3228.5 48h0.0"></path><path d="M3049.5 48h20"></path><g class="non-terminal ">
-<path d="M3069.5 48h46.75"></path><path d="M3161.75 48h46.75"></path><rect height="22" width="45.5" x="3116.25" y="37"></rect><text x="3139.0" y="52">l=v</text></g><path d="M3208.5 48h20"></path><path d="M3049.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3069.5 78h42.5"></path><path d="M3166.0 78h42.5"></path><rect height="22" width="54.0" x="3112.0" y="67"></rect><text x="3139.0" y="82">l!=v</text></g><path d="M3208.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M3049.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3069.5 108h51.0"></path><path d="M3157.5 108h51.0"></path><rect height="22" width="37.0" x="3120.5" y="97"></rect><text x="3139.0" y="112">l=</text></g><path d="M3208.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M3049.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3069.5 138h46.75"></path><path d="M3161.75 138h46.75"></path><rect height="22" width="45.5" x="3116.25" y="127"></rect><text x="3139.0" y="142">l!=</text></g><path d="M3208.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M3049.5 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3069.5 168h4.25"></path><path d="M3204.25 168h4.25"></path><rect height="22" width="130.5" x="3073.75" y="157"></rect><text x="3139.0" y="172">l=(v1,v2,...)</text></g><path d="M3208.5 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M3049.5 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="non-terminal ">
-<path d="M3069.5 198h0.0"></path><path d="M3208.5 198h0.0"></path><rect height="22" width="139.0" x="3069.5" y="187"></rect><text x="3139.0" y="202">l!=(v1,v2,...)</text></g><path d="M3208.5 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M3228.5 48h10"></path><path d="M2968.5 48a10 10 0 0 0 -10 10v149a10 10 0 0 0 10 10"></path><g>
-<path d="M2968.5 217h260.0"></path></g><path d="M3228.5 217a10 10 0 0 0 10 -10v-149a10 10 0 0 0 -10 -10"></path></g><path d="M3238.5 48h20"></path></g></g><path d="M3258.5 48h10"></path><g>
-<path d="M3268.5 48h0.0"></path><path d="M3661.0 48h0.0"></path><path d="M3268.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
-<path d="M3288.5 28h352.5"></path></g><path d="M3641.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M3268.5 48h20"></path><g>
-<path d="M3288.5 48h0.0"></path><path d="M3641.0 48h0.0"></path><g class="terminal ">
-<path d="M3288.5 48h0.0"></path><path d="M3368.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="3288.5" y="37"></rect><text x="3328.25" y="52">GROUPBY</text></g><path d="M3368.0 48h10"></path><path d="M3378.0 48h10"></path><g class="non-terminal ">
-<path d="M3388.0 48h0.0"></path><path d="M3450.5 48h0.0"></path><rect height="22" width="62.5" x="3388.0" y="37"></rect><text x="3419.25" y="52">label</text></g><path d="M3450.5 48h10"></path><path d="M3460.5 48h10"></path><g class="non-terminal ">
-<path d="M3470.5 48h0.0"></path><path d="M3541.5 48h0.0"></path><rect height="22" width="71.0" x="3470.5" y="37"></rect><text x="3506.0" y="52">REDUCE</text></g><path d="M3541.5 48h10"></path><path d="M3551.5 48h10"></path><g class="non-terminal ">
-<path d="M3561.5 48h0.0"></path><path d="M3641.0 48h0.0"></path><rect height="22" width="79.5" x="3561.5" y="37"></rect><text x="3601.25" y="52">reducer</text></g></g><path d="M3641.0 48h20"></path></g></g><path d="M3661.0 48h10"></path><path d="M 3671.0 48 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M577.0 48h0.0"></path><path d="M895.5 48h0.0"></path><path d="M577.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M597.0 28h278.5"></path></g><path d="M875.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M577.0 48h20"></path><g>
+<path d="M597.0 48h0.0"></path><path d="M875.5 48h0.0"></path><path d="M597.0 48h10"></path><g>
+<path d="M607.0 48h0.0"></path><path d="M865.5 48h0.0"></path><g class="terminal ">
+<path d="M607.0 48h0.0"></path><path d="M729.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="607.0" y="37"></rect><text x="668.0" y="52">FILTER&#95;BY&#95;TS</text></g><path d="M729.0 48h10"></path><path d="M739.0 48h10"></path><g>
+<path d="M749.0 48h0.0"></path><path d="M865.5 48h0.0"></path><path d="M749.0 48h10"></path><g class="non-terminal ">
+<path d="M759.0 48h0.0"></path><path d="M855.5 48h0.0"></path><rect height="22" width="96.5" x="759.0" y="37"></rect><text x="807.25" y="52">timestamp</text></g><path d="M855.5 48h10"></path><path d="M759.0 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M759.0 68h96.5"></path></g><path d="M855.5 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M865.5 48h10"></path><path d="M607.0 48a10 10 0 0 0 -10 10v8a10 10 0 0 0 10 10"></path><g>
+<path d="M607.0 76h258.5"></path></g><path d="M865.5 76a10 10 0 0 0 10 -10v-8a10 10 0 0 0 -10 -10"></path></g><path d="M875.5 48h20"></path></g><g>
+<path d="M895.5 48h0.0"></path><path d="M1214.0 48h0.0"></path><path d="M895.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M915.5 28h278.5"></path></g><path d="M1194.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M895.5 48h20"></path><g>
+<path d="M915.5 48h0.0"></path><path d="M1194.0 48h0.0"></path><g class="terminal ">
+<path d="M915.5 48h0.0"></path><path d="M1063.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="915.5" y="37"></rect><text x="989.25" y="52">FILTER&#95;BY&#95;VALUE</text></g><path d="M1063.0 48h10"></path><path d="M1073.0 48h10"></path><g class="non-terminal ">
+<path d="M1083.0 48h0.0"></path><path d="M1128.5 48h0.0"></path><rect height="22" width="45.5" x="1083.0" y="37"></rect><text x="1105.75" y="52">min</text></g><path d="M1128.5 48h10"></path><path d="M1138.5 48h10"></path><g class="non-terminal ">
+<path d="M1148.5 48h0.0"></path><path d="M1194.0 48h0.0"></path><rect height="22" width="45.5" x="1148.5" y="37"></rect><text x="1171.25" y="52">max</text></g></g><path d="M1194.0 48h20"></path></g><g>
+<path d="M1214.0 48h0.0"></path><path d="M1544.0 48h0.0"></path><path d="M1214.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1234.0 28h290.0"></path></g><path d="M1524.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1214.0 48h20"></path><g>
+<path d="M1234.0 48h0.0"></path><path d="M1524.0 48h0.0"></path><path d="M1234.0 48h20"></path><g class="terminal ">
+<path d="M1254.0 48h72.5"></path><path d="M1431.5 48h72.5"></path><rect height="22" rx="10" ry="10" width="105.0" x="1326.5" y="37"></rect><text x="1379.0" y="52">WITHLABELS</text></g><path d="M1504.0 48h20"></path><path d="M1234.0 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M1254.0 78h0.0"></path><path d="M1504.0 78h0.0"></path><g class="terminal ">
+<path d="M1254.0 78h0.0"></path><path d="M1401.5 78h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="1254.0" y="67"></rect><text x="1327.75" y="82">SELECTED&#95;LABELS</text></g><path d="M1401.5 78h10"></path><path d="M1411.5 78h10"></path><g>
+<path d="M1421.5 78h0.0"></path><path d="M1504.0 78h0.0"></path><path d="M1421.5 78h10"></path><g class="non-terminal ">
+<path d="M1431.5 78h0.0"></path><path d="M1494.0 78h0.0"></path><rect height="22" width="62.5" x="1431.5" y="67"></rect><text x="1462.75" y="82">label</text></g><path d="M1494.0 78h10"></path><path d="M1431.5 78a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M1431.5 98h62.5"></path></g><path d="M1494.0 98a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M1504.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><path d="M1524.0 48h20"></path></g><g>
+<path d="M1544.0 48h0.0"></path><path d="M1729.0 48h0.0"></path><path d="M1544.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1564.0 28h145.0"></path></g><path d="M1709.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1544.0 48h20"></path><g>
+<path d="M1564.0 48h0.0"></path><path d="M1709.0 48h0.0"></path><g>
+<path d="M1564.0 48h0.0"></path><path d="M1709.0 48h0.0"></path><g class="terminal ">
+<path d="M1564.0 48h0.0"></path><path d="M1626.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1564.0" y="37"></rect><text x="1595.25" y="52">COUNT</text></g><path d="M1626.5 48h10"></path><path d="M1636.5 48h10"></path><g class="non-terminal ">
+<path d="M1646.5 48h0.0"></path><path d="M1709.0 48h0.0"></path><rect height="22" width="62.5" x="1646.5" y="37"></rect><text x="1677.75" y="52">count</text></g></g></g><path d="M1709.0 48h20"></path></g><g>
+<path d="M1729.0 48h0.0"></path><path d="M2816.5 48h0.0"></path><path d="M1729.0 48a10 10 0 0 0 10 -10v-8a10 10 0 0 1 10 -10"></path><g>
+<path d="M1749.0 20h1047.5"></path></g><path d="M2796.5 20a10 10 0 0 1 10 10v8a10 10 0 0 0 10 10"></path><path d="M1729.0 48h20"></path><g>
+<path d="M1749.0 48h0.0"></path><path d="M2796.5 48h0.0"></path><g>
+<path d="M1749.0 48h0.0"></path><path d="M1968.0 48h0.0"></path><path d="M1749.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M1769.0 28h179.0"></path></g><path d="M1948.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M1749.0 48h20"></path><g>
+<path d="M1769.0 48h0.0"></path><path d="M1948.0 48h0.0"></path><g>
+<path d="M1769.0 48h0.0"></path><path d="M1948.0 48h0.0"></path><g class="terminal ">
+<path d="M1769.0 48h0.0"></path><path d="M1831.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="1769.0" y="37"></rect><text x="1800.25" y="52">ALIGN</text></g><path d="M1831.5 48h10"></path><path d="M1841.5 48h10"></path><g class="non-terminal ">
+<path d="M1851.5 48h0.0"></path><path d="M1948.0 48h0.0"></path><rect height="22" width="96.5" x="1851.5" y="37"></rect><text x="1899.75" y="52">alignment</text></g></g></g><path d="M1948.0 48h20"></path></g><path d="M1968.0 48h10"></path><g>
+<path d="M1978.0 48h0.0"></path><path d="M2796.5 48h0.0"></path><g class="terminal ">
+<path d="M1978.0 48h0.0"></path><path d="M2091.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="1978.0" y="37"></rect><text x="2034.75" y="52">AGGREGATION</text></g><path d="M2091.5 48h10"></path><path d="M2101.5 48h10"></path><g class="non-terminal ">
+<path d="M2111.5 48h0.0"></path><path d="M2225.0 48h0.0"></path><rect height="22" width="113.5" x="2111.5" y="37"></rect><text x="2168.25" y="52">aggregators</text></g><path d="M2225.0 48h10"></path><path d="M2235.0 48h10"></path><g class="non-terminal ">
+<path d="M2245.0 48h0.0"></path><path d="M2384.0 48h0.0"></path><rect height="22" width="139.0" x="2245.0" y="37"></rect><text x="2314.5" y="52">bucketDuration</text></g><path d="M2384.0 48h10"></path><g>
+<path d="M2394.0 48h0.0"></path><path d="M2694.0 48h0.0"></path><path d="M2394.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2414.0 28h260.0"></path></g><path d="M2674.0 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2394.0 48h20"></path><g>
+<path d="M2414.0 48h0.0"></path><path d="M2674.0 48h0.0"></path><g class="terminal ">
+<path d="M2414.0 48h0.0"></path><path d="M2561.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="2414.0" y="37"></rect><text x="2487.75" y="52">BUCKETTIMESTAMP</text></g><path d="M2561.5 48h10"></path><g>
+<path d="M2571.5 48h0.0"></path><path d="M2674.0 48h0.0"></path><path d="M2571.5 48h20"></path><g class="terminal ">
+<path d="M2591.5 48h8.5"></path><path d="M2645.5 48h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2600.0" y="37"></rect><text x="2622.75" y="52">mid</text></g><path d="M2654.0 48h20"></path><path d="M2571.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2591.5 78h0.0"></path><path d="M2654.0 78h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2591.5" y="67"></rect><text x="2622.75" y="82">start</text></g><path d="M2654.0 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M2571.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2591.5 108h8.5"></path><path d="M2645.5 108h8.5"></path><rect height="22" rx="10" ry="10" width="45.5" x="2600.0" y="97"></rect><text x="2622.75" y="112">end</text></g><path d="M2654.0 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M2571.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2591.5 138h17.0"></path><path d="M2637.0 138h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2608.5" y="127"></rect><text x="2622.75" y="142">+</text></g><path d="M2654.0 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M2571.5 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2591.5 168h17.0"></path><path d="M2637.0 168h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2608.5" y="157"></rect><text x="2622.75" y="172">-</text></g><path d="M2654.0 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M2571.5 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M2591.5 198h17.0"></path><path d="M2637.0 198h17.0"></path><rect height="22" rx="10" ry="10" width="28.5" x="2608.5" y="187"></rect><text x="2622.75" y="202">~</text></g><path d="M2654.0 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path></g></g><path d="M2674.0 48h20"></path></g><g>
+<path d="M2694.0 48h0.0"></path><path d="M2796.5 48h0.0"></path><path d="M2694.0 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M2714.0 28h62.5"></path></g><path d="M2776.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M2694.0 48h20"></path><g class="terminal ">
+<path d="M2714.0 48h0.0"></path><path d="M2776.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="2714.0" y="37"></rect><text x="2745.25" y="52">EMPTY</text></g><path d="M2776.5 48h20"></path></g></g></g><path d="M2796.5 48h20"></path></g><path d="M2816.5 48h10"></path><g>
+<path d="M2826.5 48h0.0"></path><path d="M3042.5 48h0.0"></path><g class="terminal ">
+<path d="M2826.5 48h0.0"></path><path d="M2897.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="2826.5" y="37"></rect><text x="2862.0" y="52">FILTER</text></g><path d="M2897.5 48h10"></path><path d="M2907.5 48h10"></path><g>
+<path d="M2917.5 48h0.0"></path><path d="M3042.5 48h0.0"></path><path d="M2917.5 48h10"></path><g class="non-terminal ">
+<path d="M2927.5 48h0.0"></path><path d="M3032.5 48h0.0"></path><rect height="22" width="105.0" x="2927.5" y="37"></rect><text x="2980.0" y="52">filterExpr</text></g><path d="M3032.5 48h10"></path><path d="M2927.5 48a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M2927.5 68h105.0"></path></g><path d="M3032.5 68a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M3042.5 48h10"></path><g>
+<path d="M3052.5 48h0.0"></path><path d="M3483.5 48h0.0"></path><path d="M3052.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M3072.5 28h391.0"></path></g><path d="M3463.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M3052.5 48h20"></path><g>
+<path d="M3072.5 48h0.0"></path><path d="M3463.5 48h0.0"></path><g class="terminal ">
+<path d="M3072.5 48h0.0"></path><path d="M3152.0 48h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="3072.5" y="37"></rect><text x="3112.25" y="52">GROUPBY</text></g><path d="M3152.0 48h10"></path><path d="M3162.0 48h10"></path><g class="non-terminal ">
+<path d="M3172.0 48h0.0"></path><path d="M3234.5 48h0.0"></path><rect height="22" width="62.5" x="3172.0" y="37"></rect><text x="3203.25" y="52">label</text></g><path d="M3234.5 48h10"></path><path d="M3244.5 48h10"></path><g class="terminal ">
+<path d="M3254.5 48h0.0"></path><path d="M3325.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="3254.5" y="37"></rect><text x="3290.0" y="52">REDUCE</text></g><path d="M3325.5 48h10"></path><g>
+<path d="M3335.5 48h0.0"></path><path d="M3463.5 48h0.0"></path><path d="M3335.5 48h20"></path><g class="terminal ">
+<path d="M3355.5 48h21.25"></path><path d="M3422.25 48h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3376.75" y="37"></rect><text x="3399.5" y="52">avg</text></g><path d="M3443.5 48h20"></path><path d="M3335.5 48a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 78h21.25"></path><path d="M3422.25 78h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3376.75" y="67"></rect><text x="3399.5" y="82">sum</text></g><path d="M3443.5 78a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v40a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 108h21.25"></path><path d="M3422.25 108h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3376.75" y="97"></rect><text x="3399.5" y="112">min</text></g><path d="M3443.5 108a10 10 0 0 0 10 -10v-40a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v70a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 138h21.25"></path><path d="M3422.25 138h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3376.75" y="127"></rect><text x="3399.5" y="142">max</text></g><path d="M3443.5 138a10 10 0 0 0 10 -10v-70a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v100a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 168h12.75"></path><path d="M3430.75 168h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3368.25" y="157"></rect><text x="3399.5" y="172">range</text></g><path d="M3443.5 168a10 10 0 0 0 10 -10v-100a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v130a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 198h12.75"></path><path d="M3430.75 198h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3368.25" y="187"></rect><text x="3399.5" y="202">count</text></g><path d="M3443.5 198a10 10 0 0 0 10 -10v-130a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v160a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 228h12.75"></path><path d="M3430.75 228h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3368.25" y="217"></rect><text x="3399.5" y="232">first</text></g><path d="M3443.5 228a10 10 0 0 0 10 -10v-160a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v190a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 258h17.0"></path><path d="M3426.5 258h17.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="3372.5" y="247"></rect><text x="3399.5" y="262">last</text></g><path d="M3443.5 258a10 10 0 0 0 10 -10v-190a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v220a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 288h12.75"></path><path d="M3430.75 288h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3368.25" y="277"></rect><text x="3399.5" y="292">std.p</text></g><path d="M3443.5 288a10 10 0 0 0 10 -10v-220a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v250a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 318h12.75"></path><path d="M3430.75 318h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3368.25" y="307"></rect><text x="3399.5" y="322">std.s</text></g><path d="M3443.5 318a10 10 0 0 0 10 -10v-250a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v280a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 348h12.75"></path><path d="M3430.75 348h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3368.25" y="337"></rect><text x="3399.5" y="352">var.p</text></g><path d="M3443.5 348a10 10 0 0 0 10 -10v-280a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v310a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 378h12.75"></path><path d="M3430.75 378h12.75"></path><rect height="22" rx="10" ry="10" width="62.5" x="3368.25" y="367"></rect><text x="3399.5" y="382">var.s</text></g><path d="M3443.5 378a10 10 0 0 0 10 -10v-310a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v340a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 408h21.25"></path><path d="M3422.25 408h21.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="3376.75" y="397"></rect><text x="3399.5" y="412">twa</text></g><path d="M3443.5 408a10 10 0 0 0 10 -10v-340a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v370a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 438h0.0"></path><path d="M3443.5 438h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="3355.5" y="427"></rect><text x="3399.5" y="442">countnan</text></g><path d="M3443.5 438a10 10 0 0 0 10 -10v-370a10 10 0 0 1 10 -10"></path><path d="M3335.5 48a10 10 0 0 1 10 10v400a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M3355.5 468h0.0"></path><path d="M3443.5 468h0.0"></path><rect height="22" rx="10" ry="10" width="88.0" x="3355.5" y="457"></rect><text x="3399.5" y="472">countall</text></g><path d="M3443.5 468a10 10 0 0 0 10 -10v-400a10 10 0 0 1 10 -10"></path></g></g><path d="M3463.5 48h20"></path></g><g>
+<path d="M3483.5 48h0.0"></path><path d="M3645.5 48h0.0"></path><path d="M3483.5 48a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M3503.5 28h122.0"></path></g><path d="M3625.5 28a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M3483.5 48h20"></path><g class="terminal ">
+<path d="M3503.5 48h0.0"></path><path d="M3625.5 48h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="3503.5" y="37"></rect><text x="3564.5" y="52">EXCLUDEEMPTY</text></g><path d="M3625.5 48h20"></path></g></g><path d="M3645.5 48h10"></path><path d="M 3655.5 48 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes describing a new optional query flag; no runtime or security-sensitive code in this diff.
> 
> **Overview**
> Documents the **Redis 8.10** optional flag **`EXCLUDEEMPTY`** on **`TS.MRANGE`** and **`TS.MREVRANGE`**.
> 
> The flag drops matched time series that have **no samples in the requested range** (default behavior still returns them with an empty sample list). Series whose only in-range samples are **NaN** are **not** treated as empty. **`EXCLUDEEMPTY`** cannot be combined with **`GROUPBY … REDUCE`** (error).
> 
> Updates include command frontmatter, **`syntax`** / **`syntax_fmt`**, an optional-arguments section, a new **“Exclude empty time series”** example, and refreshed railroad SVGs for both commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3966abe92e40e6db3e3b929fcba894f7e4e8e9cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->