### PR TITLE
Speed up build_docs CI: split version discovery, parallel GCS upload, make ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,11 @@ env:
   BUCKET: docs-prod-learn-redis-com
 
 jobs:
-  # Discover versions and build the latest docs
-  setup_and_build_latest:
-    name: Setup and build latest docs
+  # Discover versions and compute deployment paths. This job is intentionally
+  # lightweight (checkout only) so the versioned matrix builds can start
+  # without waiting for the full latest build.
+  discover_versions:
+    name: Discover versions
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -25,13 +27,6 @@ jobs:
       bucket_path: ${{ steps.set-paths.outputs.bucket_path }}
 
     steps:
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-
     - name: Validate the branch name
       env:
         BRANCH_NAME: ${{ github.ref_name }}
@@ -42,11 +37,6 @@ jobs:
           echo "ERROR: Invalid branch name $BRANCH_NAME!"
           exit 1
         fi
-
-    - name: Install Hugo
-      run: |
-        wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-        && sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
     - name: Check the branch out
       uses: actions/checkout@v4
@@ -87,20 +77,44 @@ jobs:
         echo "  RDI: ${rdi_versions}"
         echo "  RedisVL: ${redisvl_versions}"
 
+  # Build the latest docs
+  setup_and_build_latest:
+    name: Setup and build latest docs
+    needs: discover_versions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+
+    steps:
+    - name: Free up disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+    - name: Install Hugo
+      run: |
+        wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
+        && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+
+    - name: Check the branch out
+      uses: actions/checkout@v4
+
     - name: Install dependencies
       run: make deps
 
     - name: Build latest (without versioned content)
       run: |
         set -x
-        hugo_root_path="${{ steps.set-paths.outputs.hugo_root_path }}"
+        hugo_root_path="${{ needs.discover_versions.outputs.hugo_root_path }}"
         sed -i "s#baseURL = \"https://redis.io\"#baseURL = \"https://redis.io/${hugo_root_path}\"#g" config.toml
 
         # Remove all versioned directories for the latest build
-        kubernetes_versions='${{ steps.discover.outputs.kubernetes_versions }}'
-        rs_versions='${{ steps.discover.outputs.rs_versions }}'
-        rdi_versions='${{ steps.discover.outputs.rdi_versions }}'
-        redisvl_versions='${{ steps.discover.outputs.redisvl_versions }}'
+        kubernetes_versions='${{ needs.discover_versions.outputs.kubernetes_versions }}'
+        rs_versions='${{ needs.discover_versions.outputs.rs_versions }}'
+        rdi_versions='${{ needs.discover_versions.outputs.rdi_versions }}'
+        redisvl_versions='${{ needs.discover_versions.outputs.redisvl_versions }}'
 
         for version in $(echo "$kubernetes_versions" | jq -r '.[]'); do
           rm -rf "content/operate/kubernetes/${version}"
@@ -121,7 +135,9 @@ jobs:
         echo "$rdi_versions" | jq -r '.[]' > rdi-versions
         echo "$redisvl_versions" | jq -r '.[]' > redisvl-versions
 
-        make all
+        # `make ci` skips `clean` (the CI workspace is a fresh checkout, and
+        # `clean` would delete the node_modules that `make deps` just installed).
+        make ci
 
     - name: List client examples
       run: ls "${{ github.workspace }}/examples"
@@ -139,15 +155,15 @@ jobs:
   # Build Kubernetes versions in parallel
   build_kubernetes:
     name: Build Kubernetes ${{ matrix.version }}
-    needs: setup_and_build_latest
-    if: ${{ needs.setup_and_build_latest.outputs.kubernetes_versions != '[]' }}
+    needs: discover_versions
+    if: ${{ needs.discover_versions.outputs.kubernetes_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.kubernetes_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.kubernetes_versions) }}
 
     steps:
     - name: Free up disk space
@@ -175,12 +191,12 @@ jobs:
       run: |
         set -x
         version="${{ matrix.version }}"
-        hugo_root_path="${{ needs.setup_and_build_latest.outputs.hugo_root_path }}"
+        hugo_root_path="${{ needs.discover_versions.outputs.hugo_root_path }}"
 
         sed -i "s#baseURL = \"https://redis.io\"#baseURL = \"https://redis.io/${hugo_root_path}\"#g" config.toml
 
         # Remove all other kubernetes versions
