### PR TITLE
DOC-6836 Rename resolveCredentials() to resolveCredentialsAsync() in Lettuce AMR docs [PARKED]

### DIFF
--- a/content/develop/clients/lettuce/amr.md
+++ b/content/develop/clients/lettuce/amr.md
@@ -89,7 +89,7 @@ test it by obtaining a token, as shown in the following example:
 
 ```java
 // Test that the Entra ID credentials provider can resolve credentials.
-credentials.resolveCredentials()
+credentials.resolveCredentialsAsync()
         .doOnNext(c-> System.out.println(c.getUsername()))
         .block();
 ```
@@ -188,7 +188,7 @@ try (EntraIDTokenAuthConfigBuilder builder = EntraIDTokenAuthConfigBuilder.build
 }
 
 // Optionally test the credentials provider.
-// credentialsSP.resolveCredentials().doOnNext(c -> System.out.println("SPI ID :" + c.getUsername())).block();
+// credentialsSP.resolveCredentialsAsync().doOnNext(c -> System.out.println("SPI ID :" + c.getUsername())).block();
 
 // Enable automatic re-authentication.
 ClientOptions clientOptions = ClientOptions.builder()


### PR DESCRIPTION
Updates the Lettuce Azure Managed Redis (AMR) / Entra ID auth page for the upcoming
credential-provider SPI rename in Lettuce: `RedisCredentialsProvider` →
`CredentialsProvider`, and its `resolveCredentials()` method → `resolveCredentialsAsync()`.
Two call sites in [`amr.md`](content/develop/clients/lettuce/amr.md) are updated to the new
async name.

