### PR TITLE
Remove "Free up disk space" step from build_docs jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,13 +86,6 @@ jobs:
       contents: 'read'
 
     steps:
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-
     - name: Install Hugo
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
@@ -166,13 +159,6 @@ jobs:
         version: ${{ fromJson(needs.discover_versions.outputs.kubernetes_versions) }}
 
     steps:
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-
     - name: Install Hugo
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
@@ -244,13 +230,6 @@ jobs:
         version: ${{ fromJson(needs.discover_versions.outputs.rs_versions) }}
 
     steps:
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-
     - name: Install Hugo
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
@@ -322,13 +301,6 @@ jobs:
         version: ${{ fromJson(needs.discover_versions.outputs.rdi_versions) }}
 
     steps:
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-
     - name: Install Hugo
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
@@ -400,13 +372,6 @@ jobs:
         version: ${{ fromJson(needs.discover_versions.outputs.redisvl_versions) }}
 
     steps:
-    - name: Free up disk space
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        sudo rm -rf /opt/hostedtoolcache/CodeQL
-
     - name: Install Hugo
       run: |
         wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \


### PR DESCRIPTION
The five build jobs each ran `sudo rm -rf` over the runner's pre-installed toolcache (dotnet/android/ghc/CodeQL) before building. Measured on staging: a docs build consumes ~2G while the runner has 34-86G free, so the ~20G freed was never needed -- but the deletion of many small files took 74-410s per job (runner-dependent) and sat on the critical path.

Removing it cut a representative run from 10m45s to 6m52s, with no build regressions (df -h probes confirmed tens of GB of headroom throughout).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that removes a slow optional cleanup step; Hugo install and build steps are untouched, with staging evidence of ample disk headroom.
> 
> **Overview**
> Removes the **Free up disk space** step (bulk `sudo rm -rf` of dotnet, Android, GHC, and CodeQL toolcache) from all five Hugo docs build jobs in `main.yml`: `setup_and_build_latest`, `build_kubernetes`, `build_rs`, `build_rdi`, and `build_redisvl`.
> 
> Those jobs now start directly with **Install Hugo**; build and deploy logic is unchanged. The cleanup was meant to avoid disk exhaustion, but docs builds use far less space than the runner already has free, while the deletions added large per-job latency on the critical path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 725bb799d7986b55980bef400dec001ad357db02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->