### PR TITLE
OP: docs for installing standalone redis-cli binary

### DIFF
--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -39,6 +39,7 @@ You have several options for installing or using `redis-cli`.
     `$ make redis-cli`.
     
     The `redis-cli` utility will be built in the `/path/to/redis-source/src` directory as `/path/to/redis-source/src/redis-cli`.
+- [Install the standalone `redis-cli` binary]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) for Linux or macOS.
 
 If you prefer not to install Redis, you can also run `redis-cli` in Docker. See the [Run `redis-cli` using Docker]({{< relref "/operate/oss_and_stack/install/install-stack/docker/#connect-with-redis-cli" >}}) page for instructions.
 

--- a/content/operate/oss_and_stack/install/install-stack/_index.md
+++ b/content/operate/oss_and_stack/install/install-stack/_index.md
@@ -175,4 +175,6 @@ While you can install Redis Open Source on any of the platforms listed below, yo
 
 You can also download [Redis Insight]({{< relref "/operate/redisinsight/install/" >}}), a free developer companion tool with an intuitive GUI and advanced CLI, which you can use alongside Redis Open Source.
 
+If you only need the Redis CLI (`redis-cli`) to connect to a remote Redis server, and not the full Redis Open Source distribution, see [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}).
+
 <hr/>

--- a/content/operate/oss_and_stack/install/install-stack/apt.md
+++ b/content/operate/oss_and_stack/install/install-stack/apt.md
@@ -12,6 +12,10 @@ weight: 2
 
 ## Install Redis Open Source on Ubuntu or Debian Linux using APT
 
+{{< note >}}
+If you only need the Redis CLI (`redis-cli`) and not the full Redis Open Source distribution, see [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}).
+{{< /note >}}
+
 Add the repository to the APT index, update it, and install Redis Open Source:
 
 {{< highlight bash >}}

--- a/content/operate/oss_and_stack/install/install-stack/docker.md
+++ b/content/operate/oss_and_stack/install/install-stack/docker.md
@@ -40,7 +40,10 @@ If you don’t have `redis-cli` installed locally, you can run it from the Docke
 $ docker exec -it redis redis-cli
 {{< / highlight >}}
 
-If you do have `redis-cli` installed locally, you can run it from your terminal:
+If you want to install `redis-cli` locally, see
+[Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}).
+
+If you already have `redis-cli` installed locally, you can run it from your terminal:
 
 {{< highlight bash >}}
 $ redis-cli -h 127.0.0.1 -p 6379

--- a/content/operate/oss_and_stack/install/install-stack/homebrew.md
+++ b/content/operate/oss_and_stack/install/install-stack/homebrew.md
@@ -15,6 +15,10 @@ weight: 6
 ## Install Redis Open Source on macOS using Homebrew
 
 {{< note >}}Installation using Homebrew is only supported on macOS.{{< /note >}}
