### PR TITLE
Build tooling to guarantee correct output from interactive redis-cli commands

### DIFF
--- a/build/check_tryit_output.py
+++ b/build/check_tryit_output.py
@@ -30,9 +30,12 @@ Outcomes and CI gating:
                 unavoidable non-determinism (auto stream IDs, unordered
                 SMEMBERS/HGETALL, timestamps, cumulative session state).
 
-Commands whose reply order Redis does not guarantee (KEYS, SMEMBERS, HGETALL,
-scans, set algebra, random picks — see UNORDERED_CMDS) are compared as an
-unordered multiset, so a different element order is not a mismatch.
+Commands whose reply *order* Redis does not guarantee (KEYS, SMEMBERS, HGETALL,
+scans, set algebra, FT.SEARCH/FT.AGGREGATE without SORTBY — see UNORDERED_CMDS)
+are compared as an unordered multiset, so a different element order is not a
+mismatch. Commands whose *output itself* is random rather than merely unordered
+(SPOP, SRANDMEMBER, ZRANDMEMBER, HRANDFIELD — see NONDETERMINISTIC_CMDS) can't
+be verified at all: any example using one is auto-skipped, with a logged notice.
 
 No content annotations are required. Volatile values are masked by default
 (--raw to disable); anything you want to permanently exclude goes in a build-side
@@ -193,16 +196,22 @@ def normalize(s, on):
 UNORDERED_CMDS = {
     # keyspace / scan
     "KEYS", "SCAN", "HSCAN", "SSCAN", "ZSCAN",
-    # sets (membership order undefined; set-algebra results unordered; random picks)
-    "SMEMBERS", "SINTER", "SUNION", "SDIFF", "SRANDMEMBER", "SPOP",
-    # hashes (field order undefined for hashtable-encoded hashes)
-    "HKEYS", "HVALS", "HGETALL", "HRANDFIELD",
-    # sorted-set random pick
-    "ZRANDMEMBER",
+    # sets: membership order undefined; set-algebra results unordered
+    "SMEMBERS", "SINTER", "SUNION", "SDIFF",
+    # hashes: field order undefined for hashtable-encoded hashes
+    "HKEYS", "HVALS", "HGETALL",
+    # search/aggregate without SORTBY: result order is not guaranteed
+    "FT.SEARCH", "FT.AGGREGATE",
     # vector set similarity: ranked by score, but equal-score ties break in any
     # order (compared as a multiset, so tied elements may swap places)
     "VSIM",
 }
+
+# Commands whose *output itself* is non-deterministic (random element(s)), not
+# merely unordered — the result can't be verified against a fixed transcript.
+# Any example that uses one is auto-skipped (with a logged notice); it still
+# runs, so later examples that build on it see the same cumulative state.
+NONDETERMINISTIC_CMDS = {"SPOP", "SRANDMEMBER", "ZRANDMEMBER", "HRANDFIELD"}
 
 _IDX = re.compile(r'^\s*\d+\)\s+')  # a redis-cli "N) " list index
 
@@ -294,10 +303,20 @@ def main():
         if "clients-example" not in text:
             continue
 
-        items = []  # (cmd, expected, set, step) in document order
+        items = []        # (cmd, expected, set, step) in document order
+        autoskip = set()  # (set, step) of examples auto-skipped as non-deterministic
         for blk in parse_page(text):
             if not args.include_nonrunnable and blk["runnable"] == "false":
                 continue
+            nondet = sorted({c.split()[0].upper() for c, _ in blk["pairs"]
+                             if c.split() and c.split()[0].upper() in NONDETERMINISTIC_CMDS})
+            if nondet:
+                # Random-output commands can't be verified against a transcript;
+                # skip the whole example (but still run it, below, so cumulative
+                # state stays correct for later examples that build on it).
+                autoskip.add((blk["set"], blk["step"]))
+                print("SKIP   %s  [%s/%s]  (non-deterministic: %s)"
+                      % (f, blk["set"], blk["step"], ", ".join(nondet)))
             for cmd, exp in blk["pairs"]:
                 items.append((cmd, exp, blk["set"], blk["step"]))
         if not items:
@@ -328,7 +347,7 @@ def main():
             total += 1
             if exp == "":            # command has no documented output to check
                 continue
-            if is_skipped(f, setn, step):
+            if (setn, step) in autoskip or is_skipped(f, setn, step):
                 skipped_ct += 1
                 continue
             a = normalize(render(rep), normalize_on)

--- a/build/check_tryit_output.py
+++ b/build/check_tryit_output.py
@@ -56,8 +56,8 @@ import re
 import subprocess
 import sys
 
-# API_DEFAULT = "https://redis.io/cli"
-API_DEFAULT = "http://localhost:5000"
+API_DEFAULT = "https://redis.io/cli"
+
 BATCH_MAX = 20  # redis.io/cli rejects requests with more than 20 commands
 
 # --- reply formatting: faithful port of static/js/cli.js formatReply/reprString ---

