### PR TITLE
DEV: add 8.10 what's new page

### DIFF
--- a/content/develop/whats-new/8-0.md
+++ b/content/develop/whats-new/8-0.md
@@ -10,7 +10,7 @@ categories:
 - rc
 description: What's new in Redis 8.0
 linkTitle: What's new in Redis 8.0
-weight: 5
+weight: 6
 ---
 
 Redis 8.0 introduces powerful new capabilities, including the beta release of the Vector Set data structure, designed for AI use cases such as semantic search and recommendation systems.

--- a/content/develop/whats-new/8-10.md
+++ b/content/develop/whats-new/8-10.md
@@ -72,7 +72,7 @@ The new [`FT.ALIASLIST`]({{< relref "/commands/ft.aliaslist/" >}}) command (#Q96
 
 ### Additional stemmer languages
 
-Search and Query adds stemmer support for Malay and Tagalog (#Q9052, RED-132425).
+Redis Search adds stemmer support for Malay and Tagalog (#Q9052, RED-132425).
 
 ### FT.AGGREGATE COLLECT reducer
 
@@ -116,7 +116,7 @@ JSON adds extensive JSONPath extensions (#J1602, #J1603, #J1604, #J1607, #J1618;
 
 - The new [`TS.NRANGE`]({{< relref "/commands/ts.nrange/" >}}) and [`TS.NREVRANGE`]({{< relref "/commands/ts.nrevrange/" >}}) commands (#T2052) query a range across multiple time series and group results by timestamp (RED-149232).
 - The new [`TS.READ`]({{< relref "/commands/ts.read/" >}}) command (#T2054) performs an optionally blocking read (RED-132421).
-- The new `TS.QUERYLABELS` command (#T2090) returns a list of labels and label-values (RED-132355).
+- The new [`TS.QUERYLABELS`]({{< relref "/commands/ts.querylabels" >}}) command (#T2090) returns a list of labels and label-values (RED-132355).
 - [`TS.MRANGE`]({{< relref "/commands/ts.mrange/" >}}) and [`TS.MREVRANGE`]({{< relref "/commands/ts.mrevrange/" >}}) accept a new `EXCLUDEEMPTY` argument (#T2072) to exclude series with no reported samples (RED-132536).
 
 ## Bug fixes
@@ -145,7 +145,7 @@ Redis 8.10 includes a broad set of bug fixes (compared to 8.8.0).
 - Partial crash log on LoongArch architecture (#15247).
 - `VADD ... CAS SETATTR`: wrong attributes count (#15270).
 
-### Search and Query fixes
+### Redis Search fixes
 
 - Range query returns incomplete results when the lower bound is an excluded empty string (MOD-15897).
 - `FT.AGGREGATE .. WITHCOUNT` coordinator leaks resources on timeout (MOD-16210).
@@ -184,7 +184,7 @@ Redis 8.10 delivers a broad set of performance improvements (compared to 8.8.0).
 - Improve `RESTORE REPLACE` performance for new keys (#15397).
 - Optimizes an internal memory accounting (#14704).
 
-### Search and Query improvements
+### Redis Search improvements
 
 - Write operations no longer block on a read lock held throughout vector range query result collection (#Q10246, MOD-16437).
 

--- a/content/develop/whats-new/8-10.md
+++ b/content/develop/whats-new/8-10.md
@@ -1,0 +1,206 @@
+---
+title: Redis 8.10
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+- rc
+description: What's new in Redis 8.10
+linkTitle: What's new in Redis 8.10
+weight: 1
+---
+
+Redis 8.10 introduces new features and performance improvements, building on the foundation of Redis 8.8.
+
+This release delivers improvements across multiple areas:
+- Hash templates
+- `LMOVEM`, `BLMOVEM`: move multiple elements between lists
+- `SUNIONCARD`, `SDIFFCARD`: get the cardinality of the union or difference of sets
+- `XREAD`, `XREADGROUP`: new `MAXCOUNT` and `MAXSIZE` arguments to cap the cumulative reply
+- New `SCRIPT_RUNNER` command flag for commands that execute scripts or functions
+- `FT.ALIASLIST`: get all aliases for a Search index
+- `FT.AGGREGATE`: new `COLLECT` reducer, plus stricter query `TIMEOUT` enforcement
+- Extensive JSONPath extensions for JSON
+- New Time Series commands: `TS.NRANGE`, `TS.NREVRANGE`, `TS.READ`, `TS.QUERYLABELS`
+- Performance and resource utilization improvements across core, Search, and JSON
+- Numerous bug fixes across core, Search, JSON, Time Series, and Probabilistic
+- New Modules API events and functions
+
+Below is a detailed breakdown of these updates.
+
+## Supported operating systems
+
+Redis 8.10 is tested on:
+
+- Ubuntu 22.04 (Jammy Jellyfish), 24.04 (Noble Numbat), 26.04 (Resolute Raccoon)
+- Rocky Linux 8.10, 9.7, 10.1
+- AlmaLinux 8.10, 9.7, 10.1
+- Debian 12.13 (Bookworm), Debian 13.4 (Trixie)
+- Alpine 3.23
+- macOS 14.8.4 (Sonoma), 15.7.4 (Sequoia), 26.3 (Tahoe) - for both Intel and ARM
+
+## New features
+
+### Hash templates
+
+Redis 8.10 introduces hash templates.
+
+### List multi-element moves
+
+The new [`LMOVEM`]({{< relref "/commands/lmovem/" >}}) and [`BLMOVEM`]({{< relref "/commands/blmovem/" >}}) commands (#15405) move multiple elements between lists in a single operation.
+
+### Set cardinality commands
+
+The new [`SUNIONCARD`]({{< relref "/commands/sunioncard/" >}}) command (#14893) returns the cardinality of the union of multiple sets, and the new [`SDIFFCARD`]({{< relref "/commands/sdiffcard/" >}}) command (#15278) returns the cardinality of the difference between sets, without materializing the result.
+
+### Streams reply caps
+
+[`XREAD`]({{< relref "/commands/xread/" >}}) and [`XREADGROUP`]({{< relref "/commands/xreadgroup/" >}}) accept new `MAXCOUNT` and `MAXSIZE` arguments (#15282) to cap the cumulative number of reply entries and the cumulative reply size.
+
+### SCRIPT_RUNNER command flag
+
+A new `SCRIPT_RUNNER` command flag (#15337) flags commands that execute scripts or functions.
+
+### SLOWLOG GET total argument count
+
+[`SLOWLOG GET`]({{< relref "/commands/slowlog-get/" >}}) adds a new reply argument (#15347): the total argument count for the logged command.
+
+### FT.ALIASLIST
+
+The new [`FT.ALIASLIST`]({{< relref "/commands/ft.aliaslist/" >}}) command (#Q9626) returns all aliases for an index (RED-197340).
+
+### Additional stemmer languages
+
+Search and Query adds stemmer support for Malay and Tagalog (#Q9052, RED-132425).
+
+### FT.AGGREGATE COLLECT reducer
+
+[`FT.AGGREGATE`]({{< relref "/commands/ft.aggregate/" >}}) gains a new `COLLECT` reducer (#Q9291) that separates remote and local reducer invocations (RED-177887).
+
+### Stricter query timeout enforcement
+
+[`FT.SEARCH`]({{< relref "/commands/ft.search/" >}}), [`FT.AGGREGATE`]({{< relref "/commands/ft.aggregate/" >}}), and [`FT.HYBRID`]({{< relref "/commands/ft.hybrid/" >}}) now enforce the query `TIMEOUT` more strictly (#Q8169, #Q8236, #Q9234, #Q9443).
+
+The `search-on-timeout` policy now offers three options:
+
+- `FAIL` — reject timed-out queries. With `search-workers > 0` (the default), the timeout is enforced preemptively.
+- `RETURN` (default) — return best-effort partial results, without enforcing strictness during post-processing.
+- `RETURN_STRICT` (new) — return best-effort partial results while enforcing the timeout through the post-processing (result) pipeline. Available when `search-workers > 0`.
+
+Queries executed on the main thread (that is, when `search-workers` is 0) are capped by `search-max-foreground-timeout-limit` (default 60000 ms).
+
+### JSONPath extensions
+
+JSON adds extensive JSONPath extensions (#J1602, #J1603, #J1604, #J1607, #J1618; MOD-16274, MOD-16275):
+
+- Projection expressions at the top level of a JSONPath query
+- `==` and `!=` can now compare any literal, including array and object literals
+- Filter negation operator: `!`
+- `size`/`sizeof` and `empty` operators on string, array, object, and nodelist
+- `in` and `nin` operators: membership test on an array and nodelist
+- Operators on numbers: binary `-`, `+`, `*`, `/`, `%`, and unary `-` and `+`
+- Operator on object: `~`
+- `length()` function on array, object, and string
+- Functions on number: `abs()`, `ceiling()`, `floor()`
+- Functions on string: `match()`, `search()`
+- Strings concatenation with `concat()`
+- Functions on array: `first()`, `last()`, `index()`, `append()`
+- Aggregation functions on array: `min()`, `max()`, `avg()`, `sum()`, `stddev()`
+- Function on object: `keys()`
+- Function on nodelist: `count()`
+- Function on nodelist with exactly one node: `value()`
+- Relations functions on array and nodelist: `subsetof()`, `anyof()`, `noneof()`
+
+### Time series range and query commands
+
+- The new [`TS.NRANGE`]({{< relref "/commands/ts.nrange/" >}}) and [`TS.NREVRANGE`]({{< relref "/commands/ts.nrevrange/" >}}) commands (#T2052) query a range across multiple time series and group results by timestamp (RED-149232).
+- The new [`TS.READ`]({{< relref "/commands/ts.read/" >}}) command (#T2054) performs an optionally blocking read (RED-132421).
+- The new `TS.QUERYLABELS` command (#T2090) returns a list of labels and label-values (RED-132355).
+- [`TS.MRANGE`]({{< relref "/commands/ts.mrange/" >}}) and [`TS.MREVRANGE`]({{< relref "/commands/ts.mrevrange/" >}}) accept a new `EXCLUDEEMPTY` argument (#T2072) to exclude series with no reported samples (RED-132536).
+
+## Bug fixes
+
+Redis 8.10 includes a broad set of bug fixes (compared to 8.8.0).
+
+### Core fixes
+
+- Full sync under heavy write load (#15447).
+- Unit mismatch disables the FAST expire cycle stale trigger (#15412).
+- Crash on `VRANDMEMBER` with `LLONG_MIN` count (#15392).
+- `CONFIG SET`: crash on of TLS options in non-TLS builds (#15409).
+- ACL key-name leak in BCAST client-side caching invalidations (#15371).
+- Signed overflow in `BITFIELD` offset parsing (#15433).
+- The select-based event loop backend enqueues registered file descriptors that `select()` did not mark ready (#15446).
+- `mem_clients_normal` drift when a replica drops its cached master after a failed partial resync (#15309).
+- Crash on missing module numeric config (#15357).
+- In-progress atomic slot migration tasks keep running on `RM_ResetDataset` and `RM_RdbLoad` (#15377).
+- NULL dereference (#15391, #15356).
+- Overflow on memory unit conversions (#15390).
+- `SET` does not enforce mutually exclusive `NX`/`XX` and `IF*` options (#15291).
+- `CONFIG SET` does not reject duplicate arguments when using both primary name and alias (#15322).
+- `LSET` out-of-range 64-bit index truncation (#15407).
+- Improve RDB load robustness for streams (#15308).
+- Tighter cluster bus parsing for `PING`, `PONG`, and `MEET` packets (#15263).
+- Partial crash log on LoongArch architecture (#15247).
+- `VADD ... CAS SETATTR`: wrong attributes count (#15270).
+
+### Search and Query fixes
+
+- Range query returns incomplete results when the lower bound is an excluded empty string (MOD-15897).
+- `FT.AGGREGATE .. WITHCOUNT` coordinator leaks resources on timeout (MOD-16210).
+- Local `FT.HYBRID` ignores `ON_TIMEOUT RETURN_STRICT` and continues execution past the deadline (MOD-16492).
+- Blocked search clients trigger unnecessary query dumps, adding CPU and log overhead (MOD-16518).
+- `FT.HYBRID` supports `EXPLAINSCORE`, exposing the fusion method (`RRF` or `LINEAR`) (MOD-10044).
+
+### JSON fixes
+
+- Wrong results when evaluating paths with recursive descent (MOD-6722, MOD-14664).
+- Any literal that starts with true/false/null is interpreted as true/false/null (MOD-7266).
+- Improve RDB load robustness.
+
+### Time series fixes
+
+- `TS.INFO`: inaccurate memory usage calculation (MOD-6409).
+- Aggregation fixes (MOD-8187, MOD-16224, MOD-15565).
+- Improve RDB load robustness.
+
+### Probabilistic fixes
+
+- `CF.LOADCHUNK` partial replication (MOD-16050).
+- Improve RDB load robustness.
+
+## Performance and resource utilization improvements
+
+Redis 8.10 delivers a broad set of performance improvements (compared to 8.8.0).
+
+### Core improvements
+
+- Optimize `lpSeek()` by validating entries only when necessary (#15376).
+- Optimize wide `HSET`/`HMSET` on a fresh hash with a single batched listpack append (#15345).
+- Avoid recomputing allocator fragmentation twice per cron tick (#15330, RED-200844).
+- Trim excess SDS allocation in inline command parsing (#15259).
+- rax memory reduction: leaf-inlining for fixed-length-key trees, improving `XREADGROUP` performance (#15256).
+- Improve `RESTORE REPLACE` performance for new keys (#15397).
+- Optimizes an internal memory accounting (#14704).
+
+### Search and Query improvements
+
+- Write operations no longer block on a read lock held throughout vector range query result collection (#Q10246, MOD-16437).
+
+### JSON improvements
+
+- JSON memory object footprint improvements (#J1617, MOD-16608).
+
+## Modules API
+
+- `RedisModuleEvent_ClusterTopologyChange`: cluster topology change (#15350).
+- `REDISMODULE_SUBEVENT_FORK_CHILD_*`: allow multi-threaded modules to quiesce background work before `fork()` (#15327).
+- `REDISMODULE_SUBEVENT_CLUSTER_SLOT_MIGRATION_MIGRATE_MODULE_PROPAGATE_END`: inject commands after the ASM replication stream (#15373).
+- `RedisModule_AddPostNotificationJobForKey`: binds deferred work to a specific key from a keyspace-notification handler (#15242).
+
+## CLI tools
+
+- Adds `--latency-percentiles <p1,p2,...>` to `--latency` / `--latency-history` for reporting user-chosen percentiles (#15352).
+- `redis-cli --cluster rebalance`: CROSSSLOT error when using `-user` without `-a` (#15262).
+- `redis-cli --cluster reshard` and `rebalance` now move slots with server-side atomic slot migration (#15338).

--- a/content/develop/whats-new/8-2.md
+++ b/content/develop/whats-new/8-2.md
@@ -8,7 +8,7 @@ categories:
 - rc
 description: What's new in Redis 8.2
 linkTitle: What's new in Redis 8.2
-weight: 4
+weight: 5
 ---
 
 Redis 8.2 builds on the foundation of Redis 8.0 with significant performance and memory optimizations, enhanced streaming capabilities, and improved cluster management tools.

--- a/content/develop/whats-new/8-4.md
+++ b/content/develop/whats-new/8-4.md
@@ -8,7 +8,7 @@ categories:
 - rc
 description: What's new in Redis 8.4
 linkTitle: What's new in Redis 8.4
-weight: 3
+weight: 4
 ---
 
 Redis 8.4 builds on the foundation of Redis 8.2 with significant enhancements to cluster operations, string manipulation, and stream processing capabilities.

--- a/content/develop/whats-new/8-6.md
+++ b/content/develop/whats-new/8-6.md
@@ -8,7 +8,7 @@ categories:
 - rc
 description: What's new in Redis 8.6
 linkTitle: What's new in Redis 8.6
-weight: 2
+weight: 3
 ---
 
 Redis 8.6 builds on the foundation of Redis 8.4 with significant enhancements to stream reliability, memory management, and security features.

--- a/content/develop/whats-new/8-8.md
+++ b/content/develop/whats-new/8-8.md
@@ -8,7 +8,7 @@ categories:
 - rc
 description: What's new in Redis 8.8
 linkTitle: What's new in Redis 8.8
-weight: 1
+weight: 2
 ---
 
 Redis 8.8 introduces new features and performance improvements, building on the foundation of Redis 8.6.

--- a/content/develop/whats-new/_index.md
+++ b/content/develop/whats-new/_index.md
@@ -12,6 +12,12 @@ hideListLinks: true
 weight: 10
 ---
 
+## Q3 2026 (July - September) Updates
+
+### Redis Version Updates
+
+- [Redis 8.10]({{< relref "/develop/whats-new/8-10" >}}) - New commands (`LMOVEM`/`BLMOVEM`, `SUNIONCARD`/`SDIFFCARD`, `FT.ALIASLIST`, `TS.NRANGE`/`TS.NREVRANGE`, `TS.READ`), hash templates, `FT.AGGREGATE` `COLLECT` reducer and stricter query timeout enforcement, extensive JSONPath extensions, plus core, Search, and JSON performance improvements.
+
 ## Q2 2026 (April - June) Updates
 
 ### Redis Version Updates

--- a/content/develop/whats-new/redis-feature-sets.md
+++ b/content/develop/whats-new/redis-feature-sets.md
@@ -17,6 +17,7 @@ To use a new feature introduced in a later feature set, you must upgrade the cor
 
 | Redis feature set | What's new |
 |-------------------|------------|
+| **Feature set version:** 8.10| See [here]({{< relref "/develop/whats-new/8-10" >}})|
 | **Feature set version:** 8.8| See [here]({{< relref "/develop/whats-new/8-8" >}})|
 | **Feature set version:** 8.6| See [here]({{< relref "/develop/whats-new/8-6" >}})|
 | **Feature set version:** 8.4| See [here]({{< relref "/develop/whats-new/8-4" >}})|


### PR DESCRIPTION
This is a Redis 8.10 feature. There will probably be a few minor changes between now and RC1/GA, and I'll take care of those in another PR.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Hugo content with no runtime or application code changes.
> 
> **Overview**
> Adds a new **Redis 8.10** what's-new page (`8-10.md`) in the same style as prior 8.x release notes, covering supported OSes, new capabilities (hash templates, list/set/stream commands, Search/JSON/Time Series updates, Modules API, CLI), bug fixes, and performance notes.
> 
> Wires **8.10** into navigation: **`weight: 1`** on the new page and **`weight` bumped by 1** on 8.0–8.8 so ordering stays newest-first. The develop **What's new** index gets a **Q3 2026** entry with a short summary link, and **`redis-feature-sets.md`** lists feature set **8.10** at the top of the table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f5e24a0f386aab979eed1eef5bd24d06cf39eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->