### PR TITLE
DEV: (cmds) add new backup-related command pages/docs

### DIFF
--- a/content/commands/backup-abort.md
+++ b/content/commands/backup-abort.md
@@ -39,7 +39,7 @@ OK
 
 ## Details
 
-`BACKUP ABORT` cancels an in-progress backup and moves the backup state machine to `failed`. It is valid from the `pending`, `snapshotting`, and `incrementing` states. Once the backup has been sealed, use [`BACKUP CLEANUP`]({{< relref "/commands/backup-cleanup" >}}) instead.
+`BACKUP ABORT` cancels an in-progress backup and moves the backup state machine to `failed`. It is valid from the `pending`, `snapshotting`, and `incrementing` states. After the backup has been sealed, use [`BACKUP CLEANUP`]({{< relref "/commands/backup-cleanup" >}}) instead.
 
 After aborting, you can start a new backup with [`BACKUP START`]({{< relref "/commands/backup-start" >}}).
 

--- a/content/commands/backup-abort.md
+++ b/content/commands/backup-abort.md
@@ -1,0 +1,74 @@
+---
+acl_categories:
+- '@admin'
+- '@slow'
+- '@dangerous'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- admin
+- noscript
+complexity: O(1)
+description: Cancel a backup that has not been sealed yet.
+group: server
+hidden: false
+linkTitle: BACKUP ABORT
+railroad_diagram: /images/railroad/backup-abort.svg
+since: 8.10.0
+summary: Cancel a backup that has not been sealed yet.
+syntax_fmt: BACKUP ABORT
+title: BACKUP ABORT
+---
+Cancels a backup that has not been sealed yet.
+
+## Examples
+
+```
+127.0.0.1:6379> BACKUP ABORT
+OK
+```
+
+## Details
+
+`BACKUP ABORT` cancels an in-progress backup and moves the backup state machine to `failed`. It is valid from the `pending`, `snapshotting`, and `incrementing` states. Once the backup has been sealed, use [`BACKUP CLEANUP`]({{< relref "/commands/backup-cleanup" >}}) instead.
+
+After aborting, you can start a new backup with [`BACKUP START`]({{< relref "/commands/backup-start" >}}).
+
+For the full workflow, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="backup-abort-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+-tab-sep-
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+{{< /multitabs >}}
+
+## See also
+
+[`BACKUP START`]({{< relref "commands/backup-start/" >}}) | [`BACKUP SEAL`]({{< relref "commands/backup-seal/" >}}) | [`BACKUP STATUS`]({{< relref "commands/backup-status/" >}}) | [`BACKUP LIST`]({{< relref "commands/backup-list/" >}}) | [`BACKUP CLEANUP`]({{< relref "commands/backup-cleanup/" >}})
+
+## Related topics
+
+- [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}})

--- a/content/commands/backup-cleanup.md
+++ b/content/commands/backup-cleanup.md
@@ -1,0 +1,74 @@
+---
+acl_categories:
+- '@admin'
+- '@slow'
+- '@dangerous'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- admin
+- noscript
+complexity: O(1)
+description: Remove a sealed backup's files and return to idle.
+group: server
+hidden: false
+linkTitle: BACKUP CLEANUP
+railroad_diagram: /images/railroad/backup-cleanup.svg
+since: 8.10.0
+summary: Remove a sealed backup's files and return to idle.
+syntax_fmt: BACKUP CLEANUP
+title: BACKUP CLEANUP
+---
+Removes a sealed backup's files and returns the backup state machine to idle.
+
+## Examples
+
+```
+127.0.0.1:6379> BACKUP CLEANUP
+OK
+```
+
+## Details
+
+`BACKUP CLEANUP` removes the sealed (or failed) backup artifacts and releases the files that were pinned by hard links, moving the backup state machine from `sealed` back to `idle`. Call it after the data plane has finished copying the files reported by [`BACKUP LIST`]({{< relref "/commands/backup-list" >}}).
+
+By default a sealed backup is kept until you clean it up explicitly. If the `backup-sealed-ttl` configuration setting is non-zero, Redis automatically cleans up a sealed backup after the configured number of seconds; a value of `0` disables automatic cleanup.
+
+For the full workflow, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="backup-cleanup-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+-tab-sep-
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+{{< /multitabs >}}
+
+## See also
+
+[`BACKUP START`]({{< relref "commands/backup-start/" >}}) | [`BACKUP SEAL`]({{< relref "commands/backup-seal/" >}}) | [`BACKUP STATUS`]({{< relref "commands/backup-status/" >}}) | [`BACKUP LIST`]({{< relref "commands/backup-list/" >}}) | [`BACKUP ABORT`]({{< relref "commands/backup-abort/" >}})
+
+## Related topics
+
+- [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}})

