### PR TITLE
DEV: document search-on-timeout config. parameter changes

### DIFF
--- a/content/develop/ai/search-and-query/administration/configuration.md
+++ b/content/develop/ai/search-and-query/administration/configuration.md
@@ -399,11 +399,12 @@ Default: `FALSE`
 The response policy for queries that exceed the [`search-timeout`](#search-timeout) setting can be one of the following:
 
 * `RETURN`: this policy will return the top results accumulated by the query until it timed out.
+* `RETURN_STRICT`: like `RETURN`, returns the partial results accumulated when a query exceeds the timeout instead of failing, but strictly enforces the configured timeout as a hard deadline. This matters most in clustered deployments: with `RETURN`, the first shard to time out aborts the whole query early; with `RETURN_STRICT`, the coordinator keeps gathering results from all shards up to the deadline and then returns whatever accumulated at that point. Available in Redis Query Engine 8.10 and later.
 * `FAIL`: will return an error when the query exceeds the timeout value.
 
 Type: string
 
-Valid values: `RETURN`, `FAIL`
+Valid values: `RETURN`, `RETURN_STRICT`, `FAIL`
 
 Default: `RETURN`
 


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to configuration.md with no runtime or code impact.
> 
> **Overview**
> Documents the new **`RETURN_STRICT`** value for **`search-on-timeout`** (Redis Query Engine / Redis 8.10), alongside existing **`RETURN`** and **`FAIL`**.
> 
> The new option is described as returning partial results on timeout while treating **`search-timeout`** as a hard deadline—especially in clusters, where **`RETURN`** can end the query when the first shard times out, whereas **`RETURN_STRICT`** keeps collecting from shards until the deadline. The **Valid values** line is updated to include **`RETURN_STRICT`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca816af14fbf9cf069837f9c7a97c07d1fba7dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->