### PR TITLE
RDSC-5692 Update public docs that Flink processor is GA

### DIFF
--- a/content/embeds/rdi-when-to-use.md
+++ b/content/embeds/rdi-when-to-use.md
@@ -25,7 +25,7 @@ RDI is a good fit when:
 
 {{< note >}}The throughput and data-size limits above assume the
 [classic processor]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}}).
-The Flink processor (currently in Preview) roughly doubles each limit.{{< /note >}}
+The Flink processor roughly doubles each limit.{{< /note >}}
 
 ### When not to use RDI
 

--- a/content/integrate/redis-data-integration/architecture/classic-vs-flink.md
+++ b/content/integrate/redis-data-integration/architecture/classic-vs-flink.md
@@ -31,10 +31,8 @@ for a step-by-step migration guide.
 | Aspect | Classic processor | Flink processor |
 |---|---|---|
 | Implementation | Python | Java on top of [Apache Flink](https://flink.apache.org/) |
-| Deployment targets | VM and Kubernetes | Kubernetes only |
 | Scaling | Single replica | Horizontal: TaskManager replicas × task slots per TaskManager |
 | Fault tolerance | Source-stream consumer-group replay | Source-stream consumer-group replay plus Flink checkpointing |
-| Supported `data_type` outputs | `hash`, `json`, `set`, `sorted_set`, `stream`, `string` | `hash`, `json` |
 | Metrics endpoint | `rdi-metrics-exporter` service | Flink JobManager `/metrics` (no metrics exporter) |
 | Metric naming | `rdi_*` (e.g., `rdi_incoming_entries`) | `flink_*` (e.g., `flink_jobmanager_job_operator_coordinator_stream_type_rdiRecords`) |
 | End-to-end latency | Bounded by the per-batch read-process-write cycle | Records flow through pipelined operator chains without a per-batch barrier |
@@ -54,9 +52,7 @@ all task slots in the cluster. The Flink processor scales
 horizontally by changing the number of TaskManager replicas
 (`advanced.resources.taskManager.replicas`); with adaptive
 parallelism, the default parallelism is the product of TaskManager
-replicas and task slots per TaskManager. The Flink processor
-currently runs on Kubernetes only; VM support is planned for a future
-release.
+replicas and task slots per TaskManager.
 
 Both processors retain at-least-once delivery semantics; the Flink
 processor adds Flink checkpointing on top of the shared
@@ -64,7 +60,9 @@ consumer-group replay mechanism.
 
 See
 [Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}})
-for the Helm settings.
+for the Kubernetes Helm settings, and
+[Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-vm#configure-the-flink-processor" >}})
+for VM installations.
 
 ## Configuration
 
@@ -79,22 +77,14 @@ and are silently ignored by the other implementation. The Flink
 processor exposes additional fine-grained tuning under
 `processors.advanced.*`.
 
-## Supported output formats
-
-The classic processor supports all `data_type` values: `hash`, `json`,
-`set`, `sorted_set`, `stream`, and `string`. The Flink processor
-currently supports only `hash` and `json`. Pipelines that use any other
-output type must remain on the classic processor or rewrite the
-affected jobs. Support for the remaining output types is planned for a
-future release.
-
 ## Transformation extensions
 
 The two processors support the same set of transformation blocks
 (`filter`, `map`, `add_field`, `remove_field`, `rename_field`,
-`redis.lookup`) and the same expression languages (JMESPath and SQL).
-Pipelines written for one processor generally execute on the other
-without changes.
+`redis.lookup`), the same expression languages (JMESPath and SQL),
+and the same data types in output blocks: `hash`, `json`, `set`,
+`sorted_set`, `stream`, and `string`. Pipelines written for one processor
+generally execute on the other without changes.
 
 The Flink processor adds three optional, performance-oriented
 extensions that are not available with the classic processor:

--- a/content/integrate/redis-data-integration/architecture/classic-vs-flink.md
+++ b/content/integrate/redis-data-integration/architecture/classic-vs-flink.md
@@ -45,8 +45,8 @@ The classic processor runs as a single pod managed by the operator
 and can be deployed on either VMs or Kubernetes through the RDI Helm
 chart.
 
-The Flink processor runs as an Apache Flink application cluster: one
-JobManager pod plus one or more TaskManager pods. Source,
+The Flink processor runs as an Apache Flink application cluster managed by
+RDI: one JobManager pod plus one or more TaskManager pods. Source,
 transformation, and sink operators run as parallel subtasks across
 all task slots in the cluster. The Flink processor scales
 horizontally by changing the number of TaskManager replicas

--- a/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
+++ b/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
@@ -275,10 +275,8 @@ configuration above contains the following properties:
 
 - `type`: Stream processor implementation to run for this pipeline.
   The options are `classic` (the default) for the Python-based classic processor
-  and `flink` for the
-  [Apache Flink](https://flink.apache.org/)-based processor.
-  The Flink processor runs on Kubernetes only and supports the `hash` and `json`
-  target data types. See
+  and `flink` for the [Apache Flink](https://flink.apache.org/)-based processor.
+  See
   [Stream processor implementations]({{< relref "/integrate/redis-data-integration/architecture#stream-processor-implementations" >}})
   for an overview, and
   [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}})

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-set-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-set-example.md
@@ -19,9 +19,6 @@ weight: 30
 In the example below, data is captured from the source table named `invoice` and is written to a Redis set. The `connection` is an optional parameter that refers to the corresponding connection name defined in `config.yaml`. When you specify the
 `data_type` parameter for the job, it overrides the system-wide setting `target_data_type` defined in `config.yaml`.
 
-{{< note >}}The `set` data type is supported by the classic processor only.
-The Flink processor currently supports only `hash` and `json` outputs.{{< /note >}}
-
 When writing to a set, you must supply an extra argument, `member`, which specifies the field that will be written. In this case, the result will be a Redis set with key names based on the key expression (for example, `invoices:Germany`, `invoices:USA`) and with an expiration of 100 seconds. If you don't supply an `expire` parameter, the keys will never expire.    
 
 ```yaml

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-sorted-set-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-sorted-set-example.md
@@ -19,9 +19,6 @@ weight: 30
 In the example below, data is captured from the source table named `invoice` and is written to a Redis sorted set. The `connection` is an optional parameter that refers to the corresponding connection name defined in `config.yaml`. When
 you specify the `data_type` parameter for the job, it overrides the system-wide setting `target_data_type` defined in `config.yaml`.
 
-{{< note >}}The `sorted_set` data type is supported by the classic processor only.
-The Flink processor currently supports only `hash` and `json` outputs.{{< /note >}}
-
 When writing to sorted sets, you must provide two additional arguments, `member` and `score`. These specify the field names that will be used as a member and a score to add an element to a sorted set. In this case, the result will be a Redis sorted set named `invoices:sorted` based on the key expression and with an expiration of 100 seconds for each set member. If you don't supply an `expire` parameter, the keys will never expire.
 
 ```yaml

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-stream-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-stream-example.md
@@ -19,9 +19,6 @@ weight: 30
 In the example below, data is captured from the source table named `invoice` and is written to a Redis stream. The `connection` is an optional parameter that refers to the corresponding connection name defined in `config.yaml`.
 When you specify the `data_type` parameter for the job, it overrides the system-wide setting `target_data_type` defined in `config.yaml`.
 
