### PR TITLE
DEV: (cmds) add TS.QUERYLABELS command page

### DIFF
--- a/content/commands/ts.mget.md
+++ b/content/commands/ts.mget.md
@@ -89,20 +89,9 @@ Otherwise, it will reply with "*(error): current user doesn't have read permissi
 <details open>
 <summary><code>FILTER filterExpr...</code></summary>
 
-filters time series based on their labels and label values. Each filter expression has one of the following syntaxes:
+filters time series based on their labels and label values.
 
-  - `label!=` - the time series has a label named `label`
-  - `label=value` - the time series has a label named `label` with a value equal to `value`
-  - `label=(value1,value2,...)` - the time series has a label named `label` with a value equal to one of the values in the list
-  - `label=` - the time series does not have a label named `label`
-  - `label!=value` - the time series does not have a label named `label` with a value equal to `value`
-  - `label!=(value1,value2,...)` - the time series does not have a label named `label` with a value equal to any of the values in the list
-
-  <note><b>Notes:</b>
-   - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
-   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that a time series is a temperature time series of a study room.
-   - Whitespaces are unallowed in a filter expression except between quotes or double quotes in values - e.g., `x="y y"` or `x='(y y,z z)'`.
-   </note>
+{{< embed-md "ts-filter-expr.md" >}}
 </details>
 
 ## Optional arguments