-        kubernetes_versions='${{ needs.setup_and_build_latest.outputs.kubernetes_versions }}'
+        kubernetes_versions='${{ needs.discover_versions.outputs.kubernetes_versions }}'
         for v in $(echo "$kubernetes_versions" | jq -r '.[]'); do
           if [[ "$v" != "$version" ]]; then
             rm -rf "content/operate/kubernetes/${v}"
@@ -200,10 +216,10 @@ jobs:
         sed -i "12i \{\{ \$gh_path = replaceRE \`\^operate\/kubernetes\/\` \"operate\/kubernetes\/${version}\/\" \$gh_path }}" layouts/partials/meta-links.html
 
         # Create version files for docs-nav.html dropdowns
-        echo '${{ needs.setup_and_build_latest.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
-        echo '${{ needs.setup_and_build_latest.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
+        echo '${{ needs.discover_versions.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
+        echo '${{ needs.discover_versions.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
+        echo '${{ needs.discover_versions.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
+        echo '${{ needs.discover_versions.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
 
         hugo -d "output"
 
@@ -217,15 +233,15 @@ jobs:
   # Build RS versions in parallel
   build_rs:
     name: Build RS ${{ matrix.version }}
-    needs: setup_and_build_latest
-    if: ${{ needs.setup_and_build_latest.outputs.rs_versions != '[]' }}
+    needs: discover_versions
+    if: ${{ needs.discover_versions.outputs.rs_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.rs_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.rs_versions) }}
 
     steps:
     - name: Free up disk space
@@ -253,12 +269,12 @@ jobs:
       run: |
         set -x
         version="${{ matrix.version }}"
-        hugo_root_path="${{ needs.setup_and_build_latest.outputs.hugo_root_path }}"
+        hugo_root_path="${{ needs.discover_versions.outputs.hugo_root_path }}"
 
         sed -i "s#baseURL = \"https://redis.io\"#baseURL = \"https://redis.io/${hugo_root_path}\"#g" config.toml
 
         # Remove all other rs versions
-        rs_versions='${{ needs.setup_and_build_latest.outputs.rs_versions }}'
+        rs_versions='${{ needs.discover_versions.outputs.rs_versions }}'
         for v in $(echo "$rs_versions" | jq -r '.[]'); do
           if [[ "$v" != "$version" ]]; then
             rm -rf "content/operate/rs/${v}"
@@ -278,10 +294,10 @@ jobs:
         sed -i "12i \{\{ \$gh_path = replaceRE \`\^operate\/rs\/\` \"operate\/rs\/${version}\/\" \$gh_path }}" layouts/partials/meta-links.html
 
         # Create version files for docs-nav.html dropdowns
-        echo '${{ needs.setup_and_build_latest.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
-        echo '${{ needs.setup_and_build_latest.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
+        echo '${{ needs.discover_versions.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
+        echo '${{ needs.discover_versions.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
+        echo '${{ needs.discover_versions.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
+        echo '${{ needs.discover_versions.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
 
         hugo -d "output"
 
@@ -295,15 +311,15 @@ jobs:
   # Build RDI versions in parallel
   build_rdi:
     name: Build RDI ${{ matrix.version }}
-    needs: setup_and_build_latest
-    if: ${{ needs.setup_and_build_latest.outputs.rdi_versions != '[]' }}
+    needs: discover_versions
+    if: ${{ needs.discover_versions.outputs.rdi_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.rdi_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.rdi_versions) }}
 
     steps:
     - name: Free up disk space
@@ -331,12 +347,12 @@ jobs:
       run: |
         set -x
         version="${{ matrix.version }}"
-        hugo_root_path="${{ needs.setup_and_build_latest.outputs.hugo_root_path }}"
+        hugo_root_path="${{ needs.discover_versions.outputs.hugo_root_path }}"
 
         sed -i "s#baseURL = \"https://redis.io\"#baseURL = \"https://redis.io/${hugo_root_path}\"#g" config.toml
 
         # Remove all other rdi versions
-        rdi_versions='${{ needs.setup_and_build_latest.outputs.rdi_versions }}'
+        rdi_versions='${{ needs.discover_versions.outputs.rdi_versions }}'
         for v in $(echo "$rdi_versions" | jq -r '.[]'); do
           if [[ "$v" != "$version" ]]; then
             rm -rf "content/integrate/redis-data-integration/${v}"
@@ -356,10 +372,10 @@ jobs:
         sed -i "12i \{\{ \$gh_path = replaceRE \`\^integrate\/redis-data-integration\/\` \"integrate\/redis-data-integration\/${version}\/\" \$gh_path }}" layouts/partials/meta-links.html
 
         # Create version files for docs-nav.html dropdowns