-{{< note >}}The `stream` data type is supported by the classic processor only.
-The Flink processor currently supports only `hash` and `json` outputs.{{< /note >}}
-
 When writing to streams, you can use the optional parameter `mapping` to limit the number of fields sent in a message and to provide aliases for them. If you don't use the `mapping` parameter, all fields captured in the source will be passed as the message payload. 
 
 Note that streams are different from other data structures because existing messages are never updated or deleted. Any operation in the source will generate a new message with the corresponding operation code (`op_code` field) that is automatically added to the message payload. 

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-string-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-string-example.md
@@ -19,9 +19,6 @@ weight: 30
 The string data type is useful for capturing a string representation of a single column from
 a source table.
 
-{{< note >}}The `string` data type is supported by the classic processor only.
-The Flink processor currently supports only `hash` and `json` outputs.{{< /note >}}
-
 In the example job below, the `title` column is captured from the `album` table in the source.
 The `title` is then written to the Redis target database as a string under a custom key of the
 form `AlbumTitle:42`, where the `42` is the primary key value of the table (the `albumid` column).

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -127,28 +127,31 @@ This option is available in RDI 1.16.2 and later.
 ## Which processor should I use? {#which-processor-should-i-use}
 
 RDI ships with two stream processor implementations: the *classic*
-processor and the *Flink* processor. The classic processor is the
-production-supported default. The Flink processor was introduced in
-RDI 1.18.0 as a **Preview** and is not yet supported for production
-use; we encourage you to try it on new, non-production pipelines and
-share feedback so we can prioritize improvements before general
-availability. Regular preview terms apply.
+processor and the *Flink* processor. Both are fully supported for
+production on VM and Kubernetes installations. The Flink processor
+is generally available as of RDI 1.19.0 and is enabled per pipeline.
 
 The Flink processor delivers significantly higher snapshot throughput,
 lower end-to-end latency, horizontal scaling, and Flink checkpointing
 on top of the same at-least-once delivery guarantees as the classic
-processor.
+processor. It also adds optional expression and `redis.lookup` result
+caching.
 
-Continue to use the classic processor for production pipelines, and
-in any of the following cases where the Flink processor does not yet
-apply:
+**We strongly recommend using the Flink processor** for new pipelines and
+migrating existing pipelines to it, to benefit from these improvements. The
+*classic* processor is still the default, so pipelines keep using it until
+you opt in, and it remains a fully supported choice — for example, when you
+want to ensure your pipelines continue to work as before until you have
+consciously migrated them. In a future release, however, the Flink processor
+will become the default and the classic processor may be deprecated, so adopting
+the Flink processor now avoids a later migration.
 
--   **Output `data_type` other than `hash` or `json`** (for example,
-    `set`, `sorted_set`, `stream`, or `string`).
--   **VM installations.** The Flink processor currently runs on
-    Kubernetes only.
+Switch a pipeline to the Flink processor by setting
+[`processors.type`]({{< relref "/integrate/redis-data-integration/data-pipelines/pipeline-config#processors" >}})
+to `flink` (`classic` is the default). You can adopt it per pipeline without
+changing the others.
 
-Both limitations are expected to be lifted in a future release. See
+See
 [Differences between the classic and Flink processors]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}})
 for a side-by-side comparison and
 [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}})

--- a/content/integrate/redis-data-integration/installation/install-k8s.md
+++ b/content/integrate/redis-data-integration/installation/install-k8s.md
@@ -327,7 +327,9 @@ processor and the
 [Apache Flink](https://flink.apache.org/)-based *Flink* processor.
 See
 [Stream processor implementations]({{< relref "/integrate/redis-data-integration/architecture#stream-processor-implementations" >}})
-for an overview of the differences.
+for an overview of the differences and
+[Differences between the classic and Flink processors]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}})
+for a side-by-side comparison.
 
 To configure the Flink processor at the Helm chart level, add the
 `operator.dataPlane.flinkProcessor` block to your `rdi-values.yaml` file. The
@@ -357,7 +359,9 @@ that the operator will use when deploying the JobManager and TaskManager workloa
 To run a specific pipeline on the Flink processor, set
 [`processors.type`]({{< relref "/integrate/redis-data-integration/data-pipelines/pipeline-config#processors" >}})
 to `flink` in that pipeline's `config.yaml`. Pipelines without this setting
-continue to use the classic processor.
+continue to use the classic processor. Fine-tune the Flink runtime
+through the `processors.advanced` section of `config.yaml` (see the
+[configuration reference]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#processors" >}})).
 
 For migrating existing pipelines to the Flink processor, see
 [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}).

--- a/content/integrate/redis-data-integration/installation/install-vm.md
+++ b/content/integrate/redis-data-integration/installation/install-vm.md
@@ -294,6 +294,27 @@ prefer to run it from your own laptop or desktop instead, you can
 [download it separately]({{< relref "/integrate/redis-data-integration/installation/install-k8s#download-the-rdi-cli" >}})
 for your platform.{{< /note >}}
 
+## Configure the Flink processor
+
+RDI ships with two stream processor implementations: the default *classic*
+processor and the
+[Apache Flink](https://flink.apache.org/)-based *Flink* processor. 
+See
+[Stream processor implementations]({{< relref "/integrate/redis-data-integration/architecture#stream-processor-implementations" >}})
+for an overview of the differences and
+[Differences between the classic and Flink processors]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}})
+for a side-by-side comparison.
+
+To run a specific pipeline on the Flink processor, set
+[`processors.type`]({{< relref "/integrate/redis-data-integration/data-pipelines/pipeline-config#processors" >}})
+to `flink` in that pipeline's `config.yaml` and redeploy it. Pipelines without
+this setting continue to use the classic processor. Fine-tune the Flink runtime
+through the `processors.advanced` section of `config.yaml` (see the
+[configuration reference]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#processors" >}})).
+
+For migrating existing pipelines to the Flink processor, see
+[Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}).
+
 ## Uninstall RDI
 
 If you want to remove your RDI installation, go to the installation folder and run

