### PR TITLE
OP: add Redis OSS release notes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisce-7.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisce-7.4-release-notes.md
@@ -12,6 +12,14 @@ min-version-rs: blah
 weight: 100
 ---
 
+## Redis Community Edition 7.4.10 (July 2026)
+
+Update urgency: `SECURITY`: There are security fixes in the release.
+
+### Security fixes
+
+- A crafted stream `RESTORE` payload can make two consumers share the same NACK, leading to a use-after-free that may result in Remote Code Execution.
+
 ## Redis Community Edition 7.4.9 (May 2026):
 
 Update urgency: `SECURITY`: There are security fixes in the release.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisce-7.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisce-7.4-release-notes.md
@@ -14,7 +14,7 @@ weight: 100
 
 ## Redis Community Edition 7.4.10 (July 2026)
 
-Update urgency: `SECURITY`: There are security fixes in the release.
+Update urgency: `SECURITY`: There is a security fix in the release.
 
 ### Security fixes
 

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.2-release-notes.md
@@ -12,6 +12,19 @@ min-version-rs: blah
 weight: 60
 ---
 
+## Redis Open Source 8.2.8 (July 2026)
+
+SECURITY: There are security fixes in the release.
+
+### Security fixes
+
+- Use-after-free when loading a stream consumer group via `RESTORE` may lead to Remote Code Execution.
+- RedisBloom/RedisBloom[#1041](https://github.com/redisbloom/redisbloom/pull/1041) Crafted RESTORE payloads in RedisBloom and TDigest may trigger out-of-bounds writes, potentially leading to remote code execution.
+
+### Bug fixes
+
+- RedisBloom/RedisBloom[#1019](https://github.com/redisbloom/redisbloom/pull/1019) Replicate `CF.LOADCHUNK` data chunks to prevent silent Cuckoo Filter data loss on failover.
+
 ## Redis Open Source 8.2.7 (June 2026)
 
 Update urgency: `HIGH`: There are critical bugs that may affect a subset of users.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.4-release-notes.md
@@ -12,6 +12,20 @@ min-version-rs: blah
 weight: 40
 ---
 
+## Redis Open Source 8.4.5 (July 2026)
+
+SECURITY: There are security fixes in the release.
+
+### Security fixes
+
+- Use-after-free when loading a stream consumer group via `RESTORE` may lead to Remote Code Execution.
+- RedisBloom/RedisBloom[#1039](https://github.com/redisbloom/redisbloom/pull/1039) Crafted RESTORE payloads in RedisBloom and TDigest may trigger out-of-bounds writes, potentially leading to remote code execution.
+
+### Bug fixes
+
+- RedisBloom/RedisBloom[#1020](https://github.com/redisbloom/redisbloom/pull/1020) Replicate `CF.LOADCHUNK` data chunks to prevent silent Cuckoo Filter data loss on failover.
+
+
 ## Redis Open Source 8.4.4 (June 2026)
 
 Update urgency: `HIGH`: There are critical bugs that may affect a subset of users.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.6-release-notes.md
@@ -12,6 +12,19 @@ min-version-rs: blah
 weight: 20
 ---
 
+## Redis Open Source 8.6.5 (July 2026)
+
+SECURITY: There are security fixes in the release.
+
+### Security fixes
+
+- A crafted stream RESTORE payload can make two consumers share the same NACK, leading to a use-after-free that may result in Remote Code Execution.
+- RedisBloom/RedisBloom[#1046](https://github.com/redisbloom/redisbloom/pull/1046) Crafted RESTORE payloads in RedisBloom and TDigest may trigger out-of-bounds writes, potentially leading to remote code execution.
+
+### Bug fixes
+
+- RedisBloom/RedisBloom[#1021](https://github.com/redisbloom/redisbloom/pull/1021) Replicate `CF.LOADCHUNK` data chunks to prevent silent Cuckoo Filter data loss on failover.
+
 ## Redis Open Source 8.6.4 (June 2026)
 
 Update urgency: `HIGH`: There are critical bugs that may affect a subset of users.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.8-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.8-release-notes.md
@@ -12,6 +12,14 @@ min-version-rs: blah
 weight: 15
 ---
 
+## Redis Open Source 8.8.1 (July 2026)
+
+SECURITY: There is a security fix in the release.
+
+### Security fixes
+
+- RedisBloom/RedisBloom[#1044](https://github.com/redisbloom/redisbloom/pull/1044) Crafted RESTORE payloads in RedisBloom and TDigest may trigger out-of-bounds writes, potentially leading to remote code execution.
+
 ## Redis Open Source 8.8.0 (May 2026)
 
 This is the General Availability release of Redis 8.8 in Redis Open Source.


### PR DESCRIPTION
Release notes for Redis Open Source versions: 7.4.1, 8.2.8, 8.4.5, 8.6.5, and 8.8.1.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to release notes; no application or infrastructure code changes.
> 
> **Overview**
> Adds **July 2026** patch sections at the top of five existing release-note pages under `release-notes/redisce/`, matching the usual security / bug-fix layout.
> 
> **Redis Community Edition 7.4.10** documents a **SECURITY** stream `RESTORE` use-after-free (shared NACK / RCE).
> 
> **Redis Open Source 8.2.8, 8.4.5, and 8.6.5** each add **SECURITY** items for stream consumer-group `RESTORE` UAF and crafted **RedisBloom/TDigest** `RESTORE` payloads, plus a **RedisBloom** fix to replicate **`CF.LOADCHUNK`** so Cuckoo Filter data is not lost on failover. **8.2.8** and **8.4.5** use the stream consumer-group wording; **8.6.5** uses the same stream RESTORE/NACK wording as 7.4.10.
> 
> **Redis Open Source 8.8.1** adds only the RedisBloom/TDigest `RESTORE` security fix (no core stream or `CF.LOADCHUNK` entries in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c093ff3eeeedf64726151cbc7dac2a2bddaa624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->