### PR TITLE
DEV: (cmds) add new hash bulk insertion commands/docs

### DIFF
--- a/content/commands/himport-discard.md
+++ b/content/commands/himport-discard.md
@@ -51,6 +51,12 @@ OK
 (integer) 0
 ```
 
+## Details
+
+Discarding a fieldset only removes the fieldset itself; it does not affect any hashes already created from it with [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}).
+
+Use `HIMPORT DISCARD` to free up resources on the connection once a bulk-ingestion job that used a given fieldset has finished. If you don't discard it, the fieldset stays allocated on the connection until the connection closes or the client issues the [`RESET`]({{< relref "/commands/reset" >}}) command.
+
 ## Redis Software and Redis Cloud compatibility
 
 | Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |

--- a/content/commands/himport-discard.md
+++ b/content/commands/himport-discard.md
@@ -1,0 +1,76 @@
+---
+acl_categories:
+- '@hash'
+- '@slow'
+arguments:
+- display_text: fieldset-name
+  name: fieldset-name
+  type: string
+arity: 3
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+complexity: O(N) where N is the number of session-local fieldsets.
+description: Removes a single session-local fieldset by name.
+group: hash
+hidden: false
+hints:
+- request_policy:all_shards
+linkTitle: HIMPORT DISCARD
+railroad_diagram: /images/railroad/himport-discard.svg
+since: 8.10.0
+summary: Removes a single session-local fieldset by name.
+syntax_fmt: HIMPORT DISCARD fieldset-name
+title: HIMPORT DISCARD
+---
+Removes a single session-local fieldset, previously defined with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}), from the current connection.
+
+## Required arguments
+
+<details open><summary><code>fieldset-name</code></summary>
+
+The name of the fieldset to remove from the current connection.
+
+</details>
+
+## Examples
+
+```shell
+> HIMPORT PREPARE u name email age
+OK
+> HIMPORT DISCARD u
+(integer) 1
+> HIMPORT DISCARD u
+(integer) 0
+```
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="himport-discard-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): `1` if the fieldset was removed, or `0` if no fieldset with that name existed on the connection.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): `1` if the fieldset was removed, or `0` if no fieldset with that name existed on the connection.
+
+{{< /multitabs >}}
+
+## See also
+
+[`HIMPORT PREPARE`]({{< relref "commands/himport-prepare/" >}}) | [`HIMPORT DISCARDALL`]({{< relref "commands/himport-discardall/" >}})

--- a/content/commands/himport-discardall.md
+++ b/content/commands/himport-discardall.md
@@ -1,0 +1,64 @@
+---
+acl_categories:
+- '@hash'
+- '@slow'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+complexity: O(N) where N is the number of session-local fieldsets.
+description: Removes all session-local fieldsets for the connection.
+group: hash
+hidden: false
+hints:
+- request_policy:all_shards
+linkTitle: HIMPORT DISCARDALL
+railroad_diagram: /images/railroad/himport-discardall.svg
+since: 8.10.0
+summary: Removes all session-local fieldsets for the connection.
+syntax_fmt: HIMPORT DISCARDALL
+title: HIMPORT DISCARDALL
+---
+Removes every fieldset held by the current connection, discarding all definitions previously created with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}).
+
+## Examples
+
+```shell
+> HIMPORT PREPARE u name email age
+OK
+> HIMPORT PREPARE o id total
+OK
+> HIMPORT DISCARDALL
+(integer) 2
+```
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="himport-discardall-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Integer reply](../../develop/reference/protocol-spec#integers): the number of fieldsets removed.
+
+-tab-sep-
+
+[Integer reply](../../develop/reference/protocol-spec#integers): the number of fieldsets removed.
+
+{{< /multitabs >}}
+
+## See also
+
+[`HIMPORT PREPARE`]({{< relref "commands/himport-prepare/" >}}) | [`HIMPORT DISCARD`]({{< relref "commands/himport-discard/" >}})

--- a/content/commands/himport-prepare.md
+++ b/content/commands/himport-prepare.md
@@ -1,0 +1,92 @@
+---
+acl_categories:
+- '@hash'
+- '@slow'
+arguments:
+- display_text: fieldset-name
+  name: fieldset-name
+  type: string
+- display_text: field
+  multiple: true
+  name: field
+  type: string
+arity: -4
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- denyoom
+complexity: O(N*log(N)) where N is the number of fields.
+description: Defines a session-local fieldset that maps a name to a sorted set of
+  field names.
+group: hash
+hidden: false
+hints:
+- request_policy:all_shards
+linkTitle: HIMPORT PREPARE
+railroad_diagram: /images/railroad/himport-prepare.svg
+since: 8.10.0
+summary: Defines a session-local fieldset that maps a name to a sorted set of field
+  names.
+syntax_fmt: HIMPORT PREPARE fieldset-name field [field ...]
+title: HIMPORT PREPARE
+---
+Defines a session-local fieldset that maps a name to an ordered list of field names, to be used by later [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}) commands on the same connection.
+
+## Required arguments
+
+<details open><summary><code>fieldset-name</code></summary>
+
+The name to give the fieldset. The fieldset is scoped to the current connection. Preparing a fieldset with a name that already exists on the connection replaces the previous definition.
+
+</details>
+
+<details open><summary><code>field [field ...]</code></summary>
+
+One or more field names to store under the fieldset, in the order you intend to supply their values to [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}). A field name must not appear more than once in the same fieldset.
+
+</details>
+
+## Examples
+
+```shell
+> HIMPORT PREPARE u name email age
+OK
+```
+
+## Details
+
+A fieldset is scoped to the client connection: it is not visible to other clients and is discarded when the connection closes or the client issues the [`RESET`]({{< relref "/commands/reset" >}}) command. A connection can prepare several fieldsets, each under its own name.
+
+The command returns an error if the same field name is given more than once.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="himport-prepare-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+-tab-sep-
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+{{< /multitabs >}}
+
+## See also
+
+[`HIMPORT SET`]({{< relref "commands/himport-set/" >}}) | [`HIMPORT DISCARD`]({{< relref "commands/himport-discard/" >}}) | [`HIMPORT DISCARDALL`]({{< relref "commands/himport-discardall/" >}})

--- a/content/commands/himport-set.md
+++ b/content/commands/himport-set.md
@@ -1,0 +1,127 @@
+---
+acl_categories:
+- '@write'
+- '@hash'
+- '@slow'
+arguments:
+- display_text: key
+  key_spec_index: 0
+  name: key
+  type: key
+- display_text: fieldset-name
+  name: fieldset-name
+  type: string
+- display_text: value
+  multiple: true
+  name: value
+  type: string
+arity: -5
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- write
+- denyoom
+complexity: O(N) where N is the number of fields in the fieldset.
+description: Creates a fieldset-based hash from values supplied in the order matching
+  a previously prepared fieldset.
+group: hash
+hidden: false
+key_specs:
+- OW: true
+  begin_search:
+    spec:
+      index: 2
+    type: index
+  find_keys:
+    spec:
+      keystep: 1
+      lastkey: 0
+      limit: 0
+    type: range
+  update: true
+linkTitle: HIMPORT SET
+railroad_diagram: /images/railroad/himport-set.svg
+since: 8.10.0
+summary: Creates a fieldset-based hash from values supplied in the order matching
+  a previously prepared fieldset.
+syntax_fmt: HIMPORT SET key fieldset-name value [value ...]
+title: HIMPORT SET
+---
+Creates a hash from a fieldset previously defined with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}), pairing the fieldset's field names with the supplied values by position.
+
+## Required arguments
+
+<details open><summary><code>key</code></summary>
+
+The key to create. If the key already exists, it is overwritten.
+
+</details>
+
+<details open><summary><code>fieldset-name</code></summary>
+
+The name of a fieldset previously defined with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}) on the same connection.
+
+</details>
+
+<details open><summary><code>value [value ...]</code></summary>
+
+The field values, given in the same order as the field names were declared in the fieldset. The number of values must equal the number of fields in the fieldset.
+
+</details>
+
+## Examples
+
+```shell
+> HIMPORT PREPARE u name email age
+OK
+> HIMPORT SET user:1 u alice a@example.com 30
+OK
+> HIMPORT SET user:2 u bob b@example.com 25
+OK
+> HGET user:1 name
+"alice"
+> HGET user:1 email
+"a@example.com"
+> HGET user:1 age
+"30"
+```
+
+## Details
+
+`HIMPORT SET` creates or overwrites `key` as a hash whose fields are the field names of the prepared fieldset, each paired with the value at the same position. The number of values must match the number of fields in the fieldset.
+
+The command returns an error if the fieldset has not been prepared on the current connection, or if the number of values does not match the fieldset's field count.
+
+Keys created this way behave exactly like any other hash and work with all existing hash commands. Because they share a fixed set of field names, Redis can store them with an internal encoding that keeps a single copy of the field names, reducing memory when many keys share the same layout.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="himport-set-return-info"
+    tab1="RESP2"
+    tab2="RESP3" >}}
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+-tab-sep-
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+{{< /multitabs >}}
+
+## See also
+
+[`HIMPORT PREPARE`]({{< relref "commands/himport-prepare/" >}}) | [`HSET`]({{< relref "commands/hset/" >}}) | [`HIMPORT DISCARD`]({{< relref "commands/himport-discard/" >}})

--- a/content/commands/himport-set.md
+++ b/content/commands/himport-set.md
@@ -100,7 +100,7 @@ OK
 
 The command returns an error if the fieldset has not been prepared on the current connection, or if the number of values does not match the fieldset's field count.
 
-Keys created this way behave exactly like any other hash and work with all existing hash commands. Because they share a fixed set of field names, Redis can store them with an internal encoding that keeps a single copy of the field names, reducing memory when many keys share the same layout.
+Keys created this way behave exactly like any other hash and work with all existing hash commands. Because they share a fixed set of field names, Redis can store them as [compact hashes]({{< relref "/develop/data-types/hashes#compact-hashes" >}}), keeping a single copy of the field names to reduce memory when many keys share the same layout.
 
 ## Redis Software and Redis Cloud compatibility
 

--- a/content/commands/himport.md
+++ b/content/commands/himport.md
@@ -45,4 +45,4 @@ HIMPORT SET user:1 u alice a@example.com 30
 HIMPORT SET user:2 u bob b@example.com 25
 ```
 
