### PR TITLE
DOC-6833: Fix four RDI Cloud doc issues from #rdi-cloud

### DIFF
--- a/content/operate/rc/rdi/_index.md
+++ b/content/operate/rc/rdi/_index.md
@@ -84,7 +84,8 @@ RDI is not a good fit when:
 - You need complex stream processing of data (aggregations, sliding window processing, complex 
   custom logic).
 - You need to write data to multiple targets from the same pipeline (Redis supports other
-  ways to replicate data across Redis databases such as replicaOf and  Active Active).
+  ways to replicate data across Redis databases such as replicaOf).
+- Your target Redis database is configured with Active-Active topology. Active-Active is not supported as an RDI Cloud target database.
 - Your database administrator has rejected RDI's requirements for the source database.
 <!-- End of embed replacement -->
 
@@ -146,3 +147,9 @@ To create a new data pipeline, you need to:
 1. [Define the source connection and data pipeline]({{<relref "/operate/rc/rdi/define">}}) by selecting which tables to sync.
 
 Once your data pipeline is defined, you can [view and edit]({{<relref "/operate/rc/rdi/view-edit">}}) it.
+
+## Maintenance windows
+
+RDI Cloud maintenance follows the same subscription-wide maintenance window as your Redis Cloud Pro subscription. During a maintenance window, your data pipeline may experience brief interruptions as Redis applies updates.
+
+To control when maintenance occurs, [set a manual maintenance window]({{< relref "/operate/rc/subscriptions/maintenance/set-maintenance-windows" >}}) for your Redis Cloud Pro subscription. Any maintenance window you configure applies to both your databases and your RDI data pipeline.

--- a/content/operate/rc/rdi/define.md
+++ b/content/operate/rc/rdi/define.md
@@ -131,7 +131,11 @@ You can add collector source properties in the **Collector source properties** s
 
 ## Dataset
 
-In this step, you'll select the data that you want to import and synchronize with your primary database. 
+In this step, you'll select the data that you want to import and synchronize with your primary database.
+
+{{< warning >}}
+Do not write data directly to the target database outside of RDI. Writing to the target database from other sources can cause transformation failures and data inconsistencies. If you need to reset the pipeline and resync from the source, any data written to the target outside of RDI will be lost.
+{{< /warning >}} 
 
 {{< note >}}
 This step may change depending on your source database.

--- a/content/operate/rc/rdi/define.md
+++ b/content/operate/rc/rdi/define.md
@@ -135,7 +135,8 @@ In this step, you'll select the data that you want to import and synchronize wit
 
 {{< warning >}}
 Do not write data directly to the target database outside of RDI. Writing to the target database from other sources can cause transformation failures and data inconsistencies. If you need to reset the pipeline and resync from the source, any data written to the target outside of RDI will be lost.
-{{< /warning >}} 
+{{< /warning >}}
+&nbsp;
 
 {{< note >}}
 This step may change depending on your source database.