--- a/build/check_tryit_output.py
+++ b/build/check_tryit_output.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""
+Verify that docs redis-cli examples still produce the documented output.
+
+Companion to check_tryit_payloads.py (which checks URL size). This one actually
+runs the examples and compares their output, so it catches examples that have
+gone stale, reference a command the sandbox can't run, or depend on setup that
+no longer happens.
+
+What it does, per page:
+  * Parse every `clients-example` block into (command, expected-output) pairs
+    from its `> ` / `redis> ` transcript (the command line plus the output lines
+    that follow it, up to the next command).
+  * Run that page's commands in ONE redis.io/cli session, in document order,
+    mirroring the live page's shared session (static/js/cli.js). The API caps a
+    request at 20 commands, so commands are sent in <=20-command batches with the
+    session id threaded across them so state accumulates.
+  * Format each reply exactly the way the in-page terminal does — a faithful port
+    of cli.js's formatReply / reprString (RESP -> redis-cli text: `(integer)`,
+    `(nil)`, quoted/escaped bulk strings, nested `1) 2) ...` arrays, `(error) ...`).
+  * Compare formatted-actual to documented-expected.
+
+Outcomes and CI gating:
+  * PASS      — matched (after normalization).
+  * ERROR     — the command errored *and the docs show real output* -> a
+                genuinely broken example. This is the gating signal.
+  * (a documented error that errors is a PASS: error-message text is volatile.)
+  * MISMATCH  — output differs but did not error. Reported for review but does
+                NOT gate CI by default (use --strict), because much of it is
+                unavoidable non-determinism (auto stream IDs, unordered
+                SMEMBERS/HGETALL, timestamps, cumulative session state).
+
+Commands whose reply order Redis does not guarantee (KEYS, SMEMBERS, HGETALL,
+scans, set algebra, random picks — see UNORDERED_CMDS) are compared as an
+unordered multiset, so a different element order is not a mismatch.
+
+No content annotations are required. Volatile values are masked by default
+(--raw to disable); anything you want to permanently exclude goes in a build-side
+--skip-file (never in the docs).
+
+Usage:
+    python build/check_tryit_output.py [--content-dir content] [--page GLOB]
+        [--raw] [--strict] [--skip-file build/tryit_verify_skip.txt]
+        [--include-nonrunnable] [--api URL] [--quiet]
+
+Exit status: 1 if any ERROR (or, with --strict, any MISMATCH), else 0.
+Requires `curl` on PATH (uses the system cert store; avoids macOS Python's
+missing-CA issue). Hits the live redis.io/cli, which runs commands in a
+throwaway sandbox session, so run it sparingly / in CI, not on every save.
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+# API_DEFAULT = "https://redis.io/cli"
+API_DEFAULT = "http://localhost:5000"
+BATCH_MAX = 20  # redis.io/cli rejects requests with more than 20 commands
+
+# --- reply formatting: faithful port of static/js/cli.js formatReply/reprString ---
+_ESC = {0x5c: "\\\\", 0x22: '\\"', 0x0a: "\\n", 0x0d: "\\r",
+        0x09: "\\t", 0x07: "\\a", 0x08: "\\b"}
+
+
+def _repr_string(s):
+    """Quote/escape a bulk string byte-for-byte the way redis-cli's sdscatrepr does."""
+    out = ['"']
+    for b in s.encode("utf-8"):
+        if b in _ESC:
+            out.append(_ESC[b])
+        elif 0x20 <= b <= 0x7e:
+            out.append(chr(b))
+        else:
+            out.append("\\x%02x" % b)
+    out.append('"')
+    return "".join(out)
+
+
+def format_reply(reply, indent="", status=False):
+    if reply is None:
+        return "(nil)"
+    if isinstance(reply, dict) and isinstance(reply.get("$int"), str):
+        return "(integer) %s" % reply["$int"]
+    if isinstance(reply, dict) and isinstance(reply.get("$status"), str):
+        # RESP simple-string element inside an array (e.g. CMS.INFO field names);
+        # rendered unquoted like a top-level status reply.
+        return reply["$status"]
+    if isinstance(reply, bool):
+        return "(integer) %d" % (1 if reply else 0)
+    if isinstance(reply, str):
+        return reply if status else _repr_string(reply)
+    if isinstance(reply, (int, float)):
+        return "(integer) %s" % reply
+    if isinstance(reply, list):
+        if not reply:
+            return "(empty array)"
+        # redis-cli right-justifies list indices to the width of the largest index
+        # (so "1)".."9)" get a leading space once there are >=10 elements), and uses
+        # that same width for the nested-element indent.
+        width = len(str(len(reply)))
+        parts = []
+        for i, x in enumerate(reply):
+            idx = str(i + 1).rjust(width)
+            nested = indent + " " * (width + 2)
+            prefix = "" if i == 0 else "\n" + indent
+            parts.append("%s%s) %s" % (prefix, idx, format_reply(x, nested)))
+        return "".join(parts)
+    return "-PROTOCOLERR Unknown reply type"
+
+
+def render(reply):
+    """Render one API reply object ({error,value,status}) as redis-cli text."""
+    if reply.get("error"):
+        return "(error) %s" % reply.get("value")
+    return format_reply(reply.get("value"), "", bool(reply.get("status")))
+
+
+# --- parsing ---
+_OPEN = re.compile(r'\{\{<\s*clients-example\s+(.*?)>\}\}', re.S)
+_CLOSE = "{{< /clients-example"
+
+
+def _attr(tag, name):
+    # negative lookbehind so prereq="..." doesn't match inside needs_prereq="..."
+    m = re.search(r'(?<![\w])' + re.escape(name) + r'="([^"]*)"', tag)
+    return m.group(1) if m else None
+
+
+def parse_page(text):
+    """Yield {runnable, try_it, set, step, pairs:[(cmd, expected_str)]} per block, in order."""
+    parts = re.split(r'(' + _OPEN.pattern + r')', text, flags=re.S)
+    # parts = [pre, fulltag, attrs, body, fulltag, attrs, body, ...]
+    i = 1
+    while i < len(parts):
+        tag = parts[i]
+        pairs = []
+        # Self-closing tags ("... />}}") are data-driven (content from examples.json)
+        # and have no inline "> "-transcript. Skip body parsing for them: otherwise the
+        # "body" runs to the next tag and we'd treat following prose — including markdown
+        # "> " blockquotes — as redis commands (e.g. "unknown command 'The'").
+        if not tag.rstrip().endswith("/>}}"):
+            body = parts[i + 2] if i + 2 < len(parts) else ""
+            end = body.find(_CLOSE)
+            if end >= 0:
+                body = body[:end]
+            cur, out = None, []
+            for line in body.split("\n"):
+                s = line.strip()
+                if s.startswith("redis> ") or s.startswith("> "):
+                    if cur is not None:
+                        pairs.append((cur, "\n".join(out).strip("\n")))
+                    cur = s[len("redis> "):] if s.startswith("redis> ") else s[2:]
+                    out = []
+                elif cur is not None:
+                    # Discard doc comment lines (e.g. "# Retrieve data points ...") —
+                    # they describe the example, they're not part of any reply. A redis
+                    # reply never renders as a standalone "#"-prefixed line (INFO comes
+                    # back as one quoted bulk string), so this only strips prose.
+                    if line.strip().startswith("#"):
+                        continue
+                    out.append(line.rstrip())
+            if cur is not None:
+                pairs.append((cur, "\n".join(out).strip("\n")))
+        yield {"runnable": _attr(tag, "runnable"), "try_it": _attr(tag, "try_it"),
+               "set": _attr(tag, "set"), "step": _attr(tag, "step"), "pairs": pairs}
+        i += 3
+
+
+# --- normalization for volatile values ---
+_NORM = [
+    (re.compile(r'\b\d{13}-\d+\b'), "<stream-id>"),   # auto stream IDs (ms-seq)
+    (re.compile(r'\b\d{10}-\d+\b'), "<stream-id>"),
+    (re.compile(r'\b1[6-9]\d{8,11}\b'), "<timestamp>"),  # unix seconds/ms (2022+)
+]
+
+
+def normalize(s, on):
+    if not on:
+        return s
+    for rx, repl in _NORM:
+        s = rx.sub(repl, s)
+    return s
+
+
+# Commands whose reply element ORDER is not guaranteed by Redis. Their output is
+# the same *set* of elements every run but in an arbitrary order (hash-bucket
+# layout, set encoding, cursor iteration, randomization), so it's compared as an
+# unordered multiset instead of exact text. Ordered commands (LRANGE, ZRANGE,
+# SORT, XRANGE, HMGET, ...) are intentionally NOT here — their order is meaningful.
+UNORDERED_CMDS = {
+    # keyspace / scan
+    "KEYS", "SCAN", "HSCAN", "SSCAN", "ZSCAN",
+    # sets (membership order undefined; set-algebra results unordered; random picks)
+    "SMEMBERS", "SINTER", "SUNION", "SDIFF", "SRANDMEMBER", "SPOP",
+    # hashes (field order undefined for hashtable-encoded hashes)
+    "HKEYS", "HVALS", "HGETALL", "HRANDFIELD",
+    # sorted-set random pick
+    "ZRANDMEMBER",
+}
+
+_IDX = re.compile(r'^\s*\d+\)\s+')  # a redis-cli "N) " list index
+
+
+def _multiset(text):
+    """Order-insensitive key: the sorted list of element lines with their
+    "N) " index stripped. Two renderings of the same flat reply in different
+    orders produce the same key."""
+    return sorted(_IDX.sub("", ln).strip() for ln in text.split("\n") if ln.strip())
+
+
+# --- execution ---
+def execute(commands, api, session_id, auth=None):
+    payload = json.dumps({"commands": commands, "id": session_id})
+    # -L follows redirects (e.g. http->https); --post301/--post302 keep it a POST
+    # across the redirect (curl would otherwise downgrade to GET and get a 400).
+    cmd = ["curl", "-sS", "-L", "--post301", "--post302", "-X", "POST", api,
+           "-H", "Content-Type: application/json", "--data", payload]
+    stdin = None
+    if auth:
+        # Feed HTTP basic-auth credentials via a --config file on stdin so they
+        # never appear in the process list (unlike -u user:pass on argv).
+        cmd += ["--config", "-"]
+        stdin = 'user = "%s"\n' % auth
+    out = subprocess.run(cmd, input=stdin,
+                         capture_output=True, text=True, timeout=60)
+    if out.returncode != 0:
+        raise RuntimeError(out.stderr.strip() or ("curl exit %d" % out.returncode))
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        raise RuntimeError("non-JSON response from %s (check the URL/scheme, e.g. https): %r"
+                           % (api, out.stdout[:100]))
+
+
+def run_session(commands, api, auth=None):
+    """Run all commands in one session, reusing the id across <=20-command batches."""
+    replies, sid = [], None
+    for i in range(0, len(commands), BATCH_MAX):
+        rep = execute(commands[i:i + BATCH_MAX], api, sid, auth)
+        if "replies" not in rep:
+            raise RuntimeError(rep.get("value", rep))
+        sid = rep.get("id", sid)
+        replies.extend(rep["replies"])
+    return replies
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--content-dir", default="content")
+    ap.add_argument("--page", default="**/*.md", help="glob under --content-dir")
+    ap.add_argument("--raw", action="store_true",
+                    help="disable volatile-value normalization (on by default)")
+    ap.add_argument("--strict", action="store_true",
+                    help="also exit non-zero on MISMATCH (default: only ERROR gates)")
+    ap.add_argument("--skip-file", default=None,
+                    help="build-side config (NOT content): lines of 'set/step' or a "
+                         "file-path substring to exclude; '#' starts a comment")
+    ap.add_argument("--include-nonrunnable", action="store_true",
+                    help="also verify runnable=\"false\" blocks (default: skip them)")
+    ap.add_argument("--api", default=API_DEFAULT)
+    ap.add_argument("--auth", default=os.environ.get("TRYIT_AUTH"),
+                    help="HTTP basic auth as user:pass (or set env TRYIT_AUTH); "
+                         "for password-protected endpoints e.g. staging")
+    ap.add_argument("--quiet", action="store_true", help="suppress the summary line")
+    args = ap.parse_args()
+    normalize_on = not args.raw
+
+    skips = []
+    if args.skip_file and os.path.exists(args.skip_file):
+        for ln in open(args.skip_file, encoding="utf-8"):
+            ln = ln.split("#", 1)[0].strip()
+            if ln:
+                skips.append(ln)
+
+    def is_skipped(f, setn, step):
+        key = "%s/%s" % (setn, step)
+        return any(s == key or s in f for s in skips)
+
+    files = sorted(glob.glob(os.path.join(args.content_dir, args.page), recursive=True))
+    total = passed = mismatched = errored = skipped_ct = 0
+
+    for f in files:
+        try:
+            text = open(f, encoding="utf-8").read()
+        except (OSError, UnicodeDecodeError):
+            continue
+        if "clients-example" not in text:
+            continue
+
+        items = []  # (cmd, expected, set, step) in document order
+        for blk in parse_page(text):
+            if not args.include_nonrunnable and blk["runnable"] == "false":
+                continue
+            for cmd, exp in blk["pairs"]:
+                items.append((cmd, exp, blk["set"], blk["step"]))
+        if not items:
+            continue
+
+        cmds = [c for c, _, _, _ in items]
+        try:
+            replies = run_session(cmds, args.api, args.auth)
+        except Exception as e:
+            print("ERROR  %s  (request failed: %s)" % (f, e))
+            errored += len(items)
+            total += len(items)
+            continue
+
+        for (cmd, exp, setn, step), rep in zip(items, replies):
+            total += 1
+            if exp == "":            # command has no documented output to check
+                continue
+            if is_skipped(f, setn, step):
+                skipped_ct += 1
+                continue
+            a = normalize(render(rep), normalize_on)
+            e = normalize(exp, normalize_on)
+            first = cmd.split()[0].upper() if cmd.split() else ""
+            if a == e:
+                passed += 1
+            elif first in UNORDERED_CMDS and _multiset(a) == _multiset(e):
+                passed += 1  # same elements, order not guaranteed for this command
+            elif rep.get("error"):
+                if e.startswith("(error)"):
+                    passed += 1      # errors as documented; message text is volatile
+                else:
+                    errored += 1
+                    print("ERROR  %s  [%s/%s]  (errored, but docs expect output)\n"
+                          "    cmd:      %s\n    expected: %s\n    got:      %s"
+                          % (f, setn, step, cmd,
+                             e.replace("\n", "\n              "),
+                             a.replace("\n", "\n              ")))
+            else:
+                mismatched += 1
+                print("MISMATCH  %s  [%s/%s]\n    cmd:      %s\n    expected: %s\n    actual:   %s"
+                      % (f, setn, step, cmd,
+                         e.replace("\n", "\n              "),
+                         a.replace("\n", "\n              ")))
+
+    if not args.quiet:
+        print("\n%d commands: %d pass, %d mismatch, %d error, %d skipped%s. Gating on: %s"
+              % (total, passed, mismatched, errored, skipped_ct,
+                 "" if normalize_on else " (raw)",
+                 "error+mismatch" if args.strict else "error only"))
+
+    return 1 if (errored or (args.strict and mismatched)) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/build/check_tryit_output.py
+++ b/build/check_tryit_output.py
@@ -312,6 +312,18 @@ def main():
             total += len(items)
             continue
 
