### PR TITLE
DOC-6863: Add redisctl to developer tools, Redis Cloud, and Redis Sof…

### DIFF
--- a/content/develop/tools/_index.md
+++ b/content/develop/tools/_index.md
@@ -23,6 +23,7 @@ manage it and interact with the data:
 * The [`redis-cli`](#redis-command-line-interface-cli) command line tool
 * [Redis Insight](#redis-insight) (a graphical user interface tool)
 * The Redis [VSCode extension](#redis-vscode-extension)
+* [`redisctl`](#redisctl) (a unified CLI for managing Redis Cloud and Redis Software)
 
 ## Redis command line interface (CLI)
 
@@ -41,3 +42,9 @@ The [Redis command line interface]({{< relref "/develop/tools/cli" >}}) (also kn
 
 [Redis for VS Code]({{< relref "/develop/tools/redis-for-vscode" >}})
 is an extension that allows you to connect to your Redis databases from within Microsoft Visual Studio Code. After connecting to a database, you can view, add, modify, and delete keys, and interact with your Redis databases using a Redis Insight like UI and also a built-in CLI interface.
+
+## redisctl
+
+[`redisctl`](https://github.com/redis/redisctl) is a unified command-line tool for managing Redis Cloud and Redis Software from your terminal. It provides complete API coverage for both platforms — including subscriptions, databases, VPC peering, ACLs, clusters, and users — without needing custom scripts. It also includes an MCP server component that exposes management operations to AI assistants.
+
+Install via Homebrew, Cargo, or download a binary release from the [GitHub repository](https://github.com/redis/redisctl).

--- a/content/operate/rc/_index.md
+++ b/content/operate/rc/_index.md
@@ -59,6 +59,7 @@ Manage [secure connections]({{< relref "/operate/rc/security" >}}) to cloud data
 Use the [REST API]({{< relref "/operate/rc/api" >}}) to manage Redis Cloud databases and subscriptions.
 - [Get started with the REST API]({{< relref "/operate/rc/api/get-started" >}})
 - REST API [reference]({{< relref "/operate/rc/api/api-reference" >}}) & [examples]({{< relref "/operate/rc/api/examples" >}})
+- [`redisctl`](https://github.com/redis/redisctl) — a CLI tool that wraps the Redis Cloud and Redis Software APIs for terminal-based management
 
 ## Migrate to Redis Cloud
 Follow the step-by-step guide for your source environment:

--- a/content/operate/rs/_index.md
+++ b/content/operate/rs/_index.md
@@ -52,6 +52,7 @@ Create and manage a [Redis database]({{< relref "/operate/rs/databases" >}}) on 
 ## Reference
 Use command-line utilities and the REST API to manage the cluster and databases.
 - [rladmin]({{< relref "/operate/rs/references/cli-utilities/rladmin" >}}), [crdb-cli]({{< relref "/operate/rs/references/cli-utilities/crdb-cli" >}}), & [other utilities]({{< relref "/operate/rs/references/cli-utilities" >}})
+- [`redisctl`](https://github.com/redis/redisctl) — a unified CLI for managing Redis Software and Redis Cloud from your terminal
 - [REST API reference]({{< relref "/operate/rs/references/rest-api" >}}) & [examples]({{< relref "/operate/rs/references/rest-api/quick-start" >}})
 - [Redis commands]({{< relref "/commands" >}})
 


### PR DESCRIPTION
…tware pages

Introduces redisctl as a unified CLI for managing Redis Cloud and Redis Software, with links to the GitHub repo from all three relevant pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with external links; no product code or behavior changes.
> 
> **Overview**
> Documents **`redisctl`** across three hub pages so readers can discover the unified CLI for Redis Cloud and Redis Software management.
> 
> On **Client tools**, adds a bullet in the tools list and a new **`redisctl`** section describing API coverage (subscriptions, databases, VPC peering, ACLs, clusters, users), the MCP server for AI assistants, and install options (Homebrew, Cargo, GitHub releases).
> 
> On **Redis Cloud** and **Redis Software**, adds a single list item under REST API / Reference linking to the GitHub repo and positioning `redisctl` as a terminal wrapper around the Cloud and Software APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c9c7b131c7b896d12624347af8f015e44a695e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->