### PR TITLE
DOC-6700: fix k8s_apis_sync role CRD filenames

### DIFF
--- a/.github/workflows/k8s_apis_sync.yaml
+++ b/.github/workflows/k8s_apis_sync.yaml
@@ -109,19 +109,19 @@ jobs:
           sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_cluster_role_binding_api.md
           awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_cluster_role_binding_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_cluster_role_binding_api.md
 
-          crdoc --resources crds/redbrole_crd.yaml --output artifacts/redis_enterprise_database_role_api.md --template templates/template.tmpl
-          sed -E -i 's/^### RedisEnterpriseDatabaseRole\./### /g' artifacts/redis_enterprise_database_role_api.md
-          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterprisedatabaserole/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_database_role_api.md
-          sed -E -i 's/<td><a href="#redisenterprisedatabaserole/<td><a href="#/' artifacts/redis_enterprise_database_role_api.md
-          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_database_role_api.md
-          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_database_role_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_database_role_api.md
+          crdoc --resources crds/rerole_crd.yaml --output artifacts/redis_enterprise_role_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseRole\./### /g' artifacts/redis_enterprise_role_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterpriserole/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_role_api.md
+          sed -E -i 's/<td><a href="#redisenterpriserole/<td><a href="#/' artifacts/redis_enterprise_role_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_role_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_role_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_role_api.md
 
-          crdoc --resources crds/redbrolebinding_crd.yaml --output artifacts/redis_enterprise_database_role_binding_api.md --template templates/template.tmpl
-          sed -E -i 's/^### RedisEnterpriseDatabaseRoleBinding\./### /g' artifacts/redis_enterprise_database_role_binding_api.md
-          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterprisedatabaserolebinding/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_database_role_binding_api.md
-          sed -E -i 's/<td><a href="#redisenterprisedatabaserolebinding/<td><a href="#/' artifacts/redis_enterprise_database_role_binding_api.md
-          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_database_role_binding_api.md
-          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_database_role_binding_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_database_role_binding_api.md
+          crdoc --resources crds/rerolebinding_crd.yaml --output artifacts/redis_enterprise_role_binding_api.md --template templates/template.tmpl
+          sed -E -i 's/^### RedisEnterpriseRoleBinding\./### /g' artifacts/redis_enterprise_role_binding_api.md
+          sed -E -i 's/^<sup><sup>\[↩ Parent\]\(#redisenterpriserolebinding/<sup><sup>\[↩ Parent\]\(#/g' artifacts/redis_enterprise_role_binding_api.md
+          sed -E -i 's/<td><a href="#redisenterpriserolebinding/<td><a href="#/' artifacts/redis_enterprise_role_binding_api.md
+          sed -E -i 's/\[index\]/\[\]/g' artifacts/redis_enterprise_role_binding_api.md
+          awk '/(#[^")]+)index/ {gsub(/index/,"")}; {print}' artifacts/redis_enterprise_role_binding_api.md > _tmp.md && mv _tmp.md artifacts/redis_enterprise_role_binding_api.md
 
           crdoc --resources crds/reuser_crd.yaml --output artifacts/redis_enterprise_user_api.md --template templates/template.tmpl
           sed -E -i 's/^### RedisEnterpriseUser\./### /g' artifacts/redis_enterprise_user_api.md
@@ -206,8 +206,8 @@ jobs:
           sed -E -i 's/linkTitle: RedisEnterpriseACL API Reference/linkTitle: REACL API/g' artifacts/redis_enterprise_acl_api.md
           sed -E -i 's/linkTitle: RedisEnterpriseClusterRole API Reference/linkTitle: RECROLE API/g' artifacts/redis_enterprise_cluster_role_api.md
           sed -E -i 's/linkTitle: RedisEnterpriseClusterRoleBinding API Reference/linkTitle: RECROLEBINDING API/g' artifacts/redis_enterprise_cluster_role_binding_api.md
