### PR TITLE
DEV: add links from vector set cmd pages to datatype page

### DIFF
--- a/content/commands/vadd.md
+++ b/content/commands/vadd.md
@@ -141,3 +141,4 @@ One of the following:
 ## Related topics
 
 - [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+- [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})

--- a/content/commands/vgetattr.md
+++ b/content/commands/vgetattr.md
@@ -68,3 +68,4 @@ One of the following:
 ## Related topics
 
 - [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+- [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})

--- a/content/commands/vrange.md
+++ b/content/commands/vrange.md
@@ -130,3 +130,7 @@ One of the following:
 - **Iteration guarantees**: Each range will produce exactly the elements that were present in the range at the moment the `VRANGE` command was executed.
 - **Concurrent modifications**: Elements removed or added during iteration may or may not be returned, depending on when they were modified.
 - **Empty key**: If the key doesn't exist, returns an empty array.
+
+## Related topics
+
+- [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})

--- a/content/commands/vsetattr.md
+++ b/content/commands/vsetattr.md
@@ -82,3 +82,4 @@ One of the following:
 ## Related topics
 
 - [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+- [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})

--- a/content/commands/vsim.md
+++ b/content/commands/vsim.md
@@ -114,13 +114,13 @@ controls the search effort. Higher values explore more nodes, improving recall a
 <details open>
 <summary><code>FILTER expression</code></summary>
 
-applies a filter expression to restrict matching elements. See the filtered search section for syntax details.
+applies a filter expression to restrict matching elements. See [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}}) for syntax details.
 </details>
 
 <details open>
 <summary><code>FILTER-EF max-filtering-effort</code></summary>
 
-limits the number of filtering attempts for the `FILTER` expression. See the filtered search section for more.
+limits the number of filtering attempts for the `FILTER` expression. See [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}}) for more information.
 </details>
 
 <details open>
@@ -168,3 +168,4 @@ One of the following:
 ## Related topics
 
 - [Vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+- [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})


### PR DESCRIPTION
Fixes #3651.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only cross-links and wording updates; no runtime, API, or build logic changes.
> 
> **Overview**
> Improves navigation from vector set **command** docs to the **Filtered search** datatype page (`/develop/data-types/vector-sets/filtered-search`).
> 
> **Related topics** on `VADD`, `VGETATTR`, `VSETATTR`, and `VSIM` now include a Filtered search link alongside Vector sets. `VRANGE` gains a new **Related topics** section pointing at Vector sets only.
> 
> On `VSIM`, the `FILTER` and `FILTER-EF` option descriptions no longer refer vaguely to “the filtered search section”; they link directly to the Filtered search page for syntax and behavior details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38822fc60d5c018ce0e6cb6b7f9715eb55b4c3e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->