### PR TITLE
Document RDI API v1 deprecation and migration

### DIFF
--- a/content/integrate/redis-data-integration/reference/_index.md
+++ b/content/integrate/redis-data-integration/reference/_index.md
@@ -17,3 +17,6 @@ summary:
 type: integration
 weight: 60
 ---
+
+For API clients, [RDI API v1 is deprecated as of RDI 1.19.0]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}).
+Use [RDI API v2]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for new integrations and migrate existing clients.

--- a/content/integrate/redis-data-integration/reference/_index.md
+++ b/content/integrate/redis-data-integration/reference/_index.md
@@ -19,4 +19,4 @@ weight: 60
 ---
 
 For API clients, [RDI API v1 is deprecated as of RDI 1.19.0]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}).
-Use [RDI API v2]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for new integrations and migrate existing clients.
+Use [RDI API v2]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for new integrations and migrate existing clients. API v1 will not be extended with new RDI features and may be removed in a future RDI version.

--- a/content/integrate/redis-data-integration/reference/api-migration.md
+++ b/content/integrate/redis-data-integration/reference/api-migration.md
@@ -1,0 +1,57 @@
+---
+Title: Migrate from RDI API v1 to v2
+aliases:
+  - /integrate/redis-data-integration/ingest/reference/api-migration/
+categories:
+  - docs
+  - integrate
+  - rs
+  - rdi
+description: Migrate RDI API clients from API v1 to API v2
+group: di
+linkTitle: API migration
+summary: Migrate existing RDI API clients from the deprecated API v1 to API v2.
+type: integration
+weight: 61
+---
+
+RDI API v1 is deprecated as of RDI 1.19.0. Existing v1 endpoints remain available for compatibility, but Redis recommends migrating all clients to API v2. Use the [RDI API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the current request and response schemas.
+
+## What changes in API v2
+
+API v2 uses the pipeline resource as the source of truth. Pipeline operations update that resource and return its current state instead of returning an action ID that clients must poll. API v2 also supports named pipelines and groups related operations under a pipeline path.
+
+The API version is part of the URL. Change `/api/v1` to `/api/v2` only where an equivalent v2 endpoint exists; the request and response models can also differ.
+
+## Endpoint mapping
+
+| API v1 | API v2 |
+| --- | --- |
+| `GET /api/v1/pipelines` | `GET /api/v2/pipelines` |
+| `POST /api/v1/pipelines` | `POST /api/v2/pipelines` |
+| `PATCH /api/v1/pipelines` | `PATCH /api/v2/pipelines/{name}` |
+| `GET /api/v1/status` | `GET /api/v2/pipelines/{name}/status` |
+| `POST /api/v1/pipelines/start` | `POST /api/v2/pipelines/{name}/start` |
+| `POST /api/v1/pipelines/stop` | `POST /api/v2/pipelines/{name}/stop` |
+| `POST /api/v1/pipelines/reset` | `POST /api/v2/pipelines/{name}/reset` |
+| `GET /api/v1/monitoring/statistics` | `GET /api/v2/pipelines/{name}/metric-collections/{collection_name}` |
+| `PUT /api/v1/pipelines/sources` and source subresources | `PATCH /api/v2/pipelines/{name}` with `sources` in the payload |
+| `PUT /api/v1/pipelines/targets` and target subresources | `PATCH /api/v2/pipelines/{name}` with `targets` in the payload |
+| Secret provider endpoints | `POST`, `PUT`, or `DELETE /api/v2/pipelines/{name}/secrets[/{key}]` |
+| Source metadata, schemas, databases, tables, and columns endpoints | `GET /api/v2/pipelines/{name}/source-schemas/{source_name}` with the appropriate filters |
+| `POST /api/v1/pipelines/sources/dry-run` | `POST /api/v2/pipelines/{name}?dry_run=true` |
+| `POST /api/v1/pipelines/targets/dry-run` | `POST /api/v2/pipelines/{name}?dry_run=true` |
+| `GET /api/v1/actions/{action_id}` | No replacement. v2 operations return pipeline state; do not poll action IDs. |
+
+API v2 also adds endpoints for DLQ inspection, target flushing, metric collections, and API information. See the generated [API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the complete list.
+
+## Migration steps
+
+1. Inventory clients that call `/api/v1`, including custom scripts and generated SDKs.
+2. Add the pipeline name to v2 requests. The default installation pipeline is named `default` unless your installation uses another supported name.
+3. Replace action polling with checks of the pipeline response or `GET /api/v2/pipelines/{name}/status`.
+4. Combine source, target, processor, and secret-provider changes into the v2 pipeline request where appropriate. Preserve the existing configuration sections that are not being changed when using `PATCH`.
+5. Replace v1 monitoring and source-introspection calls with the v2 metric-collection and source-schema endpoints.
+6. Test create, update, dry-run, start, stop, reset, and delete flows against a non-production RDI 1.19.0 or later installation before switching production clients.
+
+Authentication and the API base URL are unchanged. Only the versioned endpoint paths, resource scoping, request models, and operation-status handling need to be updated.

--- a/content/integrate/redis-data-integration/reference/api-migration.md
+++ b/content/integrate/redis-data-integration/reference/api-migration.md
@@ -35,36 +35,34 @@ The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` w
 | `POST /api/v1/pipelines/stop` | `POST /api/v2/pipelines/{name}/stop` |
 | `POST /api/v1/pipelines/reset` | `POST /api/v2/pipelines/{name}/reset` |
 | `GET /api/v1/monitoring/statistics` | `GET /api/v2/pipelines/{name}/metric-collections/{collection_name}` |
+| `GET /api/v1/pipelines/config/schemas` | `GET /api/v2/schemas/config` |
+| `GET /api/v1/pipelines/config/templates/ingest/{db_type}` | `GET /api/v2/config-templates/{name}` |
+| `GET /api/v1/pipelines/jobs/functions` | `GET /api/v2/functions` |
+| `GET /api/v1/pipelines/jobs/schemas` | `GET /api/v2/schemas/jobs` |
+| `GET /api/v1/pipelines/jobs/templates/ingest` | `GET /api/v2/job-templates/{name}` |
 | `PUT /api/v1/pipelines/sources` and source subresources | `PATCH /api/v2/pipelines/{name}` with `sources` in the payload |
 | `PUT /api/v1/pipelines/targets` and target subresources | `PATCH /api/v2/pipelines/{name}` with `targets` in the payload |
+| `PUT /api/v1/pipelines/processors` and `PUT /api/v1/pipelines/processors/{prop}` | `PATCH /api/v2/pipelines/{name}` with `processors` in the payload |
 | Secret provider endpoints | `POST`, `PUT`, or `DELETE /api/v2/pipelines/{name}/secrets[/{key}]` |
 | Source metadata, schemas, databases, tables, and columns endpoints | `GET /api/v2/pipelines/{name}/source-schemas/{source_name}` with the appropriate filters |
 | `POST /api/v1/pipelines/sources/dry-run` | `POST /api/v2/pipelines/{name}?dry_run=true` |
 | `POST /api/v1/pipelines/targets/dry-run` | `POST /api/v2/pipelines/{name}?dry_run=true` |
+| `POST /api/v1/pipelines/undeploy` | `DELETE /api/v2/pipelines/{name}` |
+| `POST /api/v1/trace/start` | `POST /api/v2/pipelines/{name}/traces` |
 | `GET /api/v1/actions/{action_id}` | No replacement. v2 operations return pipeline state; do not poll action IDs. |
 
 API v2 also adds endpoints for DLQ inspection, target flushing, metric collections, and API information. See the generated [API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the complete list.
 
 ## v1 endpoints without a v2 equivalent
 
-Not every v1 endpoint has moved to v2. The following endpoints remain available under v1 because there is currently no corresponding v2 endpoint:
+Most v1 endpoints have a v2 replacement. The following endpoints remain available under v1 because the current API v2 design does not define a corresponding endpoint:
 
 | v1 endpoint | Notes |
 | --- | --- |
-| `POST /api/v1/login` | Authentication endpoint. |
 | `GET /api/v1/me` | Returns the authenticated user. |
-| `GET /api/v1/pipelines/config/schemas` | Returns the pipeline configuration schema. |
-| `GET /api/v1/pipelines/config/templates/ingest/{db_type}` | Returns a configuration template. |
-| `GET /api/v1/pipelines/jobs/functions` | Returns available job functions. |
-| `GET /api/v1/pipelines/jobs/schemas` | Returns the jobs schema. |
-| `GET /api/v1/pipelines/jobs/templates/ingest` | Returns the jobs template. |
-| `POST /api/v1/pipelines/jobs/dry-run` | Validates jobs. |
-| `PUT /api/v1/pipelines/processors` and `PUT /api/v1/pipelines/processors/{prop}` | Processor properties are managed as part of the v2 pipeline configuration instead. |
 | `GET /api/v1/pipelines/strategies` | Returns pipeline strategies. |
-| `POST /api/v1/pipelines/undeploy` | There is no v2 undeploy operation. |
-| `POST /api/v1/trace/start` | There is no v2 trace-start endpoint in the current API implementation. |
 
-These endpoints are not part of the API v2 migration described above. Continue calling them through v1 unless your use case has an alternative in the v2 API or in the `redis-di` CLI. The v1 action endpoint is different: it is only used by the v1 operation-polling model and should be removed when migrating those operations to v2.
+Authentication continues to use `POST /api/v1/login`; the Confluence design defines the v2 login endpoint with the same path. The v1 action endpoint is different: it is only used by the v1 operation-polling model and should be removed when migrating those operations to v2. For all other endpoints, use the v2 mappings above or the generated API reference.
 
 ## Replace action polling with pipeline-status polling
 

--- a/content/integrate/redis-data-integration/reference/api-migration.md
+++ b/content/integrate/redis-data-integration/reference/api-migration.md
@@ -49,7 +49,6 @@ The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` w
 | `POST /api/v1/pipelines/targets/dry-run` | `POST /api/v2/pipelines/{name}?dry_run=true` |
 | `POST /api/v1/pipelines/undeploy` | `DELETE /api/v2/pipelines/{name}` |
 | `POST /api/v1/trace/start` | `POST /api/v2/pipelines/{name}/traces` |
-| `GET /api/v1/actions/{action_id}` | No replacement. v2 operations return pipeline state; do not poll action IDs. |
 
 API v2 also adds endpoints for DLQ inspection, target flushing, metric collections, and API information. See the generated [API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the complete list.
 
@@ -61,8 +60,8 @@ Most v1 endpoints have a v2 replacement. The following endpoints remain availabl
 | --- | --- |
 | `GET /api/v1/me` | Returns the authenticated user. |
 | `GET /api/v1/pipelines/strategies` | Returns pipeline strategies. |
-
-Authentication continues to use `POST /api/v1/login`; the Confluence design defines the v2 login endpoint with the same path. The v1 action endpoint is different: it is only used by the v1 operation-polling model and should be removed when migrating those operations to v2. For all other endpoints, use the v2 mappings above or the generated API reference.
+| `POST /api/v1/login` | API v2 continues to use this endpoint for authentication. |
+| `GET /api/v1/actions/{action_id}` | No replacement. v2 operations return pipeline state; do not poll action IDs. |
 
 ## Replace action polling with pipeline-status polling
 

--- a/content/integrate/redis-data-integration/reference/api-migration.md
+++ b/content/integrate/redis-data-integration/reference/api-migration.md
@@ -40,10 +40,8 @@ The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` w
 | `POST /api/v1/pipelines/reset` | `POST /api/v2/pipelines/{name}/reset` |
 | `GET /api/v1/monitoring/statistics` | `GET /api/v2/pipelines/{name}/metric-collections/{collection_name}` |
 | `GET /api/v1/pipelines/config/schemas` | `GET /api/v2/schemas/config` |
-| `GET /api/v1/pipelines/config/templates/ingest/{db_type}` | `GET /api/v2/config-templates/{name}` |
 | `GET /api/v1/pipelines/jobs/functions` | `GET /api/v2/functions` |
 | `GET /api/v1/pipelines/jobs/schemas` | `GET /api/v2/schemas/jobs` |
-| `GET /api/v1/pipelines/jobs/templates/ingest` | `GET /api/v2/job-templates/{name}` |
 | `PUT /api/v1/pipelines/sources` and source subresources | `PATCH /api/v2/pipelines/{name}` with `sources` in the payload |
 | `PUT /api/v1/pipelines/targets` and target subresources | `PATCH /api/v2/pipelines/{name}` with `targets` in the payload |
 | `PUT /api/v1/pipelines/processors` and `PUT /api/v1/pipelines/processors/{prop}` | `PATCH /api/v2/pipelines/{name}` with `processors` in the payload |
@@ -65,6 +63,8 @@ Most v1 endpoints have a v2 replacement. The following endpoints remain availabl
 | `GET /api/v1/me` | Returns the authenticated user. |
 | `GET /api/v1/pipelines/strategies` | Returns pipeline strategies. |
 | `POST /api/v1/login` | API v2 continues to use this endpoint for authentication. |
+| `GET /api/v1/pipelines/config/templates/ingest/{db_type}` | Used by the CLI to scaffold pipeline configuration and will remain available. |
+| `GET /api/v1/pipelines/jobs/templates/ingest` | Used to scaffold jobs and will remain available. |
 
 ## Replace action polling with pipeline-status polling
 

--- a/content/integrate/redis-data-integration/reference/api-migration.md
+++ b/content/integrate/redis-data-integration/reference/api-migration.md
@@ -15,11 +15,15 @@ type: integration
 weight: 61
 ---
 
-RDI API v1 is deprecated as of RDI 1.19.0. Existing v1 endpoints remain available for compatibility, but Redis recommends moving all integrations to API v2. See the [RDI API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the current request and response schemas.
+RDI API v1 is deprecated as of RDI 1.19.0. Existing v1 endpoints remain available for backward compatibility, but Redis recommends moving all integrations to API v2. API v1 will not be extended with new RDI features and may be removed in a future RDI version. See the [RDI API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the current request and response schemas.
 
 ## What changes in API v2
 
-API v2 uses the pipeline resource to represent the current state of a pipeline. Operations update that resource and return its current state, so applications no longer need to poll a separate action ID. API v2 also supports named pipelines and groups related operations under a pipeline path.
+API v2 uses the pipeline resource to represent the current state of a pipeline. Operations update that resource and return its current state, so applications no longer need to poll a separate action ID. API v2 scopes related operations under a pipeline name in the request path.
+
+{{< note >}}
+RDI 1.19.0 supports only one pipeline, which must be named `default`. Support for other pipeline names will be added in a future version.
+{{< /note >}}
 
 The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` where a corresponding v2 endpoint is available. Review the request and response models as well, because they can differ between versions.
 
@@ -45,8 +49,8 @@ The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` w
 | `PUT /api/v1/pipelines/processors` and `PUT /api/v1/pipelines/processors/{prop}` | `PATCH /api/v2/pipelines/{name}` with `processors` in the payload |
 | Secret provider endpoints | `POST`, `PUT`, or `DELETE /api/v2/pipelines/{name}/secrets[/{key}]` |
 | Source metadata, schemas, databases, tables, and columns endpoints | `GET /api/v2/pipelines/{name}/source-schemas/{source_name}` with the appropriate filters |
-| `POST /api/v1/pipelines/sources/dry-run` | `POST /api/v2/pipelines/{name}?dry_run=true` |
-| `POST /api/v1/pipelines/targets/dry-run` | `POST /api/v2/pipelines/{name}?dry_run=true` |
+| `POST /api/v1/pipelines/sources/dry-run` | `POST /api/v2/pipelines?dry_run=true` |
+| `POST /api/v1/pipelines/targets/dry-run` | `POST /api/v2/pipelines?dry_run=true` |
 | `POST /api/v1/pipelines/undeploy` | `DELETE /api/v2/pipelines/{name}` |
 | `POST /api/v1/trace/start` | `POST /api/v2/pipelines/{name}/traces` |
 
@@ -61,7 +65,6 @@ Most v1 endpoints have a v2 replacement. The following endpoints remain availabl
 | `GET /api/v1/me` | Returns the authenticated user. |
 | `GET /api/v1/pipelines/strategies` | Returns pipeline strategies. |
 | `POST /api/v1/login` | API v2 continues to use this endpoint for authentication. |
-| `GET /api/v1/actions/{action_id}` | No replacement. v2 operations return pipeline state; do not poll action IDs. |
 
 ## Replace action polling with pipeline-status polling
 
@@ -92,24 +95,25 @@ while true; do
   status=$(curl -sS "$RDI_URL/api/v2/pipelines/$pipeline/status" \
     -H "Authorization: Bearer $RDI_TOKEN")
   phase=$(printf '%s' "$status" | jq -r '.status')
+  current=$(printf '%s' "$status" | jq -r '.current')
   printf '%s\n' "$status"
 
-  case "$phase" in
-    started|error) break ;;
+  case "$current:$phase" in
+    true:started|true:error) break ;;
     *) sleep 2 ;;
   esac
 done
 ```
 
-For a stop operation, wait for `stopped` instead of `started`. For a reset, update, or create operation, wait for the corresponding successful state returned by the API. Always handle `error` as a failed operation. Use the status values documented by the API response for the operation you are performing; do not expect an action ID from API v2.
+For a stop operation, wait for `stopped` instead of `started`. For a reset, update, or create operation, wait for the corresponding successful state returned by the API. Only accept a terminal status when `current` is `true`; when it is `false`, the status is outdated and the client should continue polling. Always handle `error` as a failed operation. Use the status values documented by the API response for the operation you are performing; do not expect an action ID from API v2.
 
 ## Migration steps
 
 1. Find the applications, scripts, and SDKs in your environment that use `/api/v1`.
-2. Add the pipeline name to each v2 request. The default pipeline is named `default`, unless your installation uses another supported name.
+2. Add the pipeline name to each v2 request. The only pipeline in 1.19.0 is always named `default`.
 3. Check the pipeline response, or call `GET /api/v2/pipelines/{name}/status`, instead of polling an action ID.
-4. Use the v2 pipeline request to update source, target, processor, and secret-provider settings as needed. When using `PATCH`, keep the configuration sections that you do not want to change.
-5. Use the v2 metric-collection and source-schema endpoints for monitoring and source metadata.
+4. Use `POST /api/v2/pipelines`, `PUT /api/v2/pipelines/{name}`, or `PATCH /api/v2/pipelines/{name}` to update source, target, processor, and secret-provider settings as needed. When using `PATCH`, omit the configuration sections that you do not want to change.
+5. Use `GET /api/v2/pipelines/{name}/metric-collections/{collection_name}` for monitoring and `GET /api/v2/pipelines/{name}/source-schemas/{source_name}` for source metadata.
 6. Test creating, updating, validating, starting, stopping, resetting, and deleting a pipeline on a non-production RDI 1.19.0 or later installation before updating production applications.
 
-Authentication and the API base URL do not change. The migration requires updates to the endpoint paths, pipeline scoping, request models, and operation-status handling.
+Authentication and the API base URL do not change. The migration requires updates to the endpoint paths, pipeline scoping, request models, and operation status handling.

--- a/content/integrate/redis-data-integration/reference/api-migration.md
+++ b/content/integrate/redis-data-integration/reference/api-migration.md
@@ -15,13 +15,13 @@ type: integration
 weight: 61
 ---
 
-RDI API v1 is deprecated as of RDI 1.19.0. Existing v1 endpoints remain available for compatibility, but Redis recommends migrating all clients to API v2. Use the [RDI API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the current request and response schemas.
+RDI API v1 is deprecated as of RDI 1.19.0. Existing v1 endpoints remain available for compatibility, but Redis recommends moving all integrations to API v2. See the [RDI API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the current request and response schemas.
 
 ## What changes in API v2
 
-API v2 uses the pipeline resource as the source of truth. Pipeline operations update that resource and return its current state instead of returning an action ID that clients must poll. API v2 also supports named pipelines and groups related operations under a pipeline path.
+API v2 uses the pipeline resource to represent the current state of a pipeline. Operations update that resource and return its current state, so applications no longer need to poll a separate action ID. API v2 also supports named pipelines and groups related operations under a pipeline path.
 
-The API version is part of the URL. Change `/api/v1` to `/api/v2` only where an equivalent v2 endpoint exists; the request and response models can also differ.
+The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` where a corresponding v2 endpoint is available. Review the request and response models as well, because they can differ between versions.
 
 ## Endpoint mapping
 
@@ -45,13 +45,74 @@ The API version is part of the URL. Change `/api/v1` to `/api/v2` only where an 
 
 API v2 also adds endpoints for DLQ inspection, target flushing, metric collections, and API information. See the generated [API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the complete list.
 
+## v1 endpoints without a v2 equivalent
+
+Not every v1 endpoint has moved to v2. The following endpoints remain available under v1 because there is currently no corresponding v2 endpoint:
+
+| v1 endpoint | Notes |
+| --- | --- |
+| `POST /api/v1/login` | Authentication endpoint. |
+| `GET /api/v1/me` | Returns the authenticated user. |
+| `GET /api/v1/pipelines/config/schemas` | Returns the pipeline configuration schema. |
+| `GET /api/v1/pipelines/config/templates/ingest/{db_type}` | Returns a configuration template. |
+| `GET /api/v1/pipelines/jobs/functions` | Returns available job functions. |
+| `GET /api/v1/pipelines/jobs/schemas` | Returns the jobs schema. |
+| `GET /api/v1/pipelines/jobs/templates/ingest` | Returns the jobs template. |
+| `POST /api/v1/pipelines/jobs/dry-run` | Validates jobs. |
+| `PUT /api/v1/pipelines/processors` and `PUT /api/v1/pipelines/processors/{prop}` | Processor properties are managed as part of the v2 pipeline configuration instead. |
+| `GET /api/v1/pipelines/strategies` | Returns pipeline strategies. |
+| `POST /api/v1/pipelines/undeploy` | There is no v2 undeploy operation. |
+| `POST /api/v1/trace/start` | There is no v2 trace-start endpoint in the current API implementation. |
+
+These endpoints are not part of the API v2 migration described above. Continue calling them through v1 unless your use case has an alternative in the v2 API or in the `redis-di` CLI. The v1 action endpoint is different: it is only used by the v1 operation-polling model and should be removed when migrating those operations to v2.
+
+## Replace action polling with pipeline-status polling
+
+In API v1, a pipeline operation returns an action ID. The client then repeatedly requests that action until it finishes:
+
+```bash
+# Start a pipeline with API v1
+action=$(curl -sS -X POST "$RDI_URL/api/v1/pipelines/start" \
+  -H "Authorization: Bearer $RDI_TOKEN" \
+  | jq -r '.action_id')
+
+# Poll the action until it completes
+curl -sS "$RDI_URL/api/v1/actions/$action" \
+  -H "Authorization: Bearer $RDI_TOKEN"
+```
+
+With API v2, include the pipeline name in the operation URL and read the pipeline status. The operation response contains the current pipeline state; if the pipeline is still changing, poll its status endpoint:
+
+```bash
+pipeline=default
+
+# Start the pipeline with API v2
+curl -sS -X POST "$RDI_URL/api/v2/pipelines/$pipeline/start" \
+  -H "Authorization: Bearer $RDI_TOKEN"
+
+# Poll the pipeline status while the operation is in progress
+while true; do
+  status=$(curl -sS "$RDI_URL/api/v2/pipelines/$pipeline/status" \
+    -H "Authorization: Bearer $RDI_TOKEN")
+  phase=$(printf '%s' "$status" | jq -r '.status')
+  printf '%s\n' "$status"
+
+  case "$phase" in
+    started|error) break ;;
+    *) sleep 2 ;;
+  esac
+done
+```
+
+For a stop operation, wait for `stopped` instead of `started`. For a reset, update, or create operation, wait for the corresponding successful state returned by the API. Always handle `error` as a failed operation. Use the status values documented by the API response for the operation you are performing; do not expect an action ID from API v2.
+
 ## Migration steps
 
-1. Inventory clients that call `/api/v1`, including custom scripts and generated SDKs.
-2. Add the pipeline name to v2 requests. The default installation pipeline is named `default` unless your installation uses another supported name.
-3. Replace action polling with checks of the pipeline response or `GET /api/v2/pipelines/{name}/status`.
-4. Combine source, target, processor, and secret-provider changes into the v2 pipeline request where appropriate. Preserve the existing configuration sections that are not being changed when using `PATCH`.
-5. Replace v1 monitoring and source-introspection calls with the v2 metric-collection and source-schema endpoints.
-6. Test create, update, dry-run, start, stop, reset, and delete flows against a non-production RDI 1.19.0 or later installation before switching production clients.
+1. Find the applications, scripts, and SDKs in your environment that use `/api/v1`.
+2. Add the pipeline name to each v2 request. The default pipeline is named `default`, unless your installation uses another supported name.
+3. Check the pipeline response, or call `GET /api/v2/pipelines/{name}/status`, instead of polling an action ID.
+4. Use the v2 pipeline request to update source, target, processor, and secret-provider settings as needed. When using `PATCH`, keep the configuration sections that you do not want to change.
+5. Use the v2 metric-collection and source-schema endpoints for monitoring and source metadata.
+6. Test creating, updating, validating, starting, stopping, resetting, and deleting a pipeline on a non-production RDI 1.19.0 or later installation before updating production applications.
 
-Authentication and the API base URL are unchanged. Only the versioned endpoint paths, resource scoping, request models, and operation-status handling need to be updated.
+Authentication and the API base URL do not change. The migration requires updates to the endpoint paths, pipeline scoping, request models, and operation-status handling.

--- a/content/integrate/redis-data-integration/reference/api-migration.md
+++ b/content/integrate/redis-data-integration/reference/api-migration.md
@@ -25,7 +25,7 @@ API v2 uses the pipeline resource to represent the current state of a pipeline. 
 RDI 1.19.0 supports only one pipeline, which must be named `default`. Support for other pipeline names will be added in a future version.
 {{< /note >}}
 
-The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` where a corresponding v2 endpoint is available. Review the request and response models as well, because they can differ between versions.
+The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` where a corresponding v2 endpoint is available. You should also review the request and response models, because they can differ between versions.
 
 ## Endpoint mapping
 
@@ -52,11 +52,11 @@ The API version is part of the URL. Update `/api/v1` requests to use `/api/v2` w
 | `POST /api/v1/pipelines/undeploy` | `DELETE /api/v2/pipelines/{name}` |
 | `POST /api/v1/trace/start` | `POST /api/v2/pipelines/{name}/traces` |
 
-API v2 also adds endpoints for DLQ inspection, target flushing, metric collections, and API information. See the generated [API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the complete list.
+API v2 also adds endpoints for DLQ inspection, target flushing, metric collections, and API information. See the [API reference]({{< relref "/integrate/redis-data-integration/reference/api-reference" >}}) for the complete list.
 
 ## v1 endpoints without a v2 equivalent
 
-Most v1 endpoints have a v2 replacement. The following endpoints remain available under v1 because the current API v2 design does not define a corresponding endpoint:
+Most v1 endpoints have a v2 replacement. However, the following endpoints remain available under v1 because the current API v2 design does not define a corresponding endpoint:
 
 | v1 endpoint | Notes |
 | --- | --- |
@@ -81,7 +81,7 @@ curl -sS "$RDI_URL/api/v1/actions/$action" \
   -H "Authorization: Bearer $RDI_TOKEN"
 ```
 
-With API v2, include the pipeline name in the operation URL and read the pipeline status. The operation response contains the current pipeline state; if the pipeline is still changing, poll its status endpoint:
+With API v2, you should instead include the pipeline name in the operation URL to read its status. The operation response contains the current pipeline state. You can check the pipeline's status by polling its status endpoint, as shown below:
 
 ```bash
 pipeline=default
@@ -105,7 +105,12 @@ while true; do
 done
 ```
 
-For a stop operation, wait for `stopped` instead of `started`. For a reset, update, or create operation, wait for the corresponding successful state returned by the API. Only accept a terminal status when `current` is `true`; when it is `false`, the status is outdated and the client should continue polling. Always handle `error` as a failed operation. Use the status values documented by the API response for the operation you are performing; do not expect an action ID from API v2.
+Note:
+
+- The successful state depends on the operation. For a stop, reset, update, or create operation, wait for the corresponding successful state returned by the API. For example, wait for `stopped` instead of `started` for a stop operation.
+- Only accept a terminal status when `current` is `true`. When it is `false`, the status is outdated, so continue polling.
+- Always handle `error` as a failed operation. Use the status values documented by the API response for the operation you are performing to check for errors.
+- Do not expect an action ID from API v2.
 
 ## Migration steps
 

--- a/content/integrate/redis-data-integration/reference/api-reference.md
+++ b/content/integrate/redis-data-integration/reference/api-reference.md
@@ -4,3 +4,9 @@ Title: Redis Data Integration API
 layout: apireference
 type: page
 ---
+
+{{< note >}}
+RDI API v1 is deprecated as of RDI 1.19.0. Use [RDI API v2]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}) for new integrations and migrate existing clients.
+{{< /note >}}
+
+See the [RDI API migration guide]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}) for endpoint mappings and migration guidance.

