### PR TITLE
DOC-6878 Expand RDI FAQ CDC section with all supported databases

### DIFF
--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -44,9 +44,7 @@ supported source databases:
   only when RDI is deployed on Kubernetes with Helm.
 
 For the complete list of supported source databases and versions, see
-[Prepare source databases]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs" >}}):
-
-{{< embed-md "rdi-supported-source-versions.md" >}}
+[Prepare source databases]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs" >}}).
 
 ## How much data can RDI process?
 

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -24,14 +24,29 @@ Redis Enterprise shards (primary and replica) for the staging database.
 
 ## How does RDI track data changes in the source database?
 
-RDI uses mechanisms that are specific for each of the supported
-source databases:
+RDI uses change data capture (CDC) mechanisms that are specific to each of the
+supported source databases:
 
-- **Oracle**:  RDI uses `logminer` to parse the Oracle `binary log` and `archive logs`. This
-  lists any changes in a database view that RDI can query.
-- **MySQL/MariaDB**: RDI uses `binary log replication` to get all the commits.
-- **PostgreSQL**:  RDI uses the `pgoutput` plugin.
-- **SQL Server**: RDI uses the CDC mechanism.
+- **Oracle**: RDI uses `LogMiner` to read Oracle's `redo logs` and `archive logs`,
+  or, alternatively, `XStream`.
+- **MySQL/MariaDB**: RDI uses `binary log` (binlog) replication to capture all commits.
+- **PostgreSQL**: RDI uses the `pgoutput` logical decoding plugin. The same
+  applies to the PostgreSQL-compatible databases that RDI supports, including
+  Supabase, AlloyDB for PostgreSQL, Amazon Aurora/RDS for PostgreSQL, and Neon.
+- **SQL Server**: RDI uses the database's built-in CDC feature.
+- **MongoDB**: RDI uses `change streams` to read the `oplog`. The source must be
+  a replica set, sharded cluster, or MongoDB Atlas deployment, because a
+  standalone MongoDB server has no oplog.
+- **Google Cloud Spanner**: RDI uses `Spanner change streams` for the streaming
+  phase and the JDBC driver for the initial snapshot. Spanner is supported only
+  when RDI is deployed on Kubernetes with Helm.
+- **Snowflake** (preview): RDI uses `Snowflake Streams`. Snowflake is supported
+  only when RDI is deployed on Kubernetes with Helm.
+
+For the complete list of supported source databases and versions, see
+[Prepare source databases]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs" >}}):
+
+{{< embed-md "rdi-supported-source-versions.md" >}}
 
 ## How much data can RDI process?
 


### PR DESCRIPTION
## What

Resolves [DOC-6878](https://redislabs.atlassian.net/browse/DOC-6878): expand the *"How does RDI track data changes in the source database?"* FAQ answer to cover the complete set of supported source databases, consistent with the current docs.

## Changes

- **Added the missing databases** with mechanisms sourced from their *Prepare source databases* pages:
  - **MongoDB** — change streams (reads the oplog; requires replica set / sharded cluster / Atlas)
  - **Google Cloud Spanner** — Spanner change streams (K8s/Helm only)
  - **Snowflake (preview)** — Snowflake Streams (K8s/Helm only)
- **Grouped the PostgreSQL-compatible databases** (Supabase, AlloyDB, Amazon Aurora/RDS for PostgreSQL, Neon) under the `pgoutput` bullet.
- **Corrected the Oracle mechanism**: redo/archive logs via `LogMiner` (or `XStream`), not a "binary log" (that was MySQL's term).
- **Embedded the canonical `rdi-supported-source-versions.md` table** (and linked *Prepare source databases*) so the FAQ list can't drift from the source of truth.

## For review

- **XStream** is included alongside LogMiner for Oracle (it's documented on `oracle.md`). Flagging for a second opinion on whether to surface it in the FAQ or keep to the LogMiner default.
- Worth a sanity-check on the MongoDB / Spanner / Snowflake mechanism wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6878]: https://redislabs.atlassian.net/browse/DOC-6878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to an FAQ; no product code, auth, or data paths.
> 
> **Overview**
> Expands the RDI FAQ answer **“How does RDI track data changes in the source database?”** so it documents CDC for the full set of supported sources, not only the original four relational databases.
> 
> The section is reframed around **CDC**, with per-database bullets updated or added: **Oracle** now describes `LogMiner` on redo/archive logs (and optional `XStream`) instead of incorrect “binary log” wording; **PostgreSQL** groups Supabase, AlloyDB, Aurora/RDS, and Neon under `pgoutput`; **MongoDB**, **Google Cloud Spanner**, and **Snowflake (preview)** are new, including oplog/replica-set requirements and K8s/Helm-only notes where applicable. A link to **Prepare source databases** points readers at the canonical supported-versions list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf0d9061122ccb6d9a6da0cd9a72a99e6e80e0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->