### PR TITLE
DEV: (cmds) update SLOWLOG GET command page

### DIFF
--- a/content/commands/slowlog-get.md
+++ b/content/commands/slowlog-get.md
@@ -60,7 +60,7 @@ Each entry from the slow log is comprised of the following seven values:
 4. The array composing the arguments of the command.
 5. Client IP address and port.
 6. Client name if set via the [`CLIENT SETNAME`]({{< relref "/commands/client-setname" >}}) command.
-7. The total number of arguments in the command, including the command name.
+7. The total number of arguments in the command, including the command name. Added in Redis 8.10.
 
 The logged argument array (value 4) is truncated when the command has more arguments than the `slowlog-max-argc` configuration directive allows (32 by default). In that case, the last logged element is replaced with a string of the form `... (N more arguments)`. The total argument count (value 7) always reflects the command's original argument count, captured before truncation, so it can be read directly without parsing that string.
 

--- a/content/commands/slowlog-get.md
+++ b/content/commands/slowlog-get.md
@@ -33,6 +33,8 @@ hints:
 history:
 - - 4.0.0
   - Added client IP address, port and name to the reply.
+- - 8.10.0
+  - Added original command argument count to the reply.
 linkTitle: SLOWLOG GET
 railroad_diagram: /images/railroad/slowlog-get.svg
 since: 2.2.12
@@ -50,7 +52,7 @@ The maximum number of entries in the slow log is governed by the `slowlog-max-le
 
 By default the command returns latest ten entries in the log. The optional `count` argument limits the number of returned entries, so the command returns at most up to `count` entries, the special number -1 means return all entries.
 
-Each entry from the slow log is comprised of the following six values:
+Each entry from the slow log is comprised of the following seven values:
 
 1. A unique progressive identifier for every slow log entry.
 2. The unix timestamp at which the logged command was processed.
@@ -58,6 +60,9 @@ Each entry from the slow log is comprised of the following six values:
 4. The array composing the arguments of the command.
 5. Client IP address and port.
 6. Client name if set via the [`CLIENT SETNAME`]({{< relref "/commands/client-setname" >}}) command.
+7. The total number of arguments in the command, including the command name.
+
+The logged argument array (value 4) is truncated when the command has more arguments than the `slowlog-max-argc` configuration directive allows (32 by default). In that case, the last logged element is replaced with a string of the form `... (N more arguments)`. The total argument count (value 7) always reflects the command's original argument count, captured before truncation, so it can be read directly without parsing that string.
 
 The entry's unique ID can be used in order to avoid processing slow log entries multiple times (for instance you may have a script sending you an email alert for every new slow log entry).
 The ID is never reset in the course of the Redis server execution, only a server
@@ -70,6 +75,34 @@ restart will reset it.
 The number of recent slow-log entries to return. `-1` returns all entries; the default is 10.
 
 </details>
+
+## Examples
+
+The seventh element of each entry reports the command's total argument count. This is most useful for variadic commands whose logged argument list has been truncated. In the following example, the `slowlog-max-argc` limit is left at its default of 32 and a `SADD` command is issued with 33 arguments (the command name, the key, and 31 members):
+
+```
+redis> CONFIG SET slowlog-log-slower-than 0
+OK
+redis> SLOWLOG RESET
+OK
+redis> SADD myset 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33
+(integer) 31
+redis> SLOWLOG GET 1
+1) 1) (integer) 12
+   2) (integer) 1752422400
+   3) (integer) 21
+   4)  1) "SADD"
+       2) "myset"
+       3) "3"
+       4) "4"
+          ...
+      32) "... (2 more arguments)"
+   5) "127.0.0.1:52276"
+   6) ""
+   7) (integer) 33
+```
+
+The logged argument array (element 4) is truncated to 32 items, with the final item indicating how many more arguments were omitted. The argument count (element 7) still reports the original total of `33`.
 
 ## Redis Software and Redis Cloud compatibility
 


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a command reference page; no runtime or API implementation in this PR.
> 
> **Overview**
> Updates the **SLOWLOG GET** command reference for **Redis 8.10**, which adds a seventh reply field: the command’s **original argument count** (including the command name), recorded before slow-log argument truncation.
> 
> The page now lists **seven** values per entry (was six), adds an **8.10.0** history note, and explains how field 7 relates to **`slowlog-max-argc`** truncation and the `... (N more arguments)` placeholder in the logged argv array. A new **Examples** section walks through a truncated **`SADD`** with 33 arguments and shows element 7 reporting `33` while element 4 is capped at 32 items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc12fa8e9b023bd51e9fad68b20836cd8cfd185d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->