--- a/content/integrate/redis-data-integration/reference/api-reference.md
+++ b/content/integrate/redis-data-integration/reference/api-reference.md
@@ -5,8 +5,11 @@ layout: apireference
 type: page
 ---
 
-{{< note >}}
-RDI API v1 is deprecated as of RDI 1.19.0. Use [RDI API v2]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}) for new integrations and migrate existing clients.
-{{< /note >}}
+<!--
+This page uses the `apireference` layout, which renders a standalone Redoc page
+from ./api-reference/openapi.json and does NOT render this markdown body.
+The deprecation note is set in the spec's `info.description` field so Redoc
+displays it at the top of the page. Note: openapi.json is auto-generated from
+upstream RDI, so the note must also be set upstream to survive the next sync.
+-->
 
-See the [RDI API migration guide]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}) for endpoint mappings and migration guidance.

--- a/content/integrate/redis-data-integration/reference/api-reference/openapi.json
+++ b/content/integrate/redis-data-integration/reference/api-reference/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Redis Data Integration API",
-    "description": "> **NOTE:** RDI API v1 is deprecated as of RDI 1.19.0. Use RDI API v2 for new integrations and migrate existing clients. See the [RDI API migration guide](/integrate/redis-data-integration/reference/api-migration/).\n\nAPI for Redis Data Integration services",
+    "description": "> **NOTE:** RDI API v1 is deprecated as of RDI 1.19.0. Use RDI API v2 for new integrations and migrate existing clients. API v1 will not be extended with new RDI features and may be removed in a future RDI version. See the [RDI API migration guide](/integrate/redis-data-integration/reference/api-migration/).\n\nAPI for Redis Data Integration services",
     "version": "1.19.0"
   },
   "paths": {

--- a/content/integrate/redis-data-integration/reference/api-reference/openapi.json
+++ b/content/integrate/redis-data-integration/reference/api-reference/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Redis Data Integration API",
-    "description": "API for Redis Data Integration services",
+    "description": "> **NOTE:** RDI API v1 is deprecated as of RDI 1.19.0. Use RDI API v2 for new integrations and migrate existing clients. See the [RDI API migration guide](/integrate/redis-data-integration/reference/api-migration/).\n\nAPI for Redis Data Integration services",
     "version": "1.19.0"
   },
   "paths": {

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-19-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-19-0.md
@@ -18,6 +18,7 @@ weight: 969
 
 ### Compatibility Notes
 
+- **RDI API v1 deprecated**: RDI API v1 is deprecated as of RDI 1.19.0. Existing v1 clients remain available for compatibility, but new integrations should use RDI API v2. See the [RDI API migration guide]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}).
 - **Unified JSON merge behavior for the Flink processor**: JSON merge behavior is now the same regardless of the target Redis version. Previously, targets without native `JSON.MERGE` support (RedisJSON below 2.6) used a fallback path that preserved null leaf values as JSON nulls, while targets with native support deleted them. Both paths now delete null leaf values. This also differs from the classic processor, which still writes JSON nulls in its fallback path.
 - **`redis/rdi-cli` image and `rdi-secret.sh` retired**: The `redis/rdi-cli` Docker image is no longer built or published, and the `rdi-secret.sh` script has been removed. Manage RDI secrets with the `redis-di` CLI secret commands instead.
 

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-19-0.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-19-0.md
@@ -18,7 +18,7 @@ weight: 969
 
 ### Compatibility Notes
 
