### PR TITLE
Add Redis Cloud Agent Memory REST quickstart

### DIFF
--- a/content/develop/ai/context-engine/agent-memory/_index.md
+++ b/content/develop/ai/context-engine/agent-memory/_index.md
@@ -18,7 +18,7 @@ Give your AI agents persistent memory and context that gets smarter over time.
 Transform your AI agents from simple chatbots into intelligent assistants with Redis-powered memory that automatically learns, organizes, and recalls information across conversations and sessions.
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
-  {{< image-card image="images/ai-brain.svg" alt="Quick start icon" title="Quick Start — Get up and running in 5 minutes with our step-by-step Cloud setup guide" url="/operate/rc/context-engine/agent-memory/create-service" >}}
+  {{< image-card image="images/ai-brain.svg" alt="Quick start icon" title="REST quickstart — Create an Agent Memory service on Redis Cloud and make your first API requests" url="/operate/rc/context-engine/agent-memory/use-agent-memory" >}}
   {{< image-card image="images/ai-LLM-memory.svg" alt="Use cases icon" title="API and SDK Examples — See real-world usage patterns with session events and long-term memory" url="/develop/ai/context-engine/agent-memory/api-examples" >}}
   {{< image-card image="images/ai-brain-2.svg" alt="Python SDK icon" title="Python SDK — Install the redis-agent-memory package from PyPI" url="https://pypi.org/project/redis-agent-memory/" >}}
 </div>
@@ -97,7 +97,7 @@ POST /v1/stores/{storeId}/long-term-memory
 }
 ```
 
-See the full [API and SDK examples]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) for more.
+Follow the [Redis Cloud Agent Memory REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) to run complete `curl` commands.
 
 ## Two-tier memory model
 

--- a/content/develop/ai/context-engine/agent-memory/api-examples.md
+++ b/content/develop/ai/context-engine/agent-memory/api-examples.md
@@ -27,7 +27,7 @@ To access the Agent Memory API, you need:
 
 When you call the API, you need to pass the Agent Memory API key in the `Authorization` header as a Bearer token and the store ID as the `storeId` path parameter.
 
-The examples expect the following variables from the [REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory#save-the-connection-values" >}}):
+The [REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory#save-the-connection-values" >}}) uses the following environment variables:
 
 - **$AGENT_MEMORY_URL** - the complete Agent Memory API base URL
 - **$STORE_ID** - the Store ID of your Agent Memory service

--- a/content/develop/ai/context-engine/agent-memory/api-examples.md
+++ b/content/develop/ai/context-engine/agent-memory/api-examples.md
@@ -11,7 +11,9 @@ title: Use the Redis Agent Memory API and SDK
 weight: 10
 ---
 
-Use the [Agent Memory API]({{< relref "/develop/ai/context-engine/agent-memory/api-reference" >}}) from your client app to store and retrieve agent memory information.
+If you're new to Agent Memory on Redis Cloud, complete the [REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) first. It covers service creation, authentication, and runnable requests.
+
+The examples on this page supplement the quickstart. Use the [Agent Memory API reference]({{< relref "/develop/ai/context-engine/agent-memory/api-reference" >}}) for complete request and response schemas.
 
 You can use any standard REST client or library to access the API. If your app is written in Python, you can also use the [Agent Memory Software Development Kit](https://pypi.org/project/redis-agent-memory/) (SDK) to access the API.
 
@@ -25,19 +27,11 @@ To access the Agent Memory API, you need:
 
 When you call the API, you need to pass the Agent Memory API key in the `Authorization` header as a Bearer token and the store ID as the `storeId` path parameter.
 
-For example:
+The examples expect the following variables from the [REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory#save-the-connection-values" >}}):
 
-```sh
-curl -s -X GET "https://$HOST/v1/stores/$STORE_ID/session-memory" \
-    -H "accept: application/json" \
-    -H "Authorization: Bearer $API_KEY" 
-```
-
-This example expects several variables to be set in the shell:
-
-- **$HOST** - the Agent Memory API endpoint
+- **$AGENT_MEMORY_URL** - the complete Agent Memory API base URL
 - **$STORE_ID** - the Store ID of your Agent Memory service
-- **$API_KEY** - The Agent Memory API token
+- **$API_KEY** - the Agent Memory API key
 
 ## Examples
 
@@ -46,7 +40,6 @@ This example expects several variables to be set in the shell:
 Use [`POST /v1/stores/{storeId}/session-memory/events`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/session-memory/operation/AddSessionEvent" >}}) to add an event to a session in short-term memory. If a session doesn't exist yet, it will be created.
 
 ```json