-Because every key created this way shares one fixed set of field names, `HIMPORT` reduces the network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key. Redis also uses the shared field names as a hint to store the keys with an internal encoding that keeps a single copy of the field names, which reduces memory when many keys share the same layout. This encoding is internal and does not change the behavior or replies of any existing hash command.
+Because every key created this way shares one fixed set of field names, `HIMPORT` reduces the network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key. Redis also uses the shared field names as a hint to store the keys as [compact hashes]({{< relref "/develop/data-types/hashes#compact-hashes" >}}), an internal encoding that keeps a single copy of the field names and reduces memory when many keys share the same layout. This encoding does not change the behavior or replies of any existing hash command.

--- a/content/commands/himport.md
+++ b/content/commands/himport.md
@@ -24,7 +24,7 @@ summary: A container for session-based hash import commands using fieldsets.
 syntax_fmt: HIMPORT
 title: HIMPORT
 ---
-`HIMPORT` is a container command for session-based bulk hash import. Its subcommands let a client import many similarly-shaped hashes efficiently by declaring the shared field names once and then sending only the values for each key.
+`HIMPORT` is a container command for session-based bulk hash import. Its subcommands let a client import many hashes that share the same field names efficiently by declaring those field names once and then sending only the values for each key.
 
 The subcommands are:
 

