### PR TITLE
DOC-6845: Add MongoDB Atlas Private Link tab to Cloud RDI setup guide

### DIFF
--- a/content/operate/rc/rdi/setup.md
+++ b/content/operate/rc/rdi/setup.md
@@ -85,7 +85,8 @@ Select the steps for your database setup.
 
 {{< multitabs id="rdi-cloud-connectivity"
       tab1="EC2 instance"
-      tab2="AWS RDS or Aurora" >}}
+      tab2="AWS RDS or Aurora"
+      tab3="MongoDB Atlas" >}}
 
 To set up PrivateLink for a database hosted on an EC2 instance:
 
@@ -316,6 +317,49 @@ See the [AWS RDS PrivateLink Failover Example](https://github.com/redis/rdi-clou
 
 For custom implementations, refer to the AWS documentation:
 [Access Amazon RDS across VPCs using AWS PrivateLink and Network Load Balancer](https://aws.amazon.com/blogs/database/access-amazon-rds-across-vpcs-using-aws-privatelink-and-network-load-balancer/)
+
+--tab-sep--
+
+To set up Private Link for a MongoDB Atlas source database:
+
+MongoDB Atlas manages its own endpoint service. The flow is a two-way handshake — you get an endpoint service ID from Atlas, give it to Redis Cloud, and then take the VPC Endpoint ID that Redis Cloud returns back to Atlas to complete the connection.
+
+{{< note >}}
+Create the Atlas private endpoint in the same AWS region as your Redis Cloud target database.
+{{< /note >}}
+
+### Create a private endpoint in MongoDB Atlas
+
+1. In the [MongoDB Atlas UI](https://cloud.mongodb.com/), go to **Security** > **Network Access**.
+1. Select the **Private Endpoint** tab, then select **Dedicated Cluster**.
+1. Select **Add Private Endpoint**.
+    - Select **AWS** as the cloud provider.
+    - Select the AWS region that matches your Redis Cloud target database.
+    - Select **Next**.
+1. Atlas displays an **Endpoint Service ID** (for example, `vpce-svc-xxxxxxxxxxxxxxxxx`). Copy this value.
+
+### Register the endpoint service with Redis Cloud
+
+1. In the Redis Cloud console, in the pipeline creation flow, go to the **Source connectivity** step.
+1. In the **Private Link service name** field, paste the Endpoint Service ID you copied from Atlas.
+1. Redis Cloud creates a VPC endpoint and displays a **VPC Endpoint ID** (for example, `vpce-xxxxxxxxxxxxxxxxx`). Copy this value.
+
+### Complete the connection in MongoDB Atlas
+
+1. Return to the **Add Private Endpoint** page in the Atlas UI. In the **Your VPC Endpoint ID** field, enter the VPC Endpoint ID you copied from the Redis Cloud console. Select **Create**.
+1. Wait for the endpoint status to show as **Available**. This can take a few minutes.
+1. In the Atlas UI, go to your cluster and select **Connect** > **Private Endpoint**.
+1. Choose the private endpoint you just registered (the `vpce-` ID you entered above).
+1. Choose a connection method, then select **Shell**.
+1. Copy the connection string shown.
+
+    {{< note >}}
+Copy the connection string from the **Private Endpoint** connection method only. The standard connection string does not route traffic through the private endpoint.
+    {{< /note >}}
+
+### Finish pipeline setup
+
+1. Return to the Redis Cloud pipeline creation flow and paste the connection string into the **Source configuration** section.
 
 {{< /multitabs >}}
 


### PR DESCRIPTION
Documents the two-way handshake flow for connecting a MongoDB Atlas source database to Cloud RDI via Private Link: get the Atlas endpoint service ID, register it in Redis Cloud to receive a VPC Endpoint ID, complete the interface endpoint in Atlas, then copy the private connection string back into the pipeline setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the RDI setup guide; no application or infrastructure code affected.
> 
> **Overview**
> Adds a **MongoDB Atlas** tab to the Cloud RDI **Set up AWS Private Link connectivity** multitabs in `setup.md`, alongside the existing EC2 and RDS/Aurora paths.
> 
> The new content documents Atlas’s **two-way Private Link handshake**: copy Atlas’s **Endpoint Service ID** into Redis Cloud’s **Private Link service name**, copy the returned **VPC Endpoint ID** back into Atlas, wait until the endpoint is **Available**, then use the **Private Endpoint** connection string (not the standard URI) in the pipeline **Source configuration**. A note calls out matching the Atlas private endpoint **AWS region** to the Redis Cloud target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf524987f7f7cb86c9e2533bce661ca6ff30d903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->