--- a/content/commands/backup-cleanup.md
+++ b/content/commands/backup-cleanup.md
@@ -18,13 +18,13 @@ command_flags:
 - admin
 - noscript
 complexity: O(1)
-description: Remove a sealed backup's files and return to idle.
+description: Remove sealed backup files and return to idle.
 group: server
 hidden: false
 linkTitle: BACKUP CLEANUP
 railroad_diagram: /images/railroad/backup-cleanup.svg
 since: 8.10.0
-summary: Remove a sealed backup's files and return to idle.
+summary: Remove sealed backup files and return to idle.
 syntax_fmt: BACKUP CLEANUP
 title: BACKUP CLEANUP
 ---

--- a/content/commands/backup-cleanup.md
+++ b/content/commands/backup-cleanup.md
@@ -28,7 +28,7 @@ summary: Remove a sealed backup's files and return to idle.
 syntax_fmt: BACKUP CLEANUP
 title: BACKUP CLEANUP
 ---
-Removes a sealed backup's files and returns the backup state machine to idle.
+Removes sealed backup files and returns the backup state machine to idle.
 
 ## Examples
 

--- a/content/commands/backup-help.md
+++ b/content/commands/backup-help.md
@@ -1,0 +1,49 @@
+---
+acl_categories:
+- '@slow'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- loading
+- stale
+complexity: O(1)
+description: Return helpful text about BACKUP command parameters.
+group: server
+hidden: true
+linkTitle: BACKUP HELP
+railroad_diagram: /images/railroad/backup-help.svg
+since: 8.10.0
+summary: Return helpful text about BACKUP command parameters.
+syntax_fmt: BACKUP HELP
+title: BACKUP HELP
+---
+The `BACKUP HELP` command returns a helpful text describing the different subcommands.
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="backup-help-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays): a list of sub-commands and their descriptions.
+
+-tab-sep-
+
+[Array reply](../../develop/reference/protocol-spec#arrays): a list of sub-commands and their descriptions.
+
+{{< /multitabs >}}

--- a/content/commands/backup-help.md
+++ b/content/commands/backup-help.md
@@ -26,7 +26,7 @@ summary: Return helpful text about BACKUP command parameters.
 syntax_fmt: BACKUP HELP
 title: BACKUP HELP
 ---
-The `BACKUP HELP` command returns a helpful text describing the different subcommands.
+The `BACKUP HELP` command returns helpful text describing the different subcommands.
 
 ## Redis Software and Redis Cloud compatibility
 

--- a/content/commands/backup-list.md
+++ b/content/commands/backup-list.md
@@ -50,7 +50,7 @@ After [`BACKUP SEAL`]({{< relref "/commands/backup-seal" >}}), the INCR file and
 
 ## Details
 
-`BACKUP LIST` reports the absolute paths of the files that have been pinned by hard links so far. This lets the data plane start uploading the BASE snapshot while Redis is still accumulating incremental writes, before the backup is sealed. Once the backup is sealed, the list also includes the INCR file and the manifest.
+`BACKUP LIST` reports the absolute paths of the files that have been pinned by hard links so far. This lets the data plane start uploading the BASE snapshot while Redis is still accumulating incremental writes, before the backup is sealed. After the backup is sealed, the list also includes the INCR file and the manifest.
 
 For the full workflow, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).
 