--- a/content/commands/himport.md
+++ b/content/commands/himport.md
@@ -1,0 +1,48 @@
+---
+acl_categories:
+- '@hash'
+- '@slow'
+arity: -2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+complexity: Depends on subcommand.
+description: A container for session-based hash import commands using fieldsets.
+group: hash
+hidden: false
+linkTitle: HIMPORT
+railroad_diagram: /images/railroad/himport.svg
+since: 8.10.0
+summary: A container for session-based hash import commands using fieldsets.
+syntax_fmt: HIMPORT
+title: HIMPORT
+---
+`HIMPORT` is a container command for session-based bulk hash import. Its subcommands let a client import many similarly-shaped hashes efficiently by declaring the shared field names once and then sending only the values for each key.
+
+The subcommands are:
+
+- [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}) — define a session-local fieldset that names an ordered list of field names.
+- [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}) — create a hash from a prepared fieldset and a list of values.
+- [`HIMPORT DISCARD`]({{< relref "/commands/himport-discard" >}}) — remove a single fieldset by name.
+- [`HIMPORT DISCARDALL`]({{< relref "/commands/himport-discardall" >}}) — remove every fieldset held by the connection.
+
+## Details
+
+A *fieldset* is a named, ordered list of field names that is scoped to the client connection: it is not visible to other clients and is discarded when the connection closes or the client issues the [`RESET`]({{< relref "/commands/reset" >}}) command. A connection can prepare several fieldsets, each under its own name, and refer to them by name in later commands.
+
+The typical workflow is to declare a fieldset once with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}), then create many keys from it with [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}), sending only the values each time:
+
+```shell
+HIMPORT PREPARE u name email age
+HIMPORT SET user:1 u alice a@example.com 30
+HIMPORT SET user:2 u bob b@example.com 25
+```
+
+Because every key created this way shares one fixed set of field names, `HIMPORT` reduces the network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key. Redis also uses the shared field names as a hint to store the keys with an internal encoding that keeps a single copy of the field names, which reduces memory when many keys share the same layout. This encoding is internal and does not change the behavior or replies of any existing hash command.

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -199,6 +199,12 @@ print(expire_time)
 # prints [1717668041] # your actual value may vary
 ```
 
+## Bulk import
+
+Redis 8.10 introduced the [`HIMPORT`]({{< relref "/commands/himport" >}}) command family for importing many similarly-shaped hashes efficiently. When your keys share the same field names (for example, one hash per user, each with `name`, `email`, and `age`), you declare the shared field names once and then create each key by sending only its values. This reduces the network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key, and lets Redis store the keys with an internal encoding that keeps a single copy of the shared field names, reducing memory when many keys share the same layout.
+
+See [`HIMPORT`]({{< relref "/commands/himport" >}}) for the full workflow and its subcommands.
+
 ## Performance
 
 Most Redis hash commands are O(1).

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -203,11 +203,22 @@ print(expire_time)
 
 Redis 8.10 introduced *compact hashes*, a way to reduce the memory used by hashes that share the same field names. When many hashes have the same layout (for example, one hash per user, each with `name`, `email`, and `age`), Redis can store the shared set of field names once and keep only the values, plus a small reference to that set, in each key. This is an internal encoding: existing hash commands keep working exactly as before, with the same semantics and replies. The hash just uses less memory.
 
-Compact hashes work best when many keys share the same, mostly stable set of field names. They are a poor fit when field names change often or are unique per key, or for very large hashes. There are two ways to opt in.
+**Compact hashes work well when:**
+
+- Many keys share the same, mostly stable set of field names — classic object mapping, such as one hash per user, order, or session. The more keys that share a field set, the greater the memory saving.
+- Reads and value updates stay as fast as on a regular hash. Reading any field (for example, [`HGET`]({{< relref "/commands/hget" >}}), [`HGETALL`]({{< relref "/commands/hgetall" >}}), or [`HRANDFIELD`]({{< relref "/commands/hrandfield" >}})) and overwriting an existing field's value (`HSET key field value` where `field` already exists) are unaffected.
+
+**Compact hashes are not a good fit when:**
+
+- **Field names change often.** Adding a new field with [`HSET`]({{< relref "/commands/hset" >}}) or removing one with [`HDEL`]({{< relref "/commands/hdel" >}}) detaches the key from its shared field-name set and re-resolves it against the new set, creating a new one if that layout hasn't been seen before. A workload that constantly adds or removes field names erodes the benefit. Note also that once a hash becomes a compact hash, it stays one for the life of the key: it moves between field-name sets as its fields change, but never reverts to a plain hash.
+- **Field names are unique or highly dynamic per key.** With little sharing, a key ends up with its own field-name set, which carries some metadata overhead. A set used by only a few keys can therefore consume more memory than a plain hash. Compact hashes pay off when hundreds or thousands of keys share a set.
+- **Hashes are very large.** Because a compact hash is transferred as a single blob during replication and slot migration, very large hash keys may reduce or negate the benefit.
+
+There are two ways to opt in.
 
 ### Bulk import with HIMPORT
 
-The [`HIMPORT`]({{< relref "/commands/himport" >}}) command family lets a client import many similarly-shaped hashes efficiently. You declare the shared field names once with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}), then create each key with [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}) by sending only its values. This reduces network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key, and hints Redis to store the new keys as compact hashes. See [`HIMPORT`]({{< relref "/commands/himport" >}}) for the full workflow and its subcommands.
+The [`HIMPORT`]({{< relref "/commands/himport" >}}) command family lets a client import many hashes that share the same field names efficiently. You declare the shared field names once with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}), then create each key with [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}) by sending only its values. This reduces network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key, and hints Redis to store the new keys as compact hashes. See [`HIMPORT`]({{< relref "/commands/himport" >}}) for the full workflow and its subcommands.
 
 ### Automatic conversion
 

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -199,11 +199,42 @@ print(expire_time)
 # prints [1717668041] # your actual value may vary
 ```
 
