### PR TITLE
Add Sage (Scala) to community-supported clients

### DIFF
--- a/content/develop/clients/_index.md
+++ b/content/develop/clients/_index.md
@@ -68,6 +68,7 @@ develop or contribute to these libraries directly.
 | [Dart](https://dart.dev/) | redis_dart_link | https://github.com/toolsetlink/redis_dart_link | https://github.com/toolsetlink/redis_dart_link |
 | [PHP](https://www.php.net/) | PhpRedis extension | https://github.com/phpredis/phpredis | https://github.com/phpredis/phpredis/blob/develop/README.md |
 | [Python](https://www.python.org/) | coredis | https://github.com/alisaifee/coredis | https://coredis.readthedocs.io |
+| [Scala](https://www.scala-lang.org/) | Sage | https://github.com/ghostdogpr/sage | https://ghostdogpr.github.io/sage/ |
 
 ## Requirements
 


### PR DESCRIPTION
Adds Sage to the community-supported clients table. Scala currently has no client listed on the page, so this fills a language gap.

[Sage](https://github.com/ghostdogpr/sage) is an actively maintained, Apache-2.0 Redis & Valkey client for Scala 3. It implements RESP3 natively (no wrapped Java client) and supports Redis 8+, cluster, transactions, sharded pub/sub, client-side caching, replica reads, and TLS.

Docs: https://ghostdogpr.github.io/sage/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only table row addition with no runtime or API impact.
> 
> **Overview**
> Adds **Sage** as a community-supported Redis client for **Scala** on the Connect with Redis client API libraries page (`content/develop/clients/_index.md`).
> 
> The new row in the third-party clients table links to the [ghostdogpr/sage](https://github.com/ghostdogpr/sage) GitHub repo and [Sage docs](https://ghostdogpr.github.io/sage/), giving Scala a listing alongside other community clients. No other sections (official clients table, decision tree, language guides) are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e2908c34193683c45b58b9c456ec324a1a72b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->