### PR TITLE
ATTN DevOps: fix for footer weirdness

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -66,7 +66,12 @@ html {
   scroll-padding-top: var(--header-height);
 }
 
-body {
+// Sticky-footer grid. This lives on the .site-shell wrapper (see
+// layouts/_default/baseof.html) rather than on <body> because the live-site
+// Qualified chat widget injects `body { display: block !important }`, which
+// would defeat a grid set on <body> and let the footer float up on short
+// pages (issue #3691). The widget does not touch .site-shell.
+.site-shell {
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr auto;

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -74,16 +74,21 @@
       {{ partial "navbar.html" . }}
     </header>  */}}
 
-    {{ partial "header.html" }}
+    {{/* .site-shell owns the sticky-footer grid (header / main / footer). The
+         grid lives on this wrapper rather than on <body> on purpose: on the
+         live site the Qualified chat widget (js.qualified.com/docking.js)
+         injects `body { display: block !important }` at runtime, which
+         overrides a grid set on <body> and lets the footer float up on short
+         pages (issue #3691). The widget only targets <body>, not this div, so
+         the grid survives here. See assets/scss/style.scss. */}}
+    <div class="site-shell">
+      {{ partial "header.html" }}
 
-    {{ block "main" . }}{{ end }}
+      {{ block "main" . }}{{ end }}
 
-    {{/*  <footer class="bg-midnight-700 relative z-50">
       {{ partial "footer.html" . }}
-      {{ partial "toc-js.html" . }}
-    </footer>  */}}
+    </div>
 
-    {{ partial "footer.html" . }}
     {{ partial "toc-js.html" . }}
 
     {{ partial "search-modal.html" . }}


### PR DESCRIPTION
This _might_ fix a problem with the footer as seen on this page:

https://redis.io/docs/latest/integrate/riot/

There's a description from Claude in a [Slack thread](https://redis.slack.com/archives/C06V3V5S62H/p1784748880677249?thread_ts=1784746883.151079&channel=C06V3V5S62H&message_ts=1784748880.677249). There's no way to be sure about this fix until this PR is merged, because it has to deploy on latest. @paoloredis would you please take a look?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only HTML/CSS change with documented rationale; low blast radius aside from verifying footer behavior with the Qualified widget in production.
> 
> **Overview**
> Fixes **footer floating mid-page on short content** (issue #3691) by relocating the sticky-footer layout from `<body>` to a new **`.site-shell`** wrapper in `baseof.html`.
> 
> The **min-height + CSS grid** (`auto 1fr auto` for header, main, footer) now applies to `.site-shell` instead of `body`, because the production **Qualified** chat script injects `body { display: block !important }`, which overrides a grid on `<body>` and breaks the footer stickiness. The widget does not target `.site-shell`.
> 
> **`toc-js.html`** and other partials that sat between main and footer are left **outside** the wrapper; only header, main block, and footer live inside `.site-shell`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82a7633d6ef4fd9c9804ce2af1da577c6a89f3d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->