### PR TITLE
RDSC-5718 Update RDI Flink VM and WAIT documentation

### DIFF
--- a/content/integrate/redis-data-integration/architecture/classic-vs-flink.md
+++ b/content/integrate/redis-data-integration/architecture/classic-vs-flink.md
@@ -31,7 +31,7 @@ for a step-by-step migration guide.
 | Aspect | Classic processor | Flink processor |
 |---|---|---|
 | Implementation | Python | Java on top of [Apache Flink](https://flink.apache.org/) |
-| Deployment targets | VM and Kubernetes | Kubernetes only |
+| Deployment targets | VM and Kubernetes | VM and Kubernetes |
 | Scaling | Single replica | Horizontal: TaskManager replicas × task slots per TaskManager |
 | Fault tolerance | Source-stream consumer-group replay | Source-stream consumer-group replay plus Flink checkpointing |
 | Supported `data_type` outputs | `hash`, `json`, `set`, `sorted_set`, `stream`, `string` | `hash`, `json` |
@@ -47,24 +47,22 @@ The classic processor runs as a single pod managed by the operator
 and can be deployed on either VMs or Kubernetes through the RDI Helm
 chart.
 
-The Flink processor runs as an Apache Flink application cluster: one
-JobManager pod plus one or more TaskManager pods. Source,
+The Flink processor runs as an Apache Flink application cluster managed by
+RDI: one JobManager pod plus one or more TaskManager pods. Source,
 transformation, and sink operators run as parallel subtasks across
 all task slots in the cluster. The Flink processor scales
 horizontally by changing the number of TaskManager replicas
 (`advanced.resources.taskManager.replicas`); with adaptive
 parallelism, the default parallelism is the product of TaskManager
-replicas and task slots per TaskManager. The Flink processor
-currently runs on Kubernetes only; VM support is planned for a future
-release.
+replicas and task slots per TaskManager. This architecture is available for
+both VM and Kubernetes installations.
 
 Both processors retain at-least-once delivery semantics; the Flink
 processor adds Flink checkpointing on top of the shared
 consumer-group replay mechanism.
 
-See
-[Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}})
-for the Helm settings.
+For Helm-level resource settings, see
+[Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}}).
 
 ## Configuration
 

--- a/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
+++ b/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
@@ -277,8 +277,7 @@ configuration above contains the following properties:
   The options are `classic` (the default) for the Python-based classic processor
   and `flink` for the
   [Apache Flink](https://flink.apache.org/)-based processor.
-  The Flink processor runs on Kubernetes only and supports the `hash` and `json`
-  target data types. See
+  The Flink processor supports the `hash` and `json` target data types. See
   [Stream processor implementations]({{< relref "/integrate/redis-data-integration/architecture#stream-processor-implementations" >}})
   for an overview, and
   [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}})

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -145,10 +145,8 @@ apply:
 
 -   **Output `data_type` other than `hash` or `json`** (for example,
     `set`, `sorted_set`, `stream`, or `string`).
--   **VM installations.** The Flink processor currently runs on
-    Kubernetes only.
 
-Both limitations are expected to be lifted in a future release. See
+This limitation is expected to be lifted in a future release. See
 [Differences between the classic and Flink processors]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}})
 for a side-by-side comparison and
 [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}})

