### PR TITLE
Fix --from-file key explanation in Context Retriever TLS CA docs

### DIFF
--- a/content/develop/ai/context-engine/context-retriever/install/_index.md
+++ b/content/develop/ai/context-engine/context-retriever/install/_index.md
@@ -251,7 +251,7 @@ kubectl create secret generic my-redis-ca \
   --namespace $NS
 ```
 
-The Secret key is the file's basename, so `--from-file=ca.crt=...` produces the key `ca.crt`. If you use a different key (for example, `--from-file=root.pem=...`), set `key` accordingly in the values below.
+The `--from-file=<key>=<path>` syntax sets the Secret key explicitly — `ca.crt` in this example. If you omit the key (`--from-file=/path/to/file`), kubectl uses the file's basename instead. If you use a different key name (for example, `--from-file=root.pem=...`), set `key` accordingly in the values below.
 
 ### Reference the Secret in your values
 


### PR DESCRIPTION
The original text said the Secret key comes from the file's basename, which is only true for the bare --from-file=/path/to/file form. The example uses --from-file=<key>=<path>, where the key is set explicitly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording fix with no runtime or configuration behavior changes.
> 
> **Overview**
> Updates the **Trust a custom Redis CA certificate** section so the Secret key explanation matches how `kubectl create secret --from-file` actually works.
> 
> The doc now states that **`--from-file=<key>=<path>`** sets the Secret data key explicitly (e.g. `ca.crt` in the shown example), while the **bare** `--from-file=/path/to/file` form uses the file basename as the key. The note about using a different key name and aligning `redis.tlsCA.existingSecrets[].key` in Helm values is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5314b41fc9c03c3c78772283b0586235479892b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->