-POST /v1/stores/{storeId}/session-memory/events
 {
     "sessionId": "abcd-efgh",
     "actorId": "user-name",
@@ -72,10 +65,9 @@ The Agent Memory model will automatically promote relevant short-term memories t
 
 You may want to add one or more long-term memories to add specific preference information.
 
-Use [`POST /v1/stores/{storeId}/long-term-memory/`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/long-term-memory/operation/BulkCreateLongTermMemories" >}}) to add one or more long-term memories to long-term memory storage.
+Use [`POST /v1/stores/{storeId}/long-term-memory`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/long-term-memory/operation/BulkCreateLongTermMemories" >}}) to add one or more long-term memories to long-term memory storage.
 
 ```json
-POST /v1/stores/{storeId}/long-term-memory
 {
     "memories": [
         {
@@ -83,7 +75,7 @@ POST /v1/stores/{storeId}/long-term-memory
             "text": "The user prefers vegetarian food.",
             "memoryType": "episodic",
             "sessionId": "abcd-efgh",
-            "ownerId": "user-name",
+            "ownerId": "user-name"
         }
     ]
 }
@@ -94,7 +86,6 @@ POST /v1/stores/{storeId}/long-term-memory
 Use [`POST /v1/stores/{storeId}/long-term-memory/search`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/long-term-memory/operation/SearchLongTermMemory" >}}) to search for long-term memories.
 
 ```json
-POST /v1/stores/{storeId}/long-term-memory/search
 {
     "text": "user preferences",
     "similarityThreshold": 0.48725898820184166,
@@ -135,4 +126,4 @@ For all values, you must set only one of these operators:
 | `gt` | Returns memories where the value is greater than the provided value. |
 | `lt` | Returns memories where the value is less than the provided value. |
 | `gte` | Returns memories where the value is greater than or equal to the provided value. |
-| `lte` | Returns memories where the value is less than or equal to the provided value. | 
+| `lte` | Returns memories where the value is less than or equal to the provided value. |

--- a/content/develop/ai/context-engine/agent-memory/developer-guide.md
+++ b/content/develop/ai/context-engine/agent-memory/developer-guide.md
@@ -14,7 +14,7 @@ weight: 5
 Everything you need to start building with Redis Agent Memory — REST API reference, SDK examples, and language-specific guides.
 
 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 my-8">
-  {{< image-card image="images/ai-brain.svg" alt="API examples icon" title="API and SDK Examples — Store and retrieve session events and long-term memories" url="/develop/ai/context-engine/agent-memory/api-examples" >}}
+  {{< image-card image="images/ai-brain.svg" alt="REST quickstart icon" title="REST quickstart — Create a service on Redis Cloud and make your first API requests" url="/operate/rc/context-engine/agent-memory/use-agent-memory" >}}
   {{< image-card image="images/ai-cube.svg" alt="API reference icon" title="API Reference — Full OpenAPI reference for all Agent Memory endpoints" url="/develop/ai/context-engine/agent-memory/api-reference" >}}
   {{< image-card image="images/ai-lib.svg" alt="Language guides icon" title="Build Your Own — Self-hosted agent memory using Redis client libraries (Python, Node.js, Go, Java, .NET, and more)" url="/develop/use-cases/agent-memory" >}}
 </div>
@@ -30,41 +30,20 @@ Redis Agent Memory gives your agents a two-tier memory layer available via REST 
   <li class="flex gap-3"><span class="text-redis-red-500 font-bold mt-0.5">&#9679;</span><span><strong>Direct memory writes</strong> — Bulk-create long-term memories from external sources without going through a session, for importing existing knowledge.</span></li>
 </ul>
 
-## API quick start
+## REST quickstart
 
-**1. Add a session event** — store a conversation turn in short-term memory:
+Follow the [Redis Cloud Agent Memory REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) to create a service and run complete `curl` commands for session memory and long-term memory.
 
-```json
-POST /v1/stores/{storeId}/session-memory/events
-{
-    "sessionId": "session-abc",
-    "actorId": "user-123",
-    "role": "USER",
-    "content": [{ "text": "I prefer vegetarian restaurants." }],
-    "createdAt": "2026-06-01T10:00:00Z"
-}
-```
-
-Agent Memory automatically promotes important information (like preferences) to long-term memory in the background.
-
-**2. Search long-term memory** — retrieve relevant context before the next agent response:
-
-```json
-POST /v1/stores/{storeId}/long-term-memory/search
-{
-    "text": "user dietary preferences",
-    "filter": {
-        "ownerId": { "eq": "user-123" }
-    }
-}
-```
-
-See the full [API and SDK examples]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) for all endpoints, including session retrieval, memory deletion, and search filters.
+After you finish the quickstart, review the [Agent Memory API examples]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) and [API reference]({{< relref "/develop/ai/context-engine/agent-memory/api-reference" >}}).
 
 ## Language guides
 
 {{< note >}}
-The guides below show how to implement agent memory patterns **directly using Redis client libraries** — without the managed Agent Memory service. This is a good option if you prefer to self-host, want full control over the implementation, or are using a language that doesn't yet have an Agent Memory SDK. For the managed service, use the [REST API]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) from any language.
+The guides below show how to implement agent memory patterns **directly using Redis client libraries** without the managed Agent Memory service.
+
+Use these guides if you prefer to self-host, want full control over the implementation, or use a language that doesn't have an Agent Memory SDK.
+
+For the managed service, follow the [Redis Cloud REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}).
 {{< /note >}}
 
 Step-by-step examples for building agent memory into your application using your preferred Redis client library:
@@ -81,13 +60,6 @@ Step-by-step examples for building agent memory into your application using your
 
 ## Set up authentication
 
-All API calls require an Agent Memory API key and a Store ID. Pass the key as a Bearer token and the store ID as a path parameter:
+Redis Cloud API requests require an Agent Memory API key and a Store ID. Send the key as a bearer token in the `Authorization` header, and include the Store ID in the request path.
 
-```sh
-curl -X POST "https://$HOST/v1/stores/$STORE_ID/session-memory/events" \
-    -H "Authorization: Bearer $API_KEY" \
-    -H "Content-Type: application/json" \
-    -d '{ ... }'
-```
-
-To get your API endpoint, key, and Store ID, see [Create an Agent Memory service]({{< relref "/operate/rc/context-engine/agent-memory/create-service" >}}).
+The [Redis Cloud REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) shows how to get these values and use them in a request.

--- a/content/embeds/rc-agent-memory-get-started.md
+++ b/content/embeds/rc-agent-memory-get-started.md
@@ -1,7 +1,3 @@
-To set up Agent Memory on Redis Cloud:
-
-1. [Create a database]({{< relref "/operate/rc/databases/create-database" >}}) on Redis Cloud.
-2. [Create an Agent Memory service]({{< relref "/operate/rc/context-engine/agent-memory/create-service" >}}) for your database on Redis Cloud.
-3. [Use the Agent Memory API]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) from your client app.
+Follow the [Redis Cloud Agent Memory REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) to create a service and make your first session-memory and long-term-memory requests.
 
 After you set up Agent Memory, you can [view and manage your service]({{< relref "/operate/rc/context-engine/agent-memory/view-service" >}}).

