### PR TITLE
UI: fix footer bug reported in site ticket

### DIFF
--- a/layouts/partials/docs-nav.html
+++ b/layouts/partials/docs-nav.html
@@ -229,13 +229,19 @@
       }
     }
 
-    window.addEventListener('scroll', function() {
+    function adjustSidebarHeight() {
       const scrolledHeight = window.scrollY + window.innerHeight;
       if (scrolledHeight >= footer.offsetTop) {
           sidebar.style.maxHeight = `calc(100vh - 7rem - ${scrolledHeight - footer.offsetTop}px)`;
         } else {
         sidebar.style.maxHeight = 'calc(100vh - 7rem)';
       }
-    });
+    }
+
+    window.addEventListener('scroll', adjustSidebarHeight);
+    window.addEventListener('resize', adjustSidebarHeight);
+    // Run once on load so short (non-scrolling) pages don't leave the
+    // fixed sidebar overlapping the footer (issue #3691).
+    adjustSidebarHeight();
   })
 </script>


### PR DESCRIPTION
Fixes #3691.

Reviewers: I tested a few other "short" pages, but it's hard to know if this change has side effects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-side layout tweak in docs-nav only; same height logic as before, with an extra initial and resize pass.
> 
> **Overview**
> Fixes **#3691**, where the fixed docs sidebar could **overlap the footer** on short pages that never trigger a scroll event.
> 
> The scroll-time logic that shrinks `#sidebar` `max-height` when the viewport reaches the footer is extracted into **`adjustSidebarHeight()`**. That function is now invoked on **initial load**, on **scroll**, and on **window resize**, so layout is correct even when the page does not scroll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35a85d89bf399e0ef7e6711a539f3eda2572a17d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->