### PR TITLE
K8s: yellow sub maint 11 RN

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-42-july2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-42-july2026.md
@@ -33,5 +33,3 @@ This is a maintenance release of Redis for Kubernetes to support Redis Software 
 ## Known limitations
 
 See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.
-</content>
-</invoke>

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-42-july2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-42-july2026.md
@@ -1,0 +1,37 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: Maintenance release to support Redis Software version 7.22.2-170 with bug and security fixes.
+hideListLinks: true
+linkTitle: 7.22.2-42 (July 2026)
+title: Redis for Kubernetes 7.22.2-42 (July 2026) release notes
+weight: 16
+---
+
+## Highlights
+
+This is a maintenance release of Redis for Kubernetes to support Redis Software version 7.22.2-170. For supported distributions and known limitations, see the [7.22.2 releases]({{< relref "/operate/kubernetes/release-notes/7-22-2-releases/" >}}).
+
+## Downloads
+
+- **Redis Software**: `redislabs/redis:7.22.2-170`
+- **Operator**: `redislabs/operator:7.22.2-42`
+- **Services Rigger**: `redislabs/k8s-controller:7.22.2-42`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-42`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `v7.22.2-42.0`
+- **Redis Software**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-170`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-42`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-42`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-42`
+
+## Known limitations
+
+See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.
+</content>
+</invoke>

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 7.22.2 release notes
 weight: 90
 ---
 
-Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-40 with support for Redis Enterprise Software version 7.22.2-133.
+Redis Enterprise for Kubernetes 7.22.2 includes bug fixes, enhancements, and support for Redis Enterprise Software. The latest release is 7.22.2-42 with support for Redis Enterprise Software version 7.22.2-170.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only release notes with no product or runtime code changes.
> 
> **Overview**
> Documents the **7.22.2-42 (July 2026)** maintenance release for Redis for Kubernetes, aligned with Redis Software **7.22.2-170**, including standard and OpenShift image tags and a pointer to shared 7.22.2 known limitations.
> 
> The **7.22.2 releases** index now lists **7.22.2-42** / **7.22.2-170** as the latest instead of **7.22.2-40** / **7.22.2-133**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fec124be3ec2a666b00fc44a9bf4a08d2f65403. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->