--- a/content/operate/rc/context-engine/agent-memory/create-service.md
+++ b/content/operate/rc/context-engine/agent-memory/create-service.md
@@ -49,7 +49,7 @@ This is the only time the value of the user key is available. Save it to a secur
 If you lose the service key value, you will need to [generate a new service key]({{< relref "/operate/rc/context-engine/agent-memory/view-service#replace-service-api-key" >}}) to be able to use the Agent Memory API.
     {{</warning>}}
 
-    After your service is created, you can [use the Agent Memory API]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) from your client app.
+    After Redis Cloud creates your service, [continue with the REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}).
 
 - If you want to customize your Agent Memory service, select **Create custom**. 
 
@@ -117,6 +117,6 @@ If an error occurs, verify that your database is active. For help, [contact supp
 
 ## Next steps
 
-After your service is created, you can [use the Agent Memory API]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) from your client app.
+After Redis Cloud creates your service, [continue with the REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}).
 
 You can also [view and edit the service]({{< relref "/operate/rc/context-engine/agent-memory/view-service" >}}).

--- a/content/operate/rc/context-engine/agent-memory/use-agent-memory.md
+++ b/content/operate/rc/context-engine/agent-memory/use-agent-memory.md
@@ -4,25 +4,179 @@ categories:
 - docs
 - operate
 - rc