--- a/content/commands/ts.mrange.md
+++ b/content/commands/ts.mrange.md
@@ -171,20 +171,9 @@ is the end timestamp for the range query (integer Unix timestamp in milliseconds
 <details open>
 <summary><code>FILTER filterExpr...</code></summary>
 
-filters time series based on their labels and label values. Each filter expression has one of the following syntaxes:
+filters time series based on their labels and label values.
 
-  - `label!=` - the time series has a label named `label`
-  - `label=value` - the time series has a label named `label` with a value equal to `value`
-  - `label=(value1,value2,...)` - the time series has a label named `label` with a value equal to one of the values in the list
-  - `label=` - the time series does not have a label named `label`
-  - `label!=value` - the time series does not have a label named `label` with a value equal to `value`
-  - `label!=(value1,value2,...)` - the time series does not have a label named `label` with a value equal to any of the values in the list
-
-  <note><b>Notes:</b>
-   - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
-   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that a time series is a temperature time series of a study room.
-   - Whitespaces are unallowed in a filter expression except between quotes or double quotes in values - e.g., `x="y y"` or `x='(y y,z z)'`.
-   </note>
+{{< embed-md "ts-filter-expr.md" >}}
 </details>
 
 ## Optional arguments

--- a/content/commands/ts.mrevrange.md
+++ b/content/commands/ts.mrevrange.md
@@ -171,20 +171,9 @@ is the end timestamp for the range query (integer Unix timestamp in milliseconds
 <details open>
 <summary><code>FILTER filterExpr...</code></summary> 
 
-filters time series based on their labels and label values. Each filter expression has one of the following syntaxes:
+filters time series based on their labels and label values.
 
-  - `label!=` - the time series has a label named `label`
-  - `label=value` - the time series has a label named `label` with a value equal to `value`
-  - `label=(value1,value2,...)` - the time series has a label named `label` with a value equal to one of the values in the list
-  - `label=` - the time series does not have a label named `label`
-  - `label!=value` - the time series does not have a label named `label` with a value equal to `value`
-  - `label!=(value1,value2,...)` - the time series does not have a label named `label` with a value equal to any of the values in the list
-
-  <note><b>Notes:</b>
-   - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
-   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that a time series is a temperature time series of a study room.
-   - Whitespaces are unallowed in a filter expression except between quotes or double quotes in values - e.g., `x="y y"` or `x='(y y,z z)'`.
-   </note>
+{{< embed-md "ts-filter-expr.md" >}}
 </details>
 
 ## Optional arguments

--- a/content/commands/ts.queryindex.md
+++ b/content/commands/ts.queryindex.md
@@ -60,20 +60,9 @@ Get all time series keys matching a filter list. Note: all matching keys will be
 <details open>
 <summary><code>filterExpr...</code></summary>
 
-filters time series based on their labels and label values. Each filter expression has one of the following syntaxes:
+filters time series based on their labels and label values.
 
-  - `label!=` - the time series has a label named `label`
-  - `label=value` - the time series has a label named `label` with a value equal to `value`
-  - `label=(value1,value2,...)` - the time series has a label named `label` with a value equal to one of the values in the list
-  - `label=` - the time series does not have a label named `label`
-  - `label!=value` - the time series does not have a label named `label` with a value equal to `value`
-  - `label!=(value1,value2,...)` - the time series does not have a label named `label` with a value equal to any of the values in the list
-
-  <note><b>Notes:</b>
-   - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
-   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that a time series is a temperature time series of a study room.
-   - Whitespaces are unallowed in a filter expression except between quotes or double quotes in values - e.g., `x="y y"` or `x='(y y,z z)'`.
-   </note>
+{{< embed-md "ts-filter-expr.md" >}}
 </details>
 
 <note><b>Note:</b> The `QUERYINDEX` command cannot be part of a transaction when running on a Redis cluster.</note>

--- a/content/commands/ts.querylabels.md
+++ b/content/commands/ts.querylabels.md
@@ -50,7 +50,7 @@ complexity: O(n) where n is the number of time-series that match the filters (al
   indexed series when FILTER is omitted)
 description: Get all label names, or all values of a given label, for time series
   matching a filter list, or all series
-group: module
+group: timeseries
 hidden: false
 hints:
 - dont_cache
@@ -103,8 +103,8 @@ Each filter expression has one of the following syntaxes:
 
   <note><b>Notes:</b>
    - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
-   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that a time series is a temperature time series of a study room.
-   - Whitespaces are unallowed in a filter expression except between quotes or double quotes in values - e.g., `x="y y"` or `x='(y y,z z)'`.
+   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that `type=temperature` AND `room=study`.
+   - Whitespace is not allowed in a filter expression except between quotes or double quotes in values - for example, `x="y y"` or `x='(y y,z z)'`.
    </note>
 </details>
 

--- a/content/commands/ts.querylabels.md
+++ b/content/commands/ts.querylabels.md
@@ -92,20 +92,7 @@ Each name or value appears at most once, regardless of how many series it belong
 
 restricts the command to the time series whose labels and label values match all of the filter expressions. When `FILTER` is omitted, the command considers all indexed time series.
 
-Each filter expression has one of the following syntaxes:
-
-  - `label!=` - the time series has a label named `label`
-  - `label=value` - the time series has a label named `label` with a value equal to `value`
-  - `label=(value1,value2,...)` - the time series has a label named `label` with a value equal to one of the values in the list
-  - `label=` - the time series does not have a label named `label`
-  - `label!=value` - the time series does not have a label named `label` with a value equal to `value`
-  - `label!=(value1,value2,...)` - the time series does not have a label named `label` with a value equal to any of the values in the list
-
-  <note><b>Notes:</b>
-   - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
-   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that `type=temperature` AND `room=study`.
-   - Whitespace is not allowed in a filter expression except between quotes or double quotes in values - for example, `x="y y"` or `x='(y y,z z)'`.
-   </note>
+{{< embed-md "ts-filter-expr.md" >}}
 </details>
 
 ## Examples

--- a/content/commands/ts.querylabels.md
+++ b/content/commands/ts.querylabels.md
@@ -1,0 +1,182 @@
+---
+acl_categories:
+- '@read'
+- '@timeseries'
+arguments:
+- arguments:
+  - display_text: LABELS
+    name: LABELS
+    token: LABELS
+    type: pure-token
+  - arguments:
+    - display_text: VALUES
+      name: VALUES
+      token: VALUES
+      type: pure-token
+    - display_text: label
+      name: label
+      type: string
+    name: VALUES
+    type: block
+  name: subtype
+  type: oneof
+- arguments:
+  - display_text: FILTER
+    name: FILTER
+    token: FILTER
+    type: pure-token
+  - display_text: filterExpr
+    multiple: true
+    name: filterExpr
+    type: string
+  name: FILTER
+  optional: true
+  type: block
+arity: -2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- readonly
+- module
+complexity: O(n) where n is the number of time-series that match the filters (all
+  indexed series when FILTER is omitted)
+description: Get all label names, or all values of a given label, for time series
+  matching a filter list, or all series
+group: module
+hidden: false
+hints:
+- dont_cache
+linkTitle: TS.QUERYLABELS
+module: timeseries
+railroad_diagram: /images/railroad/ts.querylabels.svg
+since: 8.10.0
+summary: Get all label names, or all values of a given label, for time series matching
+  a filter list, or all series
+syntax_fmt: "TS.QUERYLABELS <LABELS | VALUES label> [FILTER filterExpr\n  [filterExpr\
+  \ ...]]"
+title: TS.QUERYLABELS
+---
+{{< note >}}
+This command's behavior varies in clustered Redis environments. See the [multi-key operations]({{< relref "/develop/using-commands/multi-key-operations" >}}) page for more information.
+{{< /note >}}
+
+Get all label names, or all values of a given label, for the time series matching a filter list (or all series when no filter is given).
+
+[Examples](#examples)
+
+## Required arguments
+
+<details open>
+<summary><code>LABELS | VALUES label</code></summary>
+
+selects what the command returns:
+
+  - `LABELS` - returns the set of distinct label names used by the matching time series.
+  - `VALUES label` - returns the set of distinct values of `label` used by the matching time series. The result is empty (not an error) when `label` does not exist or when no matching series carries it.
+
+Each name or value appears at most once, regardless of how many series it belongs to. The order of the results is not defined.
+</details>
+
+## Optional arguments
+
+<details open>
+<summary><code>FILTER filterExpr [filterExpr ...]</code></summary>
+
+restricts the command to the time series whose labels and label values match all of the filter expressions. When `FILTER` is omitted, the command considers all indexed time series.
+
+Each filter expression has one of the following syntaxes:
+
+  - `label!=` - the time series has a label named `label`
+  - `label=value` - the time series has a label named `label` with a value equal to `value`
+  - `label=(value1,value2,...)` - the time series has a label named `label` with a value equal to one of the values in the list
+  - `label=` - the time series does not have a label named `label`
+  - `label!=value` - the time series does not have a label named `label` with a value equal to `value`
+  - `label!=(value1,value2,...)` - the time series does not have a label named `label` with a value equal to any of the values in the list
+
+  <note><b>Notes:</b>
+   - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
+   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that a time series is a temperature time series of a study room.
+   - Whitespaces are unallowed in a filter expression except between quotes or double quotes in values - e.g., `x="y y"` or `x='(y y,z z)'`.
+   </note>
+</details>
+
+## Examples
+
+<details open>
+<summary><b>List labels and label values for a set of sensors</b></summary>
+
+Create a set of sensors to measure temperature and humidity in your study and kitchen.
+
+{{< highlight bash >}}
+redis> TS.CREATE telemetry:study:temperature LABELS room study type temperature
+OK
+redis> TS.CREATE telemetry:study:humidity LABELS room study type humidity
+OK
+redis> TS.CREATE telemetry:kitchen:temperature LABELS room kitchen type temperature
+OK
+redis> TS.CREATE telemetry:kitchen:humidity LABELS room kitchen type humidity
+OK
+{{< / highlight >}}
+
+Retrieve the label names used by the time series located in the kitchen.
+
+{{< highlight bash >}}
+redis> TS.QUERYLABELS LABELS FILTER room=kitchen
+1) "room"
+2) "type"
+{{< / highlight >}}
+
+Retrieve the distinct values of the `type` label across all time series.
+
+{{< highlight bash >}}
+redis> TS.QUERYLABELS VALUES type
+1) "humidity"
+2) "temperature"
+{{< / highlight >}}
+</details>
+
+## Details
+
+### Access control
+
+Unlike [`TS.QUERYINDEX`]({{< relref "commands/ts.queryindex/" >}}), which lists every matching key whether or not the user has read access to it, `TS.QUERYLABELS` silently omits the time series that the user is not allowed to read. Label names and values that belong only to unreadable series do not appear in the result.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="ts-querylabels-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+One of the following:
+* [Array reply]({{< relref "/develop/reference/protocol-spec#arrays" >}}) where each element is a [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): a label name (with `LABELS`) or a label value (with `VALUES`). The array is empty if no time series matches the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid subtype, missing label after `VALUES`, or invalid filter expression.
+
+-tab-sep-
+
+One of the following:
+* [Set reply]({{< relref "/develop/reference/protocol-spec#sets" >}}) where each element is a [Bulk string reply]({{< relref "/develop/reference/protocol-spec#bulk-strings" >}}): a label name (with `LABELS`) or a label value (with `VALUES`). The set is empty if no time series matches the filter.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: invalid subtype, missing label after `VALUES`, or invalid filter expression.
+
+{{< /multitabs >}}
+
+## See also
+
+[`TS.QUERYINDEX`]({{< relref "commands/ts.queryindex/" >}}) | [`TS.CREATE`]({{< relref "commands/ts.create/" >}}) | [`TS.MGET`]({{< relref "commands/ts.mget/" >}}) | [`TS.MRANGE`]({{< relref "commands/ts.mrange/" >}})
+
+## Related topics
+
+[RedisTimeSeries]({{< relref "/develop/data-types/timeseries/" >}})

