### PR TITLE
RBAC API reference pages

### DIFF
--- a/content/operate/kubernetes/reference/_index.md
+++ b/content/operate/kubernetes/reference/_index.md
@@ -88,6 +88,15 @@ Review complete API specifications for all Redis Enterprise custom resources:
 - [Active-Active database API (REAADB)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_active_active_database_api" >}}) - Manage Active-Active databases
 - [Remote cluster API (RERC)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_remote_cluster_api" >}}) - Configure remote cluster connections
 
+### Access control resources
+
+- [RedisEnterpriseUser API (REUSER)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_user_api" >}}) - Manage users for access control
+- [RedisEnterpriseRole API (REROLE)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_api" >}}) - Define roles scoped to selected databases
+- [RedisEnterpriseRoleBinding API (REROLEBINDING)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_binding_api" >}}) - Bind users to a scoped role
+- [RedisEnterpriseClusterRole API (RECROLE)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_api" >}}) - Define cluster-scoped roles
+- [RedisEnterpriseClusterRoleBinding API (RECROLEBINDING)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_binding_api" >}}) - Bind users to a cluster-scoped role
+- [RedisEnterpriseACL API (REACL)]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_acl_api" >}}) - Define access control lists
+
 ## Compatibility
 
 Check supported Kubernetes distributions and versions:

--- a/content/operate/kubernetes/reference/api/_index.md
+++ b/content/operate/kubernetes/reference/api/_index.md
@@ -29,6 +29,12 @@ The operator uses different API versions to indicate stability and feature matur
 | [RedisEnterpriseDatabase (REDB)](redis_enterprise_database_api) | `v1alpha1` | Creates and configures Redis databases |
 | [RedisEnterpriseActiveActiveDatabase (REAADB)](redis_enterprise_active_active_database_api) | `v1alpha1` | Sets up active-active databases across clusters |
 | [RedisEnterpriseRemoteCluster (RERC)](redis_enterprise_remote_cluster_api) | `v1alpha1` | Defines remote cluster connections for active-active |
+| [RedisEnterpriseUser (REUSER)](redis_enterprise_user_api) | `v1alpha1` | Defines users for cluster access control |
+| [RedisEnterpriseRole (REROLE)](redis_enterprise_role_api) | `v1alpha1` | Defines a role scoped to selected databases |
+| [RedisEnterpriseRoleBinding (REROLEBINDING)](redis_enterprise_role_binding_api) | `v1alpha1` | Binds users to a RedisEnterpriseRole |
+| [RedisEnterpriseClusterRole (RECROLE)](redis_enterprise_cluster_role_api) | `v1alpha1` | Defines a cluster-scoped role |
+| [RedisEnterpriseClusterRoleBinding (RECROLEBINDING)](redis_enterprise_cluster_role_binding_api) | `v1alpha1` | Binds users to a RedisEnterpriseClusterRole |
+| [RedisEnterpriseACL (REACL)](redis_enterprise_acl_api) | `v1alpha1` | Defines an access control list (ACL) for a database |
 
 ## Working with the APIs
 


### PR DESCRIPTION
Flat folder structure for release day. Will restructure and group by workflow post-GA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only navigation updates with no runtime or security behavior changes.
> 
> **Overview**
> Adds **Access control resources** to the Kubernetes reference hub and extends the API reference index so six new `v1alpha1` CRDs are discoverable: **REUSER**, **REROLE**, **REROLEBINDING**, **RECROLE**, **RECROLEBINDING**, and **REACL**.
> 
> Each entry links to its API page and includes a short purpose blurb (users, database-scoped roles/bindings, cluster-scoped roles/bindings, and ACLs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1aed16f560d68917a7f9a1102b754db14c76e7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->