### PR TITLE
DEV: (cmds) add new list command pages

### DIFF
--- a/content/commands/blmovem.md
+++ b/content/commands/blmovem.md
@@ -1,0 +1,246 @@
+---
+acl_categories:
+- '@write'
+- '@list'
+- '@slow'
+- '@blocking'
+arguments:
+- display_text: source
+  key_spec_index: 0
+  name: source
+  type: key
+- display_text: destination
+  key_spec_index: 1
+  name: destination
+  type: key
+- arguments:
+  - display_text: left
+    name: left
+    token: LEFT
+    type: pure-token
+  - display_text: right
+    name: right
+    token: RIGHT
+    type: pure-token
+  name: wherefrom
+  type: oneof
+- arguments:
+  - display_text: left
+    name: left
+    token: LEFT
+    type: pure-token
+  - display_text: right
+    name: right
+    token: RIGHT
+    type: pure-token
+  name: whereto
+  type: oneof
+- display_text: timeout
+  name: timeout
+  type: double
+- arguments:
+  - arguments:
+    - display_text: count
+      name: count
+      token: COUNT
+      type: integer
+    - display_text: exactly
+      name: exactly
+      token: EXACTLY
+      type: integer
+    name: selector
+    type: oneof
+  - arguments:
+    - display_text: obo
+      name: obo
+      token: OBO
+      type: pure-token
+    - display_text: bulk
+      name: bulk
+      token: BULK
+      type: pure-token
+    name: ordering
+    type: oneof
+  name: how-many
+  optional: true
+  type: block
+arity: -6
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- write
+- denyoom
+- blocking
+complexity: O(N) where N is the number of elements moved.
+description: Moves up to (or exactly) a number of elements from one list to another
+  and returns them. Blocks until the elements are available otherwise. Deletes the
+  source list if it becomes empty.
+group: list
+hidden: false
+key_specs:
+- RW: true
+  access: true
+  begin_search:
+    spec:
+      index: 1
+    type: index
+  delete: true
+  find_keys:
+    spec:
+      keystep: 1
+      lastkey: 0
+      limit: 0
+    type: range
+- RW: true
+  begin_search:
+    spec:
+      index: 2
+    type: index
+  find_keys:
+    spec:
+      keystep: 1
+      lastkey: 0
+      limit: 0
+    type: range
+  insert: true
+linkTitle: BLMOVEM
+railroad_diagram: /images/railroad/blmovem.svg
+since: 8.10.0
+summary: Moves up to (or exactly) a number of elements from one list to another and
+  returns them. Blocks until the elements are available otherwise. Deletes the source
+  list if it becomes empty.
+syntax_fmt: "BLMOVEM source destination <LEFT | RIGHT> <LEFT | RIGHT> timeout\n  [<COUNT\_\
+  count | EXACTLY\_exactly> <OBO | BULK>]"
+title: BLMOVEM
+---
+{{< note >}}
+This command's behavior varies in clustered Redis environments. See the [multi-key operations]({{< relref "/develop/using-commands/multi-key-operations" >}}) page for more information.
+{{< /note >}}
+
+
+`BLMOVEM` is the blocking variant of [`LMOVEM`]({{< relref "/commands/lmovem" >}}).
+When `source` holds enough elements to satisfy the request, this command behaves
+exactly like [`LMOVEM`]({{< relref "/commands/lmovem" >}}). Otherwise, Redis blocks the connection until
+another client pushes the required elements to `source` or until `timeout` is
+reached.
+
+## Required arguments
+
+<details open><summary><code>source</code></summary>
+
+The key of the source list.
+
+</details>
+
+<details open><summary><code>destination</code></summary>
+
+The key of the destination list.
+
+</details>
+
+<details open><summary><code>LEFT | RIGHT</code></summary>
+
+The end of `source` to pop elements from: `LEFT` (head) or `RIGHT` (tail).
+
+</details>
+
+<details open><summary><code>LEFT | RIGHT</code></summary>
+
+The end of `destination` to push elements to: `LEFT` (head) or `RIGHT` (tail).
+
+</details>
+
+<details open><summary><code>timeout</code></summary>
+
+The maximum time to block, in seconds. A timeout of `0` blocks indefinitely.
+
+</details>
+
+## Optional arguments
+
+The `how-many` block controls how many elements are moved and in what order.
+When you include it, you must provide both a selector (`COUNT` or `EXACTLY`)
+and an ordering (`OBO` or `BULK`).
+
+<details open><summary><code>COUNT count | EXACTLY exactly</code></summary>
+
+The number of elements to move:
+
+- `COUNT count` moves up to `count` elements. If `source` holds fewer than
+  `count` elements, all of them are moved. This matches the `count` semantics of
+  [`LPOP`]({{< relref "/commands/lpop" >}}) and [`LMPOP`]({{< relref "/commands/lmpop" >}}).
+- `EXACTLY exactly` moves exactly `exactly` elements. If `source` holds fewer
+  than `exactly` elements, the command blocks (see [Blocking behavior](#blocking-behavior)).
+
+</details>
+
+<details open><summary><code>OBO | BULK</code></summary>
+
+The order in which elements are pushed onto `destination`:
+
+- `OBO` (one by one) moves elements individually: each element is popped from
+  `source` and pushed to `destination` before the next one is moved.
+- `BULK` moves all of the elements at once, preserving their relative order.
+
+See the [Element ordering]({{< relref "/commands/lmovem#element-ordering" >}}) section of the [`LMOVEM`]({{< relref "/commands/lmovem" >}}) documentation for details.
+
+</details>
+
+## Details
+
+### Blocking behavior
+
+Whether `BLMOVEM` blocks depends on the selector:
+
+- With `COUNT`, the command blocks only while `source` is empty. As soon as at
+  least one element is available it unblocks, moves up to `count` elements, and
+  returns them.
+- With `EXACTLY`, the command blocks while `source` holds fewer than the
+  requested number of elements. It unblocks only once `source` grows to at least
+  that length, then moves exactly that many elements atomically.
+
+A `timeout` of `0` blocks indefinitely. When used inside a
+[`MULTI`]({{< relref "/commands/multi" >}})/[`EXEC`]({{< relref "/commands/exec" >}}) block or a Lua script, `BLMOVEM` does not block; it
+behaves like [`LMOVEM`]({{< relref "/commands/lmovem" >}}) and, when the request cannot be satisfied,
+returns nil immediately.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="blmovem-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply](../../develop/reference/protocol-spec#arrays): the moved elements, in destination order.
+* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): the operation timed out.
+
+-tab-sep-
+
+One of the following:
+* [Array reply](../../develop/reference/protocol-spec#arrays): the moved elements, in destination order.
+* [Null reply](../../develop/reference/protocol-spec#nulls): the operation timed out.
+
+{{< /multitabs >}}
+
+## See also
+
+[`BLMOVE`]({{< relref "commands/blmove/" >}}) | [`LMOVEM`]({{< relref "commands/lmovem/" >}}) | [`BLMPOP`]({{< relref "commands/blmpop/" >}}) | [`BRPOPLPUSH`]({{< relref "commands/brpoplpush/" >}})
+
+## Related topics
+
+- [Redis lists]({{< relref "/develop/data-types/lists" >}})
+

--- a/content/commands/lmovem.md
+++ b/content/commands/lmovem.md
@@ -1,0 +1,264 @@
+---
+acl_categories:
+- '@write'
+- '@list'
+- '@slow'
+arguments:
+- display_text: source
+  key_spec_index: 0
+  name: source
+  type: key
+- display_text: destination
+  key_spec_index: 1
+  name: destination
+  type: key
+- arguments:
+  - display_text: left
+    name: left
+    token: LEFT
+    type: pure-token
+  - display_text: right
+    name: right
+    token: RIGHT
+    type: pure-token
+  name: wherefrom
+  type: oneof
+- arguments:
+  - display_text: left
+    name: left
+    token: LEFT
+    type: pure-token
+  - display_text: right
+    name: right
+    token: RIGHT
+    type: pure-token
+  name: whereto
+  type: oneof
+- arguments:
+  - arguments:
+    - display_text: count
+      name: count
+      token: COUNT
+      type: integer
+    - display_text: exactly
+      name: exactly
+      token: EXACTLY
+      type: integer
+    name: selector
+    type: oneof
+  - arguments:
+    - display_text: obo
+      name: obo
+      token: OBO
+      type: pure-token
+    - display_text: bulk
+      name: bulk
+      token: BULK
+      type: pure-token
+    name: ordering
+    type: oneof
+  name: how-many
+  optional: true
+  type: block
+arity: -5
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- write
+- denyoom
+complexity: O(N) where N is the number of elements moved.
+description: Moves up to (or exactly) a number of elements from one list to another
+  and returns them. Deletes the source list if it becomes empty.
+group: list
+hidden: false
+key_specs:
+- RW: true
+  access: true
+  begin_search:
+    spec:
+      index: 1
+    type: index
+  delete: true
+  find_keys:
+    spec:
+      keystep: 1
+      lastkey: 0
+      limit: 0
+    type: range
+- RW: true
+  begin_search:
+    spec:
+      index: 2
+    type: index
+  find_keys:
+    spec:
+      keystep: 1
+      lastkey: 0
+      limit: 0
+    type: range
+  insert: true
+linkTitle: LMOVEM
+railroad_diagram: /images/railroad/lmovem.svg
+since: 8.10.0
+summary: Moves up to (or exactly) a number of elements from one list to another and
+  returns them. Deletes the source list if it becomes empty.
+syntax_fmt: "LMOVEM source destination <LEFT | RIGHT> <LEFT | RIGHT>\n  [<COUNT\_\
+  count | EXACTLY\_exactly> <OBO | BULK>]"
+title: LMOVEM
+---
+{{< note >}}
+This command's behavior varies in clustered Redis environments. See the [multi-key operations]({{< relref "/develop/using-commands/multi-key-operations" >}}) page for more information.
+{{< /note >}}
+
+
+Atomically moves one or more elements from the list stored at `source` to the
+list stored at `destination` and returns the moved elements.
+`LMOVEM` is the multiple-element version of [`LMOVE`]({{< relref "/commands/lmove" >}}): without the
+optional `how-many` block, it behaves exactly like [`LMOVE`]({{< relref "/commands/lmove" >}}) but returns
+the moved element as a one-element array.
+
+## Required arguments
+
+<details open><summary><code>source</code></summary>
+
+The key of the source list.
+
+</details>
+
+<details open><summary><code>destination</code></summary>
+
+The key of the destination list.
+
+</details>
+
+<details open><summary><code>LEFT | RIGHT</code></summary>
+
+The end of `source` to pop elements from: `LEFT` (head) or `RIGHT` (tail).
+
+</details>
+
+<details open><summary><code>LEFT | RIGHT</code></summary>
+
+The end of `destination` to push elements to: `LEFT` (head) or `RIGHT` (tail).
+
+</details>
+
+## Optional arguments
+
+The `how-many` block controls how many elements are moved and in what order.
+When you include it, you must provide both a selector (`COUNT` or `EXACTLY`)
+and an ordering (`OBO` or `BULK`).
+
+<details open><summary><code>COUNT count | EXACTLY exactly</code></summary>
+
+The number of elements to move:
+
+- `COUNT count` moves up to `count` elements. If `source` holds fewer than
+  `count` elements, all of them are moved. This matches the `count` semantics of
+  [`LPOP`]({{< relref "/commands/lpop" >}}) and [`LMPOP`]({{< relref "/commands/lmpop" >}}).
+- `EXACTLY exactly` moves exactly `exactly` elements. If `source` holds fewer
+  than `exactly` elements, nothing is moved and the command returns nil.
+
+</details>
+
+<details open><summary><code>OBO | BULK</code></summary>
+
+The order in which elements are pushed onto `destination`:
+
+- `OBO` (one by one) moves elements individually: each element is popped from
+  `source` and pushed to `destination` before the next one is moved.
+- `BULK` moves all of the elements at once, preserving their relative order.
+
+The two orderings differ only in the resulting arrangement of elements. See
+[Element ordering](#element-ordering) for details.
+
+</details>
+
+## Examples
+
+{{% redis-cli %}}
+RPUSH mylist 1 2 3 4
+LMOVEM mylist myotherlist LEFT LEFT COUNT 2 OBO
+LRANGE mylist 0 -1
+LRANGE myotherlist 0 -1
+LMOVEM mylist myotherlist LEFT LEFT EXACTLY 5 BULK
+RPUSH samelist a b c
+LMOVEM samelist samelist LEFT LEFT EXACTLY 2 OBO
+LRANGE samelist 0 -1
+{{% /redis-cli %}}
+
+## Details
+
+### Moving multiple elements
+
+`LMOVEM` moves elements from one end of `source` (selected by the first
+`LEFT | RIGHT` argument) to one end of `destination` (selected by the second
+`LEFT | RIGHT` argument), and returns the moved elements as an array. If
+`source` does not exist, no operation is performed and the command returns an
+empty array (or nil when `EXACTLY` is used).
+
+The `COUNT` and `EXACTLY` selectors decide how many elements are moved:
+
+- With `COUNT count`, the command moves up to `count` elements. If `source`
+  holds fewer than `count` elements, all available elements are moved.
+- With `EXACTLY exactly`, the command moves the requested number of elements
+  only if `source` holds at least that many. Otherwise it moves nothing and
+  returns nil. This is useful when elements form fixed-size groups (for example,
+  pairs or triplets) that must be moved together or not at all.
+
+### Element ordering
+
+The `OBO` and `BULK` orderings determine how the moved elements are arranged on
+`destination`:
+
+- `OBO` (one by one) pops and pushes each element in turn, so an element popped
+  earlier ends up "beneath" one popped later at the destination end.
+- `BULK` moves the whole batch at once, preserving the elements' relative order.
+
+When `source` and `destination` are the same key, this difference becomes a
+useful side effect. `BULK` leaves the list unchanged (the elements are removed
+and re-added in the same order), so it is effectively a no-op. `OBO`, however,
+reverses the moved elements in place. For example, with `mylist` holding
+`a, b, c`, running `LMOVEM mylist mylist LEFT LEFT EXACTLY 2 OBO` pops `a` then
+`b` and pushes each back to the head, leaving `mylist` as `b, a, c`.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="lmovem-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply](../../develop/reference/protocol-spec#arrays): the moved elements, in destination order.
+* [Nil reply](../../develop/reference/protocol-spec#bulk-strings): if `EXACTLY` was used and `source` did not hold enough elements.
+
+-tab-sep-
+
+One of the following:
+* [Array reply](../../develop/reference/protocol-spec#arrays): the moved elements, in destination order.
+* [Null reply](../../develop/reference/protocol-spec#nulls): if `EXACTLY` was used and `source` did not hold enough elements.
+
+{{< /multitabs >}}
+
+## See also
+
+[`LMOVE`]({{< relref "commands/lmove/" >}}) | [`BLMOVEM`]({{< relref "commands/blmovem/" >}}) | [`LMPOP`]({{< relref "commands/lmpop/" >}}) | [`RPOPLPUSH`]({{< relref "commands/rpoplpush/" >}})
+
+## Related topics
+
+- [Redis lists]({{< relref "/develop/data-types/lists" >}})
+

--- a/static/images/railroad/blmovem.svg
+++ b/static/images/railroad/blmovem.svg
@@ -1,0 +1,70 @@
+<svg class="railroad-diagram" height="101" viewBox="0 0 1071.5 101" width="1071.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M1021.5 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M129.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="50.0" y="29"></rect><text x="89.75" y="44">BLMOVEM</text></g><path d="M129.5 40h10"></path><path d="M139.5 40h10"></path><g class="non-terminal ">
+<path d="M149.5 40h0.0"></path><path d="M220.5 40h0.0"></path><rect height="22" width="71.0" x="149.5" y="29"></rect><text x="185.0" y="44">source</text></g><path d="M220.5 40h10"></path><path d="M230.5 40h10"></path><g class="non-terminal ">
+<path d="M240.5 40h0.0"></path><path d="M354.0 40h0.0"></path><rect height="22" width="113.5" x="240.5" y="29"></rect><text x="297.25" y="44">destination</text></g><path d="M354.0 40h10"></path><g>
+<path d="M364.0 40h0.0"></path><path d="M466.5 40h0.0"></path><path d="M364.0 40h20"></path><g class="terminal ">
+<path d="M384.0 40h4.25"></path><path d="M442.25 40h4.25"></path><rect height="22" rx="10" ry="10" width="54.0" x="388.25" y="29"></rect><text x="415.25" y="44">LEFT</text></g><path d="M446.5 40h20"></path><path d="M364.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M384.0 70h0.0"></path><path d="M446.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="384.0" y="59"></rect><text x="415.25" y="74">RIGHT</text></g><path d="M446.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M466.5 40h0.0"></path><path d="M569.0 40h0.0"></path><path d="M466.5 40h20"></path><g class="terminal ">
+<path d="M486.5 40h4.25"></path><path d="M544.75 40h4.25"></path><rect height="22" rx="10" ry="10" width="54.0" x="490.75" y="29"></rect><text x="517.75" y="44">LEFT</text></g><path d="M549.0 40h20"></path><path d="M466.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M486.5 70h0.0"></path><path d="M549.0 70h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="486.5" y="59"></rect><text x="517.75" y="74">RIGHT</text></g><path d="M549.0 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><path d="M569.0 40h10"></path><g class="non-terminal ">
+<path d="M579.0 40h0.0"></path><path d="M658.5 40h0.0"></path><rect height="22" width="79.5" x="579.0" y="29"></rect><text x="618.75" y="44">timeout</text></g><path d="M658.5 40h10"></path><g>
+<path d="M668.5 40h0.0"></path><path d="M1021.5 40h0.0"></path><path d="M668.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M688.5 20h313.0"></path></g><path d="M1001.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M668.5 40h20"></path><g>
+<path d="M688.5 40h0.0"></path><path d="M1001.5 40h0.0"></path><g>
+<path d="M688.5 40h0.0"></path><path d="M907.5 40h0.0"></path><path d="M688.5 40h20"></path><g>
+<path d="M708.5 40h17.0"></path><path d="M870.5 40h17.0"></path><g class="terminal ">
+<path d="M725.5 40h0.0"></path><path d="M788.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="725.5" y="29"></rect><text x="756.75" y="44">COUNT</text></g><path d="M788.0 40h10"></path><path d="M798.0 40h10"></path><g class="non-terminal ">
+<path d="M808.0 40h0.0"></path><path d="M870.5 40h0.0"></path><rect height="22" width="62.5" x="808.0" y="29"></rect><text x="839.25" y="44">count</text></g></g><path d="M887.5 40h20"></path><path d="M688.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M708.5 70h0.0"></path><path d="M887.5 70h0.0"></path><g class="terminal ">
+<path d="M708.5 70h0.0"></path><path d="M788.0 70h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="708.5" y="59"></rect><text x="748.25" y="74">EXACTLY</text></g><path d="M788.0 70h10"></path><path d="M798.0 70h10"></path><g class="non-terminal ">
+<path d="M808.0 70h0.0"></path><path d="M887.5 70h0.0"></path><rect height="22" width="79.5" x="808.0" y="59"></rect><text x="847.75" y="74">exactly</text></g></g><path d="M887.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M907.5 40h0.0"></path><path d="M1001.5 40h0.0"></path><path d="M907.5 40h20"></path><g class="terminal ">
+<path d="M927.5 40h4.25"></path><path d="M977.25 40h4.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="931.75" y="29"></rect><text x="954.5" y="44">OBO</text></g><path d="M981.5 40h20"></path><path d="M907.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M927.5 70h0.0"></path><path d="M981.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="927.5" y="59"></rect><text x="954.5" y="74">BULK</text></g><path d="M981.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g></g><path d="M1001.5 40h20"></path></g></g><path d="M1021.5 40h10"></path><path d="M 1031.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/lmovem.svg
+++ b/static/images/railroad/lmovem.svg
@@ -1,0 +1,69 @@
+<svg class="railroad-diagram" height="101" viewBox="0 0 963.5 101" width="963.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M913.5 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M121.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="29"></rect><text x="85.5" y="44">LMOVEM</text></g><path d="M121.0 40h10"></path><path d="M131.0 40h10"></path><g class="non-terminal ">
+<path d="M141.0 40h0.0"></path><path d="M212.0 40h0.0"></path><rect height="22" width="71.0" x="141.0" y="29"></rect><text x="176.5" y="44">source</text></g><path d="M212.0 40h10"></path><path d="M222.0 40h10"></path><g class="non-terminal ">
+<path d="M232.0 40h0.0"></path><path d="M345.5 40h0.0"></path><rect height="22" width="113.5" x="232.0" y="29"></rect><text x="288.75" y="44">destination</text></g><path d="M345.5 40h10"></path><g>
+<path d="M355.5 40h0.0"></path><path d="M458.0 40h0.0"></path><path d="M355.5 40h20"></path><g class="terminal ">
+<path d="M375.5 40h4.25"></path><path d="M433.75 40h4.25"></path><rect height="22" rx="10" ry="10" width="54.0" x="379.75" y="29"></rect><text x="406.75" y="44">LEFT</text></g><path d="M438.0 40h20"></path><path d="M355.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M375.5 70h0.0"></path><path d="M438.0 70h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="375.5" y="59"></rect><text x="406.75" y="74">RIGHT</text></g><path d="M438.0 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M458.0 40h0.0"></path><path d="M560.5 40h0.0"></path><path d="M458.0 40h20"></path><g class="terminal ">
+<path d="M478.0 40h4.25"></path><path d="M536.25 40h4.25"></path><rect height="22" rx="10" ry="10" width="54.0" x="482.25" y="29"></rect><text x="509.25" y="44">LEFT</text></g><path d="M540.5 40h20"></path><path d="M458.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M478.0 70h0.0"></path><path d="M540.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="478.0" y="59"></rect><text x="509.25" y="74">RIGHT</text></g><path d="M540.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M560.5 40h0.0"></path><path d="M913.5 40h0.0"></path><path d="M560.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M580.5 20h313.0"></path></g><path d="M893.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M560.5 40h20"></path><g>
+<path d="M580.5 40h0.0"></path><path d="M893.5 40h0.0"></path><g>
+<path d="M580.5 40h0.0"></path><path d="M799.5 40h0.0"></path><path d="M580.5 40h20"></path><g>
+<path d="M600.5 40h17.0"></path><path d="M762.5 40h17.0"></path><g class="terminal ">
+<path d="M617.5 40h0.0"></path><path d="M680.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="62.5" x="617.5" y="29"></rect><text x="648.75" y="44">COUNT</text></g><path d="M680.0 40h10"></path><path d="M690.0 40h10"></path><g class="non-terminal ">
+<path d="M700.0 40h0.0"></path><path d="M762.5 40h0.0"></path><rect height="22" width="62.5" x="700.0" y="29"></rect><text x="731.25" y="44">count</text></g></g><path d="M779.5 40h20"></path><path d="M580.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M600.5 70h0.0"></path><path d="M779.5 70h0.0"></path><g class="terminal ">
+<path d="M600.5 70h0.0"></path><path d="M680.0 70h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="600.5" y="59"></rect><text x="640.25" y="74">EXACTLY</text></g><path d="M680.0 70h10"></path><path d="M690.0 70h10"></path><g class="non-terminal ">
+<path d="M700.0 70h0.0"></path><path d="M779.5 70h0.0"></path><rect height="22" width="79.5" x="700.0" y="59"></rect><text x="739.75" y="74">exactly</text></g></g><path d="M779.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M799.5 40h0.0"></path><path d="M893.5 40h0.0"></path><path d="M799.5 40h20"></path><g class="terminal ">
+<path d="M819.5 40h4.25"></path><path d="M869.25 40h4.25"></path><rect height="22" rx="10" ry="10" width="45.5" x="823.75" y="29"></rect><text x="846.5" y="44">OBO</text></g><path d="M873.5 40h20"></path><path d="M799.5 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g class="terminal ">
+<path d="M819.5 70h0.0"></path><path d="M873.5 70h0.0"></path><rect height="22" rx="10" ry="10" width="54.0" x="819.5" y="59"></rect><text x="846.5" y="74">BULK</text></g><path d="M873.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g></g><path d="M893.5 40h20"></path></g></g><path d="M913.5 40h10"></path><path d="M 923.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime or build-logic changes; accuracy of command semantics is the main review surface.
> 
> **Overview**
> Documents **Redis 8.10** list commands **`LMOVEM`** and **`BLMOVEM`**: multi-element atomic moves between lists (extensions of `LMOVE` / `BLMOVE`), with optional `COUNT`/`EXACTLY` and `OBO`/`BULK` ordering.
> 
> **`LMOVEM`** covers non-blocking behavior, CLI examples, element-ordering semantics (including same-key `OBO` vs `BULK`), RESP2/RESP3 returns, and compatibility tables. **`BLMOVEM`** adds timeout and blocking rules (`COUNT` vs `EXACTLY`, `MULTI`/Lua non-blocking), cross-links to `LMOVEM`, and matching metadata (ACL, key specs, `since: 8.10.0`). New railroad diagrams **`lmovem.svg`** and **`blmovem.svg`** accompany the command pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc8ce9e00f47c890f99f307d19c8c80a9ef48ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->