-- **RDI API v1 deprecated**: RDI API v1 is deprecated as of RDI 1.19.0. Existing v1 clients remain available for compatibility, but new integrations should use RDI API v2. See the [RDI API migration guide]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}).
+- **RDI API v1 deprecated**: RDI API v1 is deprecated as of RDI 1.19.0. Existing API v1 endpoints remain available for backward compatibility, but new integrations should use RDI API v2. API v1 may be removed in a future RDI version. See the [RDI API migration guide]({{< relref "/integrate/redis-data-integration/reference/api-migration" >}}).
 - **Unified JSON merge behavior for the Flink processor**: JSON merge behavior is now the same regardless of the target Redis version. Previously, targets without native `JSON.MERGE` support (RedisJSON below 2.6) used a fallback path that preserved null leaf values as JSON nulls, while targets with native support deleted them. Both paths now delete null leaf values. This also differs from the classic processor, which still writes JSON nulls in its fallback path.
 - **`redis/rdi-cli` image and `rdi-secret.sh` retired**: The `redis/rdi-cli` Docker image is no longer built or published, and the `rdi-secret.sh` script has been removed. Manage RDI secrets with the `redis-di` CLI secret commands instead.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> **Documents RDI API v1 deprecation as of RDI 1.19.0** and steers integrators toward API v2.
> 
> Adds a dedicated **API migration** page with v1→v2 endpoint mapping, notes on v1-only endpoints (login, templates, etc.), and guidance to replace action-ID polling with pipeline-scoped status polling (including `curl` examples). The Reference index, **1.19.0 release notes**, and OpenAPI `info.description` (shown in Redoc) now surface the same deprecation message and link to the migration guide; `api-reference.md` documents that Redoc ignores the markdown body so the notice lives in the spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7e1d54e3c85f79916559f3a0f16761a37497d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->