### PR TITLE
Mark SCAN command examples as runnable="false"

### DIFF
--- a/content/commands/scan.md
+++ b/content/commands/scan.md
@@ -190,7 +190,7 @@ To do so, just append the `MATCH <pattern>` arguments at the end of the `SCAN` c
 
 This is an example of iteration using **MATCH**:
 
-{{< clients-example set="cmds_generic" step="scan1" description="Set iteration: Iterate set members with pattern matching using SSCAN MATCH (cursor-based iteration, non-blocking)" difficulty="intermediate" >}}
+{{< clients-example set="cmds_generic" step="scan1" description="Set iteration: Iterate set members with pattern matching using SSCAN MATCH (cursor-based iteration, non-blocking)" difficulty="intermediate" runnable="false" >}}
 > sadd myset 1 2 3 foo foobar feelsgood
 (integer) 6
 > sscan myset 0 match f*
@@ -202,7 +202,7 @@ This is an example of iteration using **MATCH**:
 
 It is important to note that the **MATCH** filter is applied after elements are retrieved from the collection, just before returning data to the client. This means that if the pattern matches very little elements inside the collection, `SCAN` will likely return no elements in most iterations. An example is shown below:
 
-{{< clients-example set="cmds_generic" step="scan2" description="Keyspace iteration: Iterate database keys with pattern matching using SCAN MATCH and COUNT (demonstrates cursor iteration with sparse results)" difficulty="intermediate" >}}
+{{< clients-example set="cmds_generic" step="scan2" description="Keyspace iteration: Iterate database keys with pattern matching using SCAN MATCH and COUNT (demonstrates cursor iteration with sparse results)" difficulty="intermediate" runnable="false" >}}
 > scan 0 MATCH *11*
 1) "288"
 2) 1) "key:911"
@@ -252,7 +252,7 @@ You can use the `TYPE` option to ask `SCAN` to only return objects that match a 
 
 The `type` argument is the same string name that the [`TYPE`]({{< relref "/commands/type" >}}) command returns. Note a quirk where some Redis types, such as GeoHashes, HyperLogLogs, Bitmaps, and Bitfields, may internally be implemented using other Redis types, such as a string or zset, so can't be distinguished from other keys of that same type by `SCAN`. For example, a ZSET and GEOHASH:
 
-{{< clients-example set="cmds_generic" step="scan3" description="Iterate keyspace by type: Iterate database keys filtered by type using SCAN TYPE (filters keys by data type, useful for type-specific operations)" difficulty="intermediate" >}}
+{{< clients-example set="cmds_generic" step="scan3" description="Iterate keyspace by type: Iterate database keys filtered by type using SCAN TYPE (filters keys by data type, useful for type-specific operations)" difficulty="intermediate" runnable="false" >}}
 > GEOADD geokey 0 0 value
 (integer) 1
 > ZADD zkey 1000 value
@@ -273,7 +273,7 @@ It is important to note that the **TYPE** filter is also applied after elements 
 
 When using [`HSCAN`]({{< relref "/commands/hscan" >}}), you can use the `NOVALUES` option to make Redis return only the keys in the hash table without their corresponding values.
 
-{{< clients-example set="cmds_generic" step="scan4" description="Hash iteration: Iterate hash fields with optional NOVALUES using HSCAN (returns field-value pairs or fields only)" difficulty="intermediate" >}}
+{{< clients-example set="cmds_generic" step="scan4" description="Hash iteration: Iterate hash fields with optional NOVALUES using HSCAN (returns field-value pairs or fields only)" difficulty="intermediate" runnable="false" >}}
 > HSET myhash a 1 b 2
 OK
 > HSCAN myhash 0


### PR DESCRIPTION
The redis.io/cli sandbox is one shared, per-session-namespaced database (~100k keys), so keyspace SCAN examples cannot reproduce their documented output: SCAN 0 returns a partial page and a non-zero cursor instead of the single-page result shown. Render scan1-scan4 as static blocks rather than live terminals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only shortcode attribute changes with no impact on application logic, security, or data handling.
> 
> **Overview**
> Sets **`runnable="false"`** on the four `clients-example` blocks (`scan1`–`scan4`) in the SCAN command docs so they render as **static** transcripts instead of connecting to the redis.io CLI sandbox.
> 
> That avoids misleading live runs: the sandbox uses a **shared, large keyspace**, so keyspace **`SCAN`** (and related demos that assume a controlled DB) cannot match the documented cursors and output shown in the page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb5fc4d098f39d4c855bb09a3432d3b11ae6aad7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->