--- a/content/integrate/redis-data-integration/installation/migration-classic-to-flink.md
+++ b/content/integrate/redis-data-integration/installation/migration-classic-to-flink.md
@@ -19,16 +19,13 @@ weight: 35
 RDI ships with two stream processor implementations. The default *classic*
 processor is implemented in Python and runs on both VMs and Kubernetes. The
 *Flink* processor is built on top of [Apache Flink](https://flink.apache.org/)
-and currently runs on Kubernetes only. It can achieve much higher throughput
+and runs on both VMs and Kubernetes. It can achieve much higher throughput
 during snapshots, scales horizontally by changing the number of TaskManager replicas,
 and uses Flink checkpointing for fault tolerance. See [Stream processor implementations]({{< relref "/integrate/redis-data-integration/architecture#stream-processor-implementations" >}})
 for an overview.
 
 This page describes how to migrate an existing pipeline from the classic
 processor to the Flink processor.
-
-{{< note >}}The Flink processor is currently supported on Kubernetes only. VM
-installations must continue to use the classic processor.{{< /note >}}
 
 ## Before you migrate
 
@@ -42,12 +39,12 @@ Confirm that your pipeline is compatible with the Flink processor:
     [`use_native_json_merge`]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#processors" >}})).
     The Flink processor always uses the native `JSON.MERGE` command when the
     target database supports it.
--   Ensure your Kubernetes cluster has enough capacity for the Flink JobManager
-    and TaskManager pods (see
+-   Ensure your RDI host or Kubernetes cluster has enough capacity for the
+    Flink JobManager and TaskManager workloads. For Helm installations, see
     [Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}})
     for the default sizing).
 
-## Step 1: Configure the Flink processor at the Helm chart level
+## Step 1: Configure the Flink processor at the Helm chart level (Helm installations only)
 
 The Flink processor is always available — no opt-in is required at the Helm
 chart level. The defaults are sized for typical workloads, so you can skip
@@ -57,6 +54,9 @@ your `rdi-values.yaml` file and run `helm upgrade` as described in
 [Configure the Flink processor]({{< relref "/integrate/redis-data-integration/installation/install-k8s#configure-the-flink-processor" >}}).
 Existing pipelines continue to run on the classic processor until you switch
 them in step 2.
+
+For VM installations, skip this step. You can configure per-pipeline Flink
+resources in step 4.
 
 ## Step 2: Switch the pipeline to the Flink processor
 
@@ -107,10 +107,6 @@ processors:
     source:
       # Time between checks for new input streams.
       discovery.interval.ms: 1000
-    target:
-      # Verify writes are replicated before acknowledging.
-      wait.enabled: true
-      wait.write.timeout.ms: 1000
     flink:
       # Number of parallel task slots per TaskManager pod.
       taskmanager.numberOfTaskSlots: 2
@@ -125,6 +121,44 @@ processors:
 See the
 [`processors.advanced` reference]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference#processors" >}})
 for the full set of available properties.
+
+### Optional replica acknowledgement
+
+Enable `processors.advanced.target.wait.enabled` only when replication is
+enabled for the target Redis database and at least one replica is available
+and healthy:
+
+```yaml
+processors:
+  type: flink
+  advanced:
+    target:
+      wait.enabled: true
+      wait.write.timeout.ms: 1000
+```
+
+{{< warning >}}
+If target database replication is disabled, don't enable `wait.enabled` with
+the default `wait.retry.enabled: true`.
+The writes can reach the target, but Redis returns `WAIT failed: 0/1 replicas`
+because no replica can acknowledge them. The Flink processor retries
+indefinitely. Records
+remain pending instead of being rejected because this is a batch durability
+failure, not a record-level error. The target can appear as disconnected,
+checkpoints fail, the job can alternate between retrying and restarting, the
+initial snapshot does not complete, and later records accumulate behind the
+blocked sink batches.
+
+To recover, enable target database replication or remove `wait.enabled` (or
+set it to `false`) and redeploy the pipeline. You don't need to reset the
+pipeline. RDI replays and acknowledges the pending records after a successful
+checkpoint. Some target writes can be repeated during recovery, consistent
+with RDI's at-least-once delivery guarantee.
+
+Setting `wait.retry.enabled: false` lets processing continue after a failed
+replica acknowledgement, so it does not provide the durability guarantee that
+`wait.enabled` is intended to enforce.
+{{< /warning >}}
 
 ## Step 5: Update observability
 