+        # The API returns one reply per command; if it returns fewer (partial
+        # batch, dropped tail), zip() below would silently skip the trailing
+        # commands and the run could still exit 0. Count the shortfall as errors
+        # so it gates instead of passing unverified.
+        if len(replies) < len(items):
+            missing = len(items) - len(replies)
+            print("ERROR  %s  (API returned %d replies for %d commands; "
+                  "%d trailing command(s) unverified)"
+                  % (f, len(replies), len(items), missing))
+            errored += missing
+            total += missing
+
         for (cmd, exp, setn, step), rep in zip(items, replies):
             total += 1
             if exp == "":            # command has no documented output to check

--- a/build/check_tryit_output.py
+++ b/build/check_tryit_output.py
@@ -199,6 +199,9 @@ UNORDERED_CMDS = {
     "HKEYS", "HVALS", "HGETALL", "HRANDFIELD",
     # sorted-set random pick
     "ZRANDMEMBER",
+    # vector set similarity: ranked by score, but equal-score ties break in any
+    # order (compared as a multiset, so tied elements may swap places)
+    "VSIM",
 }
 
 _IDX = re.compile(r'^\s*\d+\)\s+')  # a redis-cli "N) " list index

--- a/content/commands/del.md
+++ b/content/commands/del.md
@@ -72,9 +72,9 @@ One or more keys to delete.
 
 {{< clients-example set="cmds_generic" step="del" description="Foundational: Delete one or more keys using DEL (ignores non-existent keys, returns count of deleted keys)" difficulty="beginner" >}}
 > SET key1 "Hello"