--- a/content/operate/rc/rdi/view-edit.md
+++ b/content/operate/rc/rdi/view-edit.md
@@ -75,7 +75,6 @@ The **Metrics** tab shows the following metrics for each data stream:
 | **Filtered** | Number of records from the source table that were filtered from being inserted into the target database. |
 | **Rejected** | Number of records from the source table that could not be parsed or inserted into the target database. Select a rejected count to open the [Rejected records](#rejected-records) view for that table. |
 
-<!--
 ### View metrics endpoints
 
 You can use [Prometheus and Grafana]({{< relref "/integrate/prometheus-with-redis-cloud/" >}}) to track and display metrics for the data pipeline. 
@@ -84,8 +83,11 @@ To view the metrics endpoints for the source collector and pipeline processor, s
 
 Prometheus endpoints are exposed on Redis Cloud's internal network. To access this network, enable [VPC peering]({{< relref "/operate/rc/security/vpc-peering" >}}) or [AWS Transit Gateway]({{< relref "/operate/rc/security/aws-transit-gateway" >}}). See [Prometheus and Grafana with Redis Cloud]({{< relref "/integrate/prometheus-with-redis-cloud/" >}}) for more information.
 
+{{< note >}}
+VPC peering and AWS Transit Gateway are the tested and supported methods for accessing Prometheus endpoints. AWS PrivateLink support for this feature is under evaluation and is not currently supported.
+{{< /note >}}
+
 For more information about available RDI metrics, see [Observability]({{< relref "/integrate/redis-data-integration/observability" >}}).
--->
 
 ## Rejected records
 

--- a/content/operate/rc/subscriptions/maintenance/set-maintenance-windows.md
+++ b/content/operate/rc/subscriptions/maintenance/set-maintenance-windows.md
@@ -14,6 +14,10 @@ weight: $weight
 
 By default, Redis will maintain your Redis Cloud subscriptions and databases as needed. During maintenance, you may notice some latency when connecting to your databases. For more information about the types of maintenance and how Redis maintains your subscriptions, see [Maintenance]({{< relref "/operate/rc/subscriptions/maintenance" >}}).
 
+{{< note >}}
+If your subscription includes an [RDI data pipeline]({{< relref "/operate/rc/rdi" >}}), maintenance windows apply to the pipeline as well. The pipeline may experience brief interruptions during the configured maintenance window.
+{{< /note >}}
+
 For Redis Cloud Pro plans, Redis will perform maintenance automatically while limiting service disruption as much as possible. If you want to control when Redis performs maintenance for a Redis Cloud Pro subscription, you can [set manual maintenance windows](#set-manual-maintenance-windows) to ensure non-urgent maintenance will occur at set times. Configuring or altering the maintenance window will not have any impact on your subscription or databases.
 
 {{<note>}}

--- a/content/operate/rc/subscriptions/maintenance/set-maintenance-windows.md
+++ b/content/operate/rc/subscriptions/maintenance/set-maintenance-windows.md
@@ -15,7 +15,7 @@ weight: $weight
 By default, Redis will maintain your Redis Cloud subscriptions and databases as needed. During maintenance, you may notice some latency when connecting to your databases. For more information about the types of maintenance and how Redis maintains your subscriptions, see [Maintenance]({{< relref "/operate/rc/subscriptions/maintenance" >}}).
 
 {{< note >}}
-If your subscription includes an [RDI data pipeline]({{< relref "/operate/rc/rdi" >}}), maintenance windows apply to the pipeline as well. The pipeline may experience brief interruptions during the configured maintenance window.
+If your subscription includes an [RDI data pipeline]({{< relref "/operate/rc/rdi#data-pipeline-architecture" >}}), maintenance windows apply to the pipeline as well. The pipeline may experience brief interruptions during the configured maintenance window.
 {{< /note >}}
 
 For Redis Cloud Pro plans, Redis will perform maintenance automatically while limiting service disruption as much as possible. If you want to control when Redis performs maintenance for a Redis Cloud Pro subscription, you can [set manual maintenance windows](#set-manual-maintenance-windows) to ensure non-urgent maintenance will occur at set times. Configuring or altering the maintenance window will not have any impact on your subscription or databases.


### PR DESCRIPTION
- Remove Active-Active from the 'multiple targets' use case sentence; add it as an explicit unsupported target topology under 'When not to use RDI'
- Add warning in define.md against writing to the target database outside of RDI (causes transformation failures and data loss on pipeline reset)
- Add maintenance windows section to the RDI Cloud landing page; add cross-reference note to set-maintenance-windows.md
- Uncomment and update the Prometheus metrics endpoints section in view-edit.md; note that only VPC peering and Transit Gateway are supported (Private Link is under evaluation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no application or infrastructure code changes.
> 
> **Overview**
> Documentation updates address four RDI Cloud gaps from support feedback.
> 
> **Fit and targets:** The “multiple targets” bullet no longer mentions Active-Active as an alternative replication path; **Active-Active is called out separately** as an unsupported RDI Cloud target topology.
> 
> **Pipeline setup:** **`define.md`** adds a warning not to write to the target Redis outside RDI (transformation failures, inconsistency, and loss on reset/resync).
> 
> **Maintenance:** The RDI landing page gets a **Maintenance windows** section tying pipeline interruptions to the Pro subscription window, with a reciprocal note on **`set-maintenance-windows.md`**.
> 
> **Observability:** The **View metrics endpoints** content in **`view-edit.md`** is restored/updated with a note that **VPC peering and AWS Transit Gateway** are the supported ways to reach Prometheus endpoints; **AWS PrivateLink for this use case is not supported** (under evaluation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2935286d20ef067e20db449ed25521ed92df1dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->