-          sed -E -i 's/linkTitle: RedisEnterpriseDatabaseRole API Reference/linkTitle: REDBROLE API/g' artifacts/redis_enterprise_database_role_api.md
-          sed -E -i 's/linkTitle: RedisEnterpriseDatabaseRoleBinding API Reference/linkTitle: REDBROLEBINDING API/g' artifacts/redis_enterprise_database_role_binding_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseRole API Reference/linkTitle: REROLE API/g' artifacts/redis_enterprise_role_api.md
+          sed -E -i 's/linkTitle: RedisEnterpriseRoleBinding API Reference/linkTitle: REROLEBINDING API/g' artifacts/redis_enterprise_role_binding_api.md
           sed -E -i 's/linkTitle: RedisEnterpriseUser API Reference/linkTitle: REUSER API/g' artifacts/redis_enterprise_user_api.md
 
       - name: 'Generate YAML snippets'
@@ -265,8 +265,8 @@ jobs:
           cp artifacts/redis_enterprise_acl_api.md content/operate/kubernetes/reference/api/
           cp artifacts/redis_enterprise_cluster_role_api.md content/operate/kubernetes/reference/api/
           cp artifacts/redis_enterprise_cluster_role_binding_api.md content/operate/kubernetes/reference/api/
-          cp artifacts/redis_enterprise_database_role_api.md content/operate/kubernetes/reference/api/
-          cp artifacts/redis_enterprise_database_role_binding_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_role_api.md content/operate/kubernetes/reference/api/
+          cp artifacts/redis_enterprise_role_binding_api.md content/operate/kubernetes/reference/api/
           cp artifacts/redis_enterprise_user_api.md content/operate/kubernetes/reference/api/
 
           git add content/operate/kubernetes/reference/api/


### PR DESCRIPTION
TLDR; fixing the name of two new CRDs that have changed since the action was last updated. Need these for the 8.2.0 release on July 20. 



## What

Fixes the `k8s_apis_sync` GitHub Action, which fails in the *Generate READMEs* step with `stat crds/redbrole_crd.yaml: no such file`.

The workflow referenced `crds/redbrole_crd.yaml` and `crds/redbrolebinding_crd.yaml`, assuming a `RedisEnterpriseDatabaseRole` kind that was never shipped. The actual namespaced role CRDs are `rerole_crd.yaml` / `rerolebinding_crd.yaml` (kinds `RedisEnterpriseRole` / `RedisEnterpriseRoleBinding`, shortNames `rerole` / `rerolebinding`), verified against operator tag `v8.2.0-8`.

## Changes

Renames the role generation consistently:

- Input CRD files → `rerole_crd.yaml` / `rerolebinding_crd.yaml` (unblocks the action)
- Kind-strip + anchor `sed` patterns → `RedisEnterpriseRole` / `RedisEnterpriseRoleBinding` (so headings and anchors are actually rewritten instead of silently no-op'ing)
- `linkTitle` → `REROLE API` / `REROLEBINDING API` (matches shipped shortNames and the cluster pair's `RECROLE`)
- Output + published page filenames → `redis_enterprise_role_api.md` / `redis_enterprise_role_binding_api.md`

## Verification

Reproduced the *Generate READMEs* step locally with `crdoc` v0.6.3 (the version the workflow installs) against the real `v8.2.0-8` CRDs:

- Both files generate cleanly (previously crashed) — exit 0
- `title` / `linkTitle` correct (`REROLE API` / `REROLEBINDING API`)
- Top-level kind headings stripped; `[index]` → `[]` and anchor cleanup applied

## Notes

- These role reference pages are generated for the first time, so the published filenames are `redis_enterprise_role_api.md` / `redis_enterprise_role_binding_api.md`. DOC-6687 (RBAC reference nav) should reference those names.
- Ready to re-run `k8s_apis_sync` with the GA build once it's cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/docs workflow only; no runtime operator or application code changes.
> 
> **Overview**
> Fixes the **`k8s_apis_sync`** workflow so the *Generate READMEs* step no longer fails on missing `crds/redbrole_crd.yaml` / `redbrolebinding_crd.yaml`.
> 
> Role API doc generation is retargeted to the operator-shipped namespaced CRDs **`rerole_crd.yaml`** and **`rerolebinding_crd.yaml`** (`RedisEnterpriseRole` / `RedisEnterpriseRoleBinding`). Matching **`sed`** patterns, **`linkTitle`** values (`REROLE API` / `REROLEBINDING API`), artifact names, and **`cp`** paths into `content/operate/kubernetes/reference/api/` are updated in parallel so headings, anchors, and published pages stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbca58b407c4991ba1eae27f7843b0f7ba368fd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->