--- a/content/commands/backup-list.md
+++ b/content/commands/backup-list.md
@@ -1,0 +1,83 @@
+---
+acl_categories:
+- '@admin'
+- '@slow'
+- '@dangerous'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- admin
+- stale
+complexity: O(1)
+description: List the immutable backup file paths pinned so far.
+group: server
+hidden: false
+linkTitle: BACKUP LIST
+railroad_diagram: /images/railroad/backup-list.svg
+since: 8.10.0
+summary: List the immutable backup file paths pinned so far.
+syntax_fmt: BACKUP LIST
+title: BACKUP LIST
+---
+Returns the absolute paths of the immutable backup files pinned so far.
+
+## Examples
+
+While the backup is still in the `incrementing` state, only the BASE file is pinned:
+
+```
+127.0.0.1:6379> BACKUP LIST
+1) "/var/lib/redis/backupdir/appendonly.aof.3.base.rdb"
+```
+
+After [`BACKUP SEAL`]({{< relref "/commands/backup-seal" >}}), the INCR file and the manifest are pinned as well:
+
+```
+127.0.0.1:6379> BACKUP LIST
+1) "/var/lib/redis/backupdir/appendonly.aof.3.base.rdb"
+2) "/var/lib/redis/backupdir/appendonly.aof.3.incr.aof"
+3) "/var/lib/redis/backupdir/appendonly.aof.manifest"
+```
+
+## Details
+
+`BACKUP LIST` reports the absolute paths of the files that have been pinned by hard links so far. This lets the data plane start uploading the BASE snapshot while Redis is still accumulating incremental writes, before the backup is sealed. Once the backup is sealed, the list also includes the INCR file and the manifest.
+
+For the full workflow, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="backup-list-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays): the absolute paths of the immutable files pinned so far.
+
+-tab-sep-
+
+[Array reply](../../develop/reference/protocol-spec#arrays): the absolute paths of the immutable files pinned so far.
+
+{{< /multitabs >}}
+
+## See also
+
+[`BACKUP START`]({{< relref "commands/backup-start/" >}}) | [`BACKUP SEAL`]({{< relref "commands/backup-seal/" >}}) | [`BACKUP STATUS`]({{< relref "commands/backup-status/" >}}) | [`BACKUP ABORT`]({{< relref "commands/backup-abort/" >}}) | [`BACKUP CLEANUP`]({{< relref "commands/backup-cleanup/" >}})
+
+## Related topics
+
+- [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}})

--- a/content/commands/backup-seal.md
+++ b/content/commands/backup-seal.md
@@ -1,0 +1,80 @@
+---
+acl_categories:
+- '@admin'
+- '@slow'
+- '@dangerous'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- admin
+- noscript
+complexity: O(1)
+description: Freeze the current backup (BASE + INCR + manifest).
+group: server
+hidden: false
+linkTitle: BACKUP SEAL
+railroad_diagram: /images/railroad/backup-seal.svg
+since: 8.10.0
+summary: Freeze the current backup (BASE + INCR + manifest).
+syntax_fmt: BACKUP SEAL
+title: BACKUP SEAL
+---
+Freezes the current backup, producing the final immutable file set: the BASE snapshot, the incremental append-only file (INCR), and a standalone manifest.
+
+## Examples
+
+```
+127.0.0.1:6379> BACKUP SEAL
+OK
+```
+
+## Details
+
+`BACKUP SEAL` moves the backup state machine from `incrementing` to `sealed`. Restore loads `BASE + INCR`, so the restored dataset reflects the state at the seal boundary, not merely the earlier BASE snapshot. Sealing performs the following steps:
+
+* Flushes and fsyncs the current INCR file.
+* Hard-links the INCR file into the backup directory.
+* Writes a standalone manifest that references only this backup's `{BASE, INCR}` file set.
+* Rotates the live AOF when AOF persistence is enabled.
+* Stops and removes the temporary AOF state when the backup created it for an `appendonly no` instance.
+
+After sealing, the file set is complete and immutable. The data plane can copy the files reported by [`BACKUP LIST`]({{< relref "/commands/backup-list" >}}), then call [`BACKUP CLEANUP`]({{< relref "/commands/backup-cleanup" >}}) to release them.
+
+For the full workflow and restore procedure, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="backup-seal-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+-tab-sep-
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+{{< /multitabs >}}
+
+## See also
+
+[`BACKUP START`]({{< relref "commands/backup-start/" >}}) | [`BACKUP STATUS`]({{< relref "commands/backup-status/" >}}) | [`BACKUP LIST`]({{< relref "commands/backup-list/" >}}) | [`BACKUP ABORT`]({{< relref "commands/backup-abort/" >}}) | [`BACKUP CLEANUP`]({{< relref "commands/backup-cleanup/" >}})
+
+## Related topics
+
+- [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}})

