### PR TITLE
Add quick start links and advanced developer resources to agent build…

### DIFF
--- a/content/develop/ai/agent-builder/_index.md
+++ b/content/develop/ai/agent-builder/_index.md
@@ -12,7 +12,7 @@ weight: 50
 ---
 
 
-Agents use Redis for data storage, vector search, and conversation memory. The interactive builder generates code in your preferred programming language with your choice of model.
+Agents use Redis for data storage, [vector search]({{< relref "/develop/get-started/vector-database" >}}), and [conversation memory]({{< relref "/develop/get-started/rag" >}}). The interactive builder generates code in your preferred programming language with your choice of model.
 
 ## Get started
 
@@ -67,6 +67,13 @@ The generated code includes detailed setup instructions and best practices to ge
 - [Redis Streams](/develop/data-types/streams/) - Real-time data and conversation history
 - [AI Notebooks Collection]({{< relref "/develop/ai/notebook-collection" >}}) - Interactive tutorials and examples 
 - [Ecosystem Integrations]({{< relref "/develop/ai/ecosystem-integrations" >}}) - Redis with AI frameworks
+
+### For experienced developers
+
+If you're ready to go beyond the agent builder, these resources cover production-grade managed services and cutting-edge Redis AI projects:
+
+- [Redis Context Engine]({{< relref "/develop/ai/context-engine" >}}) — Managed services for agent memory, semantic caching, and structured data access (Redis Iris)
+- [Redis AI Incubator](https://redis.io/ai-incubator/) — Early-stage AI projects and experiments from the Redis team
 
 ### Community and support
 


### PR DESCRIPTION
…er page

Links 'vector search' and 'conversation memory' in the opening sentence to their respective quick start guides. Adds a 'For experienced developers' section linking to the Redis Context Engine and AI Incubator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to one Hugo page with no runtime, auth, or data-handling impact.
> 
> **Overview**
> The **Agent builder** page intro now links **vector search** and **conversation memory** to their get-started guides (`vector-database` and `rag`) instead of plain text.
> 
> A new **For experienced developers** section under **Learn more** points readers to the **Redis Context Engine** doc and the **Redis AI Incubator** for production-oriented and experimental work beyond the interactive builder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946db18691f00a11e1347e9398f843bb7ef20c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->