--- a/content/embeds/ts-filter-expr.md
+++ b/content/embeds/ts-filter-expr.md
@@ -1,0 +1,14 @@
+Each filter expression has one of the following syntaxes:
+
+  - `label!=` - the time series has a label named `label`
+  - `label=value` - the time series has a label named `label` with a value equal to `value`
+  - `label=(value1,value2,...)` - the time series has a label named `label` with a value equal to one of the values in the list
+  - `label=` - the time series does not have a label named `label`
+  - `label!=value` - the time series does not have a label named `label` with a value equal to `value`
+  - `label!=(value1,value2,...)` - the time series does not have a label named `label` with a value equal to any of the values in the list
+
+  <note><b>Notes:</b>
+   - At least one filter expression with a syntax `label=value` or `label=(value1,value2,...)` is required.
+   - Filter expressions are conjunctive. For example, the filter `type=temperature room=study` means that `type=temperature` AND `room=study`.
+   - Whitespace is not allowed in a filter expression except between quotes or double quotes in values - for example, `x="y y"` or `x='(y y,z z)'`.
+   </note>

--- a/static/images/railroad/ts.querylabels.svg
+++ b/static/images/railroad/ts.querylabels.svg
@@ -1,0 +1,60 @@
+<svg class="railroad-diagram" height="101" viewBox="0 0 698.5 101" width="698.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M648.5 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M189.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="139.0" x="50.0" y="29"></rect><text x="119.5" y="44">TS.QUERYLABELS</text></g><path d="M189.0 40h10"></path><g>
+<path d="M199.0 40h0.0"></path><path d="M392.5 40h0.0"></path><path d="M199.0 40h20"></path><g class="terminal ">
+<path d="M219.0 40h41.25"></path><path d="M331.25 40h41.25"></path><rect height="22" rx="10" ry="10" width="71.0" x="260.25" y="29"></rect><text x="295.75" y="44">LABELS</text></g><path d="M372.5 40h20"></path><path d="M199.0 40a10 10 0 0 1 10 10v10a10 10 0 0 0 10 10"></path><g>
+<path d="M219.0 70h0.0"></path><path d="M372.5 70h0.0"></path><g class="terminal ">
+<path d="M219.0 70h0.0"></path><path d="M290.0 70h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="219.0" y="59"></rect><text x="254.5" y="74">VALUES</text></g><path d="M290.0 70h10"></path><path d="M300.0 70h10"></path><g class="non-terminal ">
+<path d="M310.0 70h0.0"></path><path d="M372.5 70h0.0"></path><rect height="22" width="62.5" x="310.0" y="59"></rect><text x="341.25" y="74">label</text></g></g><path d="M372.5 70a10 10 0 0 0 10 -10v-10a10 10 0 0 1 10 -10"></path></g><g>
+<path d="M392.5 40h0.0"></path><path d="M648.5 40h0.0"></path><path d="M392.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M412.5 20h216.0"></path></g><path d="M628.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M392.5 40h20"></path><g>
+<path d="M412.5 40h0.0"></path><path d="M628.5 40h0.0"></path><g class="terminal ">
+<path d="M412.5 40h0.0"></path><path d="M483.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="412.5" y="29"></rect><text x="448.0" y="44">FILTER</text></g><path d="M483.5 40h10"></path><path d="M493.5 40h10"></path><g>
+<path d="M503.5 40h0.0"></path><path d="M628.5 40h0.0"></path><path d="M503.5 40h10"></path><g class="non-terminal ">
+<path d="M513.5 40h0.0"></path><path d="M618.5 40h0.0"></path><rect height="22" width="105.0" x="513.5" y="29"></rect><text x="566.0" y="44">filterExpr</text></g><path d="M618.5 40h10"></path><path d="M513.5 40a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M513.5 60h105.0"></path></g><path d="M618.5 60a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M628.5 40h20"></path></g></g><path d="M648.5 40h10"></path><path d="M 658.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior in this repo; low review risk aside from verifying accuracy against the 8.10 command spec.
> 
> **Overview**
> Documents **TS.QUERYLABELS** (Redis 8.10): optional `FILTER` on indexed series, `LABELS` for distinct label names or `VALUES label` for distinct values, with examples, RESP2/RESP3 return shapes, and a note that unreadable series are omitted (unlike `TS.QUERYINDEX`). Includes a railroad diagram SVG.
> 
> **Deduplication:** Time-series `FILTER` syntax and notes move into `content/embeds/ts-filter-expr.md`; **TS.MGET**, **TS.MRANGE**, **TS.MREVRANGE**, and **TS.QUERYINDEX** now pull that block via `{{< embed-md "ts-filter-expr.md" >}}` instead of repeating the same paragraphs inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0330398557aff046af13705822f2bbd6196f3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->