--- a/content/commands/backup-start.md
+++ b/content/commands/backup-start.md
@@ -1,0 +1,81 @@
+---
+acl_categories:
+- '@admin'
+- '@slow'
+- '@dangerous'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- admin
+- noscript
+complexity: O(1)
+description: Start a new backup into the configured 'backupdirname'.
+group: server
+hidden: false
+linkTitle: BACKUP START
+railroad_diagram: /images/railroad/backup-start.svg
+since: 8.10.0
+summary: Start a new backup into the configured 'backupdirname'.
+syntax_fmt: BACKUP START
+title: BACKUP START
+---
+Starts a new backup, opening a backup window and producing a fresh BASE snapshot in the directory named by the `backupdirname` configuration setting.
+
+## Examples
+
+```
+127.0.0.1:6379> BACKUP START
+OK
+```
+
+## Details
+
+`BACKUP START` moves the backup state machine from `idle` to `snapshotting` and begins producing a fresh BASE snapshot through an append-only file rewrite (AOFRW). It works whether or not AOF persistence is enabled:
+
+* If AOF is enabled, Redis reuses the existing [multi-part AOF]({{< relref "/operate/oss_and_stack/management/persistence" >}}#append-only-file) directly.
+* If AOF is disabled, Redis temporarily starts the AOF machinery without changing the configured `appendonly` value.
+* If an AOFRW is already active or scheduled and can be reused, the backup attaches to it.
+* If another child process is active, the backup enters the `pending` state and starts when an AOFRW can run.
+
+After the snapshot rewrite completes, Redis hard-links the BASE file into the backup directory and enters the `incrementing` state, where it continues to accumulate incremental writes until you call [`BACKUP SEAL`]({{< relref "/commands/backup-seal" >}}).
+
+The backup directory (named by `backupdirname` and resolved under the Redis working directory `dir`) must be empty when you call `BACKUP START`. Only one backup can be in progress at a time.
+
+For the full workflow and restore procedure, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="backup-start-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+-tab-sep-
+
+[Simple string reply](../../develop/reference/protocol-spec#simple-strings): `OK`.
+
+{{< /multitabs >}}
+
+## See also
+
+[`BACKUP SEAL`]({{< relref "commands/backup-seal/" >}}) | [`BACKUP STATUS`]({{< relref "commands/backup-status/" >}}) | [`BACKUP LIST`]({{< relref "commands/backup-list/" >}}) | [`BACKUP ABORT`]({{< relref "commands/backup-abort/" >}}) | [`BACKUP CLEANUP`]({{< relref "commands/backup-cleanup/" >}})
+
+## Related topics
+
+- [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}})