-"OK"
+OK
 > SET key2 "World"
-"OK"
+OK
 > DEL key1 key2 key3
 (integer) 2
 {{< /clients-example >}}

--- a/content/commands/expire.md
+++ b/content/commands/expire.md
@@ -152,13 +152,13 @@ Set the expiry only when the new expiry is less than the current one. A non-vola
 
 {{< clients-example set="cmds_generic" step="expire" description="Foundational: Set key expiration time using EXPIRE (supports conditional options NX/XX/GT/LT, returns 1 if set or 0 if not)" difficulty="beginner" >}}
 > SET mykey "Hello"
-"OK"
+OK
 > EXPIRE mykey 10
 (integer) 1
 > TTL mykey
 (integer) 10
 > SET mykey "Hello World"
-"OK"
+OK
 > TTL mykey
 (integer) -1
 > EXPIRE mykey 10 XX

--- a/content/commands/get.md
+++ b/content/commands/get.md
@@ -65,7 +65,7 @@ The name of the key.
 > GET nonexisting
 (nil)
 > SET mykey "Hello"
-"OK"
+OK
 > GET mykey
 "Hello"
 {{< /clients-example >}}

--- a/content/commands/hexpire.md
+++ b/content/commands/hexpire.md
@@ -157,7 +157,8 @@ Starting with Redis 8, Redis Search has enhanced behavior when handling expiring
 
 {{< clients-example set="cmds_hash" step="hexpire" description="Field expiration: Set TTL on individual hash fields using HEXPIRE with conditional options (NX, XX, GT, LT) when you need fine-grained control over field lifecycle" difficulty="intermediate" >}}
 > HEXPIRE no-key 20 NX FIELDS 2 field1 field2
-(nil)
+1) (integer) -2
+2) (integer) -2
 > HSET mykey field1 "hello" field2 "world"
 (integer) 2
 > HEXPIRE mykey 10 FIELDS 3 field1 field2 field3

--- a/content/commands/hmget.md
+++ b/content/commands/hmget.md
@@ -82,7 +82,6 @@ One or more fields whose values to retrieve.
 1) "Hello"
 2) "World"
 3) (nil)
->
 {{< /clients-example >}}
 
 ## Redis Software and Redis Cloud compatibility

--- a/content/commands/incr.md
+++ b/content/commands/incr.md
@@ -77,7 +77,7 @@ The name of the key.
 
 {{< clients-example set="cmds_string" step="incr" description="Foundational: Increment the integer value of a key by one using INCR (initializes to 0 if key doesn't exist)" difficulty="beginner" >}}
 > SET mykey "10"
-"OK"
+OK
 > INCR mykey
 (integer) 11
 > GET mykey

--- a/content/commands/keys.md
+++ b/content/commands/keys.md
@@ -91,7 +91,7 @@ To use pattern with a hash tag, see [Hash tags]({{< relref "operate/oss_and_stac
 
 {{< clients-example set="cmds_generic" step="keys" description="Returns all key names that match a pattern" difficulty="beginner" >}}
 > MSET firstname Jack lastname Stuntman age 35
-"OK"
+OK
 > KEYS *name*
 1) "lastname"
 2) "firstname"

--- a/content/commands/mget.md
+++ b/content/commands/mget.md
@@ -69,9 +69,9 @@ One or more keys whose values to retrieve.
 
 {{< clients-example set="cmds_string" step="mget" description="Returns the values of all specified keys." difficulty="beginner" >}}
 > SET key1 "Hello"
-"OK"
+OK
 > SET key2 "World"
-"OK"
+OK
 > MGET key1 key2 nonexisting
 1) "Hello"
 2) "World"

