### PR TITLE
json.incrby, json.multby: Use actual argument name in description

### DIFF
--- a/content/commands/json.numincrby.md
+++ b/content/commands/json.numincrby.md
@@ -34,7 +34,7 @@ summary: Increments the numeric value at path by a value
 syntax_fmt: JSON.NUMINCRBY key path value
 title: JSON.NUMINCRBY
 ---
-Increment the number value stored at `path` by `number`
+Increment the number value stored at `path` by `value`
 
 [Examples](#examples)
 

--- a/content/commands/json.nummultby.md
+++ b/content/commands/json.nummultby.md
@@ -35,7 +35,7 @@ summary: Multiplies the numeric value at path by a value
 syntax_fmt: JSON.NUMMULTBY key path value
 title: JSON.NUMMULTBY
 ---
-Multiply the number value stored at `path` by `number`
+Multiply the number value stored at `path` by `value`
 
 [Examples](#examples)
 


### PR DESCRIPTION
The description mentioned `number`, while the relevant argument is called `value`. So we switch to `value`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only documentation changes with no runtime or API behavior impact.
> 
> **Overview**
> **Documentation-only wording fix** for `JSON.NUMINCRBY` and `JSON.NUMMULTBY`: the one-line command descriptions now refer to the third argument as **`value`**, matching the documented argument name and `syntax_fmt`, instead of **`number`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04a176823090edc23864b15fcd1b14f162a2a537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->