--- a/content/commands/backup-status.md
+++ b/content/commands/backup-status.md
@@ -1,0 +1,99 @@
+---
+acl_categories:
+- '@admin'
+- '@slow'
+- '@dangerous'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+command_flags:
+- admin
+- stale
+complexity: O(1)
+description: Report the current backup state.
+group: server
+hidden: false
+linkTitle: BACKUP STATUS
+railroad_diagram: /images/railroad/backup-status.svg
+since: 8.10.0
+summary: Report the current backup state.
+syntax_fmt: BACKUP STATUS
+title: BACKUP STATUS
+---
+Reports the current backup state.
+
+## Examples
+
+```
+127.0.0.1:6379> BACKUP STATUS
+1) "state"
+2) "incrementing"
+3) "error"
+4) ""
+5) "start_time"
+6) "1717921800"
+7) "end_time"
+8) "0"
+```
+
+## Details
+
+`BACKUP STATUS` reports the current state of the backup state machine along with timing and error information. The reply contains the following fields:
+
+| Field | Description |
+|:------|:------------|
+| `state` | The current backup state (see below). |
+| `error` | The error message if the backup failed; an empty string otherwise. |
+| `start_time` | The Unix time, in seconds, when the current backup started; `0` if no backup has started. |
+| `end_time` | The Unix time, in seconds, when the current backup was sealed; `0` if it has not been sealed. |
+
+The `state` field is one of the following:
+
+| State | Description |
+|:------|:------------|
+| `idle` | No backup is in progress. |
+| `pending` | A backup was requested but is waiting for an append-only file rewrite (AOFRW) to become available. |
+| `snapshotting` | Redis is producing the BASE snapshot. |
+| `incrementing` | The BASE snapshot is complete and pinned; Redis is accumulating incremental writes and waiting to be sealed. |
+| `sealed` | The backup is frozen; the file set is complete and immutable, awaiting data-plane consumption and cleanup. |
+| `failed` | The backup failed or was aborted. A new backup can be started. |
+
+For lightweight monitoring, `INFO persistence` also exposes a `backup_in_progress` boolean. Full backup state, error, and timestamps are available only through `BACKUP STATUS`.
+
+For the full workflow, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).
+
+## Redis Software and Redis Cloud compatibility
+
+| Redis<br />Software | Redis<br />Cloud | <span style="min-width: 9em; display: table-cell">Notes</span> |
+|:----------------------|:-----------------|:------|
+| <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> | <span title="Not supported">&#x274c; Standard</span><br /><span title="Not supported"><nobr>&#x274c; Active-Active</nobr></span> |  |
+
+## Return information
+
+{{< multitabs id="backup-status-return-info" 
+    tab1="RESP2" 
+    tab2="RESP3" >}}
+
+[Array reply](../../develop/reference/protocol-spec#arrays): a flat array of field-value pairs describing the current backup state.
+
+-tab-sep-
+
+[Map reply](../../develop/reference/protocol-spec#maps): a map of fields to values describing the current backup state.
+
+{{< /multitabs >}}
+
+## See also
+
+[`BACKUP START`]({{< relref "commands/backup-start/" >}}) | [`BACKUP SEAL`]({{< relref "commands/backup-seal/" >}}) | [`BACKUP LIST`]({{< relref "commands/backup-list/" >}}) | [`BACKUP ABORT`]({{< relref "commands/backup-abort/" >}}) | [`BACKUP CLEANUP`]({{< relref "commands/backup-cleanup/" >}})
+
+## Related topics
+
+- [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}})