--- a/content/integrate/redis-data-integration/observability.md
+++ b/content/integrate/redis-data-integration/observability.md
@@ -50,7 +50,7 @@ The way you access the metrics endpoints depends on whether you are using a VM i
 
 For VM installations, the metrics are available by default on the following endpoints:
 - Collector metrics: `https://<RDI_HOST>/collector-source/metrics`
-- Stream processor metrics: `https://<RDI_HOST>/metrics`
+- Stream processor metrics: `https://<RDI_HOST>/processor/metrics`
 - Operator metrics: `https://<RDI_HOST>/operator/metrics`
 
 Please note that for RDI versions prior to 1.16.0 the collector metrics are not accessible.

--- a/content/integrate/redis-data-integration/reference/config-yaml-reference.md
+++ b/content/integrate/redis-data-integration/reference/config-yaml-reference.md
@@ -622,7 +622,7 @@ Settings that control how data is processed, including batch sizes, error handli
 
 |Name|Type|Description|Required|
 |----|----|-----------|--------|
-|**type**<br/>(Processor type)|`string`|Processor implementation to run. `classic` runs the classic processor; `flink` runs the Apache Flink-based processor (Kubernetes deployments only).<br/>Default: `"classic"`<br/>Enum: `"classic"`, `"flink"`<br/>||
+|**type**<br/>(Processor type)|`string`|Processor implementation to run. `classic` runs the classic processor; `flink` runs the Apache Flink-based processor.<br/>Default: `"classic"`<br/>Enum: `"classic"`, `"flink"`<br/>||
 |**read\_batch\_size**|`integer`, `string`|Maximum number of records read from the source streams in a single batch.<br/>Default: `2000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
 |**read\_batch\_timeout\_ms**<br/>(Read batch timeout)|`integer`|Maximum time in milliseconds to wait for a batch to fill before processing it.<br/>Default: `100`<br/>Minimum: `1`<br/>||
 |**duration**<br/>(Batch duration limit)|`integer`, `string`|(DEPRECATED)<br/>This property has no effect; use `read_batch_timeout_ms` instead.<br/>Default: `100`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
@@ -645,7 +645,7 @@ Settings that control how data is processed, including batch sizes, error handli
 |**retry\_max\_attempts**<br/>(Maximum retry attempts)|`integer`, `string`|Maximum number of attempts for a failed write to the target Redis database before giving up.<br/>Default: `5`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
 |**retry\_initial\_delay\_ms**<br/>(Initial retry delay)|`integer`, `string`|Initial delay in milliseconds before the first retry of a failed write.<br/>Default: `1000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>Maximum: `999999`<br/>||
 |**retry\_max\_delay\_ms**<br/>(Maximum retry delay)|`integer`, `string`|Maximum delay in milliseconds between retry attempts.<br/>Default: `10000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>Maximum: `999999`<br/>||
-|**wait\_enabled**<br/>(Enable replica wait)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it.<br/>Default: `false`<br/>||
+|**wait\_enabled**<br/>(Enable replica wait)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it. Enable this only when target database replication is enabled and a healthy replica is available. For the Flink processor, `processors.advanced.target.wait.enabled` takes priority.<br/>Default: `false`<br/>||
 |**wait\_timeout**<br/>(Replica wait timeout)|`integer`, `string`|Maximum time in milliseconds to wait for replica write verification on the target database.<br/>Default: `1000`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
 |**retry\_on\_replica\_failure**|`boolean`|When `true`, RDI keeps retrying a write until replica replication is confirmed; when `false`, it gives up after the first failure.<br/>Default: `true`<br/>||
 |**on\_failed\_retry\_interval**<br/>(Retry interval on failure)|`integer`, `string`|(DEPRECATED)<br/>This property has no effect; remove it from the configuration.<br/>Default: `5`<br/>Pattern: `^\${.*}$`<br/>Minimum: `1`<br/>||
@@ -807,10 +807,29 @@ Advanced configuration properties for the target Redis client and sink. **Flink 
 |**retry\.initial\.delay\.ms**<br/>(Target retry initial delay)|`integer`|Initial delay in milliseconds before the first retry of a failed target Redis operation. Alias for `processors.retry_initial_delay_ms`; takes priority when both are set.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
 |**retry\.max\.delay\.ms**<br/>(Target retry max delay)|`integer`|Maximum delay in milliseconds between retry attempts for target Redis operations. Alias for `processors.retry_max_delay_ms`; takes priority when both are set.<br/>Default: `10000`<br/>Minimum: `1`<br/>||
 |**retry\.backoff\.multiplier**<br/>(Target retry backoff multiplier)|`number`|Exponential backoff multiplier between retry attempts for target Redis operations.<br/>Default: `2`<br/>Minimum: `1`<br/>||
-|**wait\.enabled**<br/>(Target replica wait enabled)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it. Alias for `processors.wait_enabled`; takes priority when both are set.<br/>Default: `false`<br/>||
+|**wait\.enabled**<br/>(Target replica wait enabled)|`boolean`|When `true`, RDI verifies that each write has been replicated to the target database's replica shards before acknowledging it. Enable this only when target database replication is enabled and a healthy replica is available. Alias for `processors.wait_enabled`; takes priority when both are set.<br/>Default: `false`<br/>||
 |**wait\.write\.timeout\.ms**<br/>(Target replica wait timeout)|`integer`|Maximum time in milliseconds to wait for target replica write verification. Alias for `processors.wait_timeout`; takes priority when both are set.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
-|**wait\.retry\.enabled**<br/>(Target replica wait retry enabled)|`boolean`|When `true`, RDI keeps retrying a target write until replica replication is confirmed; when `false`, it gives up after the first failure. Alias for `processors.retry_on_replica_failure`; takes priority when both are set. When enabled, the Flink processor retries indefinitely until the checkpoint timeout, unlike the classic processor which retries once.<br/>Default: `true`<br/>||
+|**wait\.retry\.enabled**<br/>(Target replica wait retry enabled)|`boolean`|When `true`, RDI keeps retrying a target write until replica replication is confirmed; when `false`, it gives up after the first failure. Alias for `processors.retry_on_replica_failure`; takes priority when both are set. When enabled, the Flink processor retries indefinitely. Failed checkpoints can restart the job, after which the retries resume. The classic processor retries once.<br/>Default: `true`<br/>||
 |**wait\.retry\.delay\.ms**<br/>(Target replica wait retry delay)|`integer`|Delay in milliseconds between target replica wait retry attempts.<br/>Default: `1000`<br/>Minimum: `1`<br/>||
+
+{{< warning >}}
+If target database replication is disabled, `wait.enabled: true` with the
+default `wait.retry.enabled: true` prevents the processor from making progress.
+Target writes can succeed, but replica verification returns
+`WAIT failed: 0/1 replicas`. Flink retries indefinitely. Records remain pending
+rather than rejected, the target can appear as disconnected, checkpoints fail,
+the job can retry or restart, and the initial snapshot does not complete. Later
+records accumulate behind the blocked sink batches.
+
+To recover, enable target database replication or remove `wait.enabled` (or set
+it to `false`) and redeploy. A reset is not required. RDI replays the pending
+records and clears them after a successful checkpoint. Target writes can be
+repeated during recovery because RDI provides at-least-once delivery.
+
+Setting `wait.retry.enabled: false` lets processing continue after a failed
+replica acknowledgement, so it does not provide the durability guarantee that
+`wait.enabled` is intended to enforce.
+{{< /warning >}}
 
 **Additional Properties**
 

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-18-0.md
@@ -6,7 +6,7 @@ categories:
 - operate
 - rs
 description: |
-  New Flink-based stream processor for Kubernetes deployments (Preview), with horizontal scaling, Flink checkpointing, and significantly higher throughput.
+  New Flink-based stream processor (Preview), with horizontal scaling, Flink checkpointing, and significantly higher throughput.
   Preview for Snowflake source support for Helm installations, including multi-schema capture and system truststore support.
   New API v2 endpoints for DLQ inspection, flushing the target database, and CDC-readiness validation.
   Better deployment reliability, new validation and resource controls, and security refreshes across core images.
@@ -23,7 +23,7 @@ weight: 971
 
 ### Flink Processor
 
-- **New Flink-based stream processor for Kubernetes (Preview)**: RDI 1.18.0 introduces a new stream processor implementation built on [Apache Flink](https://flink.apache.org/) alongside the existing classic processor. The Flink processor delivers significantly higher snapshot throughput, lower end-to-end latency, horizontal scaling across TaskManager replicas and task slots, and Flink checkpointing on top of the same at-least-once delivery guarantees. The Flink processor is available as a Preview and is not yet supported for production use; we encourage you to try it on new, non-production pipelines and share feedback so we can prioritize improvements before general availability. Regular preview terms apply. To enable it, set `processors.type: flink` in your pipeline configuration. The Flink processor is available for Kubernetes deployments only and currently supports the `hash` and `json` target data types. See [Classic vs. Flink processor]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}}) for a full comparison and [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}) for the step-by-step migration guide.
+- **New Flink-based stream processor (Preview)**: RDI 1.18.0 introduces a new stream processor implementation built on [Apache Flink](https://flink.apache.org/) alongside the existing classic processor. The Flink processor delivers significantly higher snapshot throughput, lower end-to-end latency, horizontal scaling across TaskManager replicas and task slots, and Flink checkpointing on top of the same at-least-once delivery guarantees. The Flink processor is available as a Preview and is not yet supported for production use; we encourage you to try it on new, non-production pipelines and share feedback so we can prioritize improvements before general availability. Regular preview terms apply. To enable it, set `processors.type: flink` in your pipeline configuration. The Flink processor currently supports the `hash` and `json` target data types. See [Classic vs. Flink processor]({{< relref "/integrate/redis-data-integration/architecture/classic-vs-flink" >}}) for a full comparison and [Migrate from the classic processor to the Flink processor]({{< relref "/integrate/redis-data-integration/installation/migration-classic-to-flink" >}}) for the step-by-step migration guide.
 
 ### Snowflake and Source Integration
 


### PR DESCRIPTION
## What changed

- Remove stale statements that restrict the Flink processor to Kubernetes, including the migration guide, processor comparison, FAQ, pipeline configuration reference, and 1.18 release notes.
- Clarify that Helm-level Flink resource configuration applies only to Helm installations and that VM users can configure per-pipeline Flink resources.
- Correct the VM stream processor metrics endpoint from `/metrics` to `/processor/metrics`.
- Remove `wait.enabled: true` from the general Flink tuning example.
- Document the replication prerequisite, observable failure behavior, and non-destructive recovery path for `wait.enabled`.

## Why

Manual smoke testing for the RDI 1.19.0 release showed that VM installations support Flink, the installed VM ingress exposes processor metrics at `/processor/metrics`, and enabling replica acknowledgement against a target without replication prevents Flink from making progress.

With `wait.enabled: true` and the default retry behavior, writes can reach the target while records remain pending, rejected remains zero, target connectivity can appear false, checkpoints fail, the job retries or restarts, and the initial snapshot does not complete. Removing the setting and redeploying allows the existing backlog to recover without a reset.

Jira: [RDSC-5718](https://redislabs.atlassian.net/browse/RDSC-5718)

## Validation

- `git diff --check`
- Scanned all current RDI docs and release notes for remaining Kubernetes-only Flink statements.
- Verified the corrected VM metrics endpoint is consistently documented.
- Full Hugo build attempted after installing Node/Python dependencies and generating components. It remains blocked by an unrelated existing command-navigation error: `docs-nav-int.html ... can't evaluate field ByWeight in type []interface {}`.


[RDSC-5718]: https://redislabs.atlassian.net/browse/RDSC-5718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