-description: Use the Agent Memory API to store and retrieve working and long-term memory for AI agents.
+description: Create an Agent Memory service on Redis Cloud and make your first session-memory and long-term-memory REST API requests.
 hideListLinks: true
-linktitle: Use Agent Memory
-title: Use the Agent Memory API on Redis Cloud
+linktitle: REST quickstart
+title: Redis Cloud Agent Memory REST quickstart
 weight: 10
 ---
 
-You can use the [Agent Memory API and SDK]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) from your client app to store and retrieve working and long-term memory for AI agents.
+Use this quickstart to create an Agent Memory service on Redis Cloud and make your first REST API requests.
 
-To access the Agent Memory API, you need:
+{{< note >}}
+Redis Agent Memory on Redis Cloud is available as a public preview. Features and behavior can change before general availability.
+{{< /note >}}
 
-- Agent Memory API endpoint
-- Agent Memory service API key
-- Store ID
+## Before you begin
 
-For Agent Memory on Redis Cloud, the endpoint and Store ID are available in the Agent Memory service's **Configuration** page in the [**General settings** section]({{< relref "/operate/rc/context-engine/agent-memory/view-service#general-settings" >}}).
+To complete this quickstart, you need:
 
-The Agent Memory API key is only available immediately after you create the service API key. If you lost this value, you will need to [generate a new service API key]({{< relref "/operate/rc/context-engine/agent-memory/view-service#replace-service-api-key" >}}) to be able to use the Agent Memory API.
+- A Redis Cloud account that can create Agent Memory services.
+- An eligible Redis Cloud database, or permission to create one.
+- A shell with `curl` installed.
 
-When you call the API, you need to pass the Agent Memory API key in the `Authorization` header as a Bearer token and the Store ID as the `storeId` path parameter.
+An eligible database is active, uses a Pro or Essentials plan, has a public endpoint and Query Engine, runs a supported Redis version, and has the default user enabled.
 