--- a/content/commands/set.md
+++ b/content/commands/set.md
@@ -235,11 +235,11 @@ Note: Since the `SET` command options can replace [`SETNX`]({{< relref "/command
 
 {{< clients-example set="set_and_get" step="set" description="Foundational: Set the string value of a key using SET (creates key if needed, overwrites existing value, supports expiration options)" difficulty="beginner" >}}
 > SET mykey "Hello"
-"OK"
+OK
 > GET mykey
 "Hello"
 > SET anotherkey "will expire in a minute" EX 60
-"OK"
+OK
 {{< /clients-example >}}
 
 ## Details

--- a/content/commands/ttl.md
+++ b/content/commands/ttl.md
@@ -76,7 +76,7 @@ The name of the key.
 
 {{< clients-example set="cmds_generic" step="ttl" description="Foundational: Check remaining time-to-live of a key using TTL (returns seconds remaining, -1 if no expiry, -2 if key doesn't exist)" difficulty="beginner" >}}
 > SET mykey "Hello"
-"OK"
+OK
 > EXPIRE mykey 10
 (integer) 1
 > TTL mykey

--- a/content/commands/xadd.md
+++ b/content/commands/xadd.md
@@ -253,11 +253,11 @@ remove data from a stream.
 
 {{< clients-example set="cmds_stream" step="xadd1" description="Basic XADD: Add entries to a stream with auto-generated IDs, check stream the stream size, and read entries" difficulty="beginner" >}}
 > XADD mystream * name Sara surname OConnor
-4378417975-0"
+"4378417975-0"
 > XADD mystream * field1 value1 field2 value2 field3 value3
-4378417976-0"
+"4378417976-0"
 > XLEN mystream
-eger) 2
+(integer) 2
 > XRANGE mystream - +
 1) 1) "1774378417975-0"
    2) 1) "name"
@@ -285,7 +285,7 @@ eger) 2
 > XADD mystream IDMPAUTO producer2 * field value
 "1774378417977-0"
 > XCFGSET mystream IDMP-DURATION 300 IDMP-MAXSIZE 1000
-"OK"
+OK
 {{< /clients-example >}}
 
 ## Details

--- a/content/commands/zrange.md
+++ b/content/commands/zrange.md
@@ -163,6 +163,8 @@ Also return the score of each member.
 The following example using `WITHSCORES` shows how the command returns always an array, but this time, populated with *element_1*, *score_1*, *element_2*, *score_2*, ..., *element_N*, *score_N*.
 
 {{< clients-example set="cmds_sorted_set" step="zrange2" description="Return scores with members: Retrieve members with their scores from a sorted set using ZRANGE with WITHSCORES option" difficulty="intermediate" >}}
+> DEL myzset
+(integer) 1
 > ZADD myzset 1 "one" 2 "two" 3 "three"
 (integer) 3
 > ZRANGE myzset 0 1 WITHSCORES
@@ -175,6 +177,8 @@ The following example using `WITHSCORES` shows how the command returns always an
 This example shows how to query the sorted set by score, excluding the value `1` and up to infinity, returning only the second element of the result:
 
 {{< clients-example set="cmds_sorted_set" step="zrange3" description="Query by score: Query a sorted set by score range using ZRANGE with BYSCORE and LIMIT options (supports exclusive ranges and pagination)" difficulty="intermediate" >}}
+> DEL myzset
+(integer) 1
 > ZADD myzset 1 "one" 2 "two" 3 "three"
 (integer) 3
 > ZRANGE myzset (1 +inf BYSCORE LIMIT 1 1

--- a/content/develop/ai/search-and-query/indexing/geoindex.md
+++ b/content/develop/ai/search-and-query/indexing/geoindex.md
@@ -50,7 +50,7 @@ OK
 > JSON.SET product:46886 $ '{"description": "Bright Green Socks","price": 25.50,"city": "Fort Collins","location": "-105.0618814,40.5150098"}'
 OK
 > FT.SEARCH productidx '@location:[-104.800644 38.846127 100 mi]'
-1) "1"
+1) (integer) 1
 2) "product:46885"
 3) 1) "$"
    2) "{\"description\":\"Navy Blue Slippers\",\"price\":45.99,\"city\":\"Denver\",\"location\":\"-104.991531, 39.742043\"}"
@@ -86,7 +86,7 @@ OK
 1) (integer) 1
 2) "shape:4"
 3) 1) "name"
-   2) "[\"Purple Point\"]"
+   2) "Purple Point"
 {{< /clients-example >}}
 
 You can also run queries to find whether shapes in the index completely contain

--- a/content/develop/data-types/arrays.md
+++ b/content/develop/data-types/arrays.md
@@ -170,6 +170,8 @@ To iterate only the elements that exist and retrieve their indexes alongside the
 This is particularly useful when an array stores line-indexed text such as a log file, where each element holds one line:
 
 {{< clients-example set="arrays_tutorial" step="argrep" description="Find elements matching textual predicates (EXACT, MATCH, GLOB, RE) with ARGREP, combined with AND or OR" >}}
+> DEL log
+(integer) 1
 > ARMSET log 0 "boot: ok" 1 "warn: disk" 2 "ERROR: cpu" 3 "info: ready" 4 "error: net"
 (integer) 5
 > ARGREP log - + MATCH "error" NOCASE

--- a/content/develop/data-types/arrays.md
+++ b/content/develop/data-types/arrays.md
@@ -84,12 +84,12 @@ To iterate only the elements that exist and retrieve their indexes alongside the
 
 {{< clients-example set="arrays_tutorial" step="arscan" description="Iterate only the elements that exist with ARSCAN, retrieving each index alongside its value" buildsUpon="argetrange" >}}
 > ARSCAN seq 0 3
-1) (integer) 0
-2) "a"
-3) (integer) 1
-4) "b"
-5) (integer) 3
-6) "d"
+1) 1) (integer) 0
+   2) "a"
+2) 1) (integer) 1
+   2) "b"
+3) 1) (integer) 3
+   2) "d"
 {{< /clients-example >}}
 
 ## Sequential insertion
@@ -176,10 +176,10 @@ This is particularly useful when an array stores line-indexed text such as a log
 1) (integer) 2
 2) (integer) 4
 > ARGREP log 0 4 GLOB "warn:*" OR GLOB "error:*" WITHVALUES