--- a/content/integrate/redis-data-integration/installation/migration-classic-to-flink.md
+++ b/content/integrate/redis-data-integration/installation/migration-classic-to-flink.md
@@ -57,6 +57,9 @@ your `rdi-values.yaml` file and run `helm upgrade` as described in
 Existing pipelines continue to run on the classic processor until you switch
 them in step 2.
 
+For VM installations, skip this step. You can configure per-pipeline Flink
+resources in step 4.
+
 ## Step 2: Switch the pipeline to the Flink processor
 
 In the pipeline's `config.yaml`, set
@@ -106,10 +109,6 @@ processors:
     source:
       # Time between checks for new input streams.
       discovery.interval.ms: 1000
-    target:
-      # Verify writes are replicated before acknowledging.
-      wait.enabled: true
-      wait.write.timeout.ms: 1000
     flink:
       # Number of parallel task slots per TaskManager pod.
       taskmanager.numberOfTaskSlots: 2

--- a/content/integrate/redis-data-integration/installation/migration-classic-to-flink.md
+++ b/content/integrate/redis-data-integration/installation/migration-classic-to-flink.md
@@ -17,37 +17,36 @@ weight: 35
 ---
 
 RDI ships with two stream processor implementations. The default *classic*
-processor is implemented in Python and runs on both VMs and Kubernetes. The
-*Flink* processor is built on top of [Apache Flink](https://flink.apache.org/)
-and currently runs on Kubernetes only. It can achieve much higher throughput
+processor is implemented in Python. The *Flink* processor is built on top of
+[Apache Flink](https://flink.apache.org/). Both run on VM and Kubernetes
+installations. The Flink processor can achieve much higher throughput
 during snapshots, scales horizontally by changing the number of TaskManager replicas,
 and uses Flink checkpointing for fault tolerance. See [Stream processor implementations]({{< relref "/integrate/redis-data-integration/architecture#stream-processor-implementations" >}})
 for an overview.
 
 This page describes how to migrate an existing pipeline from the classic
-processor to the Flink processor.
-
-{{< note >}}The Flink processor is currently supported on Kubernetes only. VM
-installations must continue to use the classic processor.{{< /note >}}
+processor to the Flink processor. The steps are the same on VMs and Kubernetes,
+except for the optional Helm-level tuning in [Step 1](#step-1-configure-the-flink-processor-at-the-helm-chart-level-kubernetes),
+which applies to Kubernetes only.
 
 ## Before you migrate
 
 Confirm that your pipeline is compatible with the Flink processor:
 
--   The Flink processor supports `hash` and `json` target data types only. If
-    any of your jobs use the `set`, `sorted_set`, `stream`, or `string` data
-    types, those jobs must be rewritten or kept on the classic processor.
 -   `JSON.MERGE` semantics differ from the classic processor's Lua-based merge
     when null values are involved (see
     [`use_native_json_merge`]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#processors" >}})).
     The Flink processor always uses the native `JSON.MERGE` command when the
     target database supports it.
--   Ensure your Kubernetes cluster has enough capacity for the Flink JobManager
+-   Ensure your Kubernetes cluster or VM has enough capacity for the Flink JobManager
     and TaskManager pods (see
     [Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}})
     for the default sizing).
 
-## Step 1: Configure the Flink processor at the Helm chart level
+## Step 1: Configure the Flink processor at the Helm chart level (Kubernetes)
+
+This step applies to **Kubernetes** installations only. On VM installations,
+skip it and enable the Flink processor per pipeline in step 2.
 
 The Flink processor is always available — no opt-in is required at the Helm
 chart level. The defaults are sized for typical workloads, so you can skip

--- a/content/integrate/redis-data-integration/installation/upgrade.md
+++ b/content/integrate/redis-data-integration/installation/upgrade.md
@@ -153,26 +153,6 @@ you must adapt your `rdi-values.yaml` file to the following changes:
     `rdiMetricsExporter.service.port`, `rdiMetricsExporter.serviceMonitor.path`,
     `api.service.name`.
 
-### Enabling the Flink processor
-
-The
-[Apache Flink](https://flink.apache.org/)-based stream processor is
-available after upgrading to RDI 1.18.0 or later. Once the upgrade
-completes, it is always available — no Helm-level opt-in is required, and
-the chart defaults are sized for typical workloads. Upgrading the Helm
-chart does not change the processor used by existing pipelines, which keep
-running on the classic processor until you explicitly switch them by
-setting
-[`processors.type`]({{< relref "/integrate/redis-data-integration/data-pipelines/pipeline-config#processors" >}})
-to `flink` in their `config.yaml`.
-
-To override the Flink processor defaults, add an
-`operator.dataPlane.flinkProcessor` block to your `rdi-values.yaml` file as
-described in
-[Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}}).
-For the per-pipeline migration steps, see
-[Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}).
-
 ### Verifying the upgrade
 
 Check that all pods have `Running` status:
@@ -192,6 +172,28 @@ will not work. If you need to perform such an upgrade, uninstall RDI completely 
 described in [Uninstall RDI]({{< relref "/integrate/redis-data-integration/installation/install-k8s#uninstall-rdi" >}}),
 and then install the old version.
 {{< /note >}}
+
+## Enabling the Flink processor
+
+The
+[Apache Flink](https://flink.apache.org/)-based stream processor is
+fully supported on both VM and Kubernetes installations after upgrading to
+RDI 1.19.0. Once the upgrade completes, it is always available —
+no opt-in is required, and the defaults are sized for typical workloads.
+Upgrading does not change the processor used by existing pipelines, which keep
+running on the classic processor until you explicitly switch them by
+setting
+[`processors.type`]({{< relref "/integrate/redis-data-integration/data-pipelines/pipeline-config#processors" >}})
+to `flink` in their `config.yaml`.
+
+On Kubernetes, to override the Flink processor defaults, add an
+`operator.dataPlane.flinkProcessor` block to your `rdi-values.yaml` file as
+described in
+[Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}}).
+On VMs, see
+[Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-vm#configure-the-flink-processor" >}}).
+For the per-pipeline migration steps, see
+[Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}).
 
 ## What happens during the upgrade?
 

--- a/content/integrate/redis-data-integration/observability.md
+++ b/content/integrate/redis-data-integration/observability.md
@@ -50,7 +50,7 @@ The way you access the metrics endpoints depends on whether you are using a VM i
 
 For VM installations, the metrics are available by default on the following endpoints:
 - Collector metrics: `https://<RDI_HOST>/collector-source/metrics`