-See the [Agent Memory API and SDK examples]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}) for more information on how to use the Agent Memory API.
+Agent Memory doesn't support Flex, Active-Active, or AWS PrivateLink databases during public preview.
+
+For the complete list, see [prerequisites and limitations]({{< relref "/operate/rc/context-engine/agent-memory/create-service#prerequisites-and-limitations" >}}).
+
+## Create an Agent Memory service
+
+1. Sign in to the [Redis Cloud console](https://cloud.redis.io/).
+1. Select **Agent Memory** from the navigation menu.
+1. If Redis Cloud displays the public-preview terms, review and accept them.
+1. Select **Quick create** to use the default settings, or select **Create custom** and choose an eligible database.
+1. After Redis Cloud creates the service, copy the Agent Memory API key and store it securely.
+
+{{< warning >}}
+Redis Cloud displays the Agent Memory API key only once. If you lose it, [generate a new API key]({{< relref "/operate/rc/context-engine/agent-memory/view-service#replace-service-api-key" >}}).
+{{< /warning >}}
+
+For screenshots and configuration details, see [create an Agent Memory service]({{< relref "/operate/rc/context-engine/agent-memory/create-service" >}}).
+
+## Save the connection values
+
+1. Open the Agent Memory service in the Redis Cloud console.
+1. On the **Configuration** tab, copy the **API Base URL** and **Store ID**.
+1. Export the values in your shell. Replace each placeholder with the value from Redis Cloud:
+
+    ```sh
+    export AGENT_MEMORY_URL='<API_BASE_URL>'
+    export STORE_ID='<STORE_ID>'
+    export API_KEY='<API_KEY>'
+    export SESSION_ID='quickstart-session'
+    export OWNER_ID='quickstart-user'
+    export MEMORY_ID='quickstart-preference'
+    ```
+
+Use the complete API base URL returned by Redis Cloud. Don't add another URL scheme, such as `https://`, to `AGENT_MEMORY_URL`.
+
+Send the API key as a bearer token in the `Authorization` header. Keep the key out of source control, application logs, and other unsecured locations.
+
+## Add a session event
+
+Set the event timestamp to the current Coordinated Universal Time (UTC):
+
+```sh
+export EVENT_CREATED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+```
+
+Add a user event to session memory:
+
+```sh
+curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer $API_KEY" \
+  --header 'Content-Type: application/json' \
+  --data @- \
+  "$AGENT_MEMORY_URL/v1/stores/$STORE_ID/session-memory/events" <<JSON
+{
+  "sessionId": "$SESSION_ID",
+  "actorId": "$OWNER_ID",
+  "role": "USER",
+  "content": [
+    {
+      "text": "I prefer vegetarian restaurants."
+    }
+  ],
+  "createdAt": "$EVENT_CREATED_AT"
+}
+JSON
+```
+
+A successful request returns `201 Created`. The response contains the stored event and its server-generated event ID.
+
+For request and response details, see [`AddSessionEvent`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/session-memory/operation/AddSessionEvent" >}}).
+
+## Retrieve the session
+
+Retrieve the session event that you added:
+
+```sh
+curl --fail-with-body --silent --show-error \
+  --header "Authorization: Bearer $API_KEY" \
+  "$AGENT_MEMORY_URL/v1/stores/$STORE_ID/session-memory/$SESSION_ID"
+```
+
+A successful request returns `200 OK`. The response contains the session ID, owner ID, and stored events.
+
+For request and response details, see [`GetSessionMemory`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/session-memory/operation/GetSessionMemory" >}}).
+
+## Understand automatic extraction
+
+Agent Memory processes session events asynchronously and extracts relevant information into long-term memory. By default, extraction runs on a five-minute cadence, so extracted memories might not appear immediately.
+
+The next step creates a long-term memory directly. This approach lets you verify long-term-memory search without waiting for automatic extraction.
+
+## Create a long-term memory
+
+Create a long-term memory for the same owner and session:
+
+```sh
+curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer $API_KEY" \
+  --header 'Content-Type: application/json' \
+  --data @- \
+  "$AGENT_MEMORY_URL/v1/stores/$STORE_ID/long-term-memory" <<JSON
+{
+  "memories": [
+    {
+      "id": "$MEMORY_ID",
+      "text": "The user prefers vegetarian restaurants.",
+      "memoryType": "semantic",
+      "sessionId": "$SESSION_ID",
+      "ownerId": "$OWNER_ID"
+    }
+  ]
+}
+JSON
+```
+
+A successful request returns `201 Created`. The `created` array in the response contains the value of `MEMORY_ID`.
+
+For request and response details, see [`BulkCreateLongTermMemories`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/long-term-memory/operation/BulkCreateLongTermMemories" >}}).
+
+## Search long-term memory
+
+Search for the long-term memory by meaning and owner:
+
+```sh
+curl --fail-with-body --silent --show-error \
+  --request POST \
+  --header "Authorization: Bearer $API_KEY" \
+  --header 'Content-Type: application/json' \
+  --data @- \
+  "$AGENT_MEMORY_URL/v1/stores/$STORE_ID/long-term-memory/search" <<JSON
+{
+  "text": "What food does the user prefer?",
+  "filter": {
+    "ownerId": {
+      "eq": "$OWNER_ID"
+    }
+  },
+  "limit": 5
+}
+JSON
+```
+
+A successful request returns `200 OK`. The `items` array contains matching long-term memories, including the memory that you created.
+
+For request and response details, see [`SearchLongTermMemory`]({{< relref "/develop/ai/context-engine/agent-memory/api-reference#tag/long-term-memory/operation/SearchLongTermMemory" >}}).
+
+## Next steps
+
+- Review more [Agent Memory API examples]({{< relref "/develop/ai/context-engine/agent-memory/api-examples" >}}).
+- Use the [Agent Memory API reference]({{< relref "/develop/ai/context-engine/agent-memory/api-reference" >}}) for endpoint and schema details.
+- [View and manage the service]({{< relref "/operate/rc/context-engine/agent-memory/view-service" >}}) to update configuration, manage API keys, review metrics, flush memories, or delete the service.

--- a/content/operate/rc/context-engine/agent-memory/view-service.md
+++ b/content/operate/rc/context-engine/agent-memory/view-service.md
@@ -44,7 +44,7 @@ The **General settings** section provides section provides the connection detail
 
 Select the **Copy** button next to the Store ID and API Base URL to copy them to the clipboard.
 
-See [use the Agent Memory API]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) for more information on how to use the connection information and API keys.
+Follow the [Redis Cloud Agent Memory REST quickstart]({{< relref "/operate/rc/context-engine/agent-memory/use-agent-memory" >}}) to use the connection information and API key.
 
 ### Memory configuration
 


### PR DESCRIPTION
## Summary

- Add a runnable Redis Cloud Agent Memory REST quickstart covering session events, session retrieval, long-term memory creation, and memory search.
- Connect the service creation and service details pages to the new workflow.
- Align the Agent Memory developer landing page, developer guide, and API examples with the quickstart.

## Testing

- Full Hugo site build with garbage collection and debug logging
- Shell syntax validation for the runnable examples
- JSON request-body validation with jq
- Independent technical accuracy review against the Smithy API definitions and integration tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code, APIs, or infrastructure impact.
> 
> **Overview**
> **Redis Cloud Agent Memory REST quickstart** replaces the thin `use-agent-memory` page with an end-to-end guide: prerequisites, service creation, shell exports (`AGENT_MEMORY_URL`, `STORE_ID`, `API_KEY`), and runnable `curl` flows for session events, session retrieval, direct long-term memory creation, and semantic search—including notes on async extraction and one-time API keys.
> 
> **Doc navigation** is retargeted so Agent Memory on Redis Cloud starts at that quickstart: landing cards on `_index` and `developer-guide`, the Redis Cloud get-started embed, and “next steps” on create/view service pages now say “continue with the REST quickstart” instead of generic API usage links.
> 
> **Develop docs are slimmed** so they complement the quickstart: `api-examples` drops the sample auth `curl` and defers env vars to the quickstart; JSON examples lose redundant `POST` line prefixes; `developer-guide` removes inline API quick-start JSON and short auth `curl` in favor of links to the quickstart, API examples, and reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d350227587c3aee42741ba33ba4a0e8f730e9607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->