-1) (integer) 1
-2) "warn: disk"
-3) (integer) 4
-4) "error: net"
+1) 1) (integer) 1
+   2) "warn: disk"
+2) 1) (integer) 4
+   2) "error: net"
 {{< /clients-example >}}
 
 The special values `-` and `+` denote the first and last index of the array. Combined with [ring buffer mode](#ring-buffer-mode), this lets a fixed-size array hold the most recent *N* log lines and be searched in place.

--- a/content/develop/data-types/json/_index.md
+++ b/content/develop/data-types/json/_index.md
@@ -71,7 +71,7 @@ OK
 > JSON.NUMINCRBY crashes $ -0.75
 "[1.75]"
 > JSON.NUMMULTBY crashes $ 24
-"[42]"
+"[42.0]"
 {{< /clients-example >}}
 
 Here's a more interesting example that includes JSON arrays and objects:

--- a/content/develop/data-types/json/path.md
+++ b/content/develop/data-types/json/path.md
@@ -129,7 +129,7 @@ You can use the wildcard operator `*` to return a list of all items in the inven
 
 {{< clients-example set="json_tutorial" step="get_bikes" description="Wildcard queries: Use the * operator to retrieve all items in a collection when you need to access all elements at a specific level" buildsUpon="set_bikes" needs_prereq="true" >}}
 > JSON.GET bikes:inventory $.inventory.*
-"[[{\"id\":\"bike:1\",\"model\":\"Phoebe\",\"description\":\"This is a mid-travel trail slayer...
+"[[{\"id\":\"bike:1\",\"model\":\"Phoebe\",\"description\":\"This is a mid-travel trail slayer that is a fantastic daily driver or one bike quiver. The Shimano Claris 8-speed groupset gives plenty of gear range to tackle hills and there's room for mudguards and a rack too. This is the bike for the rider who wants trail manners with low fuss ownership.\",\"price\":1920,\"specs\":{\"material\":\"carbon\",\"weight\":13.1},\"colors\":[\"black\",\"silver\"]},{\"id\":\"bike:2\",\"model\":\"Quaoar\",\"description\":\"Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.\",\"price\":2072,\"specs\":{\"material\":\"aluminium\",\"weight\":7.9},\"colors\":[\"black\",\"white\"]},{\"id\":\"bike:3\",\"model\":\"Weywot\",\"description\":\"This bike gives kids aged six years and older a durable and uberlight mountain bike for their first experience on tracks and easy cruising through forests and fields. A set of powerful Shimano hydraulic disc brakes provide ample stopping ability. If you're after a budget option, this is one of the best bikes you could get.\",\"price\":3264,\"specs\":{\"material\":\"alloy\",\"weight\":13.8}}],[{\"id\":\"bike:4\",\"model\":\"Salacia\",\"description\":\"This bike is a great option for anyone who just wants a bike to get about on With a slick-shifting Claris gears from Shimano's, this is a bike which doesn't break the bank and delivers craved performance. It's for the rider who wants both efficiency and capability.\",\"price\":1475,\"specs\":{\"material\":\"aluminium\",\"weight\":16.6},\"colors\":[\"black\",\"silver\"]},{\"id\":\"bike:5\",\"model\":\"Mimas\",\"description\":\"A real joy to ride, this bike got very high scores in last years Bike of the year report. The carefully crafted 50-34 tooth chainset and 11-32 tooth cassette give an easy-on-the-legs bottom gear for climbing, and the high-quality Vittoria Zaffiro tires give balance and grip.It includes a low-step frame , our memory foam seat, bump-resistant shocks and conveniently placed thumb throttle. Put it all together and you get a bike that helps redefine what can be done for this price.\",\"price\":3941,\"specs\":{\"material\":\"alloy\",\"weight\":11.6}}]]"
 {{< /clients-example >}}
 
 For some queries, multiple paths can produce the same results. For example, the following paths return the names of all mountain bikes:
@@ -179,7 +179,7 @@ a weight less than 10:
 
 {{< clients-example set="json_tutorial" step="filter1" description="Filter expressions: Use ?() with comparison and logical operators to select elements matching specific conditions when you need to query based on multiple criteria" difficulty="advanced" buildsUpon="get_models" needs_prereq="true" >}}
 > JSON.GET bikes:inventory '$..mountain_bikes[?(@.price < 3000 && @.specs.weight < 10)]'
-"[{\"id\":\"bike:2\",\"model\":\"Quaoar\",\"description\":\"Redesigned for the 2020 model year...
+"[{\"id\":\"bike:2\",\"model\":\"Quaoar\",\"description\":\"Redesigned for the 2020 model year, this bike impressed our testers and is the best all-around trail bike we've ever tested. The Shimano gear system effectively does away with an external cassette, so is super low maintenance in terms of wear and tear. All in all it's an impressive package for the price, making it very competitive.\",\"price\":2072,\"specs\":{\"material\":\"aluminium\",\"weight\":7.9},\"colors\":[\"black\",\"white\"]}]"
 {{< /clients-example >}}
 
 This example filters the inventory for the model names of bikes made from alloy:
@@ -244,7 +244,7 @@ JSONPath queries also work with other JSON commands that accept a path as an arg
 > JSON.ARRAPPEND bikes:inventory '$.inventory.*[?(@.price<2000)].colors' '"pink"'
 1) (integer) 3
 2) (integer) 3
-127.0.0.1:6379> JSON.GET bikes:inventory $..[*].colors
+> JSON.GET bikes:inventory $..[*].colors
 "[[\"black\",\"silver\",\"pink\"],[\"black\",\"white\"],[\"black\",\"silver\",\"pink\"]]"
 {{< /clients-example >}}
 

--- a/content/develop/data-types/lists.md
+++ b/content/develop/data-types/lists.md
@@ -234,7 +234,7 @@ want to worry about the 3 that have been on the list the longest:
 
 {{< clients-example set="list_tutorial" step="ltrim" description="Capped lists: Use LTRIM with positive indexes to keep a range of elements from the beginning when you need to maintain a fixed-size list" difficulty="intermediate" buildsUpon="lpush_rpush" >}}
 > DEL bikes:repairs
-(integer) 1
+(integer) 0
 > RPUSH bikes:repairs bike:1 bike:2 bike:3 bike:4 bike:5
 (integer) 5
 > LTRIM bikes:repairs 0 2
@@ -400,7 +400,7 @@ Example of rule 3:
 
 {{< clients-example set="list_tutorial" step="rule_3" description="Nil handling: Read-only commands on non-existent keys return empty results (0 or nil) instead of errors, treating them as empty lists" >}}
 > DEL bikes:repairs
-(integer) 0
+(integer) 1
 > LLEN bikes:repairs
 (integer) 0
 > LPOP bikes:repairs