-- Stream processor metrics: `https://<RDI_HOST>/metrics`
+- Stream processor metrics: `https://<RDI_HOST>/processor/metrics`
 - Operator metrics: `https://<RDI_HOST>/operator/metrics`
 
 Please note that for RDI versions prior to 1.16.0 the collector metrics are not accessible.

--- a/content/integrate/redis-data-integration/reference/config-yaml-reference.md
+++ b/content/integrate/redis-data-integration/reference/config-yaml-reference.md
@@ -645,7 +645,7 @@ Settings that control how data is processed, including batch sizes, error handli
 |**retry\_max\_attempts**<br/>(Maximum retry attempts)|`integer`, `string`|Maximum number of attempts for a failed write to the target Redis database before giving up.<br/>Default: `5`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
 |**retry\_initial\_delay\_ms**<br/>(Initial retry delay)|`integer`, `string`|Initial delay in milliseconds before the first retry of a failed write.<br/>Default: `1000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>Maximum: `999999`<br/>||
 |**retry\_max\_delay\_ms**<br/>(Maximum retry delay)|`integer`, `string`|Maximum delay in milliseconds between retry attempts.<br/>Default: `10000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>Maximum: `999999`<br/>||
-|**wait\_enabled**<br/>(Enable replica wait)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it.<br/>Default: `false`<br/>||
+|**wait\_enabled**<br/>(Enable replica wait)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it. Enable this only when target database replication is enabled and a healthy replica is available. For the Flink processor, `processors.advanced.target.wait.enabled` takes priority.<br/>Default: `false`<br/>||
 |**wait\_timeout**<br/>(Replica wait timeout)|`integer`, `string`|Maximum time in milliseconds to wait for replica write verification on the target database.<br/>Default: `1000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
 |**retry\_on\_replica\_failure**|`boolean`|When `true`, RDI keeps retrying a write until replica replication is confirmed; when `false`, it gives up after the first failure.<br/>Default: `true`<br/>||
 |**on\_failed\_retry\_interval**<br/>(Retry interval on failure)|`integer`, `string`|(DEPRECATED)<br/>This property has no effect; remove it from the configuration.<br/>Default: `5`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
@@ -807,10 +807,16 @@ Advanced configuration properties for the target Redis client and sink. **Flink 
 |**retry\.initial\.delay\.ms**<br/>(Target retry initial delay)|`integer`|Initial delay in milliseconds before the first retry of a failed target Redis operation. Alias for `processors.retry_initial_delay_ms`; takes priority when both are set.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
 |**retry\.max\.delay\.ms**<br/>(Target retry max delay)|`integer`|Maximum delay in milliseconds between retry attempts for target Redis operations. Alias for `processors.retry_max_delay_ms`; takes priority when both are set.<br/>Default: `10000`<br/>Minimum: `1`<br/>||
 |**retry\.backoff\.multiplier**<br/>(Target retry backoff multiplier)|`number`|Exponential backoff multiplier between retry attempts for target Redis operations.<br/>Default: `2`<br/>Minimum: `1`<br/>||
-|**wait\.enabled**<br/>(Target replica wait enabled)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it. Alias for `processors.wait_enabled`; takes priority when both are set.<br/>Default: `false`<br/>||
+|**wait\.enabled**<br/>(Target replica wait enabled)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it. Enable this only when target database replication is enabled and a healthy replica is available. Alias for `processors.wait_enabled`; takes priority when both are set.<br/>Default: `false`<br/>||
 |**wait\.write\.timeout\.ms**<br/>(Target replica wait timeout)|`integer`|Maximum time in milliseconds to wait for target replica write verification. Alias for `processors.wait_timeout`; takes priority when both are set.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
-|**wait\.retry\.enabled**<br/>(Target replica wait retry enabled)|`boolean`|When `true`, RDI keeps retrying a target write until replica replication is confirmed; when `false`, it gives up after the first failure. Alias for `processors.retry_on_replica_failure`; takes priority when both are set. When enabled, the Flink processor retries indefinitely until the checkpoint timeout, unlike the classic processor which retries once.<br/>Default: `true`<br/>||
+|**wait\.retry\.enabled**<br/>(Target replica wait retry enabled)|`boolean`|When `true`, RDI keeps retrying a target write until replica replication is confirmed; when `false`, it gives up after the first failure. Alias for `processors.retry_on_replica_failure`; takes priority when both are set. When enabled, the Flink processor retries indefinitely. Failed checkpoints can restart the job, after which the retries resume. The classic processor retries once.<br/>Default: `true`<br/>||
 |**wait\.retry\.delay\.ms**<br/>(Target replica wait retry delay)|`integer`|Delay in milliseconds between target replica wait retry attempts.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
+
+{{< warning >}}
+If target database replication is disabled, setting `wait.enabled: true` with the
+default `wait.retry.enabled: true` prevents the processor from making progress.
+To recover, enable target database replication or remove `wait.enabled` and redeploy.
+{{< /warning >}}
 
 **Additional Properties**
 

--- a/content/integrate/redis-data-integration/reference/config-yaml-reference.md
+++ b/content/integrate/redis-data-integration/reference/config-yaml-reference.md
@@ -39,7 +39,7 @@ Source collectors that capture changes from upstream databases. Each key is a un
 |[**logging**](#sourceslogging)<br/>(Logging configuration)|`object`|Logging settings for this source collector.<br/>|no|
 |[**tables**](#sourcestables)<br/>(Tables to capture)|`object`|Tables to capture from the source database, keyed by table name. The value configures column selection and key handling for that table.<br/>|no|
 |[**schemas**](#sourcesschemas)<br/>(Schema names)|`string[]`|Schema names to capture from the source database. Maps to the underlying connector's `schema.include.list`.<br/>|no|
-|[**databases**](#sourcesdatabases)<br/>(Database names)|`string[]`|Database names to capture from the source database. Maps to the underlying connector's `database.include.list`.<br/>|no|
+|[**databases**](#sourcesdatabases)<br/>(Database names)|`string[]`|Database names to capture from the source database. Maps to the underlying connector's `database.include.list`. Applies only to MySQL, MariaDB, and MongoDB connections.<br/>|no|
 |[**advanced**](#sourcesadvanced)<br/>(Advanced configuration)|`object`|Advanced configuration that overrides the underlying engine's defaults. Only required for non-standard tuning.<br/>|no|
 
 
@@ -299,15 +299,15 @@ Tables to capture from the source database, keyed by table name. The value confi
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
 |**snapshot\_sql**|`string`|Custom SQL statement used during the initial snapshot, giving fine-grained control over the data captured.<br/>||
-|[**columns**](#sourcestablesadditionalpropertiescolumns)<br/>(Columns to capture)|`string[]`|Specific columns to capture. When omitted, all columns are captured. Not supported for MongoDB connections.<br/>||
+|[**columns**](#sourcestablesadditionalpropertiescolumns)<br/>(Columns to capture)|`string[]`|List of specific columns to capture for changes. If not specified, all columns will be captured. For RIOTX Snowflake sources, this is rendered as per-table `--table-columns` projection. Note: This property cannot be used for MongoDB connections<br/>||
 |[**exclude\_columns**](#sourcestablesadditionalpropertiesexclude_columns)<br/>(Columns to exclude)|`string[]`|Specific columns to exclude from capture. When omitted, no columns are excluded. Only supported for MongoDB connections.<br/>||
-|[**keys**](#sourcestablesadditionalpropertieskeys)<br/>(Message keys)|`string[]`|Columns that together form a unique identifier for each row. Only required when the table lacks a primary key or unique constraint.<br/>||
+|[**keys**](#sourcestablesadditionalpropertieskeys)<br/>(Message keys)|`string[]`|Optional list of columns to use as a composite unique identifier. For RIOTX Snowflake sources, this is rendered as per-table `--table-keys`. Only required when the table lacks a primary key or unique constraint. Must form a unique combination of fields<br/>||
 
 **Additional Properties:** not allowed  
 <a name="sourcestablesadditionalpropertiescolumns"></a>
 ##### sources\.tables\.additionalProperties\.columns\[\]: Columns to capture
 
-Specific columns to capture. When omitted, all columns are captured. Not supported for MongoDB connections.
+List of specific columns to capture for changes. If not specified, all columns will be captured. For RIOTX Snowflake sources, this is rendered as per-table `--table-columns` projection. Note: This property cannot be used for MongoDB connections
 
 
 <a name="sourcestablesadditionalpropertiesexclude_columns"></a>
@@ -319,7 +319,7 @@ Specific columns to exclude from capture. When omitted, no columns are excluded.
 <a name="sourcestablesadditionalpropertieskeys"></a>
 ##### sources\.tables\.additionalProperties\.keys\[\]: Message keys
 
-Columns that together form a unique identifier for each row. Only required when the table lacks a primary key or unique constraint.
+Optional list of columns to use as a composite unique identifier. For RIOTX Snowflake sources, this is rendered as per-table `--table-keys`. Only required when the table lacks a primary key or unique constraint. Must form a unique combination of fields
 
 
 <a name="sourcesschemas"></a>
@@ -331,7 +331,7 @@ Schema names to capture from the source database. Maps to the underlying connect
 <a name="sourcesdatabases"></a>
 ### sources\.databases\[\]: Database names
 
-Database names to capture from the source database. Maps to the underlying connector's `database.include.list`.
+Database names to capture from the source database. Maps to the underlying connector's `database.include.list`. Applies only to MySQL, MariaDB, and MongoDB connections.
 
 
 <a name="sourcesadvanced"></a>
@@ -374,6 +374,16 @@ sink:
   redis.wait.retry.enabled: false
   redis.wait.retry.delay.ms: 1000
 source:
+  snapshot.max.threads: 1
+  poll.interval.ms: 500
+  snapshot.fetch.size: 10000
+  max.batch.size: 2048
+  max.queue.size: 8192
+  heartbeat.interval.ms: 0
+  lob.enabled: false
+  publication.autocreate.mode: all_tables
+  publication.name: dbz_publication
+  slot.name: debezium
   spanner.version.retention.period.hours: 1
   spanner.fetch.timeout.ms: 500
   spanner.fetch.heartbeat.ms: 100
@@ -449,13 +459,26 @@ redis.wait.retry.delay.ms: 1000
 <a name="sourcesadvancedsource"></a>
 #### sources\.advanced\.source: Advanced source settings
 
-Advanced configuration properties for the source database connection and CDC behavior. **Applies to the `cdc` and `flink` collector types.**<br/><br/>For the `cdc` collector type, available properties depend on the source database — refer to the relevant Debezium connector documentation: [MySQL](https://debezium.io/documentation/reference/stable/connectors/mysql.html), [MariaDB](https://debezium.io/documentation/reference/stable/connectors/mariadb.html), [PostgreSQL](https://debezium.io/documentation/reference/stable/connectors/postgresql.html), [Oracle](https://debezium.io/documentation/reference/stable/connectors/oracle.html), [SQL Server](https://debezium.io/documentation/reference/stable/connectors/sqlserver.html), [Db2](https://debezium.io/documentation/reference/stable/connectors/db2.html), [MongoDB](https://debezium.io/documentation/reference/stable/connectors/mongodb.html). When using a property from those pages, omit the `debezium.source.` prefix.<br/><br/>**The properties listed below only apply to the `flink` collector type (Spanner).**
+Advanced configuration properties for the source database connection and CDC behavior. **Applies to the `cdc` and `flink` collector types.**<br/><br/>For the `cdc` collector type, available properties depend on the source database — refer to the relevant Debezium connector documentation: [MySQL](https://debezium.io/documentation/reference/stable/connectors/mysql.html), [MariaDB](https://debezium.io/documentation/reference/stable/connectors/mariadb.html), [PostgreSQL](https://debezium.io/documentation/reference/stable/connectors/postgresql.html), [Oracle](https://debezium.io/documentation/reference/stable/connectors/oracle.html), [SQL Server](https://debezium.io/documentation/reference/stable/connectors/sqlserver.html), [Db2](https://debezium.io/documentation/reference/stable/connectors/db2.html), [MongoDB](https://debezium.io/documentation/reference/stable/connectors/mongodb.html). When using a property from those pages, omit the `debezium.source.` prefix.<br/><br/>**The named properties below cover the most commonly tuned settings: `spanner.*` properties apply to the `flink` collector type, all others apply to the `cdc` collector type. Any other property from the Debezium documentation can still be set as a free-form key-value pair.**
 
 
 **Properties**
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
+|**record\.processing\.threads**<br/>(Record processing threads)|`integer`|Controls how many worker threads process captured records before they are written downstream.<br/>Minimum: `1`<br/>||
+|**snapshot\.max\.threads**<br/>(Snapshot max threads)|`integer`|Sets the maximum number of threads used while taking the initial snapshot.<br/>Default: `1`<br/>Minimum: `1`<br/>||
+|**poll\.interval\.ms**<br/>(Poll interval ms)|`integer`|Defines how often the collector polls the source for new changes.<br/>Default: `500`<br/>Minimum: `1`<br/>||
+|**snapshot\.fetch\.size**<br/>(Snapshot fetch size)|`integer`|Defines how many rows are fetched per batch during the initial snapshot.<br/>Default: `10000`<br/>Minimum: `1`<br/>||
+|**max\.batch\.size**<br/>(Max batch size)|`integer`|Caps how many records are processed together in a single batch.<br/>Default: `2048`<br/>Minimum: `1`<br/>||
+|**max\.queue\.size**<br/>(Max queue size)|`integer`|Limits how many records can be buffered in memory before processing catches up.<br/>Default: `8192`<br/>Minimum: `1`<br/>||
+|**heartbeat\.interval\.ms**<br/>(Heartbeat interval ms)|`integer`|Sets how often heartbeat events are emitted to keep change tracking active. Use 0 to disable them.<br/>Default: `0`<br/>Minimum: `0`<br/>||
+|**heartbeat\.action\.query**<br/>(Heartbeat action query)|`string`|SQL query executed on the source whenever a heartbeat is emitted.<br/>||
+|**lob\.enabled**<br/>(Lob enabled)|`boolean`|Determines whether large object columns are included in change capture.<br/>Default: `false`<br/>||
+|**gtid\.source\.includes**<br/>(GTID source includes)|`string`|Restricts MySQL GTID processing to the listed source UUIDs.<br/>||
+|**publication\.autocreate\.mode**<br/>(Publication autocreate mode)|`string`|Controls whether and how the PostgreSQL publication is created or updated automatically.<br/>Default: `"all_tables"`<br/>Enum: `"all_tables"`, `"filtered"`, `"disabled"`<br/>||
+|**publication\.name**<br/>(Publication name)|`string`|Sets the PostgreSQL logical replication publication name used by the collector.<br/>Default: `"dbz_publication"`<br/>||
+|**slot\.name**<br/>(Slot name)|`string`|Sets the PostgreSQL replication slot name the collector reads from.<br/>Default: `"debezium"`<br/>||
 |**spanner\.version\.retention\.period\.hours**<br/>(Spanner version retention period)|`integer`|Retention period in hours for Spanner change stream versions. Determines how far back the collector can resume after an outage.<br/>Default: `1`<br/>Minimum: `1`<br/>||
 |**spanner\.fetch\.timeout\.ms**<br/>(Spanner fetch timeout)|`integer`|Timeout in milliseconds for a single change stream fetch request to Spanner.<br/>Default: `500`<br/>Minimum: `1`<br/>||
 |**spanner\.fetch\.heartbeat\.ms**<br/>(Spanner fetch heartbeat interval)|`integer`|Interval in milliseconds at which Spanner sends heartbeat records when no data changes are available.<br/>Default: `100`<br/>Minimum: `1`<br/>||
@@ -472,6 +495,16 @@ Advanced configuration properties for the source database connection and CDC beh
 **Example**
 
 ```yaml
