### PR TITLE
Deprecate usage of latest branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,9 +55,7 @@ jobs:
       id: set-paths
       run: |
         if [[ "${{ github.ref_name }}" == "main" ]]; then
-          echo "hugo_root_path=docs/staging/dev" >> $GITHUB_OUTPUT
-          echo "bucket_path=staging/dev" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.ref_name }}" == "latest" ]]; then
+          # main is the production branch: merges publish straight to /latest.
           echo "hugo_root_path=docs/latest" >> $GITHUB_OUTPUT
           echo "bucket_path=latest" >> $GITHUB_OUTPUT
         elif [[ "${{ endsWith(github.ref_name, '-build') }}" == "true" ]]; then
@@ -566,7 +564,7 @@ jobs:
           done
         }
 
-        if [[ "${{ github.ref_name }}" == "latest" ]]; then
+        if [[ "$bucket_path" == "latest" ]]; then
           gsutil -m rsync -r -c -j html -d output/operate/kubernetes "gs://${BUCKET}/kubernetes-${version}/operate/kubernetes"
           gsutil -m rsync -r -c -j html -d "output/operate/kubernetes/${version}" "gs://${BUCKET}/docs/${bucket_path}/operate/kubernetes/${version}"
           upload_assets "gs://${BUCKET}/docs/${bucket_path}"
@@ -630,7 +628,7 @@ jobs:
           done
         }
 
-        if [[ "${{ github.ref_name }}" == "latest" ]]; then
+        if [[ "$bucket_path" == "latest" ]]; then
           gsutil -m rsync -r -c -j html -d output/operate/rs "gs://${BUCKET}/rs-${version}/operate/rs"
           gsutil -m rsync -r -c -j html -d "output/operate/rs/${version}" "gs://${BUCKET}/docs/${bucket_path}/operate/rs/${version}"
           upload_assets "gs://${BUCKET}/docs/${bucket_path}"
@@ -694,7 +692,7 @@ jobs:
           done
         }
 
-        if [[ "${{ github.ref_name }}" == "latest" ]]; then
+        if [[ "$bucket_path" == "latest" ]]; then
           gsutil -m rsync -r -c -j html -d output/integrate/redis-data-integration "gs://${BUCKET}/redis-data-integration-${version}/integrate/redis-data-integration"
           gsutil -m rsync -r -c -j html -d "output/integrate/redis-data-integration/${version}" "gs://${BUCKET}/docs/${bucket_path}/integrate/redis-data-integration/${version}"
           upload_assets "gs://${BUCKET}/docs/${bucket_path}"
@@ -758,7 +756,7 @@ jobs:
           done
         }
 
-        if [[ "${{ github.ref_name }}" == "latest" ]]; then
+        if [[ "$bucket_path" == "latest" ]]; then
           gsutil -m rsync -r -c -j html -d output/develop/ai/redisvl "gs://${BUCKET}/redisvl-${version}/develop/ai/redisvl"
           gsutil -m rsync -r -c -j html -d "output/develop/ai/redisvl/${version}" "gs://${BUCKET}/docs/${bucket_path}/develop/ai/redisvl/${version}"
           upload_assets "gs://${BUCKET}/docs/${bucket_path}"
@@ -768,11 +766,11 @@ jobs:
           upload_assets "gs://${BUCKET}/docs/${bucket_path}"
         fi
 
-  # Deploy custom 404 page (only on latest branch)
+  # Deploy custom 404 page (only for the production latest build)
   deploy_404:
     name: Deploy 404 page
     needs: setup_and_build_latest
-    if: ${{ github.ref_name == 'latest' }}
+    if: ${{ needs.setup_and_build_latest.outputs.bucket_path == 'latest' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@
 
 > Note: if you are an AI agent, please see [AI_AGENT_DEVELOPER_GUIDE.md](AI_AGENT_DEVELOPER_GUIDE.md) for more information.
 
-PRs are merged first to the `main` branch of this repo.
-Periodically, the docs team will merge `main` into `latest`, which will make the changes visible on the docs site.
-Please be patient, as there may be a lag of several days before `main` is merged into `latest`. If you want to see your changes before they're merged to `latest`, you can see them on https://redis.io/docs/staging/dev/.
-If your PR is urgent, let the docs team know in the PR comments, and we will do our best to accommodate.
+PRs are merged to the `main` branch of this repo. Merging to `main` automatically builds and publishes your changes to the live docs site (under `/latest`) — there is no separate manual publish step, so allow a little time for the build and CDN cache to refresh after your PR is merged.
+Before your PR is merged, you can preview your changes on a per-branch staging URL; the docs team's bot posts the staging links as a comment on your PR.
 
 ## Site template files and folders
 


### PR DESCRIPTION
Merging to main will publish directly to redis.io/docs/latest . the `latest` branch will be removed altogether

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Git branch triggers live docs deploys and GCS paths; a misconfigured `set-paths` step could publish staging content to production or skip the 404 deploy until caught in CI.
> 
> **Overview**
> **Production publishing moves from the `latest` Git branch to `main`.** Merges to `main` now set `hugo_root_path`/`bucket_path` to the live `/docs/latest` targets; the old mapping that sent `main` to `docs/staging/dev` and reserved production for a `latest` branch is removed.
> 
> **Deploy logic keys off `bucket_path` instead of branch name.** Kubernetes, RS, RDI, and RedisVL GCS deploy steps and the custom 404 job now treat production uploads when `bucket_path == 'latest'` (so `main` qualifies), not when `github.ref_name == 'latest'`.
> 
> **Contributor docs** in `README.md` describe auto-publish on merge to `main`, per-PR staging previews, and drop the manual `main` → `latest` promotion workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57251d52a8f908a06206e6ac496a363e018729f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->