+&nbsp;
+{{< note >}}
+If you only need the Redis CLI (`redis-cli`) and not the full Redis Open Source distribution, see [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}).
+{{< /note >}}
 
 To install Redis Open Source on macOS, use [Homebrew](https://brew.sh/).
 Make sure that you have [Homebrew installed](https://docs.brew.sh/Installation) before starting on the installation instructions below.

--- a/content/operate/oss_and_stack/install/install-stack/install-redis-cli.md
+++ b/content/operate/oss_and_stack/install/install-stack/install-redis-cli.md
@@ -1,0 +1,80 @@
+---
+categories:
+- docs
+- operate
+- stack
+- oss
+description: How to install just the Redis CLI (redis-cli) without installing all of Redis
+linkTitle: Install redis-cli
+title: Install redis-cli
+weight: 8
+---
+
+If you only need the [Redis CLI]({{< relref "/develop/tools/cli" >}}) (`redis-cli`) to connect to a remote Redis server, you can install it on its own, without installing the full Redis Open Source distribution or building it from source.
+
+The installer downloads a single, statically linked `redis-cli` binary, so it works even on minimal images (such as Amazon Linux, openSUSE, or distroless). It requires only `curl` or `wget`.
+
+{{< note >}}
+This installation method is supported on **Linux** and **macOS** only, on `x86_64`/`amd64` and `arm64`/`aarch64` processors. It does not run on native Windows. You have two options:
+
+1. You can run it under the [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/windows/wsl/).
+1. You can use it with Docker; see [Run Redis Open Source on Docker]({{< relref "/operate/oss_and_stack/install/install-stack/docker" >}}) for more information.
+{{< /note >}}
+
+## Install redis-cli
+
+Run the following command:
+
+{{< highlight bash >}}
+curl -fsSL https://packages.redis.io/redis-cli/install.sh | sh
+{{< /highlight >}}
+
+The script detects your operating system and architecture, downloads the matching `redis-cli` binary, verifies its SHA-256 checksum, and installs it to `/usr/local/bin` (using `sudo` if required). If `/usr/local/bin` is not writable, it installs to `~/.local/bin` instead.
+
+{{< note >}}
+As with any `curl ... | sh` command, review the [install script](https://packages.redis.io/redis-cli/install.sh) before running it if you want to see exactly what it does.
+{{< /note >}}
+
+### Install a specific version
+
+By default, the script installs the latest stable release. To install a particular version, set the `REDIS_CLI_VERSION` environment variable:
+
+{{< highlight bash >}}
+curl -fsSL https://packages.redis.io/redis-cli/install.sh | REDIS_CLI_VERSION=8.8.0 sh
+{{< /highlight >}}
+
+### Choose the installation directory
+
+To install `redis-cli` to a location of your choice, set the `REDIS_CLI_INSTALL_DIR` environment variable:
+
+{{< highlight bash >}}
+curl -fsSL https://packages.redis.io/redis-cli/install.sh | REDIS_CLI_INSTALL_DIR="$HOME/bin" sh
+{{< /highlight >}}
+
+If the installation directory is not on your `PATH`, the script prints a note reminding you to add it.
+
+## Connect to Redis
+
+Once `redis-cli` is installed, you can use it to connect to any Redis instance. For example, to connect to a server running on `localhost` on the default port:
+
+{{< highlight bash >}}
+redis-cli
+{{< /highlight >}}
+
+To connect to a remote server, specify the host and port:
+
+{{< highlight bash >}}
+redis-cli -h <host> -p <port>
+{{< /highlight >}}
+
+Test the connection with the `ping` command:
+
+{{< highlight bash >}}
+127.0.0.1:6379> PING
+PONG
+{{< /highlight >}}
+
+## Next steps
+
+- Try the [Redis CLI tutorial]({{< relref "/develop/tools/cli" >}}).
+- If you need a full Redis installation, see the other [installation guides]({{< relref "/operate/oss_and_stack/install/install-stack" >}}).

--- a/content/operate/oss_and_stack/install/install-stack/rpm.md
+++ b/content/operate/oss_and_stack/install/install-stack/rpm.md
@@ -12,6 +12,10 @@ weight: 3
 
 ## Install Redis Open Source on Rocky Linux 8 and 9, or AlmaLinux 8 and 9 using RPM
 
+{{< note >}}
+If you only need the Redis CLI (`redis-cli`) and not the full Redis Open Source distribution, see [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}).
+{{< /note >}}
+
 Follow these steps to install Redis Open Source.
 
 1. Create the file `/etc/yum.repos.d/redis.repo` with the following contents.

--- a/content/operate/oss_and_stack/install/install-stack/snap.md
+++ b/content/operate/oss_and_stack/install/install-stack/snap.md
@@ -12,6 +12,10 @@ weight: 4
 
 ## Install Redis Open Source on Ubuntu Linux using Snap
 
+{{< note >}}
+If you only need the Redis CLI (`redis-cli`) and not the full Redis Open Source distribution, see [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}).
+{{< /note >}}
+
 To install Redis via snap, run the following commands:
 
 {{< highlight bash >}}


### PR DESCRIPTION
This is a Redis 8.10 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application or infrastructure code.
> 
> **Overview**
> Documents the **Redis 8.10** standalone `redis-cli` installer and wires it into the install docs.
> 
> A new **Install redis-cli** page describes installing only the CLI via `curl -fsSL https://packages.redis.io/redis-cli/install.sh | sh` (OS/arch detection, SHA-256 verification, default install paths, `REDIS_CLI_VERSION` and `REDIS_CLI_INSTALL_DIR`), plus platform limits (Linux/macOS; WSL or Docker on Windows) and basic connect examples.
> 
> **Cross-links** were added from the Redis CLI overview, the install stack index, APT/RPM/Snap/Homebrew guides, and the Docker “connect with redis-cli” section so readers who only need the client can skip full Redis installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 983352015de2dd705de3eef675a7b3ed7d88a656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->