### PR TITLE
RED-188637: Exposing DB tags to metrics

### DIFF
--- a/content/embeds/rs-prometheus-metrics-v2.md
+++ b/content/embeds/rs-prometheus-metrics-v2.md
@@ -46,6 +46,7 @@
 | endpoint_write_responses | counter | count | Number of write responses |
 | db_config | gauge | — | This is an information metric that holds database configuration within labels such as: db_name, db_version, db_port, tls_mode |
 | db_status | gauge | — | This is a status metric that reports on various database statuses: 0 = active, 1 = active-change-pending, 2 = pending, 3 = import-pending, 4 = delete-pending, 5 = recovery, 99 = unknown |
+| db_tags | gauge | — | Information metric that exposes database tags as labels; the value is always `1`. See [Database tags in metrics]({{< relref "/operate/rs/monitoring/metrics_stream_engine/db-tags-in-metrics" >}}). |
 
 ## Node metrics
 

--- a/content/operate/rs/databases/configure/db-tags.md
+++ b/content/operate/rs/databases/configure/db-tags.md
@@ -52,3 +52,66 @@ To edit a database's existing tags using the Cluster Manager UI:
 1. After you finish editing tags, click **Done** to close the tag manager.
 
 1. Click **Save**.
+
+## Tag validation rules
+
+The following rules apply to tags you create or edit.
+
+Tag keys and values are preserved exactly as you enter them. Redis Software does not change their casing.
+
+Key rules:
+
+- A key must not be empty or contain only whitespace.
+- A key must be unique on the database. Uniqueness is exact and case-sensitive, so `env` and `Env` are different keys.
+- A key must be at most 64 characters.
+- A key must start with a letter or an underscore and can contain only letters, digits, and underscores.
+- A key must not be a system key. See [System tags](#system-tags).
+
+Valid key examples: `env`, `team`, `TEAM`, `_owner`, `app_1`.
+
+Invalid key examples: `1team`, `env.prod`, `team-name`, `region:az`, `with space`, `bad/key`.
+
+Value rules:
+
+- A value must not be empty or contain only whitespace.
+- A value must be at most 128 characters.
+- A value can contain letters, digits, spaces, and the characters `. _ + - @ : /`.
+
+Valid value examples: `prod`, `Team A`, `us-east-1`, `service/api`, `owner@example.com`, `v1.2.3`.
+
+Count limit:
+
+- A database can have at most 30 tags that meet these rules. [System tags](#system-tags) and unchanged [legacy tags](#backward-compatibility-for-existing-tags) do not count toward this limit.
+
+### Backward compatibility for existing tags
+
+The current validation rules were introduced in Redis Software version 8.0.20, when database tags became eligible to be exposed as labels in [v2 metrics]({{<relref "/operate/rs/monitoring/metrics_stream_engine/prometheus-metrics-v2">}}). In particular, tag keys must follow the [Prometheus label name rules](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels). Tags created before version 8.0.20 might not meet these rules.
+
+Existing tags that do not meet the current validation rules can remain on a database for backward compatibility, as long as they are unchanged. A tag is considered unchanged only when both its key and its value stay exactly the same.
+
+If you edit the key or value of such a tag, the edited tag must pass the current validation rules. Unchanged legacy tags that do not meet the rules are not eligible for metrics. To use them in metrics, replace or rename them with valid tags.
+
+### System tags
+
+Some tag keys, such as `redis`, `cluster`, and `db`, are reserved for internal use by Redis Software. These are called system tags:
+
+- You cannot add or manage system tags through normal database configuration. These reserved keys are rejected.
+- System tags cannot be exposed in metrics.
+- When you retrieve tags, the response can include an `isSystem` marker that identifies system tags. This marker is computed by Redis Software each time tags are returned. It is not a customer-editable or persistent field, and any `isSystem` value you send when writing tags is ignored. You cannot turn a tag into a system tag by setting `isSystem`.
+- Editing your own tags does not remove system tags that are already stored on the database.
+
+## Use database tags in metrics
+
+You can expose selected database tags as labels in [v2 metrics]({{<relref "/operate/rs/monitoring/metrics_stream_engine/prometheus-metrics-v2">}}) through a dedicated `db_tags` metric. This lets you build dashboards, alerts, filters, and ownership views that are grouped by your tags, once the relevant tag keys are enabled in the cluster's metrics configuration.
+
+For how to enable export, choose which tag keys are exposed, query metrics with `db_tags`, and use tags in observability platforms such as Prometheus, Grafana, Datadog, New Relic, and Dynatrace, see [Database tags in metrics]({{<relref "/operate/rs/monitoring/metrics_stream_engine/db-tags-in-metrics">}}).
+
+## Troubleshooting database tags
+
+### Why can't I add a tag?
+
+Check if your tags adhere to the [validation rules]({{<relref "/operate/rs/databases/configure/db-tags#tag-validation-rules">}}).
+
+### Why can't I update the value of some of the existing tags?
+
+Those tags are likely [legacy tags]({{<relref "/operate/rs/databases/configure/db-tags#backward-compatibility-for-existing-tags">}}) that no longer meet the current validation rules.

--- a/content/operate/rs/databases/configure/db-tags.md
+++ b/content/operate/rs/databases/configure/db-tags.md
@@ -85,7 +85,7 @@ Count limit:
 
 ### Backward compatibility for existing tags
 
-The current validation rules were introduced in Redis Software version 8.0.20, when database tags became eligible to be exposed as labels in [v2 metrics]({{<relref "/operate/rs/monitoring/metrics_stream_engine/prometheus-metrics-v2">}}). In particular, tag keys must follow the [Prometheus label name rules](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels). Tags created before version 8.0.20 might not meet these rules.
+The current validation rules were introduced in Redis Software version 8.2.0, when database tags became eligible to be exposed as labels in [v2 metrics]({{<relref "/operate/rs/monitoring/metrics_stream_engine/prometheus-metrics-v2">}}). In particular, tag keys must follow the [Prometheus label name rules](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels). Tags created before version 8.2.0 might not meet these rules.
 
 Existing tags that do not meet the current validation rules can remain on a database for backward compatibility, as long as they are unchanged. A tag is considered unchanged only when both its key and its value stay exactly the same.
 

--- a/content/operate/rs/monitoring/metrics_stream_engine/db-tags-in-metrics.md
+++ b/content/operate/rs/monitoring/metrics_stream_engine/db-tags-in-metrics.md
@@ -1,0 +1,214 @@
+---
+Title: Database tags in metrics
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+description: Expose Redis Software database tag keys as labels in v2 metrics, then join them onto database metrics in your observability tools.
+group: observability
+linkTitle: Database tags in metrics
+summary: Learn how to expose Redis Software database tags in v2 metrics and use them to enrich database metrics.
+type: integration
+weight: 50
+tocEmbedHeaders: true
+---
+
+## Overview
+
+You can [expose](#enable-database-tags-in-metrics) selected [database tags]({{<relref "/operate/rs/databases/configure/db-tags">}}) as labels in the [v2 metrics]({{<relref "/operate/rs/monitoring/metrics_stream_engine/prometheus-metrics-v2">}}) scraping endpoint through a dedicated `db_tags` metric. Then [join `db_tags` onto your database metrics](#use-database-tags-in-observability-platforms) at query time, or enrich them in your observability pipeline, to group, filter, and alert on metrics by ownership, environment, service, tier, or any other metadata you store as tags.
+
+## Enable database tags in metrics
+
+Database tag exposure is controlled by two fields in the cluster's [metrics configuration]({{<relref "/operate/rs/monitoring/metrics_stream_engine/metrics-configuration">}}):
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `expose_db_tags` | boolean | `false` | When `true`, enables export of database tags through the `db_tags` metric. |
+| `metrics_tag_keys_exposed` | list of strings | `[]` | The database tag keys that are eligible to be exported as labels. Can contain at most 50 keys. |
+
+To expose database tags in metrics:
+
+1. Set `expose_db_tags` to `true`.
+
+1. Add the tag keys you want to expose to `metrics_tag_keys_exposed`. Only tags whose keys appear in this list are considered for export.
+
+Example configuration:
+
+```json
+{
+  "expose_db_tags": true,
+  "metrics_tag_keys_exposed": ["env", "team", "tier"]
+}
+```
+
+{{<warning>}}
+`metrics_tag_keys_exposed` is replaced in full whenever you update it. To add a key while keeping the current ones, send the complete list. For example, to add `tier` to `["env", "team"]`, send `["env", "team", "tier"]`; sending only `["tier"]` removes `env` and `team`.
+{{</warning>}}
+
+## Exported metric
+
+When `expose_db_tags` is enabled and a database has at least one tag whose key is listed in `metrics_tag_keys_exposed`, Redis Software emits a `db_tags` sample for that database:
+
+```prometheus
+db_tags{cluster="my-cluster", db="42", env="prod", team="core"} 1
+```
+
+Key points:
+
+- `db_tags` is an information metric. Its value is always `1`; the labels carry the information.
+- There is one `db_tags` series per database, identified by the fixed `cluster` and `db` labels.
+- Each exposed tag becomes an additional label on the series.
+
+### Emission rules
+
+Redis Software emits `db_tags` per database according to these rules:
+
+- `db_tags` is emitted only after you [enable database tags in metrics](#enable-database-tags-in-metrics).
+- Only tags that follow the [tag validation rules]({{<relref "/operate/rs/databases/configure/db-tags#tag-validation-rules">}}) can be exported. [System tags]({{<relref "/operate/rs/databases/configure/db-tags#system-tags">}}) and [legacy tags]({{<relref "/operate/rs/databases/configure/db-tags#backward-compatibility-for-existing-tags">}}) that do not meet the rules are not eligible.
+- Matching between a database's tag keys and the keys in `metrics_tag_keys_exposed` is exact and case-sensitive.
+- If a database has no tag whose key is listed in `metrics_tag_keys_exposed`, no `db_tags` sample is emitted for that database.
+
+## Use database tags in observability platforms
+
+Because tags are exported through the separate `db_tags` metric, you combine them with other database metrics by matching on the shared `cluster` and `db` labels. Match on both labels in every platform so each database is uniquely identified: database IDs can repeat across clusters.
+
+The examples below use the sample tags `env`, `team`, and `tier`, and the [`redis_server_used_memory`]({{<relref "/operate/rs/monitoring/metrics_stream_engine/prometheus-metrics-v2">}}) metric.
+
+### Prometheus and Grafana
+
+#### Dashboards
+
+PromQL joins the labels from `db_tags` onto another database metric with a many-to-one vector match using the `on` and `group_left` operators. The same PromQL works in Prometheus and in Grafana panels that use a Prometheus data source.
+
+```promql
+sum by (env, team) (
+  redis_server_used_memory
+    * on (cluster, db) group_left(env, team)
+      db_tags
+)
+```
+
+To restrict the result to specific tag values, filter on the `db_tags` side of the match:
+
+```promql
+sum by (team) (
+  redis_server_used_memory
+    * on (cluster, db) group_left(env, team)
+      db_tags{env="prod"}
+)
+```
+
+#### Alerts
+
+You can alert on tag-enriched metrics with the same join expression. The following is a Prometheus alerting rule that alerts on total memory by environment:
+
+```yaml
+groups:
+  - name: redis-db-tags
+    rules:
+      - alert: HighRedisMemoryByEnvironment
+        expr: |
+          sum by (env) (
+            redis_server_used_memory
+              * on (cluster, db) group_left(env)
+                db_tags{env="prod"}
+          ) > THRESHOLD
+        for: 5m
+```
+
+Replace `THRESHOLD` with a value appropriate for your deployment.
+
+### Datadog
+
+The Datadog OpenMetrics check can copy labels between collected metrics with the [`share_labels`](https://docs.datadoghq.com/integrations/openmetrics/) option. In your OpenMetrics instance configuration, share the `db_tags` labels with the metrics that match on `cluster` and `db`.
+
+Transformation (OpenMetrics instance configuration):
+
+```yaml
+share_labels:
+  db_tags:
+    match:
+      - cluster
+      - db
+```
+
+Query the enriched metric in Datadog:
+
+```text
+sum:rdse.redis_server_used_memory{*} by {env,team}
+```
+
+### New Relic
+
+The New Relic [Prometheus OpenMetrics integration](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/configure-prometheus-openmetrics-integrations/) can copy labels between metrics scraped from the same endpoint with the [`copy_attributes`](https://docs.newrelic.com/docs/infrastructure/prometheus-integrations/install-configure-openmetrics/add-rename-or-copy-prometheus-attributes/) transformation. Copy the `db_tags` labels onto the Redis database metrics, matching on `cluster` and `db`. The `to_metrics` prefix selects the target metrics, so adjust `redis_` to match the Redis metric names in your environment.
+
+Transformation (Prometheus OpenMetrics integration config):
+
+```yaml
+transformations:
+  - copy_attributes:
+      - from_metric: "db_tags"
+        to_metrics:
+          - "redis_"
+        match_by:
+          - cluster
+          - db
+```
+
+Query the metric in New Relic:
+
+```sql
+FROM Metric
+SELECT sum(redis_server_used_memory)
+FACET env, team
+```
+
+### Dynatrace
+
+Dynatrace has no built-in transformation to combine metrics. Use a custom transformation to attach the `db_tags` labels to your database metrics before ingestion.
+
+The transformation attaches the `db_tags` labels to each database metric, matching on `cluster` and `db`:
+
+```text
+For each db_tags sample:
+  record the exposed tag labels, keyed by (cluster, db)
+
+For each database metric with (cluster, db):
+  look up the recorded tag labels for (cluster, db)
+  add the env, team, and tier labels
+```
+
+Query the metric in Dynatrace with DQL, using the metric and dimension names as they appear in your environment:
+
+```text
+timeseries avg(redis_server_used_memory), by:{env, team}
+```
+
+## Cardinality and performance considerations
+
+Redis Software exports tags through one dedicated `db_tags` metric per database instead of adding tag labels to every database metric (which would multiply the number of series by your tag labels), so the performance overhead on the Redis cluster and the metric footprint are already small. However, the tags you expose can still negatively affect performance and cardinality, e.g. Selecting many tag keys, using high-cardinality tag values, or frequently changing tag values. Consider the following when choosing which tags to expose:
+- Start with a small set of stable, low-cardinality tags such as `env`, `team`, `service`, or `tier`.
+- Avoid user IDs, request IDs, timestamps, build numbers, and other frequently changing or high-cardinality values.
+
+## Security considerations
+
+Tags that you expose in metrics are sent to external monitoring tools. Do not use secrets, credentials, personal data, or confidential business data as tag keys or values.
+
+## Troubleshooting and FAQ
+
+### Why aren't my tags exposed to metrics?
+
+Check if your tags adhere to the [emission rules](#emission-rules).
+
+### Why do I see increased cardinality?
+
+The tag labels you expose create additional time series in your monitoring backend. To keep cardinality under control, see [Cardinality and performance considerations](#cardinality-and-performance-considerations).
+
+### Why aren't database tags added directly to every database metric?
+
+To keep the performance overhead and metrics footprint small. See [Cardinality and performance considerations](#cardinality-and-performance-considerations).
+
+### Can I expose all my tags?
+
+You can list multiple tag keys in `metrics_tag_keys_exposed`, up to a limit of 50, but you should expose only the tags you need for dashboards, alerts, routing, or ownership. Exposing unnecessary or high-cardinality tags increases monitoring costs and query load.

--- a/content/operate/rs/monitoring/metrics_stream_engine/metrics-configuration.md
+++ b/content/operate/rs/monitoring/metrics_stream_engine/metrics-configuration.md
@@ -1,0 +1,33 @@
+---
+Title: Metrics configuration
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+description: Configure the Redis Software v2 metrics stream engine.
+group: observability
+linkTitle: Metrics configuration
+summary: Configure cluster-wide settings for the Redis Software v2 metrics stream engine.
+type: integration
+weight: 48
+tocEmbedHeaders: true
+---
+
+The metrics configuration is a cluster-wide resource that controls the behavior of the [v2 metrics stream engine]({{<relref "/operate/rs/monitoring/metrics_stream_engine">}}), such as which optional metrics are collected and how metrics are stored and exported.
+
+For the full list of configuration fields, their types, and defaults, see the [metrics configuration object]({{<relref "/operate/rs/references/rest-api/objects/metrics_config">}}).
+
+## Configure metrics settings
+
+You can read and update the metrics configuration through the REST API or with `rladmin`.
+
+Changes to the metrics configuration are recorded in the cluster's [event logs]({{<relref "/operate/rs/clusters/logging">}}), so you can review who changed a setting and when.
+
+### REST API
+
+Use the `GET` and `PUT` `/v1/metrics_config` requests to read and update the configuration. For request and response details, required permissions, and status codes, see [Metrics configuration requests]({{<relref "/operate/rs/references/rest-api/requests/metrics_config">}}).
+
+### rladmin
+
+Use [`rladmin info metrics`]({{<relref "/operate/rs/references/cli-utilities/rladmin/info#info-metrics">}}) to view the current configuration and [`rladmin metrics config`]({{<relref "/operate/rs/references/cli-utilities/rladmin/metrics#metrics-config">}}) to update it.

--- a/content/operate/rs/references/cli-utilities/rladmin/info.md
+++ b/content/operate/rs/references/cli-utilities/rladmin/info.md
@@ -200,3 +200,34 @@ proxy:1
     max_threads: 8
     threads: 3
 ```
+
+## `info metrics`
+
+Shows the cluster-wide [metrics configuration]({{<relref "/operate/rs/monitoring/metrics_stream_engine/metrics-configuration">}}) for the v2 metrics stream engine.
+
+```sh
+rladmin info metrics
+```
+
+### Parameters
+
+None
+
+### Returns
+
+Returns the current metrics configuration. To update it, use [`rladmin metrics config`]({{<relref "/operate/rs/references/cli-utilities/rladmin/metrics#metrics-config">}}).
+
+### Example
+
+``` sh
+$ rladmin info metrics
+Metrics configuration:
+    key_distribution_enabled: True
+    key_size_buckets: 128M,512M
+    key_items_buckets: 1M,8M
+    local_storage_max_size_mb: 1024
+    local_storage_retention_days: 8
+    expose_db_tags: True
+    metrics_tag_keys_exposed: env,team
+    max_requests_in_flight: 2
+```

--- a/content/operate/rs/references/cli-utilities/rladmin/metrics.md
+++ b/content/operate/rs/references/cli-utilities/rladmin/metrics.md
@@ -1,0 +1,42 @@
+---
+Title: rladmin metrics
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: Configures the cluster-wide metrics stream engine settings.
+headerRange: '[1-2]'
+linkTitle: metrics
+toc: 'true'
+weight: $weight
+---
+
+Manages the cluster-wide [metrics configuration]({{<relref "/operate/rs/monitoring/metrics_stream_engine/metrics-configuration">}}) for the v2 metrics stream engine.
+
+## `metrics config`
+
+Updates the cluster's metrics configuration. Specify one or more field/value pairs; at least one pair is required.
+
+```sh
+rladmin metrics config <field> <value> [ <field> <value> ... ]
+```
+
+To view the current configuration, use [`rladmin info metrics`]({{<relref "/operate/rs/references/cli-utilities/rladmin/info#info-metrics">}}).
+
+### Parameters
+
+For the available fields and their types, defaults, and validation, see the [metrics configuration object]({{<relref "/operate/rs/references/rest-api/objects/metrics_config">}}).
+
+On the command line, boolean fields take `enabled` or `disabled`, list fields take a comma-separated set of values, and an empty value (`""`) clears a list field.
+
+### Returns
+
+Returns a confirmation message when the update succeeds.
+
+### Example
+
+```sh
+$ rladmin metrics config expose_db_tags enabled metrics_tag_keys_exposed env,team
+Metrics configuration updated successfully
+```

--- a/content/operate/rs/references/rest-api/objects/metrics_config.md
+++ b/content/operate/rs/references/rest-api/objects/metrics_config.md
@@ -1,0 +1,24 @@
+---
+Title: Metrics configuration object
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: An object that represents the cluster's v2 metrics stream engine configuration
+linkTitle: metrics_config
+weight: $weight
+---
+
+An API object that represents the cluster-wide configuration of the [v2 metrics stream engine]({{<relref "/operate/rs/monitoring/metrics_stream_engine">}}).
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| key_distribution_enabled | boolean | `false` | Enables histogram metrics that report the distribution of key sizes and key item counts |
+| key_size_buckets | string | `""` | Bucket boundaries for the key size distribution histogram. An empty value derives the boundaries from Redis. Otherwise, a comma-separated list of strictly ascending boundaries. Each boundary is a number (bytes) with an optional uppercase unit suffix `B`, `K`, `M`, `G`, `T`, `P`, or `E`; the numeric part must be between 1 and 1023. |
+| key_items_buckets | string | `""` | Bucket boundaries for the key item-count distribution histogram. Uses the same format as `key_size_buckets`. |
+| local_storage_max_size_mb | integer | `1024` | Maximum size, in MB, of on-node metrics storage (minimum 1) |
+| local_storage_retention_days | integer | `8` | Number of days metrics are retained in on-node storage (minimum 1) |
+| expose_db_tags | boolean | `false` | When `true`, enables export of database tags through the `db_tags` metric |
+| metrics_tag_keys_exposed | array of strings | `[]` | The database tag keys that are eligible to be exported as labels (maximum 50 keys). Each key must follow the [tag key validation rules]({{<relref "/operate/rs/databases/configure/db-tags#tag-validation-rules">}}). Keys are matched against database tag keys exactly and case-sensitively. |
+| max_requests_in_flight | integer | `2` | Maximum number of metrics requests the cluster processes concurrently. Set to 0 to remove the limit. |

--- a/content/operate/rs/references/rest-api/requests/metrics_config/_index.md
+++ b/content/operate/rs/references/rest-api/requests/metrics_config/_index.md
@@ -1,0 +1,137 @@
+---
+Title: Metrics configuration requests
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: Metrics configuration requests
+headerRange: '[1-2]'
+hideListLinks: true
+linkTitle: metrics_config
+weight: $weight
+---
+
+| Method | Path | Description |
+|--------|------|-------------|
+| [GET](#get-metrics-config) | `/v1/metrics_config` | Get the cluster's metrics configuration |
+| [PUT](#put-metrics-config) | `/v1/metrics_config` | Update the cluster's metrics configuration |
+
+## Get metrics configuration {#get-metrics-config}
+
+	GET /v1/metrics_config
+
+Get the cluster-wide configuration of the [v2 metrics stream engine]({{<relref "/operate/rs/monitoring/metrics_stream_engine">}}).
+
+#### Required permissions
+
+| Permission name |
+|-----------------|
+| [view_cluster_info]({{< relref "/operate/rs/references/rest-api/permissions#view_cluster_info" >}}) |
+
+### Request {#get-request}
+
+#### Example HTTP request
+
+	GET /v1/metrics_config
+
+#### Request headers
+
+| Key | Value | Description |
+|-----|-------|-------------|
+| Host | cnm.cluster.fqdn | Domain name |
+| Accept | application/json | Accepted media type |
+
+### Response {#get-response}
+
+Returns a [metrics configuration object]({{< relref "/operate/rs/references/rest-api/objects/metrics_config" >}}). If the configuration has not been set, the default values are returned.
+
+#### Example JSON body
+
+```json
+{
+    "key_distribution_enabled": false,
+    "key_size_buckets": "",
+    "key_items_buckets": "",
+    "local_storage_max_size_mb": 1024,
+    "local_storage_retention_days": 8,
+    "expose_db_tags": false,
+    "metrics_tag_keys_exposed": [],
+    "max_requests_in_flight": 2
+}
+```
+
+### Status codes {#get-status-codes}
+
+| Code | Description |
+|------|-------------|
+| [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | No error |
+
+## Update metrics configuration {#put-metrics-config}
+
+	PUT /v1/metrics_config
+
+Update the cluster's metrics configuration.
+
+This is a partial update: only the fields included in the request are changed, and any omitted fields keep their stored values. When a list field is included, its entire value is replaced; it is not merged with the stored list. The request must include at least one recognized field. If the configuration has never been set, the first update creates it, and any omitted fields take their default values.
+
+#### Required permissions
+
+| Permission name |
+|-----------------|
+| [update_cluster]({{< relref "/operate/rs/references/rest-api/permissions#update_cluster" >}}) |
+
+### Request {#put-request}
+
+#### Example HTTP request
+
+	PUT /v1/metrics_config
+
+#### Example JSON body
+
+```json
+{
+    "key_distribution_enabled": true,
+    "local_storage_retention_days": 14,
+    "metrics_tag_keys_exposed": ["env", "team"]
+}
+```
+
+The above request enables the key distribution histograms, sets local metrics retention to 14 days, and exposes the `env` and `team` database tag keys in metrics.
+
+#### Request headers
+
+| Key | Value | Description |
+|-----|-------|-------------|
+| Host | cnm.cluster.fqdn | Domain name |
+| Accept | application/json | Accepted media type |
+
+#### Request body
+
+Include a [metrics configuration object]({{< relref "/operate/rs/references/rest-api/objects/metrics_config" >}}) with the fields to update in the request body.
+
+### Response {#put-response}
+
+Returns the complete [metrics configuration object]({{< relref "/operate/rs/references/rest-api/objects/metrics_config" >}}) after the update.
+
+#### Example JSON body
+
+```json
+{
+    "key_distribution_enabled": true,
+    "key_size_buckets": "",
+    "key_items_buckets": "",
+    "local_storage_max_size_mb": 1024,
+    "local_storage_retention_days": 14,
+    "expose_db_tags": false,
+    "metrics_tag_keys_exposed": ["env", "team"],
+    "max_requests_in_flight": 2
+}
+```
+
+### Status codes {#put-status-codes}
+
+| Code | Description |
+|------|-------------|
+| [200 OK](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.2.1) | No error. |
+| [400 Bad Request](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.1) | Bad content provided, or the request body is empty. |

--- a/content/operate/rs/references/rest-api/requests/metrics_config/_index.md
+++ b/content/operate/rs/references/rest-api/requests/metrics_config/_index.md
@@ -93,11 +93,12 @@ This is a partial update: only the fields included in the request are changed, a
 {
     "key_distribution_enabled": true,
     "local_storage_retention_days": 14,
+    "expose_db_tags": true,
     "metrics_tag_keys_exposed": ["env", "team"]
 }
 ```
 
-The above request enables the key distribution histograms, sets local metrics retention to 14 days, and exposes the `env` and `team` database tag keys in metrics.
+The above request enables the key distribution histograms, sets local metrics retention to 14 days, enables database tags in metrics, and exposes the `env` and `team` tag keys.
 
 #### Request headers
 
@@ -123,7 +124,7 @@ Returns the complete [metrics configuration object]({{< relref "/operate/rs/refe
     "key_items_buckets": "",
     "local_storage_max_size_mb": 1024,
     "local_storage_retention_days": 14,
-    "expose_db_tags": false,
+    "expose_db_tags": true,
     "metrics_tag_keys_exposed": ["env", "team"],
     "max_requests_in_flight": 2
 }


### PR DESCRIPTION
Context: https://redislabs.atlassian.net/browse/RED-188637

Documents how to expose Redis Software database tags as labels in v2 metrics via the `db_tags` metric.

- Add a Database tags in metrics page: enabling exposure, the `db_tags` metric and emission rules, join/query examples for Prometheus/Grafana, Datadog, New Relic, and Dynatrace, plus cardinality, security, and FAQ.
- Add a Metrics configuration page and the `/v1/metrics_config` REST reference and `rladmin` metrics command.
- Update the database tags page with validation rules, backward compatibility, and system tags.
- Add info metrics to `rladmin` info and the `db_tags` row to the v2 metrics reference.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior modifications in this diff.
> 
> **Overview**
> Documents how Redis Software **database tags** can be exported into **v2 Prometheus metrics** via the `db_tags` information metric, and how operators configure and consume that data.
> 
> Adds **Database tags in metrics** (enable `expose_db_tags` / `metrics_tag_keys_exposed`, emission rules, PromQL joins, and platform-specific enrichment for Prometheus/Grafana, Datadog, New Relic, and Dynatrace) plus **Metrics configuration** and the **`/v1/metrics_config`** REST object and requests. **`rladmin info metrics`** and **`rladmin metrics config`** are documented for the same cluster-wide settings.
> 
> The **database tags** page gains **validation rules** (Prometheus-compatible keys, limits, legacy unchanged tags), **system tags**, a metrics overview, and troubleshooting. The v2 metrics reference embed adds a **`db_tags`** row linking to the new guide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe051c07792db8a17e44c262e00482942608f823. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->