-## Bulk import
+## Compact hashes
 
-Redis 8.10 introduced the [`HIMPORT`]({{< relref "/commands/himport" >}}) command family for importing many similarly-shaped hashes efficiently. When your keys share the same field names (for example, one hash per user, each with `name`, `email`, and `age`), you declare the shared field names once and then create each key by sending only its values. This reduces the network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key, and lets Redis store the keys with an internal encoding that keeps a single copy of the shared field names, reducing memory when many keys share the same layout.
+Redis 8.10 introduced *compact hashes*, a way to reduce the memory used by hashes that share the same field names. When many hashes have the same layout (for example, one hash per user, each with `name`, `email`, and `age`), Redis can store the shared set of field names once and keep only the values, plus a small reference to that set, in each key. This is an internal encoding: existing hash commands keep working exactly as before, with the same semantics and replies. The hash just uses less memory.
 
-See [`HIMPORT`]({{< relref "/commands/himport" >}}) for the full workflow and its subcommands.
+Compact hashes work best when many keys share the same, mostly stable set of field names. They are a poor fit when field names change often or are unique per key, or for very large hashes. There are two ways to opt in.
+
+### Bulk import with HIMPORT
+
+The [`HIMPORT`]({{< relref "/commands/himport" >}}) command family lets a client import many similarly-shaped hashes efficiently. You declare the shared field names once with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}), then create each key with [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}) by sending only its values. This reduces network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key, and hints Redis to store the new keys as compact hashes. See [`HIMPORT`]({{< relref "/commands/himport" >}}) for the full workflow and its subcommands.
+
+### Automatic conversion
+
+For workloads that can't adopt a new command, Redis can convert eligible hashes to compact hashes on its own, with no code change. All the following settings default to `0` (off) and can be changed at runtime with [`CONFIG SET`]({{< relref "/commands/config-set" >}}).
+
+#### On the write path
+
+These convert hashes created or modified by normal commands (such as [`HSET`]({{< relref "/commands/hset" >}})), so an existing application gains the memory saving with no code change. They take effect lazily, like `hash-max-listpack-entries`: a change applies to a given hash only on its next write, not the moment you run [`CONFIG SET`]({{< relref "/commands/config-set" >}}).
+
+| Config | Meaning |
+|---|---|
+| `hash-min-template-entries` | Minimum field count for a hash to be auto-converted to a compact hash on its next write. `0` disables auto-conversion. |
+| `hash-max-template-entries` | Maximum field count for auto-conversion: a hash wider than this is left a plain hash (keeps very wide hashes out of the shared registry). `0` means no upper bound. |
+
+A hash is not converted if it uses [field expiration](#field-expiration), even when its field count meets the minimum. After a hash has been converted, it stays a compact hash even if its field count later grows beyond `hash-max-template-entries`.
+
+#### On RDB load
+
+An RDB saved before this feature contains only plain hashes. These configs let Redis convert them to compact hashes *as the RDB loads*, so an upgrade reclaims memory without rewriting data. They apply only to RDBs without compact hashes; an RDB that already contains them is loaded as-is, with no load-time conversion. In effect these are one-time upgrade configs: they have no effect once the RDB contains at least one compact hash.
+
+| Config | Meaning |
+|---|---|
+| `hash-rdb-load-min-template-entries` | Minimum field count to convert a plain hash to a compact hash during load. `0` disables load-time conversion. |
+| `hash-rdb-load-max-template-entries` | Maximum field count for load-time conversion. `0` means no upper bound. |
+| `hash-rdb-load-template-disassembly-threshold` | Minimum number of keys that must end up sharing a converted field-name set for it to be kept. `0` keeps every converted set. |
+
+The disassembly threshold avoids wasting memory on field-name sets shared by only a few keys: at the end of the load, if a set is used by fewer keys than the threshold, those keys are converted back to plain hashes and the shared set is freed. It also acts as a safety valve during the load. Redis tracks how many converted sets are still below the threshold; once at least 1,000 have been created, if more than half of them are still below the threshold, Redis assumes the dataset is a poor fit for compact hashes and stops creating new ones partway through the load. From that point, only hashes whose field set matches one already created during this load are converted; the rest stay plain.
 
 ## Performance
 

--- a/static/images/railroad/himport-discard.svg
+++ b/static/images/railroad/himport-discard.svg
@@ -1,0 +1,49 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 398.0 62" width="398.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M348.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M197.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="50.0" y="20"></rect><text x="123.75" y="35">HIMPORT DISCARD</text></g><path d="M197.5 31h10"></path><path d="M207.5 31h10"></path><g class="non-terminal ">
+<path d="M217.5 31h0.0"></path><path d="M348.0 31h0.0"></path><rect height="22" width="130.5" x="217.5" y="20"></rect><text x="282.75" y="35">fieldset-name</text></g></g><path d="M348.0 31h10"></path><path d="M 358.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/himport-discardall.svg
+++ b/static/images/railroad/himport-discardall.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 273.0 62" width="273.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M223.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="173.0" x="50.0" y="20"></rect><text x="136.5" y="35">HIMPORT DISCARDALL</text></g><path d="M223.0 31h10"></path><path d="M 233.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/himport-prepare.svg
+++ b/static/images/railroad/himport-prepare.svg
@@ -1,0 +1,52 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 500.5 71" width="500.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M450.5 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M197.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="147.5" x="50.0" y="20"></rect><text x="123.75" y="35">HIMPORT PREPARE</text></g><path d="M197.5 31h10"></path><path d="M207.5 31h10"></path><g class="non-terminal ">
+<path d="M217.5 31h0.0"></path><path d="M348.0 31h0.0"></path><rect height="22" width="130.5" x="217.5" y="20"></rect><text x="282.75" y="35">fieldset-name</text></g><path d="M348.0 31h10"></path><path d="M358.0 31h10"></path><g>
+<path d="M368.0 31h0.0"></path><path d="M450.5 31h0.0"></path><path d="M368.0 31h10"></path><g class="non-terminal ">
+<path d="M378.0 31h0.0"></path><path d="M440.5 31h0.0"></path><rect height="22" width="62.5" x="378.0" y="20"></rect><text x="409.25" y="35">field</text></g><path d="M440.5 31h10"></path><path d="M378.0 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M378.0 51h62.5"></path></g><path d="M440.5 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M450.5 31h10"></path><path d="M 460.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/himport-set.svg
+++ b/static/images/railroad/himport-set.svg
@@ -1,0 +1,53 @@
+<svg class="railroad-diagram" height="71" viewBox="0 0 532.0 71" width="532.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
+<path d="M50 31h0.0"></path><path d="M482.0 31h0.0"></path><g class="terminal ">
+<path d="M50.0 31h0.0"></path><path d="M163.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="50.0" y="20"></rect><text x="106.75" y="35">HIMPORT SET</text></g><path d="M163.5 31h10"></path><path d="M173.5 31h10"></path><g class="non-terminal ">
+<path d="M183.5 31h0.0"></path><path d="M229.0 31h0.0"></path><rect height="22" width="45.5" x="183.5" y="20"></rect><text x="206.25" y="35">key</text></g><path d="M229.0 31h10"></path><path d="M239.0 31h10"></path><g class="non-terminal ">
+<path d="M249.0 31h0.0"></path><path d="M379.5 31h0.0"></path><rect height="22" width="130.5" x="249.0" y="20"></rect><text x="314.25" y="35">fieldset-name</text></g><path d="M379.5 31h10"></path><path d="M389.5 31h10"></path><g>
+<path d="M399.5 31h0.0"></path><path d="M482.0 31h0.0"></path><path d="M399.5 31h10"></path><g class="non-terminal ">
+<path d="M409.5 31h0.0"></path><path d="M472.0 31h0.0"></path><rect height="22" width="62.5" x="409.5" y="20"></rect><text x="440.75" y="35">value</text></g><path d="M472.0 31h10"></path><path d="M409.5 31a10 10 0 0 0 -10 10v0a10 10 0 0 0 10 10"></path><g>
+<path d="M409.5 51h62.5"></path></g><path d="M472.0 51a10 10 0 0 0 10 -10v0a10 10 0 0 0 -10 -10"></path></g></g><path d="M482.0 31h10"></path><path d="M 492.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/himport.svg
+++ b/static/images/railroad/himport.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 179.5 62" width="179.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M129.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="79.5" x="50.0" y="20"></rect><text x="89.75" y="35">HIMPORT</text></g><path d="M129.5 31h10"></path><path d="M 139.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents **Redis 8.10** session-based bulk hash import via the **`HIMPORT`** command family and ties it to the new **compact hashes** encoding.
> 
> Adds command reference pages for **`HIMPORT`** (overview) and subcommands **`PREPARE`**, **`SET`**, **`DISCARD`**, and **`DISCARDALL`**, including front matter, examples, RESP return info, Redis Software/Cloud compatibility tables, cross-links, and railroad SVG diagrams.
> 
> Extends **`content/develop/data-types/hashes.md`** with a **Compact hashes** section: when the encoding helps or hurts, bulk import through **`HIMPORT`**, and optional automatic conversion via **`hash-min-template-entries`** / **`hash-max-template-entries`** on writes plus **`hash-rdb-load-*`** settings during RDB load (including disassembly threshold behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99c4291d783b9182734296fdce64b8605ecfbe52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->