--- a/content/develop/data-types/probabilistic/count-min-sketch.md
+++ b/content/develop/data-types/probabilistic/count-min-sketch.md
@@ -43,7 +43,7 @@ Assume you select an error rate of 0.1% (0.001) with a certainty of 99.8% (0.998
 > CMS.INITBYPROB bikes:profit 0.001 0.002
 OK
 > CMS.INCRBY bikes:profit "Smokey Mountain Striker" 100
-(integer) 100
+1) (integer) 100
 > CMS.INCRBY bikes:profit "Rocky Mountain Racer" 200 "Cloudy City Cruiser" 150
 1) (integer) 200
 2) (integer) 150

--- a/content/develop/data-types/probabilistic/t-digest.md
+++ b/content/develop/data-types/probabilistic/t-digest.md
@@ -106,7 +106,7 @@ OK
 > TDIGEST.ADD racer_ages 45.88 44.2 58.03 19.76 39.84 69.28 50.97 25.41 19.27 85.71 42.63
 OK
 > TDIGEST.CDF racer_ages 50
-1) "0.63636363636363635"
+1) "0.6363636363636364"
 > TDIGEST.RANK racer_ages 50
 1) (integer) 7
 > TDIGEST.RANK racer_ages 50 40
@@ -124,9 +124,9 @@ And lastly, `TDIGEST.REVRANK key value...` is similar to [TDIGEST.RANK]({{< relr
 
 {{< clients-example set="tdigest_tutorial" step="tdig_quant" description="Quantile and rank value estimation: Use TDIGEST.QUANTILE to find values at specific percentiles and TDIGEST.BYRANK to find values by rank when you need to retrieve percentile values from a sketch" difficulty="intermediate" buildsUpon="tdig_cdf" needs_prereq="true" >}}
 > TDIGEST.QUANTILE racer_ages .5
-1) "44.200000000000003"
+1) "44.2"
 > TDIGEST.BYRANK racer_ages 4
-1) "42.630000000000003"
+1) "42.63"
 {{< /clients-example >}}
 
 `TDIGEST.BYREVRANK key rank...` returns, for each input **reverse rank**, an estimation of the **value** (floating point) with that reverse rank.
@@ -155,7 +155,7 @@ Use [`TDIGEST.MIN`]({{< relref "commands/tdigest.min/" >}}) and [`TDIGEST.MAX`](
 > TDIGEST.MIN racer_ages
 "19.27"
 > TDIGEST.MAX racer_ages
-"85.709999999999994"
+"85.71"
 {{< /clients-example >}}
 
 Both return `nan` when the sketch is empty.

--- a/content/develop/data-types/probabilistic/top-k.md
+++ b/content/develop/data-types/probabilistic/top-k.md
@@ -70,15 +70,15 @@ OK
 3) (nil)
 4) (nil)
 5) (nil)
-6) handlebars
+6) "handlebars"
 7) (nil)
 8) (nil)
 > TOPK.LIST bikes:keywords
-1) store
-2) seat
-3) pedals
-4) tires
-5) handles
+1) "store"
+2) "seat"
+3) "pedals"
+4) "tires"
+5) "handles"
 > TOPK.QUERY bikes:keywords store handlebars
 1) (integer) 1
 2) (integer) 0

--- a/content/develop/data-types/sets.md
+++ b/content/develop/data-types/sets.md
@@ -78,9 +78,9 @@ multiple sets, and so forth.
 > SADD bikes:racing:france bike:1 bike:2 bike:3
 (integer) 3
 > SMEMBERS bikes:racing:france
-1) bike:3
-2) bike:1
-3) bike:2
+1) "bike:3"
+2) "bike:1"
+3) "bike:2"
 {{< /clients-example >}}
 
 Here I've added three elements to my set and told Redis to return all the

--- a/content/develop/data-types/sets.md
+++ b/content/develop/data-types/sets.md
@@ -107,6 +107,8 @@ We can also find the difference between two sets. For instance, we may want
 to know which bikes are racing in France but not in the USA:
 
 {{< clients-example set="sets_tutorial" step="sdiff" description="Set difference: Find members in one set but not in others using SDIFF when you need to exclude items (warning: argument order matters)" difficulty="intermediate" buildsUpon="sadd" needs_prereq="true" >}}
+> DEL bikes:racing:usa
+(integer) 1
 > SADD bikes:racing:usa bike:1 bike:4
 (integer) 2
 > SDIFF bikes:racing:france bikes:racing:usa

--- a/content/develop/data-types/timeseries/_index.md
+++ b/content/develop/data-types/timeseries/_index.md
@@ -71,8 +71,32 @@ TSDB-TYPE
 > TS.INFO thermometer:1
  1) totalSamples
  2) (integer) 0
-    .
-    .
+ 3) memoryUsage
+ 4) (integer) 4424
+ 5) firstTimestamp
+ 6) (integer) 0
+ 7) lastTimestamp
+ 8) (integer) 0
+ 9) retentionTime
+10) (integer) 0
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
+19) labels
+20) (empty array)
+21) sourceKey
+22) (nil)
+23) rules
+24) (empty array)
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 {{< /clients-example >}}
 
 The timestamp for each data point is a 64-bit integer value. The value
@@ -87,12 +111,34 @@ the data does not expire.
 > TS.ADD thermometer:2 1 10.8 RETENTION 100
 (integer) 1
 > TS.INFO thermometer:2
-    .
-    .
+ 1) totalSamples
+ 2) (integer) 1
+ 3) memoryUsage
+ 4) (integer) 4424
+ 5) firstTimestamp
+ 6) (integer) 1
+ 7) lastTimestamp
+ 8) (integer) 1
  9) retentionTime
 10) (integer) 100
-    .
-    .
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
+19) labels
+20) (empty array)
+21) sourceKey
+22) (nil)
+23) rules
+24) (empty array)
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 {{< /clients-example >}}
 
 You can also add one or more *labels* to a time series when you create it. Labels
@@ -107,16 +153,34 @@ for queries and aggregations.
  1) totalSamples
  2) (integer) 1
  3) memoryUsage
- 4) (integer) 5000
-    .
-    .
+ 4) (integer) 4568
+ 5) firstTimestamp
+ 6) (integer) 1
+ 7) lastTimestamp
+ 8) (integer) 1
+ 9) retentionTime
+10) (integer) 0
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
 19) labels
 20) 1) 1) "location"
        2) "UK"
     2) 1) "type"
        2) "Mercury"
-    .
-    .
+21) sourceKey
+22) (nil)
+23) rules
+24) (empty array)
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 {{< /clients-example >}}
 
 ## Add data points
