### PR TITLE
K8s: cancun maint 4

### DIFF
--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-25-july2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-25-july2026.md
@@ -1,0 +1,35 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: This is a maintenance release to support Redis Enterprise Software version 8.0.20-68.
+hideListLinks: true
+linkTitle: 8.0.20-25 (July 2026)
+title: Redis Enterprise for Kubernetes 8.0.20-25 (July 2026) release notes
+weight: 28
+---
+
+## Highlights
+
+This is a maintenance release to support Redis Enterprise Software version 8.0.20-68. For version changes, supported distributions, and known limitations, see the [release notes for 8.0.18-11 (April 2026)]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026">}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:8.0.20-68.25` (`redislabs/redis:8.0.20-68.25.minimal` for minimal base image)
+- **Operator**: `redislabs/operator:8.0.20-25`
+- **Services Rigger**: `redislabs/k8s-controller:8.0.20-25`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.20-25`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `8.0.20-25.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-68.25` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-68.25.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.20-25`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.20-25`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.20-25`
+
+## Known limitations
+
+See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 8.0.20 release notes
 weight: 84
 ---
 
-Redis Enterprise for Kubernetes 8.0.20 is a maintenance release of [Redis Enterprise for Kubernetes 8.0.18]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/">}}). The latest release is 8.0.20-23 with support for Redis Enterprise Software version 8.0.20-44.
+Redis Enterprise for Kubernetes 8.0.20 is a maintenance release of [Redis Enterprise for Kubernetes 8.0.18]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/">}}). The latest release is 8.0.20-25 with support for Redis Enterprise Software version 8.0.20-68.
 
 ## Detailed release notes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to release notes and index text; no product or deployment logic affected.
> 
> **Overview**
> Adds documentation for **Redis Enterprise for Kubernetes 8.0.20-25** (July 2026), a maintenance release aligned with **Redis Enterprise Software 8.0.20-68**.
> 
> The new page lists container image tags for Redis Enterprise, operator, services rigger, and call-home client (including OpenShift/Red Hat registry variants) and points readers to **8.0.18-11** for supported distributions and limitations.
> 
> The **8.0.20 releases** index is updated so the latest release is **8.0.20-25** (was **8.0.20-23**), with the supported RE Software version **8.0.20-68** (was **8.0.20-44**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b87b1d93d49e864fa408f092f82c75ba0a152537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->