-        echo '${{ needs.setup_and_build_latest.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
-        echo '${{ needs.setup_and_build_latest.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
+        echo '${{ needs.discover_versions.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
+        echo '${{ needs.discover_versions.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
+        echo '${{ needs.discover_versions.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
+        echo '${{ needs.discover_versions.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
 
         hugo -d "output"
 
@@ -373,15 +389,15 @@ jobs:
   # Build RedisVL versions in parallel
   build_redisvl:
     name: Build RedisVL ${{ matrix.version }}
-    needs: setup_and_build_latest
-    if: ${{ needs.setup_and_build_latest.outputs.redisvl_versions != '[]' }}
+    needs: discover_versions
+    if: ${{ needs.discover_versions.outputs.redisvl_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.redisvl_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.redisvl_versions) }}
 
     steps:
     - name: Free up disk space
@@ -409,12 +425,12 @@ jobs:
       run: |
         set -x
         version="${{ matrix.version }}"
-        hugo_root_path="${{ needs.setup_and_build_latest.outputs.hugo_root_path }}"
+        hugo_root_path="${{ needs.discover_versions.outputs.hugo_root_path }}"
 
         sed -i "s#baseURL = \"https://redis.io\"#baseURL = \"https://redis.io/${hugo_root_path}\"#g" config.toml
 
         # Remove all other redisvl versions
-        redisvl_versions='${{ needs.setup_and_build_latest.outputs.redisvl_versions }}'
+        redisvl_versions='${{ needs.discover_versions.outputs.redisvl_versions }}'
         for v in $(echo "$redisvl_versions" | jq -r '.[]'); do
           if [[ "$v" != "$version" ]]; then
             rm -rf "content/develop/ai/redisvl/${v}"
@@ -434,10 +450,10 @@ jobs:
         sed -i "12i \{\{ \$gh_path = replaceRE \`\^develop\/ai\/redisvl\/\` \"develop\/ai\/redisvl\/${version}\/\" \$gh_path }}" layouts/partials/meta-links.html
 
         # Create version files for docs-nav.html dropdowns
-        echo '${{ needs.setup_and_build_latest.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
-        echo '${{ needs.setup_and_build_latest.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
-        echo '${{ needs.setup_and_build_latest.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
+        echo '${{ needs.discover_versions.outputs.kubernetes_versions }}' | jq -r '.[]' > kubernetes-versions
+        echo '${{ needs.discover_versions.outputs.rs_versions }}' | jq -r '.[]' > rs-versions
+        echo '${{ needs.discover_versions.outputs.rdi_versions }}' | jq -r '.[]' > rdi-versions
+        echo '${{ needs.discover_versions.outputs.redisvl_versions }}' | jq -r '.[]' > redisvl-versions
 
         hugo -d "output"
 
@@ -451,7 +467,9 @@ jobs:
   # Deploy latest build to GCS
   deploy_latest:
     name: Deploy latest
-    needs: setup_and_build_latest
+    needs:
+      - discover_versions
+      - setup_and_build_latest
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -483,7 +501,7 @@ jobs:
 
     - name: Deploy latest to GCS
       run: |
-        bucket_path="${{ needs.setup_and_build_latest.outputs.bucket_path }}"
+        bucket_path="${{ needs.discover_versions.outputs.bucket_path }}"
 
         # The -d flag mirrors the bucket to this build, deleting any object not
         # present locally -- including older fingerprinted css/index.min.{hash}.css
@@ -500,18 +518,37 @@ jobs:
           done
         }
 
-        gsutil -m rsync -r -c -j html -d -x '^(css|scss)/' public gs://$BUCKET/$bucket_path
-        gsutil -m rsync -r -c -j html -d -x '^(css|scss)/' public gs://$BUCKET/docs/$bucket_path
-        upload_assets "gs://$BUCKET/$bucket_path"
-        upload_assets "gs://$BUCKET/docs/$bucket_path"
+        # The two destinations are independent, so run their sync pipelines
+        # concurrently. Within each destination the destructive sync still runs
+        # before the additive css/scss upload.
+        sync_dest() {
+          local dest="$1"
+          gsutil -m rsync -r -c -j html -d -x '^(css|scss)/' public "$dest"
+          upload_assets "$dest"
+        }
+
+        sync_dest "gs://$BUCKET/$bucket_path" &
+        pid_root=$!
+        sync_dest "gs://$BUCKET/docs/$bucket_path" &
+        pid_docs=$!
+
+        # Propagate failures: either sync failing fails the step.
+        wait "$pid_root"
+        wait "$pid_docs"
 
   # Deploy Kubernetes versions to GCS
   deploy_kubernetes:
     name: Deploy Kubernetes ${{ matrix.version }}
     needs:
+      - discover_versions
       - setup_and_build_latest
       - build_kubernetes
-    if: ${{ needs.setup_and_build_latest.outputs.kubernetes_versions != '[]' }}
+      # deploy_latest mirrors public -> docs/<path> with `-d`, which deletes any
+      # versioned subdir present at mirror time. Gate the versioned deploy on it
+      # so the destructive latest sync always completes before we write versioned
+      # content into the same tree.
+      - deploy_latest
+    if: ${{ needs.discover_versions.outputs.kubernetes_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -519,7 +556,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.kubernetes_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.kubernetes_versions) }}
     env:
       PROD_PROJECT_ID: ${{ secrets.GCP_PROJECT_PROD }}
       PROD_SERVICE_ACCOUNT: ${{ secrets.PROD_SERVICE_ACCOUNT }}
@@ -548,7 +585,7 @@ jobs:
     - name: Deploy Kubernetes ${{ matrix.version }} to GCS
       run: |
         version="${{ matrix.version }}"
-        bucket_path="${{ needs.setup_and_build_latest.outputs.bucket_path }}"
+        bucket_path="${{ needs.discover_versions.outputs.bucket_path }}"
 
         # Matrix Hugo builds can produce different CSS hashes than deploy_latest,
         # so versioned pages 404 on /css/index.min.{hash}.css. Additively rsync
@@ -578,9 +615,13 @@ jobs:
   deploy_rs:
     name: Deploy RS ${{ matrix.version }}
     needs:
+      - discover_versions
       - setup_and_build_latest
       - build_rs
-    if: ${{ needs.setup_and_build_latest.outputs.rs_versions != '[]' }}
+      # See deploy_kubernetes: gate on deploy_latest so its destructive mirror
+      # runs before versioned content is written into the same tree.
+      - deploy_latest
+    if: ${{ needs.discover_versions.outputs.rs_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -588,7 +629,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.rs_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.rs_versions) }}
     env:
       PROD_PROJECT_ID: ${{ secrets.GCP_PROJECT_PROD }}
       PROD_SERVICE_ACCOUNT: ${{ secrets.PROD_SERVICE_ACCOUNT }}
@@ -617,7 +658,7 @@ jobs:
     - name: Deploy RS ${{ matrix.version }} to GCS
       run: |
         version="${{ matrix.version }}"
-        bucket_path="${{ needs.setup_and_build_latest.outputs.bucket_path }}"
+        bucket_path="${{ needs.discover_versions.outputs.bucket_path }}"
 
         upload_assets() {
           local dest="$1"
@@ -642,9 +683,13 @@ jobs:
   deploy_rdi:
     name: Deploy RDI ${{ matrix.version }}
     needs:
+      - discover_versions
       - setup_and_build_latest
       - build_rdi
-    if: ${{ needs.setup_and_build_latest.outputs.rdi_versions != '[]' }}
+      # See deploy_kubernetes: gate on deploy_latest so its destructive mirror
+      # runs before versioned content is written into the same tree.
+      - deploy_latest
+    if: ${{ needs.discover_versions.outputs.rdi_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -652,7 +697,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.rdi_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.rdi_versions) }}
     env:
       PROD_PROJECT_ID: ${{ secrets.GCP_PROJECT_PROD }}
       PROD_SERVICE_ACCOUNT: ${{ secrets.PROD_SERVICE_ACCOUNT }}
@@ -681,7 +726,7 @@ jobs:
     - name: Deploy RDI ${{ matrix.version }} to GCS
       run: |
         version="${{ matrix.version }}"