@@ -378,7 +442,7 @@ OK
       3) 1) (integer) 1
          2) 2.1
 2) 1) "rg:4"
-2) 1) 1) "location"
+   2) 1) 1) "location"
          2) "uk"
    3) 1) 1) (integer) 3
          2) 19
@@ -536,7 +600,7 @@ that have the same timestamp and the same label value (this feature is available
 
 For example, the following commands create four time series, two for the UK and two for the US, and add some data points. The first `TS.MRANGE` command groups the results by country and applies a `max` aggregation to find the maximum sample value in each country at each timestamp. The second `TS.MRANGE` command uses the same grouping, but applies an `avg` aggregation.
 
-{{< clients-example set="time_series_tutorial" step="agg_multi" description="Cross-series aggregation: Use GROUPBY and REDUCE with TS.MRANGE to aggregate data across multiple time series by label when you need to compute statistics across groups" difficulty="advanced" buildsUpon="agg, create_labels" >}}
+{{< clients-example set="time_series_tutorial" step="agg_multi" description="Cross-series aggregation: Use GROUPBY and REDUCE with TS.MRANGE to aggregate data across multiple time series by label when you need to compute statistics across groups" difficulty="advanced" buildsUpon="agg, create_labels" runnable="false" >}}
 > TS.CREATE wind:1 LABELS country uk
 OK
 > TS.CREATE wind:2 LABELS country uk
@@ -697,22 +761,37 @@ OK
 > TS.CREATERULE hyg:1 hyg:compacted AGGREGATION min 3
 OK
 > TS.INFO hyg:1
-    .
-    .
+ 1) totalSamples
+ 2) (integer) 0
+ 3) memoryUsage
+ 4) (integer) 4520
+ 5) firstTimestamp
+ 6) (integer) 0
+ 7) lastTimestamp
+ 8) (integer) 0
+ 9) retentionTime
+10) (integer) 0
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
+19) labels
+20) (empty array)
+21) sourceKey
+22) (nil)
 23) rules
 24) 1) 1) "hyg:compacted"
        2) (integer) 3
        3) MIN
        4) (integer) 0
-    .
-    .
-> TS.INFO hyg:compacted
-    .
-    .
-21) sourceKey
-22) "hyg:1"
-    .
-    .
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 {{< /clients-example >}}
 
 Adding data points within the first 3ms (the first bucket) doesn't
@@ -772,46 +851,124 @@ If you want to delete a single timestamp, use it as both the start and end of th
  1) totalSamples
  2) (integer) 2
  3) memoryUsage
- 4) (integer) 4856
+ 4) (integer) 4424
  5) firstTimestamp
  6) (integer) 1
  7) lastTimestamp
  8) (integer) 2
-    .
-    .
+ 9) retentionTime
+10) (integer) 0
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
+19) labels
+20) (empty array)
+21) sourceKey
+22) (nil)
+23) rules
+24) (empty array)
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 > TS.ADD thermometer:1 3 9.7
 (integer) 3
 > TS.INFO thermometer:1
  1) totalSamples
  2) (integer) 3
  3) memoryUsage
- 4) (integer) 4856
+ 4) (integer) 4424
  5) firstTimestamp
  6) (integer) 1
  7) lastTimestamp
  8) (integer) 3
-    .
-    .
+ 9) retentionTime
+10) (integer) 0
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
+19) labels
+20) (empty array)
+21) sourceKey
+22) (nil)
+23) rules
+24) (empty array)
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 > TS.DEL thermometer:1 1 2
 (integer) 2
 > TS.INFO thermometer:1
  1) totalSamples
  2) (integer) 1
  3) memoryUsage
- 4) (integer) 4856
+ 4) (integer) 4424
  5) firstTimestamp
  6) (integer) 3
  7) lastTimestamp
  8) (integer) 3
-    .
-    .
+ 9) retentionTime
+10) (integer) 0
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
+19) labels
+20) (empty array)
+21) sourceKey
+22) (nil)
+23) rules
+24) (empty array)
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 > TS.DEL thermometer:1 3 3
 (integer) 1
 > TS.INFO thermometer:1
  1) totalSamples
  2) (integer) 0
-    .
-    .
+ 3) memoryUsage
+ 4) (integer) 4424
+ 5) firstTimestamp
+ 6) (integer) 0
+ 7) lastTimestamp
+ 8) (integer) 0
+ 9) retentionTime
+10) (integer) 0
+11) chunkCount
+12) (integer) 1
+13) chunkSize
+14) (integer) 4096
+15) chunkType
+16) compressed
+17) duplicatePolicy
+18) block
+19) labels
+20) (empty array)
+21) sourceKey
+22) (nil)
+23) rules
+24) (empty array)
+25) ignoreMaxTimeDiff
+26) (integer) 0
+27) ignoreMaxValDiff
+28) "0"
 {{< /clients-example >}}
 
 ## Use time series with other metrics tools

--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -95,7 +95,7 @@ is applied to improve performance.
 > VEMB points pt:A
 1) "0.9999999403953552"
 2) "0.9999999403953552"
-9> VEMB points pt:B
+> VEMB points pt:B
 1) "-0.9999999403953552"
 2) "-0.9999999403953552"
 > VEMB points pt:C


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly documentation transcripts and a new optional CI script that calls the public redis.io CLI API; no runtime product or auth paths are modified.
> 
> **Overview**
> Adds **`build/check_tryit_output.py`**, a CI-oriented verifier that parses `clients-example` transcripts, runs each page’s commands in one shared **redis.io/cli** session (batched to 20 commands), formats API replies like **`static/js/cli.js`**, and compares them to documented output. **ERROR** (command fails when docs expect real output) fails the build; **MISMATCH** is reported but only gates with **`--strict`**. It handles unordered commands, skips non-deterministic ones, and can mask volatile values (stream IDs, timestamps).
> 
> Across command and develop docs, **example transcripts are updated** so they match live redis-cli text: unquoted **`OK`** for simple strings, quoted bulk strings, nested array layout (e.g. **ARSCAN**, **ARGREP**, **CMS.INCRBY**), fixed typos/corruption in **XADD** examples, **`DEL`** setup in **ZRANGE** / **ARGREP** / **SDIFF** for isolated runs, fuller **JSON** wildcard/filter output, expanded **TS.INFO** blocks, **`runnable="false"`** on a heavy **TS.MRANGE** example, and small numeric/format fixes (**t-digest**, **FT.SEARCH**, **lists** `DEL` return values).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b380478d5f06ffab3cc8a388ffa0740274dd1d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->