### PR TITLE
DEV: update various stats pages with new compact hash metrics

### DIFF
--- a/content/commands/info.md
+++ b/content/commands/info.md
@@ -179,6 +179,7 @@ Here is the meaning of all fields in the **memory** section:
 *   `used_memory_functions`: Number of bytes overhead by Function scripts (part of used_memory). Added in Redis 7.0
 *   `used_memory_scripts`: `used_memory_scripts_eval` + `used_memory_functions` (part of used_memory). Added in Redis 7.0
 *   `used_memory_scripts_human`: Human readable representation of previous value
+*   `used_memory_hash_templates`: Total memory in bytes used by all compact hash templates (the shared template registry). Added in Redis 8.10.
 *   `maxmemory`: The value of the `maxmemory` configuration directive
 *   `maxmemory_human`: Human readable representation of previous value
 *   `maxmemory_policy`: The value of the `maxmemory-policy` configuration
@@ -346,6 +347,8 @@ Here is the meaning of all fields in the **stats** section:
 *   `current_eviction_exceeded_time`: The time passed since `used_memory` last rose above `maxmemory`, in milliseconds
 *   `keyspace_hits`: Number of successful lookup of keys in the main dictionary
 *   `keyspace_misses`: Number of failed lookup of keys in the main dictionary
+*   `hash_templates`: Number of distinct compact hash templates in the shared registry. Added in Redis 8.10.
+*   `hash_template_keys`: Total number of keys backed by a compact hash template. Added in Redis 8.10.
 *   `pubsub_channels`: Global number of pub/sub channels with client
      subscriptions
 *   `pubsub_patterns`: Global number of pub/sub pattern with client

--- a/content/commands/memory-stats.md
+++ b/content/commands/memory-stats.md
@@ -51,6 +51,7 @@ values. The following metrics are reported:
      caches
 *   `functions.caches`: the summed size in bytes of the overheads of the Function scripts'
      caches
+*   `hash.templates`: Total memory in bytes used by all compact hash templates (see [`INFO`]({{< relref "/commands/info" >}})'s `used_memory_hash_templates`). Added in Redis 8.10.
 *   `dbXXX`: For each of the server's databases, the overheads of the main and
      expiry dictionaries (`overhead.hashtable.main` and
     `overhead.hashtable.expires`, respectively) are reported in bytes

--- a/content/commands/memory-usage.md
+++ b/content/commands/memory-usage.md
@@ -54,6 +54,10 @@ require to be stored in RAM.
 The reported usage is the total of memory allocations for data and
 administrative overheads that a key and its value require.
 
+For a hash stored in a compact hash encoding, the reported usage also includes
+the key's share of the shared compact hash template's memory (the template's
+size divided evenly across all keys that reference it). Added in Redis 8.10.
+
 For nested data types, the optional `SAMPLES` option can be provided, where
 `count` is the number of sampled nested values. The samples are averaged to estimate the total size.
 By default, this option is set to `5`. To sample the all of the nested values, use `SAMPLES 0`.


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API behavior impact.
> 
> **Overview**
> Documents **Redis 8.10** observability for **compact hash** shared templates across `INFO`, `MEMORY STATS`, and `MEMORY USAGE`.
> 
> The **`INFO`** page adds `used_memory_hash_templates` under the memory section, plus `hash_templates` and `hash_template_keys` under stats. **`MEMORY STATS`** documents `hash.templates`, cross-linked to `used_memory_hash_templates`. **`MEMORY USAGE`** explains that compact-hash keys count an equal share of the shared template memory in the reported byte total.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b12ed262f2287d55fc561c9d0ea319d8b31a86e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->