-        bucket_path="${{ needs.setup_and_build_latest.outputs.bucket_path }}"
+        bucket_path="${{ needs.discover_versions.outputs.bucket_path }}"
 
         upload_assets() {
           local dest="$1"
@@ -706,9 +751,13 @@ jobs:
   deploy_redisvl:
     name: Deploy RedisVL ${{ matrix.version }}
     needs:
+      - discover_versions
       - setup_and_build_latest
       - build_redisvl
-    if: ${{ needs.setup_and_build_latest.outputs.redisvl_versions != '[]' }}
+      # See deploy_kubernetes: gate on deploy_latest so its destructive mirror
+      # runs before versioned content is written into the same tree.
+      - deploy_latest
+    if: ${{ needs.discover_versions.outputs.redisvl_versions != '[]' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -716,7 +765,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ fromJson(needs.setup_and_build_latest.outputs.redisvl_versions) }}
+        version: ${{ fromJson(needs.discover_versions.outputs.redisvl_versions) }}
     env:
       PROD_PROJECT_ID: ${{ secrets.GCP_PROJECT_PROD }}
       PROD_SERVICE_ACCOUNT: ${{ secrets.PROD_SERVICE_ACCOUNT }}
@@ -745,7 +794,7 @@ jobs:
     - name: Deploy RedisVL ${{ matrix.version }} to GCS
       run: |
         version="${{ matrix.version }}"
-        bucket_path="${{ needs.setup_and_build_latest.outputs.bucket_path }}"
+        bucket_path="${{ needs.discover_versions.outputs.bucket_path }}"
 
         upload_assets() {
           local dest="$1"
@@ -769,8 +818,10 @@ jobs:
   # Deploy custom 404 page (only for the production latest build)
   deploy_404:
     name: Deploy 404 page
-    needs: setup_and_build_latest
-    if: ${{ needs.setup_and_build_latest.outputs.bucket_path == 'latest' }}
+    needs:
+      - discover_versions
+      - setup_and_build_latest
+    if: ${{ needs.discover_versions.outputs.bucket_path == 'latest' }}
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ HUGO_BUILD=--gc
 
 # ndjson implicitly depends on json_transform -> hugo
 all: clean deps components ndjson
+
+# CI build: the workspace is a fresh checkout, so skip `clean` (which would
+# delete the node_modules installed by the workflow's `make deps` step).
+ci: components ndjson
 serve: clean deps components serve_hugo
 localserve: clean deps components_local serve_hugo
 


### PR DESCRIPTION
- Split version discovery into a lightweight discover_versions job (checkout
  + set-paths + discover only). The versioned matrix build jobs now depend on discover_versions instead of the full latest build, so they start minutes earlier, in parallel with setup_and_build_latest.

- Gate each versioned deploy job on deploy_latest. deploy_latest mirrors public -> docs/<path> with `rsync -d`, which deletes any versioned subdir present at mirror time. Previously the ordering was only implicit (versioned builds depended on the latest build, adding latency); now that they start early, the dependency is made explicit so the destructive latest sync always completes before versioned content is written into the same tree.

- Parallelize the double GCS upload in deploy_latest. The /latest and /docs/latest sync pipelines are independent and run concurrently; within each destination the destructive rsync still runs before the additive css/scss upload, and either pipeline failing fails the step (bash -eo pipefail).

- Build the latest docs with the new `make ci` target (components + ndjson) instead of `make all`, whose `clean` prerequisite deleted the node_modules the workflow's separate `make deps` step had just installed, forcing a second npm/pip install. CI workspaces are fresh checkouts, so `clean` has nothing else to remove.

The "Free up disk space" steps are kept synchronous: backgrounding them races the deletion against the build that needs the freed space.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production GCS deploy ordering and concurrency; incorrect job dependencies could delete or race versioned docs, though the new `deploy_latest` gate mitigates the main hazard.
> 
> **Overview**
> **Restructures the `build_docs` workflow** so versioned matrix builds can start sooner and deploy ordering stays safe.
> 
> A new lightweight **`discover_versions`** job (branch validation, checkout, path setup, version discovery only) runs first and feeds outputs to everything else. **`setup_and_build_latest`** now depends on it; Kubernetes/RS/RDI/RedisVL **build** jobs depend on **`discover_versions`** instead of the full latest build, so they can run **in parallel** with the latest Hugo build.
> 
> The latest build uses **`make ci`** (`components` + `ndjson`, no `clean`) instead of **`make all`**, avoiding a second npm/pip install after `make deps` wipes `node_modules` via `clean`.
> 
> **`deploy_latest`** runs the two GCS mirror pipelines (`gs://…/$bucket_path` and `gs://…/docs/$bucket_path`) **concurrently** via background `sync_dest` + `wait`, while keeping destructive rsync before additive css/scss per destination.
> 
> All **versioned deploy** jobs now **`need: deploy_latest`** explicitly so the destructive latest mirror (`rsync -d`) finishes before versioned content is written into the same tree. Job outputs and `bucket_path` references are wired through **`discover_versions`** instead of **`setup_and_build_latest`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 889f53081524839f292310196eb550741c92b54e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->