### PR TITLE
Set alwaysopen to true in agent-memory index

### DIFF
--- a/content/operate/rc/context-engine/agent-memory/_index.md
+++ b/content/operate/rc/context-engine/agent-memory/_index.md
@@ -1,5 +1,5 @@
 ---
-alwaysopen: false
+alwaysopen: true
 categories:
 - docs
 - operate


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single front-matter flag on a docs index page; navigation display only, no runtime or product behavior.
> 
> **Overview**
> Sets **`alwaysopen: true`** in the front matter of `content/operate/rc/context-engine/agent-memory/_index.md` (was `false`). That Hugo setting keeps the **Redis Agent Memory on Redis Cloud** section expanded in the docs navigation so child pages are visible without manually opening the section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec6a17ff1d2e5957f8524fc2dd4a113c590576ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->