+snapshot.max.threads: 1
+poll.interval.ms: 500
+snapshot.fetch.size: 10000
+max.batch.size: 2048
+max.queue.size: 8192
+heartbeat.interval.ms: 0
+lob.enabled: false
+publication.autocreate.mode: all_tables
+publication.name: dbz_publication
+slot.name: debezium
 spanner.version.retention.period.hours: 1
 spanner.fetch.timeout.ms: 500
 spanner.fetch.heartbeat.ms: 100
@@ -550,7 +583,7 @@ Advanced configuration properties for the RIOT-X Snowflake collector. **Only app
 |**snapshot**<br/>(Snapshot mode)|`string`|Initial-load behavior. `INITIAL` performs a one-time snapshot before streaming; `NEVER` skips the snapshot.<br/>Default: `"INITIAL"`<br/>Enum: `"INITIAL"`, `"NEVER"`<br/>||
 |**streamPrefix**<br/>(Redis stream key prefix)|`string`|Prefix used when constructing Redis stream keys, for example `data:`.<br/>Default: `"data:"`<br/>||
 |**streamLimit**<br/>(Maximum stream length)|`integer`|Maximum number of entries kept in each Redis stream before older entries are trimmed.<br/>Minimum: `1`<br/>||
-|[**keyColumns**](#sourcesadvancedriotxkeycolumns)<br/>(Key columns)|`string[]`|Columns whose values form the unique message key for each row.<br/>||
+|[**keyColumns**](#sourcesadvancedriotxkeycolumns)<br/>(Key columns)|`string[]`|Deprecated RIOTX global fallback list of columns to use as message keys for every captured table. Prefer `tables.<schema.table>.keys`<br/>||
 |**clearOffset**<br/>(Clear existing offset)|`boolean`|When `true`, the stored offset is cleared on startup, forcing a fresh read.<br/>Default: `false`<br/>||
 |**count**<br/>(Record count limit)|`integer`|Maximum number of records to process. Set to `0` for unlimited.<br/>Default: `0`<br/>Minimum: `0`<br/>||
 
@@ -570,7 +603,7 @@ count: 0
 <a name="sourcesadvancedriotxkeycolumns"></a>
 ##### sources\.advanced\.riotx\.keyColumns\[\]: Key columns
 
-Columns whose values form the unique message key for each row.
+Deprecated RIOTX global fallback list of columns to use as message keys for every captured table. Prefer `tables.<schema.table>.keys`
 
 
 <a name="targets"></a>
@@ -633,10 +666,10 @@ Settings that control how data is processed, including batch sizes, error handli
 |**dedup**<br/>(Enable deduplication)|`boolean`|When `true`, the processor deduplicates incoming records. **Classic processor only.**<br/>Default: `false`<br/>||
 |**dedup\_max\_size**<br/>(Deduplication set size)|`integer`|Maximum number of entries kept in the deduplication set. **Classic processor only.**<br/>Default: `1024`<br/>Minimum: `1`<br/>||
 |**dedup\_strategy**<br/>(Deduplication strategy)|`string`|(DEPRECATED)<br/>This property has no effect — the only supported strategy is `ignore`. Remove it from the configuration. **Classic processor only.**<br/>Default: `"ignore"`<br/>Enum: `"reject"`, `"ignore"`<br/>||
-|**error\_handling**<br/>(Error handling strategy)|`string`|Strategy for handling failed records. `ignore` silently drops them; `dlq` writes them to the dead-letter queue.<br/>Default: `"dlq"`<br/>Pattern: `^\${.*}$\|ignore\|dlq`<br/>||
+|**error\_handling**<br/>(Error handling strategy)|`string`|Strategy for handling failed records. `ignore` silently drops them; `dlq` writes them to the dead-letter queue.<br/>Default: `"dlq"`<br/>||
 |**dlq\_max\_messages**<br/>(DLQ message limit)|`integer`, `string`|Maximum number of messages stored per dead-letter queue stream.<br/>Default: `1000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
-|**target\_data\_type**<br/>(Target Redis data type)|`string`|Data type used to store target records in Redis. `hash` writes a Redis Hash; `json` writes a RedisJSON document and requires the RedisJSON module.<br/>Default: `"hash"`<br/>Pattern: `^\${.*}$\|hash\|json`<br/>||
-|**json\_update\_strategy**|`string`|Strategy for updating existing JSON documents in Redis. `replace` overwrites the entire document; `merge` merges incoming fields into it.<br/>Default: `"replace"`<br/>Pattern: `^\${.*}$\|replace\|merge`<br/>||
+|**target\_data\_type**<br/>(Target Redis data type)|`string`|Data type used to store target records in Redis. `hash` writes a Redis Hash; `json` writes a RedisJSON document and requires the RedisJSON module.<br/>Default: `"hash"`<br/>||
+|**json\_update\_strategy**|`string`|Strategy for updating existing JSON documents in Redis. `replace` overwrites the entire document; `merge` merges incoming fields into it.<br/>Default: `"replace"`<br/>||
 |**use\_native\_json\_merge**<br/>(Use native JSON merge from RedisJSON module)|`boolean`|Controls whether JSON merge operations use the native `JSON.MERGE` command (when `true`) or Lua scripts (when `false`). Introduced in RDI 1.15.0. The native command provides 2x performance improvement but handles null values differently:<br/><br/>**Previous behavior (Lua merge)**: When merging `{"field1": "value1", "field2": "value2"}` with `{"field2": null, "field3": "value3"}`, the result was `{"field1": "value1", "field2": null, "field3": "value3"}` (null value is preserved).<br/><br/>**New behavior (JSON.MERGE)**: The same merge produces `{"field1": "value1", "field3": "value3"}` (null value removes the field, following [RFC 7396](https://datatracker.ietf.org/doc/html/rfc7396)).<br/><br/>**Note**: The native `JSON.MERGE` command requires RedisJSON 2.6.0 or higher. If the target database has an older version of RedisJSON, RDI automatically falls back to Lua-based merge operations regardless of this setting.<br/><br/>**Impact**: If your application logic distinguishes between a field with a `null` value and a missing field, you may need to adjust your data handling. This follows the JSON Merge Patch RFC standard but differs from the previous Lua implementation. Set to `false` to revert to the previous Lua-based merge behavior if needed.<br/><br/>The Flink processor always uses the native `JSON.MERGE` command when the target database supports it. **Classic processor only.**<br/>Default: `true`<br/>||
 |**initial\_sync\_processes**|`integer`, `string`|Number of parallel processes used to perform the initial data synchronization. For the Flink processor, parallelism is controlled by Flink properties instead. **Classic processor only.**<br/>Default: `4`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>Maximum: `32`<br/>||
 |**idle\_sleep\_time\_ms**<br/>(Idle sleep interval)|`integer`, `string`|Time in milliseconds to sleep between processing batches when idle. **Classic processor only.**<br/>Default: `200`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>Maximum: `999999`<br/>||
@@ -811,12 +844,6 @@ Advanced configuration properties for the target Redis client and sink. **Flink 
 |**wait\.write\.timeout\.ms**<br/>(Target replica wait timeout)|`integer`|Maximum time in milliseconds to wait for target replica write verification. Alias for `processors.wait_timeout`; takes priority when both are set.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
 |**wait\.retry\.enabled**<br/>(Target replica wait retry enabled)|`boolean`|When `true`, RDI keeps retrying a target write until replica replication is confirmed; when `false`, it gives up after the first failure. Alias for `processors.retry_on_replica_failure`; takes priority when both are set. When enabled, the Flink processor retries indefinitely. Failed checkpoints can restart the job, after which the retries resume. The classic processor retries once.<br/>Default: `true`<br/>||
 |**wait\.retry\.delay\.ms**<br/>(Target replica wait retry delay)|`integer`|Delay in milliseconds between target replica wait retry attempts.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
-
-{{< warning >}}
-If target database replication is disabled, setting `wait.enabled: true` with the
-default `wait.retry.enabled: true` prevents the processor from making progress.
-To recover, enable target database replication or remove `wait.enabled` and redeploy.
-{{< /warning >}}
 
 **Additional Properties**
 
@@ -1050,5 +1077,14 @@ Optional metadata describing this pipeline, such as a display name and descripti
 |----|----|-----------|--------|
 |**name**<br/>(Pipeline name)|`string`|Human-readable name for the pipeline. Maximum 100 characters.<br/>Maximal Length: `100`<br/>||
 |**description**<br/>(Pipeline description)|`string`|Free-form description of what the pipeline does. Maximum 500 characters.<br/>Maximal Length: `500`<br/>||
+|**revision**<br/>(Pipeline revision)|`integer`|Pipeline revision number. Must be a non-negative integer.<br/>Minimum: `0`<br/>||
+|[**tags**](#metadatatags)<br/>(Pipeline tags)|`string[]`|Array of pipeline tags. Each tag must be a string of up to 50 characters, containing only alphanumeric characters, dots, dashes, or underscores, and must start and end with an alphanumeric character. Tags must be unique.<br/>||
 
 **Additional Properties:** not allowed  
+<a name="metadatatags"></a>
+### metadata\.tags\[\]: Pipeline tags
+
+Array of pipeline tags. Each tag must be a string of up to 50 characters, containing only alphanumeric characters, dots, dashes, or underscores, and must start and end with an alphanumeric character. Tags must be unique.
+
+
+**Unique Items:** yes  

--- a/content/integrate/redis-data-integration/reference/config-yaml-reference.md
+++ b/content/integrate/redis-data-integration/reference/config-yaml-reference.md
@@ -622,7 +622,7 @@ Settings that control how data is processed, including batch sizes, error handli
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**type**<br/>(Processor type)|`string`|Processor implementation to run. `classic` runs the classic processor; `flink` runs the Apache Flink-based processor (Kubernetes deployments only).<br/>Default: `"classic"`<br/>Enum: `"classic"`, `"flink"`<br/>||
+|**type**<br/>(Processor type)|`string`|Processor implementation to run. `classic` runs the classic processor; `flink` runs the Apache Flink-based processor.<br/>Default: `"classic"`<br/>Enum: `"classic"`, `"flink"`<br/>||
 |**read\_batch\_size**|`integer`, `string`|Maximum number of records read from the source streams in a single batch.<br/>Default: `2000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
 |**read\_batch\_timeout\_ms**<br/>(Read batch timeout)|`integer`|Maximum time in milliseconds to wait for a batch to fill before processing it.<br/>Default: `100`<br/>Minimum: `1`<br/>||
 |**duration**<br/>(Batch duration limit)|`integer`, `string`|(DEPRECATED)<br/>This property has no effect; use `read_batch_timeout_ms` instead.<br/>Default: `100`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -6,7 +6,7 @@ categories:
 - operate
 - rs
 description: |
-  New Flink-based stream processor (Preview), with horizontal scaling, Flink checkpointing, and significantly higher throughput.
+  New Flink-based stream processor for Kubernetes deployments (Preview), with horizontal scaling, Flink checkpointing, and significantly higher throughput.
   Preview for Snowflake source support for Helm installations, including multi-schema capture and system truststore support.
   New API v2 endpoints for DLQ inspection, flushing the target database, and CDC-readiness validation.
   Better deployment reliability, new validation and resource controls, and security refreshes across core images.
@@ -23,7 +23,7 @@ weight: 971
 
 ### Flink Processor
 
-- **New Flink-based stream processor (Preview)**: RDI 1.18.0 introduces a new stream processor implementation built on [Apache Flink](https://flink.apache.org/) alongside the existing classic processor. The Flink processor delivers significantly higher snapshot throughput, lower end-to-end latency, horizontal scaling across TaskManager replicas and task slots, and Flink checkpointing on top of the same at-least-once delivery guarantees. The Flink processor is available as a Preview and is not yet supported for production use; we encourage you to try it on new, non-production pipelines and share feedback so we can prioritize improvements before general availability. Regular preview terms apply. To enable it, set `processors.type: flink` in your pipeline configuration. The Flink processor currently supports the `hash` and `json` target data types. See [Classic vs. Flink processor]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}}) for a full comparison and [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}) for the step-by-step migration guide.
+- **New Flink-based stream processor for Kubernetes (Preview)**: RDI 1.18.0 introduces a new stream processor implementation built on [Apache Flink](https://flink.apache.org/) alongside the existing classic processor. The Flink processor delivers significantly higher snapshot throughput, lower end-to-end latency, horizontal scaling across TaskManager replicas and task slots, and Flink checkpointing on top of the same at-least-once delivery guarantees. The Flink processor is available as a Preview and is not yet supported for production use; we encourage you to try it on new, non-production pipelines and share feedback so we can prioritize improvements before general availability. Regular preview terms apply. To enable it, set `processors.type: flink` in your pipeline configuration. The Flink processor is available for Kubernetes deployments only and currently supports the `hash` and `json` target data types. See [Classic vs. Flink processor]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}}) for a full comparison and [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}) for the step-by-step migration guide.
 
 ### Snowflake and Source Integration
 

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -6,7 +6,7 @@ categories:
 - operate
 - rs
 description: |
-  New Flink-based stream processor for Kubernetes deployments (Preview), with horizontal scaling, Flink checkpointing, and significantly higher throughput.
+  New Flink-based stream processor (Preview), with horizontal scaling, Flink checkpointing, and significantly higher throughput.
   Preview for Snowflake source support for Helm installations, including multi-schema capture and system truststore support.
   New API v2 endpoints for DLQ inspection, flushing the target database, and CDC-readiness validation.
   Better deployment reliability, new validation and resource controls, and security refreshes across core images.
@@ -23,7 +23,7 @@ weight: 971
 
 ### Flink Processor
 
-- **New Flink-based stream processor for Kubernetes (Preview)**: RDI 1.18.0 introduces a new stream processor implementation built on [Apache Flink](https://flink.apache.org/) alongside the existing classic processor. The Flink processor delivers significantly higher snapshot throughput, lower end-to-end latency, horizontal scaling across TaskManager replicas and task slots, and Flink checkpointing on top of the same at-least-once delivery guarantees. The Flink processor is available as a Preview and is not yet supported for production use; we encourage you to try it on new, non-production pipelines and share feedback so we can prioritize improvements before general availability. Regular preview terms apply. To enable it, set `processors.type: flink` in your pipeline configuration. The Flink processor is available for Kubernetes deployments only and currently supports the `hash` and `json` target data types. See [Classic vs. Flink processor]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}}) for a full comparison and [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}) for the step-by-step migration guide.
+- **New Flink-based stream processor (Preview)**: RDI 1.18.0 introduces a new stream processor implementation built on [Apache Flink](https://flink.apache.org/) alongside the existing classic processor. The Flink processor delivers significantly higher snapshot throughput, lower end-to-end latency, horizontal scaling across TaskManager replicas and task slots, and Flink checkpointing on top of the same at-least-once delivery guarantees. The Flink processor is available as a Preview and is not yet supported for production use; we encourage you to try it on new, non-production pipelines and share feedback so we can prioritize improvements before general availability. Regular preview terms apply. To enable it, set `processors.type: flink` in your pipeline configuration. The Flink processor currently supports the `hash` and `json` target data types. See [Classic vs. Flink processor]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}}) for a full comparison and [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}) for the step-by-step migration guide.
 
 ### Snowflake and Source Integration
 


### PR DESCRIPTION
See https://redislabs.atlassian.net/browse/RDSC-5692

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation changes with no runtime or config enforcement; risk is limited to readers acting on outdated guidance if anything was missed.
> 
> **Overview**
> Updates RDI public docs so the **Flink stream processor** is described as **generally available (RDI 1.19.0)** for **production on VMs and Kubernetes**, not Preview/Kubernetes-only.
> 
> **Positioning and guidance:** The FAQ now recommends Flink for new and migrated pipelines (classic remains default and supported), and embed/when-to-use notes drop Preview wording while still noting Flink roughly doubles throughput limits.
> 
> **Capability parity:** Docs remove prior limits that Flink only supported `hash`/`json` or ran only on K8s—the classic vs Flink page and transform examples (`set`, `sorted_set`, `stream`, `string`) no longer warn those outputs are classic-only; the comparison table drops deployment-target and supported-output rows in favor of shared transformation/data-type coverage.
> 
> **Installation and migration:** Adds **Configure the Flink processor** on **install-vm**; K8s install and migration pages clarify Helm tuning is K8s-only while per-pipeline `processors.type: flink` works on both; migration drops the output-type blocker and trims an advanced `target.wait` example.
> 
> **Reference and ops:** `config-yaml-reference` syncs processor type, source/table/RIOTX fields, Debezium `sources.advanced.source` knobs, metadata `revision`/`tags`, and replica-wait notes; **upgrade** documents enabling Flink post-1.19.0; **observability** fixes the VM classic processor metrics path to `https://<RDI_HOST>/processor/metrics`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15687fcbffce7e7eaa7b064e97a3730fccaef8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->