--- a/content/commands/backup.md
+++ b/content/commands/backup.md
@@ -1,0 +1,30 @@
+---
+acl_categories:
+- '@slow'
+arity: 2
+categories:
+- docs
+- develop
+- stack
+- oss
+- rs
+- rc
+- oss
+- kubernetes
+- clients
+complexity: Depends on subcommand.
+description: A container for backup management commands.
+group: server
+hidden: true
+linkTitle: BACKUP
+railroad_diagram: /images/railroad/backup.svg
+since: 8.10.0
+summary: A container for backup management commands.
+syntax_fmt: BACKUP
+title: BACKUP
+---
+This is a container command for backup management commands.
+
+To see the list of available commands you can call [`BACKUP HELP`]({{< relref "/commands/backup-help" >}}).
+
+For a conceptual overview of how the `BACKUP` command family creates online backups, see [Redis persistence]({{< relref "/operate/oss_and_stack/management/persistence" >}}#online-backups-with-the-backup-command-family).

--- a/content/operate/oss_and_stack/management/persistence.md
+++ b/content/operate/oss_and_stack/management/persistence.md
@@ -374,7 +374,7 @@ The typical workflow on a node is:
 2. [`BACKUP LIST`](/commands/backup-list) — get the absolute paths of the immutable files pinned so far. The data plane can begin copying the BASE file while Redis keeps accumulating INCR data.
 3. [`BACKUP SEAL`](/commands/backup-seal) — freeze the backup, hard-linking the INCR and writing the manifest. After sealing, `BACKUP LIST` also includes the INCR and manifest files.
 4. Copy the sealed files reported by `BACKUP LIST` to your backup storage.
-5. [`BACKUP CLEANUP`](/commands/backup-cleanup) — remove the sealed files and release the pinned artifacts once the copy is complete.
+5. [`BACKUP CLEANUP`](/commands/backup-cleanup) — remove the sealed files and release the pinned artifacts after the copy is complete.
 
 Use [`BACKUP STATUS`](/commands/backup-status) at any point to inspect the current backup state, and [`BACKUP ABORT`](/commands/backup-abort) to cancel a backup that has not been sealed yet.
 

--- a/content/operate/oss_and_stack/management/persistence.md
+++ b/content/operate/oss_and_stack/management/persistence.md
@@ -358,6 +358,43 @@ Just make sure to re-enable automatic rewrites when done (step 4) and persist it
 Prior to version 7.0.0 backing up the AOF file can be done simply by copying the aof file (like backing up the RDB snapshot). The file may lack the final part
 but Redis will still be able to load it (see the previous sections about [truncated AOF files](#what-should-i-do-if-my-aof-gets-truncated)).
 
+### Online backups with the BACKUP command family
+
+Since Redis 8.10.0, the [`BACKUP`](/commands/backup) command family produces a self-contained, restorable backup without stopping writes or manually managing AOF rewrites. A backup reuses the [multi-part AOF](#append-only-file) format, so it is an MP-AOF–compatible artifact set consisting of three files:
+
+* **BASE** — a point-in-time snapshot (`appendonly.aof.N.base.rdb`).
+* **INCR** — the incremental writes appended after the snapshot (`appendonly.aof.N.incr.aof`).
+* **Manifest** — a standalone manifest describing the file set (`appendonly.aof.manifest`).
+
+Because backup creation is separated from backup finalization, a control plane can stagger [`BACKUP START`](/commands/backup-start) across the nodes of a cluster so that they do not all `fork` at the same time. Each node produces its BASE independently, keeps appending to its INCR, and is later frozen with [`BACKUP SEAL`](/commands/backup-seal). A restore loads `BASE + INCR`, so the restored dataset reflects the state at the seal boundary, not merely the earlier BASE snapshot.
+
+The typical workflow on a node is:
+
+1. [`BACKUP START`](/commands/backup-start) — open a backup window and produce a fresh BASE snapshot. This works whether or not AOF persistence is enabled.
+2. [`BACKUP LIST`](/commands/backup-list) — get the absolute paths of the immutable files pinned so far. The data plane can begin copying the BASE file while Redis keeps accumulating INCR data.
+3. [`BACKUP SEAL`](/commands/backup-seal) — freeze the backup, hard-linking the INCR and writing the manifest. After sealing, `BACKUP LIST` also includes the INCR and manifest files.
+4. Copy the sealed files reported by `BACKUP LIST` to your backup storage.
+5. [`BACKUP CLEANUP`](/commands/backup-cleanup) — remove the sealed files and release the pinned artifacts once the copy is complete.
+
+Use [`BACKUP STATUS`](/commands/backup-status) at any point to inspect the current backup state, and [`BACKUP ABORT`](/commands/backup-abort) to cancel a backup that has not been sealed yet.
+
+The backup files are written to the directory named by the `backupdirname` configuration setting (default `backupdir`), resolved under the Redis working directory `dir`. `backupdirname` is a startup-only setting. The `backup-sealed-ttl` setting controls how long, in seconds, Redis keeps a sealed backup before cleaning it up automatically; a value of `0` (the default) disables automatic cleanup so the files remain pinned until `BACKUP CLEANUP` is called.
+
+#### Restoring a backup
+
+To restore a backup, use the startup-only `preload-file` configuration setting, which loads a specific file or manifest during server startup. It is specified as `<type>:<path>`, where `<type>` is either `aof` or `rdb`. To restore a sealed backup, point it at the manifest:
+
+```conf
+preload-file aof:/tmp/restore-backup/appendonly.aof.manifest
+```
+
+You can also preload a single RDB file:
+
+```conf
+preload-file rdb:/tmp/backup-to-recover.rdb
+```
+
+When `preload-file` is set, Redis loads only the specified file or manifest and its associated files. It skips the normal `appenddirname` and `dump.rdb` loading, even if AOF or RDB persistence is enabled. If the preload target is missing or cannot be loaded, startup aborts. After the preload finishes, Redis continues with its normally configured persistence mode.
 
 ## Disaster recovery
 

--- a/static/images/railroad/backup-abort.svg
+++ b/static/images/railroad/backup-abort.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 222.0 62" width="222.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M172.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="50.0" y="20"></rect><text x="111.0" y="35">BACKUP ABORT</text></g><path d="M172.0 31h10"></path><path d="M 182.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/backup-cleanup.svg
+++ b/static/images/railroad/backup-cleanup.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 239.0 62" width="239.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M189.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="139.0" x="50.0" y="20"></rect><text x="119.5" y="35">BACKUP CLEANUP</text></g><path d="M189.0 31h10"></path><path d="M 199.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/backup-help.svg
+++ b/static/images/railroad/backup-help.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 213.5 62" width="213.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M163.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="50.0" y="20"></rect><text x="106.75" y="35">BACKUP HELP</text></g><path d="M163.5 31h10"></path><path d="M 173.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/backup-list.svg
+++ b/static/images/railroad/backup-list.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 213.5 62" width="213.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M163.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="50.0" y="20"></rect><text x="106.75" y="35">BACKUP LIST</text></g><path d="M163.5 31h10"></path><path d="M 173.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/backup-seal.svg
+++ b/static/images/railroad/backup-seal.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 213.5 62" width="213.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M163.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="113.5" x="50.0" y="20"></rect><text x="106.75" y="35">BACKUP SEAL</text></g><path d="M163.5 31h10"></path><path d="M 173.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/backup-start.svg
+++ b/static/images/railroad/backup-start.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 222.0 62" width="222.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M172.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="122.0" x="50.0" y="20"></rect><text x="111.0" y="35">BACKUP START</text></g><path d="M172.0 31h10"></path><path d="M 182.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/backup-status.svg
+++ b/static/images/railroad/backup-status.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 230.5 62" width="230.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M180.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="130.5" x="50.0" y="20"></rect><text x="115.25" y="35">BACKUP STATUS</text></g><path d="M180.5 31h10"></path><path d="M 190.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/backup.svg
+++ b/static/images/railroad/backup.svg
@@ -1,0 +1,47 @@
+<svg class="railroad-diagram" height="62" viewBox="0 0 171.0 62" width="171.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<style type="text/css"><![CDATA[
+svg.railroad-diagram { background-color: transparent; }
+.terminal rect { fill: #DC382D !important; stroke: #DC382D !important; }
+.terminal text { fill: white !important; font-weight: bold; }
+.nonterminal rect { fill: none !important; stroke: #DC382D !important; stroke-width: 2; }
+.nonterminal text { fill: #DC382D !important; font-weight: bold; }
+path { stroke: #DC382D !important; stroke-width: 2; fill: none; }
+circle { fill: #DC382D !important; stroke: #DC382D !important; }
+]]></style>
+</defs>
+<g transform="translate(.5 .5)">
+<style>/* <![CDATA[ */
+	svg.railroad-diagram {
+		background-color: transparent;
+	}
+	svg.railroad-diagram path {
+		stroke-width:3;
+		stroke: #DC382D;
+		fill:rgba(0,0,0,0);
+	}
+	svg.railroad-diagram text {
+		font:bold 14px monospace;
+		text-anchor:middle;
+	}
+	svg.railroad-diagram text.label{
+		text-anchor:start;
+	}
+	svg.railroad-diagram text.comment{
+		font:italic 12px monospace;
+	}
+	svg.railroad-diagram rect{
+		stroke-width:3;
+		stroke: #DC382D;
+		fill: none;
+	}
+	svg.railroad-diagram rect.group-box {
+		stroke: #DC382D;
+		stroke-dasharray: 10 5;
+		fill: none;
+	}
+
+/* ]]> */
+</style><g>
+<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g class="terminal ">
+<path d="M50 31h0.0"></path><path d="M121.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="71.0" x="50.0" y="20"></rect><text x="85.5" y="35">BACKUP</text></g><path d="M121.0 31h10"></path><path d="M 131.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Documents the **Redis 8.10** `BACKUP` subcommand family with new reference pages for `BACKUP START`, `SEAL`, `LIST`, `STATUS`, `ABORT`, `CLEANUP`, plus container/`HELP` entries, matching railroad SVGs, and cross-links between commands and persistence.
> 
> **`persistence.md`** gains **Online backups with the BACKUP command family**: MP-AOF artifact layout (BASE/INCR/manifest), the staggered cluster workflow, `backupdirname` / `backup-sealed-ttl`, and restore via startup-only `preload-file`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c899ceed7605aaa4e311b66a0b7981675691078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->