> ⚠️ **DO NOT MERGE YET.** This is written against **unmerged** upstream PRs
> ([redis/lettuce#3838](https://github.com/redis/lettuce/pull/3838),
> [#3829](https://github.com/redis/lettuce/pull/3829),
> [#3837](https://github.com/redis/lettuce/pull/3837)) that currently target a
> `feature/reactor-optional-1` branch, not `main`. The rename only reaches our readers once
> the separate **`redis-authx-entraid`** artifact rebuilds against the new Lettuce SPI and
> releases. Merging now would leave the page documenting a method name that no released
> artifact exposes. Pick up with `/pickup <this PR>` when the trigger fires.

<!-- park-manifest -->
## Park manifest

Ticket: DOC-6836
Parked at: 2026-07-13
Trigger to pick up: **a non-prerelease Lettuce release whose `io.lettuce.authx.TokenBasedRedisCredentialsProvider` declares `resolveCredentialsAsync()`.** Testably:

```
gh api "repos/redis/lettuce/contents/src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java?ref=<tag>" \
  --jq .content | base64 -d | grep -n 'resolveCredentialsAsync'
```

The trigger is met when that grep matches at a non-prerelease tag newer than `7.7.0.RELEASE`.

> ⚠️ **Trigger test CORRECTED — 2026-08-27 (`/pr-scan-review`).** The original trigger named `redis-authx-entraid` as the artifact to watch. It could never fire: `TokenBasedRedisCredentialsProvider` is not in that artifact. See the 2026-08-27 update below.
>
> ⚠️ **Trigger test CORRECTED AGAIN — 2026-09-11 (`/pr-scan-review`).** The 2026-08-27 fix still greps the wrong file. Under the shape now landing in [lettuce#3911](https://github.com/redis/lettuce/pull/3911), `TokenBasedRedisCredentialsProvider` inherits `resolveCredentialsAsync()` as a default method from `RedisCredentialsProvider` — it never declares the string itself, so the old grep would report "not fired" forever even after release. New trigger: a non-prerelease Lettuce release where `RedisCredentialsProvider.java` declares `resolveCredentialsAsync()`:
> ```
> gh api "repos/redis/lettuce/contents/src/main/java/io/lettuce/core/RedisCredentialsProvider.java?ref=<tag>" \
>   --jq .content | base64 -d | grep -n 'resolveCredentialsAsync'
> ```
> See the 2026-09-11 update below.
Labels: parked, do not merge yet

### Pinned sources (state observed at park time)

| Source | State @ park (2026-07-13) | Re-fetch |
|---|---|---|
| [lettuce#3838](https://github.com/redis/lettuce/pull/3838) — "Remove RedisCredentialsProvider and promote CredentialsProvider as primary" | open, not merged; base `feature/reactor-optional-1`; head `625a413`; milestone none; updated 2026-07-13 | `gh api repos/redis/lettuce/pulls/3838 --jq '{state,merged,head_sha:.head.sha,base:.base.ref,milestone:.milestone.title,updated_at}'` |
| [lettuce#3829](https://github.com/redis/lettuce/pull/3829) — "Make clean transition from reactive to async credentials provider" | open, not merged; base `feature/reactor-optional-1`; head `f558dbb`; milestone none; updated 2026-07-09 | `gh api repos/redis/lettuce/pulls/3829 --jq '{state,merged,head_sha:.head.sha,base:.base.ref,milestone:.milestone.title,updated_at}'` |
| [lettuce#3837](https://github.com/redis/lettuce/pull/3837) — "Deprecate RedisCredentialsProvider interface in favor of CredentialsProvider" | open, not merged; base `main`; head `b8b2a25`; milestone none; updated 2026-07-13 | `gh api repos/redis/lettuce/pulls/3837 --jq '{state,merged,head_sha:.head.sha,base:.base.ref,milestone:.milestone.title,updated_at}'` |
| [lettuce#3842](https://github.com/redis/lettuce/pull/3842) — "[reactor-optional] Credentials as adapter 8x"; **added 2026-08-06, not present at park time** | open, not merged; base `feature/reactor-optional-1`; updated 2026-07-14; body states it is an *"alternative of #3838"* | `gh api repos/redis/lettuce/pulls/3842 --jq '{state,merged,head_sha:.head.sha,base:.base.ref,milestone:.milestone.title,updated_at}'` |
| [jvm-redis-authx-entraid](https://github.com/redis/jvm-redis-authx-entraid) — the artifact our page actually pins | no formal releases; latest tag `v0.1.1-beta2`; page pins `0.1.1-beta1` (still exposes `resolveCredentials()`) | `gh api repos/redis/jvm-redis-authx-entraid/tags --jq '.[0:5][].name'` |

### Update 2026-08-06 (`/pr-scan-review`) — a rival PR, and the remove-vs-deprecate question looks answered

Two things found while re-checking the pins. Neither has fired the trigger — all three original PRs are still
open and untouched since 13 July, and `redis-authx-entraid`'s latest tag is still `v0.1.1-beta2` — so this PR
**stays parked**. But both change what to expect on pickup.

**1. #3838 has a rival.** [lettuce#3842](https://github.com/redis/lettuce/pull/3842) describes itself as an
*"alternative of #3838"* and sits on the same `feature/reactor-optional-1` branch. One of the two will be
abandoned, so the pinned trigger above may be pinned to the loser. Check both at pickup time.

**2. Under #3842, `resolveCredentials()` survives.** This addresses the third checklist item below, which is
the one that decides whether this PR's edit is a fix or a preference. Verified from #3842's file list on
2026-08-06:

- `io/lettuce/core/RedisCredentialsProvider.java` — **modified, not deleted.** The interface stays.
- `io/lettuce/core/CredentialsProvider.java` — **added** (the new primary SPI).
- `io/lettuce/core/AsyncCredentialsProviderAdapter.java` — **added** (the bridge).

That is deprecate-with-bridge, not remove — i.e. the #3837 shape rather than the #3838 shape. **If #3842 is the
route that ships, this PR's rename is preferred-not-required and there is no reader-facing break**, which lowers
its urgency considerably and should be stated in the finalize commit.

Caveat on sourcing: this reads the *file list and add/modify/delete status* of the live diff, which is reliable.
It deliberately does **not** rely on the Bugbot summary in #3842's body — that summary was reviewed at commit
`404f10f9` and is demonstrably stale about other parts of the same PR.

### Update 2026-08-27 (`/pr-scan-review`) — the trigger was watching the wrong repo; entraid 0.2.0 shipped

**Stays parked.** Two findings, one of them a defect in this manifest.

**1. The trigger test was mis-targeted, and has been rewritten above.** The original said to watch for a
`redis-authx-entraid` release whose `TokenBasedRedisCredentialsProvider` exposes `resolveCredentialsAsync()`.
That class is not in the entraid artifact. Verified from the tag tree — all 30 Java files at `v0.2.0` are under
`redis.clients.authentication.core` / `.entraid` (`TokenAuthConfig`, `IdentityProvider`, `TokenManager`,
`EntraIDTokenAuthConfigBuilder`, …), and none is named `*CredentialsProvider*`:

```
gh api 'repos/redis/jvm-redis-authx-entraid/git/trees/v0.2.0?recursive=1' --jq '.tree[].path' | grep -i credential
```

The class lives in **redis/lettuce**, at `src/main/java/io/lettuce/authx/TokenBasedRedisCredentialsProvider.java`.
This also corrects the "Observed shape" bullet below claiming the rename "must propagate across that repo
boundary before it's real for us" — **there is no boundary to cross for the renamed method.** The page needs
both jars, but they supply different things: Lettuce supplies the provider class the rename lands on, and
entraid supplies only the `EntraIDTokenAuthConfigBuilder` / `TokenAuthConfig` passed into
`TokenBasedRedisCredentialsProvider.create(...)`. The rename becomes real for us the moment Lettuce ships it.

Baseline pinned today: on lettuce `main`, that file still declares `public Mono<RedisCredentials> resolveCredentials()`
at line 90 — the rename has **not** landed on `main`. Newest non-prerelease Lettuce release is `7.7.0.RELEASE`
(2026-08-18), which therefore cannot contain it.

**2. All four Lettuce PRs remain open and untouched for six weeks.** Re-fetched 2026-08-27:

| PR | State | Base | Last updated |
|---|---|---|---|
| [#3837](https://github.com/redis/lettuce/pull/3837) *deprecate* | open, not merged | `main` | 2026-07-13 |
| [#3838](https://github.com/redis/lettuce/pull/3838) *remove* | open, not merged | `feature/reactor-optional-1` | 2026-07-13 |
| [#3842](https://github.com/redis/lettuce/pull/3842) *rival adapter* | open, not merged | `feature/reactor-optional-1` | 2026-07-14 |
| [#3829](https://github.com/redis/lettuce/pull/3829) | open, not merged | `feature/reactor-optional-1` | 2026-07-09 |

The 2026-08-06 finding stands unchanged: #3838-vs-#3842 is still undecided, so the remove-vs-deprecate question
is still open. Today's daily scan shows lettuce activity only on unrelated PRs (#3847 deprecations, #3863 VSIM).

**3. `redis-authx-entraid` v0.2.0 shipped today — and is now a separate ticket, not a trigger.** Published
2026-08-27T07:14:36Z, `prerelease: false` (the artifact's first non-prerelease), and on Maven Central
(`maven-metadata.xml` → `<release>0.2.0</release>`). Its changelog is retry-counter behavior (#48), `msal4j`
1.19.1 → 1.26.0 and `azure-identity` 1.15.4 → 1.18.4 (#49), and a Maven Central Portal publishing move (#35) —
**no SPI change of any kind.**

The version bump is now tracked as **DOC-7006** against `main` (branch
`DOC-7006-entraid-0-2-0-dependency-bump`), covering both `jedis/amr.md` and `lettuce/amr.md`. That resolves the
first re-check item below as *independent of this PR*: the pinned version no longer has to wait for the rename.
**Expect a small conflict in `content/develop/clients/lettuce/amr.md` (lines ~43 and ~51) when DOC-7006 merges
first** — this branch still carries `0.1.1-beta1` there.

### Update 2026-09-11 (`/pr-scan-review`) — a fifth, active PR settles deprecate-vs-remove; and the mechanical trigger test had a defect

**Stays parked.** Today's daily scan surfaced [lettuce#3911](https://github.com/redis/lettuce/pull/3911)
("Introduce reactor-free CredentialsProvider and deprecate the reactive one"), opened
2026-09-10T09:48:45Z, base `main`, still open as of this check. Unlike the four PRs already pinned
above — all untouched since mid-July, three of them stuck on the abandoned
`feature/reactor-optional-1` branch — this one is fresh, targets `main` directly, and is the first
real movement on this migration since the 2026-08-27 check.

**Confirmed by reading `gh pr diff 3911`, not assumed:**

- It does **not** touch `io/lettuce/authx/TokenBasedRedisCredentialsProvider.java` at all.
- It marks the `RedisCredentialsProvider` interface `@Deprecated since 7.8` but does **not**
  remove or rename `resolveCredentials()` on it. Instead it adds a new
  `default CompletionStage<RedisCredentials> resolveCredentialsAsync()` on the interface that
  adapts `resolveCredentials()`.
- `TokenBasedRedisCredentialsProvider implements RedisCredentialsProvider` (confirmed on `main`,
  line 40) and only overrides `resolveCredentials()` (line 90) — it **inherits**
  `resolveCredentialsAsync()` from the interface default rather than declaring it itself.

**This settles the open "remove vs. deprecate" checklist item below:** deprecate-with-default-method
wins, consistent with the 2026-08-06 finding under rival #3842, now via a cleaner `main`-based PR
instead of the stale `feature/reactor-optional-1` trio. This PR's rename is confirmed
**preferred-not-required** — `resolveCredentials()` survives, there is no reader-facing break, and
that should be stated in the eventual finalize commit.

**The mechanical trigger test above was rewritten because of this finding** (see the correction
block right under "Trigger to pick up"). The old test greped
`TokenBasedRedisCredentialsProvider.java` for the literal string `resolveCredentialsAsync` — a
string that file will never contain under this shape, since the method is inherited, not
declared. The new test greps `RedisCredentialsProvider.java` instead, which is where #3911 actually
adds it.

Re-fetch: `gh api repos/redis/lettuce/pulls/3911 --jq '{state,merged,head_sha:.head.sha,base:.base.ref,updated_at}'`

### Observed shape the page assumes (confidence: LOW)

- The credential-provider SPI method is renamed `resolveCredentials()` → `resolveCredentialsAsync()`
  (return type unchanged: `CompletionStage<RedisCredentials>` / reactive `Mono` chain still `.doOnNext(...).block()`).
  **LOW** — taken from the *unmerged* #3838 diff against a feature branch, not a released artifact.
- `TokenBasedRedisCredentialsProvider` (the class our page uses) keeps its name; only its
  method is renamed. **LOW** — same source. ~~the class in the diff lives in Lettuce core
  (`io.lettuce.authx`), whereas our page consumes it from the separate `redis-authx-entraid`
  package (`redis.clients.authentication`). The rename must propagate across that repo boundary
  before it's real for us; that propagation is unverified.~~ **Corrected 2026-08-27:** the class
  is only ever in Lettuce (`io.lettuce.authx`); the entraid artifact contains no
  `*CredentialsProvider*` type at all. There is no repo boundary for the rename to cross — see the
  2026-08-27 update above.
- Three overlapping PRs with divergent verbs (`#3837` *deprecate* on `main`, `#3838` *remove* on
  the feature branch): the end-state exposed to users — remove vs. deprecate-with-alias — is not
  yet settled.

### Re-check checklist

- [x] ~~**(highest risk)** Confirm which `redis-authx-entraid` release exposes `resolveCredentialsAsync()`, and **bump the pinned version** at [`amr.md`](content/develop/clients/lettuce/amr.md) lines ~43 and ~51 (currently `0.1.1-beta1`) to match.~~ **Superseded 2026-08-27** — no entraid release exposes that method, because the class is not in that artifact. The version bump to `0.2.0` is decoupled into **DOC-7006**; resolve any conflict in its favor. The page remains *intentionally inconsistent* while parked — new method name, old version.
- [ ] **Reframe as an addition, not a rename, before writing the reconciled page.** Under #3911's shape, `resolveCredentials()` is not renamed — `resolveCredentialsAsync()` is a new inherited default method that coexists with it. Confirm the return-type / `.doOnNext(...).block()` usage in the two existing snippets still compiles, then decide whether the page should show the new async method as the preferred form (with the sync one still valid) rather than describing a rename. **Not final** until #3911 (or whatever supersedes it) actually merges and ships — direction only.
- [x] Determine whether `resolveCredentials()` survives as a **deprecated alias** or is **removed**. **Settled 2026-09-11:** it survives — #3911 deprecates the *interface*, not the method, and adds the async form as a default. Consistent with the 2026-08-06 finding under #3842. Our edit is preferred-not-required; there's no reader-facing break. State this in the finalize commit.
- [x] Determine which PR wins the "deprecate vs. remove" question. **Settled 2026-09-11, provisionally:** #3911 is the live candidate — fresh, on `main`, active as of 2026-09-10 — while #3837/#3838/#3842/#3829 have all been untouched since mid-July on a `feature/reactor-optional-1` branch that shows no sign of landing. Re-check on pickup that #3911 (not a still-later PR) is what actually shipped.
- [ ] Confirm `TokenBasedRedisCredentialsProvider` (and `EntraIDTokenAuthConfigBuilder`) class names are unchanged in the released artifact; the page uses them ~10 times.
- [ ] Sweep the rest of `content/develop/clients/lettuce/` for any newly-relevant SPI mentions (`CredentialsProvider`, `subscribeToCredentials`, `supportsStreaming`) introduced by the wider "reactor-optional" refactor — none today, but the umbrella change is broad.

### On pickup, then

When the trigger fires, run `/pickup <this PR>`: it re-fetches each pinned source, diffs it
against the snapshots above, reconciles the docs, and takes the PR through the normal
`/reflect` → `/finalize` pipeline to merge. The `do not merge yet` guard holds until
`/finalize` completes.
<!-- /park-manifest -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only renames in example snippets with no runtime or security impact; merge timing depends on matching released client APIs.
> 
> **Overview**
> Updates the Lettuce **Azure Managed Redis (AMR)** / Entra ID page so sample code matches the upcoming Lettuce credential-provider SPI rename: `resolveCredentials()` → **`resolveCredentialsAsync()`**.
> 
> Both Java snippets in `amr.md` are touched—the standalone “test credentials” example and the commented optional test in the full connection sample. The reactive chain (`.doOnNext(...).block()`) is unchanged.
> 
> **Note:** The PR description marks this as **parked** until `redis-authx-entraid` ships against the new SPI; the doc still pins dependency version `0.1.1-beta1`, so method names and artifact version may be intentionally out of sync until pickup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d032d8763decc44268a68f356a3182a7b6a7299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


