### PR TITLE
DOC-6887 Add hash field expiration examples to hash data type page

### DIFF
--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -147,57 +147,70 @@ Redis 8.0 introduced the following commands:
 
 ### Field expiration examples
 
-Support for hash field expiration in the official client libraries is not yet available, but you can test hash field expiration now with beta versions of the [Python (redis-py)](https://github.com/redis/redis-py) and [Java (Jedis)](https://github.com/redis/jedis) client libraries.
+Hash field expiration is supported by the official client libraries. The examples below
+demonstrate the field expiration commands using a hash that stores sensor data with the
+following structure:
 
-Following are some Python examples that demonstrate how to use field expiration.
+| Field           | Value |
+| :-------------- | :---- |
+| `air_quality`   | 256   |
+| `battery_level` | 89    |
 
-Consider a hash data set for storing sensor data that has the following structure:
+Because the fields expire, each example recreates the `sensor:sensor1` hash first so that
+it runs on its own.
 
-```python
-event = {
-    'air_quality': 256,
-    'battery_level':89
-}
+Set a TTL of 60 seconds for two fields of a hash and then retrieve the remaining TTL for
+those fields:
 
-r.hset('sensor:sensor1', mapping=event)
-```
+{{< clients-example set="hash_tutorial" step="hexpire" description="Field expiration: Set a TTL in seconds on individual hash fields using HEXPIRE, then read the remaining TTL with HTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+> DEL sensor:sensor1
+(integer) 1
+> HSET sensor:sensor1 air_quality 256 battery_level 89
+(integer) 2
+> HEXPIRE sensor:sensor1 60 FIELDS 2 air_quality battery_level
+1) (integer) 1
+2) (integer) 1
+> HTTL sensor:sensor1 FIELDS 2 air_quality battery_level
+1) (integer) 60
+2) (integer) 60
+{{< /clients-example >}}
 
-In the examples below, you will likely need to refresh the `sensor:sensor1` key after its fields expire.
+Set a hash field's TTL in milliseconds and then retrieve the remaining TTL in milliseconds:
 
-Set and retrieve the TTL for multiple fields in a hash:
+{{< clients-example set="hash_tutorial" step="hpexpire" description="Field expiration: Set a TTL in milliseconds on a hash field using HPEXPIRE, then read the remaining TTL with HPTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+> DEL sensor:sensor1
+(integer) 1
+> HSET sensor:sensor1 air_quality 256 battery_level 89
+(integer) 2
+> HPEXPIRE sensor:sensor1 60000 FIELDS 1 air_quality
+1) (integer) 1
+> HPTTL sensor:sensor1 FIELDS 1 air_quality
+1) (integer) 59994
+{{< /clients-example >}}
 
-```python
-# set the TTL for two hash fields to 60 seconds
-r.hexpire('sensor:sensor1', 60, 'air_quality', 'battery_level')
-ttl = r.httl('sensor:sensor1', 'air_quality', 'battery_level')
-print(ttl)
-# prints [60, 60]
-```
+Set a hash field's expiration to a specific timestamp and then retrieve that expiration
+time (both as a Unix time in seconds):
 
-Set and retrieve a hash field's TTL in milliseconds:
+{{< clients-example set="hash_tutorial" step="hexpireat" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set an absolute expiration timestamp on a hash field using HEXPIREAT, then read it back with HEXPIRETIME" difficulty="intermediate" buildsUpon="set_get_all" >}}
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+> DEL sensor:sensor1
+(integer) 1
+> HSET sensor:sensor1 air_quality 256 battery_level 89
+(integer) 2
+# Set the expiration to a Unix time in the future
+# (1719855517 is just an example; use a timestamp appropriate for your use case).
+> HEXPIREAT sensor:sensor1 1719855517 FIELDS 1 air_quality
+1) (integer) 1
+> HEXPIRETIME sensor:sensor1 FIELDS 1 air_quality
+1) (integer) 1719855517
+{{< /clients-example >}}
 
-```python
-# set the TTL of the 'air_quality' field in milliseconds
-r.hpexpire('sensor:sensor1', 60000, 'air_quality')
-# and retrieve it
-pttl = r.hpttl('sensor:sensor1', 'air_quality')
-print(pttl)
-# prints [59994] # your actual value may vary
-```
-
-Set and retrieve a hash field’s expiration timestamp:
-
-```python
-# set the expiration of 'air_quality' to now + 24 hours
-# (similar to setting the TTL to 24 hours)
-r.hexpireat('sensor:sensor1', 
-    datetime.now() + timedelta(hours=24), 
-    'air_quality')
-# and retrieve it
-expire_time = r.hexpiretime('sensor:sensor1', 'air_quality')
-print(expire_time)
-# prints [1717668041] # your actual value may vary
-```
+{{< note >}}
+The Ruby (redis-rb) client does not yet support the timestamp-based `HEXPIREAT` and
+`HEXPIRETIME` commands, so it is omitted from the last example above.
+{{< /note >}}
 
 ## Performance
 

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -163,7 +163,6 @@ Set a TTL of 60 seconds for two fields of a hash and then retrieve the remaining
 those fields:
 
 {{< clients-example set="hash_tutorial" step="hexpire" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set a TTL in seconds on individual hash fields using HEXPIRE, then read the remaining TTL with HTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
-# Recreate the sensor:sensor1 hash so this example runs on its own.
 > DEL sensor:sensor1
 (integer) 1
 > HSET sensor:sensor1 air_quality 256 battery_level 89
@@ -179,7 +178,6 @@ those fields:
 Set a hash field's TTL in milliseconds and then retrieve the remaining TTL in milliseconds:
 
 {{< clients-example set="hash_tutorial" step="hpexpire" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set a TTL in milliseconds on a hash field using HPEXPIRE, then read the remaining TTL with HPTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
-# Recreate the sensor:sensor1 hash so this example runs on its own.
 > DEL sensor:sensor1
 (integer) 1
 > HSET sensor:sensor1 air_quality 256 battery_level 89
@@ -194,7 +192,6 @@ Set a hash field's expiration to a specific timestamp and then retrieve that exp
 time (both as a Unix time in seconds):
 
 {{< clients-example set="hash_tutorial" step="hexpireat" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set an absolute expiration timestamp on a hash field using HEXPIREAT, then read it back with HEXPIRETIME" difficulty="intermediate" buildsUpon="set_get_all" >}}
-# Recreate the sensor:sensor1 hash so this example runs on its own.
 > DEL sensor:sensor1
 (integer) 1
 > HSET sensor:sensor1 air_quality 256 battery_level 89
@@ -206,11 +203,6 @@ time (both as a Unix time in seconds):
 > HEXPIRETIME sensor:sensor1 FIELDS 1 air_quality
 1) (integer) 1719855517
 {{< /clients-example >}}
-
-{{< note >}}
-The released Ruby (redis-rb) client does not yet provide dedicated methods for the hash
-field expiration commands, so it is omitted from the examples above.
-{{< /note >}}
 
 ## Performance
 

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -162,7 +162,7 @@ it runs on its own.
 Set a TTL of 60 seconds for two fields of a hash and then retrieve the remaining TTL for
 those fields:
 
-{{< clients-example set="hash_tutorial" step="hexpire" description="Field expiration: Set a TTL in seconds on individual hash fields using HEXPIRE, then read the remaining TTL with HTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
+{{< clients-example set="hash_tutorial" step="hexpire" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set a TTL in seconds on individual hash fields using HEXPIRE, then read the remaining TTL with HTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
 # Recreate the sensor:sensor1 hash so this example runs on its own.
 > DEL sensor:sensor1
 (integer) 1
@@ -178,7 +178,7 @@ those fields:
 
 Set a hash field's TTL in milliseconds and then retrieve the remaining TTL in milliseconds:
 
-{{< clients-example set="hash_tutorial" step="hpexpire" description="Field expiration: Set a TTL in milliseconds on a hash field using HPEXPIRE, then read the remaining TTL with HPTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
+{{< clients-example set="hash_tutorial" step="hpexpire" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set a TTL in milliseconds on a hash field using HPEXPIRE, then read the remaining TTL with HPTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
 # Recreate the sensor:sensor1 hash so this example runs on its own.
 > DEL sensor:sensor1
 (integer) 1
@@ -208,8 +208,8 @@ time (both as a Unix time in seconds):
 {{< /clients-example >}}
 
 {{< note >}}
-The Ruby (redis-rb) client does not yet support the timestamp-based `HEXPIREAT` and
-`HEXPIRETIME` commands, so it is omitted from the last example above.
+The released Ruby (redis-rb) client does not yet provide dedicated methods for the hash
+field expiration commands, so it is omitted from the examples above.
 {{< /note >}}
 
 ## Performance

--- a/local_examples/php/DtHashTest.php
+++ b/local_examples/php/DtHashTest.php
@@ -137,7 +137,6 @@ extends PredisTestCase
         // REMOVE_END
 
         // STEP_START hexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         $r->del('sensor:sensor1');
         $r->hmset('sensor:sensor1', [
             'air_quality' => 256,
@@ -160,7 +159,6 @@ extends PredisTestCase
         // REMOVE_END
 
         // STEP_START hpexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         $r->del('sensor:sensor1');
         $r->hmset('sensor:sensor1', [
             'air_quality' => 256,
@@ -183,7 +181,6 @@ extends PredisTestCase
         // REMOVE_END
 
         // STEP_START hexpireat
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         $r->del('sensor:sensor1');
         $r->hmset('sensor:sensor1', [
             'air_quality' => 256,

--- a/local_examples/php/DtHashTest.php
+++ b/local_examples/php/DtHashTest.php
@@ -59,7 +59,7 @@ extends PredisTestCase
         // STEP_START hmget
         // Recreate the bike:1 hash so this example runs on its own.
         $r->del('bike:1');
-        $r->hset('bike:1', [
+        $r->hmset('bike:1', [
             'model' => 'Deimos',
             'brand' => 'Ergonom',
             'type' => 'Enduro bikes',
@@ -77,7 +77,7 @@ extends PredisTestCase
         // STEP_START hincrby
         // Recreate the bike:1 hash so this example runs on its own.
         $r->del('bike:1');
-        $r->hset('bike:1', [
+        $r->hmset('bike:1', [
             'model' => 'Deimos',
             'brand' => 'Ergonom',
             'type' => 'Enduro bikes',
@@ -139,7 +139,7 @@ extends PredisTestCase
         // STEP_START hexpire
         // Recreate the sensor:sensor1 hash so this example runs on its own.
         $r->del('sensor:sensor1');
-        $r->hset('sensor:sensor1', [
+        $r->hmset('sensor:sensor1', [
             'air_quality' => 256,
             'battery_level' => 89,
         ]);
@@ -155,14 +155,14 @@ extends PredisTestCase
         // >>> 2
         // STEP_END
         // REMOVE_START
-        $this->assertCount(2, $res15);
-        $this->assertCount(2, $res16);
+        $this->assertEquals(2, count($res15));
+        $this->assertEquals(2, count($res16));
         // REMOVE_END
 
         // STEP_START hpexpire
         // Recreate the sensor:sensor1 hash so this example runs on its own.
         $r->del('sensor:sensor1');
-        $r->hset('sensor:sensor1', [
+        $r->hmset('sensor:sensor1', [
             'air_quality' => 256,
             'battery_level' => 89,
         ]);
@@ -178,14 +178,14 @@ extends PredisTestCase
         // >>> 1
         // STEP_END
         // REMOVE_START
-        $this->assertCount(1, $res17);
-        $this->assertCount(1, $res18);
+        $this->assertEquals(1, count($res17));
+        $this->assertEquals(1, count($res18));
         // REMOVE_END
 
         // STEP_START hexpireat
         // Recreate the sensor:sensor1 hash so this example runs on its own.
         $r->del('sensor:sensor1');
-        $r->hset('sensor:sensor1', [
+        $r->hmset('sensor:sensor1', [
             'air_quality' => 256,
             'battery_level' => 89,
         ]);
@@ -201,8 +201,8 @@ extends PredisTestCase
         // >>> 1
         // STEP_END
         // REMOVE_START
-        $this->assertCount(1, $res19);
-        $this->assertCount(1, $res20);
+        $this->assertEquals(1, count($res19));
+        $this->assertEquals(1, count($res20));
         // REMOVE_END
     }
 }

--- a/local_examples/php/DtHashTest.php
+++ b/local_examples/php/DtHashTest.php
@@ -135,5 +135,74 @@ extends PredisTestCase
         $this->assertEquals(3, $res13);
         $this->assertEquals([1, 1], $res14);
         // REMOVE_END
+
+        // STEP_START hexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        $r->del('sensor:sensor1');
+        $r->hset('sensor:sensor1', [
+            'air_quality' => 256,
+            'battery_level' => 89,
+        ]);
+
+        // Set a TTL of 60 seconds on two fields of the hash.
+        $res15 = $r->hexpire('sensor:sensor1', 60, ['air_quality', 'battery_level']);
+        echo json_encode($res15) . PHP_EOL;
+        // >>> [1,1]
+
+        // Retrieve the remaining TTL for those fields.
+        $res16 = $r->httl('sensor:sensor1', ['air_quality', 'battery_level']);
+        echo count($res16) . PHP_EOL;
+        // >>> 2
+        // STEP_END
+        // REMOVE_START
+        $this->assertCount(2, $res15);
+        $this->assertCount(2, $res16);
+        // REMOVE_END
+
+        // STEP_START hpexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        $r->del('sensor:sensor1');
+        $r->hset('sensor:sensor1', [
+            'air_quality' => 256,
+            'battery_level' => 89,
+        ]);
+
+        // Set the TTL of the 'air_quality' field in milliseconds.
+        $res17 = $r->hpexpire('sensor:sensor1', 60000, ['air_quality']);
+        echo json_encode($res17) . PHP_EOL;
+        // >>> [1]
+
+        // Retrieve the remaining TTL in milliseconds.
+        $res18 = $r->hpttl('sensor:sensor1', ['air_quality']);
+        echo count($res18) . PHP_EOL;
+        // >>> 1
+        // STEP_END
+        // REMOVE_START
+        $this->assertCount(1, $res17);
+        $this->assertCount(1, $res18);
+        // REMOVE_END
+
+        // STEP_START hexpireat
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        $r->del('sensor:sensor1');
+        $r->hset('sensor:sensor1', [
+            'air_quality' => 256,
+            'battery_level' => 89,
+        ]);
+
+        // Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+        $res19 = $r->hexpireat('sensor:sensor1', time() + 24 * 60 * 60, ['air_quality']);
+        echo json_encode($res19) . PHP_EOL;
+        // >>> [1]
+
+        // Retrieve the expiration time as a Unix timestamp in seconds.
+        $res20 = $r->hexpiretime('sensor:sensor1', ['air_quality']);
+        echo count($res20) . PHP_EOL;
+        // >>> 1
+        // STEP_END
+        // REMOVE_START
+        $this->assertCount(1, $res19);
+        $this->assertCount(1, $res20);
+        // REMOVE_END
     }
 }

--- a/local_examples/ruby/dt_hash.rb
+++ b/local_examples/ruby/dt_hash.rb
@@ -116,5 +116,43 @@ assert_equal(1, res11)
 assert_equal(1, res12)
 assert_equal('3', res13)
 assert_equal(['1', '1'], res14)
+# REMOVE_END
+
+# STEP_START hexpire
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+r.del('sensor:sensor1')
+r.hset('sensor:sensor1', { 'air_quality' => 256, 'battery_level' => 89 })
+
+# Set a TTL of 60 seconds on two fields of the hash.
+res15 = r.hexpire('sensor:sensor1', 60, 'air_quality', 'battery_level')
+puts res15.inspect # [1, 1]
+
+# Retrieve the remaining TTL for those fields.
+res16 = r.httl('sensor:sensor1', 'air_quality', 'battery_level')
+puts res16.length # 2 (each value is close to 60)
+# STEP_END
+
+# REMOVE_START
+assert_equal([1, 1], res15)
+raise 'Unexpected TTL' unless res16.length == 2 && res16.all? { |ttl| ttl > 0 && ttl <= 60 }
+# REMOVE_END
+
+# STEP_START hpexpire
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+r.del('sensor:sensor1')
+r.hset('sensor:sensor1', { 'air_quality' => 256, 'battery_level' => 89 })
+
+# Set the TTL of the 'air_quality' field in milliseconds.
+res17 = r.hpexpire('sensor:sensor1', 60000, 'air_quality')
+puts res17.inspect # [1]
+
+# Retrieve the remaining TTL in milliseconds.
+res18 = r.hpttl('sensor:sensor1', 'air_quality')
+puts res18.length # 1 (the value is close to 60000)
+# STEP_END
+
+# REMOVE_START
+assert_equal([1], res17)
+raise 'Unexpected PTTL' unless res18.length == 1 && res18.all? { |pttl| pttl > 0 && pttl <= 60000 }
 r.close
 # REMOVE_END

--- a/local_examples/ruby/dt_hash.rb
+++ b/local_examples/ruby/dt_hash.rb
@@ -116,43 +116,5 @@ assert_equal(1, res11)
 assert_equal(1, res12)
 assert_equal('3', res13)
 assert_equal(['1', '1'], res14)
-# REMOVE_END
-
-# STEP_START hexpire
-# Recreate the sensor:sensor1 hash so this example runs on its own.
-r.del('sensor:sensor1')
-r.hset('sensor:sensor1', { 'air_quality' => 256, 'battery_level' => 89 })
-
-# Set a TTL of 60 seconds on two fields of the hash.
-res15 = r.hexpire('sensor:sensor1', 60, 'air_quality', 'battery_level')
-puts res15.inspect # [1, 1]
-
-# Retrieve the remaining TTL for those fields.
-res16 = r.httl('sensor:sensor1', 'air_quality', 'battery_level')
-puts res16.length # 2 (each value is close to 60)
-# STEP_END
-
-# REMOVE_START
-assert_equal([1, 1], res15)
-raise 'Unexpected TTL' unless res16.length == 2 && res16.all? { |ttl| ttl > 0 && ttl <= 60 }
-# REMOVE_END
-
-# STEP_START hpexpire
-# Recreate the sensor:sensor1 hash so this example runs on its own.
-r.del('sensor:sensor1')
-r.hset('sensor:sensor1', { 'air_quality' => 256, 'battery_level' => 89 })
-
-# Set the TTL of the 'air_quality' field in milliseconds.
-res17 = r.hpexpire('sensor:sensor1', 60000, 'air_quality')
-puts res17.inspect # [1]
-
-# Retrieve the remaining TTL in milliseconds.
-res18 = r.hpttl('sensor:sensor1', 'air_quality')
-puts res18.length # 1 (the value is close to 60000)
-# STEP_END
-
-# REMOVE_START
-assert_equal([1], res17)
-raise 'Unexpected PTTL' unless res18.length == 1 && res18.all? { |pttl| pttl > 0 && pttl <= 60000 }
 r.close
 # REMOVE_END

--- a/local_examples/rust-async/dt-hash.rs
+++ b/local_examples/rust-async/dt-hash.rs
@@ -215,7 +215,6 @@ mod tests {
         // STEP_END
 
         // STEP_START hexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         let _: () = r.del("sensor:sensor1").await.expect("Failed to del");
         let _: () = r.hset_multiple(
             "sensor:sensor1",
@@ -255,7 +254,6 @@ mod tests {
         // STEP_END
 
         // STEP_START hpexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         let _: () = r.del("sensor:sensor1").await.expect("Failed to del");
         let _: () = r.hset_multiple(
             "sensor:sensor1",
@@ -295,7 +293,6 @@ mod tests {
         // STEP_END
 
         // STEP_START hexpireat
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         let _: () = r.del("sensor:sensor1").await.expect("Failed to del");
         let _: () = r.hset_multiple(
             "sensor:sensor1",

--- a/local_examples/rust-async/dt-hash.rs
+++ b/local_examples/rust-async/dt-hash.rs
@@ -213,5 +213,130 @@ mod tests {
             }
         };
         // STEP_END
+
+        // STEP_START hexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        let _: () = r.del("sensor:sensor1").await.expect("Failed to del");
+        let _: () = r.hset_multiple(
+            "sensor:sensor1",
+            &[("air_quality", "256"), ("battery_level", "89")],
+        ).await.expect("Failed to hset");
+
+        // Set a TTL of 60 seconds on two fields of the hash.
+        match r.hexpire("sensor:sensor1", 60, redis::ExpireOption::NONE, &["air_quality", "battery_level"]).await {
+            Ok(res18) => {
+                let res18: Vec<i64> = res18;
+                println!("{:?}", res18);    // >>> [1, 1]
+                // REMOVE_START
+                assert_eq!(res18, vec![1, 1]);
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error setting expiration: {e}");
+                return;
+            }
+        }
+
+        // Retrieve the remaining TTL for those fields.
+        match r.httl("sensor:sensor1", &["air_quality", "battery_level"]).await {
+            Ok(res19) => {
+                let res19: Vec<i64> = res19;
+                println!("{}", res19.len());    // >>> 2
+                // REMOVE_START
+                assert_eq!(res19.len(), 2);
+                assert!(res19.iter().all(|&ttl| ttl > 0 && ttl <= 60));
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting TTL: {e}");
+                return;
+            }
+        }
+        // STEP_END
+
+        // STEP_START hpexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        let _: () = r.del("sensor:sensor1").await.expect("Failed to del");
+        let _: () = r.hset_multiple(
+            "sensor:sensor1",
+            &[("air_quality", "256"), ("battery_level", "89")],
+        ).await.expect("Failed to hset");
+
+        // Set the TTL of the 'air_quality' field in milliseconds.
+        match r.hpexpire("sensor:sensor1", 60000, redis::ExpireOption::NONE, &["air_quality"]).await {
+            Ok(res20) => {
+                let res20: Vec<i64> = res20;
+                println!("{:?}", res20);    // >>> [1]
+                // REMOVE_START
+                assert_eq!(res20, vec![1]);
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error setting expiration: {e}");
+                return;
+            }
+        }
+
+        // Retrieve the remaining TTL in milliseconds.
+        match r.hpttl("sensor:sensor1", &["air_quality"]).await {
+            Ok(res21) => {
+                let res21: Vec<i64> = res21;
+                println!("{}", res21.len());    // >>> 1
+                // REMOVE_START
+                assert_eq!(res21.len(), 1);
+                assert!(res21.iter().all(|&pttl| pttl > 0 && pttl <= 60000));
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting PTTL: {e}");
+                return;
+            }
+        }
+        // STEP_END
+
+        // STEP_START hexpireat
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        let _: () = r.del("sensor:sensor1").await.expect("Failed to del");
+        let _: () = r.hset_multiple(
+            "sensor:sensor1",
+            &[("air_quality", "256"), ("battery_level", "89")],
+        ).await.expect("Failed to hset");
+
+        // Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs() as i64;
+
+        match r.hexpire_at("sensor:sensor1", now + 24 * 60 * 60, redis::ExpireOption::NONE, &["air_quality"]).await {
+            Ok(res22) => {
+                let res22: Vec<i64> = res22;
+                println!("{:?}", res22);    // >>> [1]
+                // REMOVE_START
+                assert_eq!(res22, vec![1]);
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error setting expiration: {e}");
+                return;
+            }
+        }
+
+        // Retrieve the expiration time as a Unix timestamp in seconds.
+        match r.hexpire_time("sensor:sensor1", &["air_quality"]).await {
+            Ok(res23) => {
+                let res23: Vec<i64> = res23;
+                println!("{}", res23.len());    // >>> 1
+                // REMOVE_START
+                assert_eq!(res23.len(), 1);
+                assert!(res23.iter().all(|&ts| ts > now));
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting expiration time: {e}");
+                return;
+            }
+        }
+        // STEP_END
     }
 }

--- a/local_examples/rust-sync/dt-hash.rs
+++ b/local_examples/rust-sync/dt-hash.rs
@@ -215,7 +215,6 @@ mod hash_tests {
         // STEP_END
 
         // STEP_START hexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         let _: () = r.del("sensor:sensor1").expect("Failed to del");
         let _: () = r.hset_multiple(
             "sensor:sensor1",
@@ -255,7 +254,6 @@ mod hash_tests {
         // STEP_END
 
         // STEP_START hpexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         let _: () = r.del("sensor:sensor1").expect("Failed to del");
         let _: () = r.hset_multiple(
             "sensor:sensor1",
@@ -295,7 +293,6 @@ mod hash_tests {
         // STEP_END
 
         // STEP_START hexpireat
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         let _: () = r.del("sensor:sensor1").expect("Failed to del");
         let _: () = r.hset_multiple(
             "sensor:sensor1",

--- a/local_examples/rust-sync/dt-hash.rs
+++ b/local_examples/rust-sync/dt-hash.rs
@@ -213,5 +213,130 @@ mod hash_tests {
             }
         };
         // STEP_END
+
+        // STEP_START hexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        let _: () = r.del("sensor:sensor1").expect("Failed to del");
+        let _: () = r.hset_multiple(
+            "sensor:sensor1",
+            &[("air_quality", "256"), ("battery_level", "89")],
+        ).expect("Failed to hset");
+
+        // Set a TTL of 60 seconds on two fields of the hash.
+        match r.hexpire("sensor:sensor1", 60, redis::ExpireOption::NONE, &["air_quality", "battery_level"]) {
+            Ok(res18) => {
+                let res18: Vec<i64> = res18;
+                println!("{:?}", res18);    // >>> [1, 1]
+                // REMOVE_START
+                assert_eq!(res18, vec![1, 1]);
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error setting expiration: {e}");
+                return;
+            }
+        }
+
+        // Retrieve the remaining TTL for those fields.
+        match r.httl("sensor:sensor1", &["air_quality", "battery_level"]) {
+            Ok(res19) => {
+                let res19: Vec<i64> = res19;
+                println!("{}", res19.len());    // >>> 2
+                // REMOVE_START
+                assert_eq!(res19.len(), 2);
+                assert!(res19.iter().all(|&ttl| ttl > 0 && ttl <= 60));
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting TTL: {e}");
+                return;
+            }
+        }
+        // STEP_END
+
+        // STEP_START hpexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        let _: () = r.del("sensor:sensor1").expect("Failed to del");
+        let _: () = r.hset_multiple(
+            "sensor:sensor1",
+            &[("air_quality", "256"), ("battery_level", "89")],
+        ).expect("Failed to hset");
+
+        // Set the TTL of the 'air_quality' field in milliseconds.
+        match r.hpexpire("sensor:sensor1", 60000, redis::ExpireOption::NONE, &["air_quality"]) {
+            Ok(res20) => {
+                let res20: Vec<i64> = res20;
+                println!("{:?}", res20);    // >>> [1]
+                // REMOVE_START
+                assert_eq!(res20, vec![1]);
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error setting expiration: {e}");
+                return;
+            }
+        }
+
+        // Retrieve the remaining TTL in milliseconds.
+        match r.hpttl("sensor:sensor1", &["air_quality"]) {
+            Ok(res21) => {
+                let res21: Vec<i64> = res21;
+                println!("{}", res21.len());    // >>> 1
+                // REMOVE_START
+                assert_eq!(res21.len(), 1);
+                assert!(res21.iter().all(|&pttl| pttl > 0 && pttl <= 60000));
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting PTTL: {e}");
+                return;
+            }
+        }
+        // STEP_END
+
+        // STEP_START hexpireat
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        let _: () = r.del("sensor:sensor1").expect("Failed to del");
+        let _: () = r.hset_multiple(
+            "sensor:sensor1",
+            &[("air_quality", "256"), ("battery_level", "89")],
+        ).expect("Failed to hset");
+
+        // Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_secs() as i64;
+
+        match r.hexpire_at("sensor:sensor1", now + 24 * 60 * 60, redis::ExpireOption::NONE, &["air_quality"]) {
+            Ok(res22) => {
+                let res22: Vec<i64> = res22;
+                println!("{:?}", res22);    // >>> [1]
+                // REMOVE_START
+                assert_eq!(res22, vec![1]);
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error setting expiration: {e}");
+                return;
+            }
+        }
+
+        // Retrieve the expiration time as a Unix timestamp in seconds.
+        match r.hexpire_time("sensor:sensor1", &["air_quality"]) {
+            Ok(res23) => {
+                let res23: Vec<i64> = res23;
+                println!("{}", res23.len());    // >>> 1
+                // REMOVE_START
+                assert_eq!(res23.len(), 1);
+                assert!(res23.iter().all(|&ts| ts > now));
+                // REMOVE_END
+            },
+            Err(e) => {
+                println!("Error getting expiration time: {e}");
+                return;
+            }
+        }
+        // STEP_END
     }
 }

--- a/local_examples/tmp/datatypes/hashes/HashExample.cs
+++ b/local_examples/tmp/datatypes/hashes/HashExample.cs
@@ -155,7 +155,6 @@ public class HashExample
         //STEP_END
 
         //STEP_START hexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         db.KeyDelete("sensor:sensor1");
         db.HashSet("sensor:sensor1", [
             new("air_quality", 256),
@@ -189,7 +188,6 @@ public class HashExample
         //STEP_END
 
         //STEP_START hpexpire
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         db.KeyDelete("sensor:sensor1");
         db.HashSet("sensor:sensor1", [
             new("air_quality", 256),
@@ -223,7 +221,6 @@ public class HashExample
         //STEP_END
 
         //STEP_START hexpireat
-        // Recreate the sensor:sensor1 hash so this example runs on its own.
         db.KeyDelete("sensor:sensor1");
         db.HashSet("sensor:sensor1", [
             new("air_quality", 256),

--- a/local_examples/tmp/datatypes/hashes/HashExample.cs
+++ b/local_examples/tmp/datatypes/hashes/HashExample.cs
@@ -153,6 +153,108 @@ public class HashExample
         //REMOVE_END
         // Bike stats: crashes=1, owners=1
         //STEP_END
+
+        //STEP_START hexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        db.KeyDelete("sensor:sensor1");
+        db.HashSet("sensor:sensor1", [
+            new("air_quality", 256),
+            new("battery_level", 89)
+        ]);
+
+        // Set a TTL of 60 seconds on two fields of the hash.
+        ExpireResult[] hexpireResult = db.HashFieldExpire(
+            "sensor:sensor1",
+            new RedisValue[] { "air_quality", "battery_level" },
+            TimeSpan.FromSeconds(60)
+        );
+        Console.WriteLine(string.Join(", ", hexpireResult));
+        // Success, Success
+        //REMOVE_START
+        Assert.Equal(2, hexpireResult.Length);
+        Assert.All(hexpireResult, r => Assert.Equal(ExpireResult.Success, r));
+        //REMOVE_END
+
+        // Retrieve the remaining TTL for those fields.
+        long[] httlResult = db.HashFieldGetTimeToLive(
+            "sensor:sensor1",
+            new RedisValue[] { "air_quality", "battery_level" }
+        );
+        Console.WriteLine(httlResult.Length);
+        // 2
+        //REMOVE_START
+        Assert.Equal(2, httlResult.Length);
+        Assert.All(httlResult, t => Assert.True(t > 0));
+        //REMOVE_END
+        //STEP_END
+
+        //STEP_START hpexpire
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        db.KeyDelete("sensor:sensor1");
+        db.HashSet("sensor:sensor1", [
+            new("air_quality", 256),
+            new("battery_level", 89)
+        ]);
+
+        // Set the TTL of the 'air_quality' field, expressed in milliseconds.
+        ExpireResult[] hpexpireResult = db.HashFieldExpire(
+            "sensor:sensor1",
+            new RedisValue[] { "air_quality" },
+            TimeSpan.FromMilliseconds(60000)
+        );
+        Console.WriteLine(string.Join(", ", hpexpireResult));
+        // Success
+        //REMOVE_START
+        Assert.Single(hpexpireResult);
+        Assert.Equal(ExpireResult.Success, hpexpireResult[0]);
+        //REMOVE_END
+
+        // Retrieve the remaining TTL.
+        long[] hpttlResult = db.HashFieldGetTimeToLive(
+            "sensor:sensor1",
+            new RedisValue[] { "air_quality" }
+        );
+        Console.WriteLine(hpttlResult.Length);
+        // 1
+        //REMOVE_START
+        Assert.Single(hpttlResult);
+        Assert.All(hpttlResult, t => Assert.True(t > 0));
+        //REMOVE_END
+        //STEP_END
+
+        //STEP_START hexpireat
+        // Recreate the sensor:sensor1 hash so this example runs on its own.
+        db.KeyDelete("sensor:sensor1");
+        db.HashSet("sensor:sensor1", [
+            new("air_quality", 256),
+            new("battery_level", 89)
+        ]);
+
+        // Set the expiration of 'air_quality' to a time 24 hours from now.
+        ExpireResult[] hexpireAtResult = db.HashFieldExpire(
+            "sensor:sensor1",
+            new RedisValue[] { "air_quality" },
+            DateTime.UtcNow.AddHours(24)
+        );
+        Console.WriteLine(string.Join(", ", hexpireAtResult));
+        // Success
+        //REMOVE_START
+        Assert.Single(hexpireAtResult);
+        Assert.Equal(ExpireResult.Success, hexpireAtResult[0]);
+        //REMOVE_END
+
+        // Retrieve the expiration time as a Unix timestamp.
+        long[] hexpireTimeResult = db.HashFieldGetExpireDateTime(
+            "sensor:sensor1",
+            new RedisValue[] { "air_quality" }
+        );
+        Console.WriteLine(hexpireTimeResult.Length);
+        // 1
+        //REMOVE_START
+        Assert.Single(hexpireTimeResult);
+        Assert.All(hexpireTimeResult, t => Assert.True(t > 0));
+        //REMOVE_END
+        //STEP_END
         //HIDE_START
     }
 }

--- a/local_examples/tmp/datatypes/hashes/HashExample.java
+++ b/local_examples/tmp/datatypes/hashes/HashExample.java
@@ -107,6 +107,69 @@ public class HashExample {
       assertEquals("3", res13);
       assertEquals("[1, 1]", res14.toString());
       // REMOVE_END
+
+      // STEP_START hexpire
+      // Recreate the sensor:sensor1 hash so this example runs on its own.
+      jedis.del("sensor:sensor1");
+      Map<String, String> sensor1 = new HashMap<>();
+      sensor1.put("air_quality", "256");
+      sensor1.put("battery_level", "89");
+      jedis.hset("sensor:sensor1", sensor1);
+
+      // Set a TTL of 60 seconds on two fields of the hash.
+      List<Long> res15 = jedis.hexpire("sensor:sensor1", 60, "air_quality", "battery_level");
+      System.out.println(res15); // [1, 1]
+
+      // Retrieve the remaining TTL for those fields.
+      List<Long> res16 = jedis.httl("sensor:sensor1", "air_quality", "battery_level");
+      System.out.println(res16.size()); // 2
+      // STEP_END
+
+      // REMOVE_START
+      assertEquals("[1, 1]", res15.toString());
+      assertEquals(2, res16.size());
+      assert res16.stream().allMatch(ttl -> ttl > 0 && ttl <= 60);
+      // REMOVE_END
+
+      // STEP_START hpexpire
+      // Recreate the sensor:sensor1 hash so this example runs on its own.
+      jedis.del("sensor:sensor1");
+      jedis.hset("sensor:sensor1", sensor1);
+
+      // Set the TTL of the 'air_quality' field in milliseconds.
+      List<Long> res17 = jedis.hpexpire("sensor:sensor1", 60000, "air_quality");
+      System.out.println(res17); // [1]
+
+      // Retrieve the remaining TTL in milliseconds.
+      List<Long> res18 = jedis.hpttl("sensor:sensor1", "air_quality");
+      System.out.println(res18.size()); // 1
+      // STEP_END
+
+      // REMOVE_START
+      assertEquals("[1]", res17.toString());
+      assert res18.stream().allMatch(pttl -> pttl > 0 && pttl <= 60000);
+      // REMOVE_END
+
+      // STEP_START hexpireat
+      // Recreate the sensor:sensor1 hash so this example runs on its own.
+      jedis.del("sensor:sensor1");
+      jedis.hset("sensor:sensor1", sensor1);
+
+      // Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+      long expireAt = System.currentTimeMillis() / 1000L + 24 * 60 * 60;
+      List<Long> res19 = jedis.hexpireAt("sensor:sensor1", expireAt, "air_quality");
+      System.out.println(res19); // [1]
+
+      // Retrieve the expiration time as a Unix timestamp in seconds.
+      List<Long> res20 = jedis.hexpireTime("sensor:sensor1", "air_quality");
+      System.out.println(res20.size()); // 1
+      // STEP_END
+
+      // REMOVE_START
+      assertEquals("[1]", res19.toString());
+      long nowSecs = System.currentTimeMillis() / 1000L;
+      assert res20.stream().allMatch(ts -> ts > nowSecs);
+      // REMOVE_END
     }
   }
 }

--- a/local_examples/tmp/datatypes/hashes/HashExample.java
+++ b/local_examples/tmp/datatypes/hashes/HashExample.java
@@ -109,7 +109,6 @@ public class HashExample {
       // REMOVE_END
 
       // STEP_START hexpire
-      // Recreate the sensor:sensor1 hash so this example runs on its own.
       jedis.del("sensor:sensor1");
       Map<String, String> sensor1 = new HashMap<>();
       sensor1.put("air_quality", "256");
@@ -132,7 +131,6 @@ public class HashExample {
       // REMOVE_END
 
       // STEP_START hpexpire
-      // Recreate the sensor:sensor1 hash so this example runs on its own.
       jedis.del("sensor:sensor1");
       jedis.hset("sensor:sensor1", sensor1);
 
@@ -151,7 +149,6 @@ public class HashExample {
       // REMOVE_END
 
       // STEP_START hexpireat
-      // Recreate the sensor:sensor1 hash so this example runs on its own.
       jedis.del("sensor:sensor1");
       jedis.hset("sensor:sensor1", sensor1);
 

--- a/local_examples/tmp/datatypes/hashes/dt-hash.js
+++ b/local_examples/tmp/datatypes/hashes/dt-hash.js
@@ -119,5 +119,63 @@ assert.equal(res14, 1);
 assert.equal(res15, 1);
 assert.equal(res16, '3');
 assert.deepEqual(res17, ['1', '1']);
+// REMOVE_END
+
+// STEP_START hExpire
+// Recreate the sensor:sensor1 hash so this example runs on its own.
+await client.del('sensor:sensor1')
+await client.hSet('sensor:sensor1', { 'air_quality': 256, 'battery_level': 89 })
+
+// Set a TTL of 60 seconds on two fields of the hash.
+const res18 = await client.hExpire('sensor:sensor1', ['air_quality', 'battery_level'], 60)
+console.log(res18)  // [1, 1]
+
+// Retrieve the remaining TTL for those fields.
+const res19 = await client.hTTL('sensor:sensor1', ['air_quality', 'battery_level'])
+console.log(res19)  // [60, 60] (or close to 60)
+// STEP_END
+
+// REMOVE_START
+assert.deepEqual(res18, [1, 1]);
+assert(res19.every(ttl => ttl > 0 && ttl <= 60));
+// REMOVE_END
+
+// STEP_START hpExpire
+// Recreate the sensor:sensor1 hash so this example runs on its own.
+await client.del('sensor:sensor1')
+await client.hSet('sensor:sensor1', { 'air_quality': 256, 'battery_level': 89 })
+
+// Set the TTL of the 'air_quality' field in milliseconds.
+const res20 = await client.hpExpire('sensor:sensor1', ['air_quality'], 60000)
+console.log(res20)  // [1]
+
+// Retrieve the remaining TTL in milliseconds.
+const res21 = await client.hpTTL('sensor:sensor1', ['air_quality'])
+console.log(res21)  // [59994] (your actual value may vary)
+// STEP_END
+
+// REMOVE_START
+assert.deepEqual(res20, [1]);
+assert(res21.every(pttl => pttl > 0 && pttl <= 60000));
+// REMOVE_END
+
+// STEP_START hExpireAt
+// Recreate the sensor:sensor1 hash so this example runs on its own.
+await client.del('sensor:sensor1')
+await client.hSet('sensor:sensor1', { 'air_quality': 256, 'battery_level': 89 })
+
+// Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+const expireAt = Math.floor(Date.now() / 1000) + 24 * 60 * 60
+const res22 = await client.hExpireAt('sensor:sensor1', ['air_quality'], expireAt)
+console.log(res22)  // [1]
+
+// Retrieve the expiration time as a Unix timestamp in seconds.
+const res23 = await client.hExpireTime('sensor:sensor1', ['air_quality'])
+console.log(res23)  // [1717668041] (your actual value will vary)
+// STEP_END
+
+// REMOVE_START
+assert.deepEqual(res22, [1]);
+assert(res23.every(ts => ts > Math.floor(Date.now() / 1000)));
 await client.close();
 // REMOVE_END

--- a/local_examples/tmp/datatypes/hashes/dt-hash.js
+++ b/local_examples/tmp/datatypes/hashes/dt-hash.js
@@ -122,7 +122,6 @@ assert.deepEqual(res17, ['1', '1']);
 // REMOVE_END
 
 // STEP_START hExpire
-// Recreate the sensor:sensor1 hash so this example runs on its own.
 await client.del('sensor:sensor1')
 await client.hSet('sensor:sensor1', { 'air_quality': 256, 'battery_level': 89 })
 
@@ -141,7 +140,6 @@ assert(res19.every(ttl => ttl > 0 && ttl <= 60));
 // REMOVE_END
 
 // STEP_START hpExpire
-// Recreate the sensor:sensor1 hash so this example runs on its own.
 await client.del('sensor:sensor1')
 await client.hSet('sensor:sensor1', { 'air_quality': 256, 'battery_level': 89 })
 
@@ -160,7 +158,6 @@ assert(res21.every(pttl => pttl > 0 && pttl <= 60000));
 // REMOVE_END
 
 // STEP_START hExpireAt
-// Recreate the sensor:sensor1 hash so this example runs on its own.
 await client.del('sensor:sensor1')
 await client.hSet('sensor:sensor1', { 'air_quality': 256, 'battery_level': 89 })
 

--- a/local_examples/tmp/datatypes/hashes/dt_hash.py
+++ b/local_examples/tmp/datatypes/hashes/dt_hash.py
@@ -133,7 +133,6 @@ assert res17 == ["1", "1"]
 # REMOVE_END
 
 # STEP_START hexpire
-# Recreate the sensor:sensor1 hash so this example runs on its own.
 r.delete("sensor:sensor1")
 r.hset("sensor:sensor1", mapping={"air_quality": 256, "battery_level": 89})
 
@@ -155,7 +154,6 @@ assert all(0 < ttl <= 60 for ttl in res19)
 # REMOVE_END
 
 # STEP_START hpexpire
-# Recreate the sensor:sensor1 hash so this example runs on its own.
 r.delete("sensor:sensor1")
 r.hset("sensor:sensor1", mapping={"air_quality": 256, "battery_level": 89})
 
@@ -177,7 +175,6 @@ assert all(0 < pttl <= 60000 for pttl in res21)
 # REMOVE_END
 
 # STEP_START hexpireat
-# Recreate the sensor:sensor1 hash so this example runs on its own.
 r.delete("sensor:sensor1")
 r.hset("sensor:sensor1", mapping={"air_quality": 256, "battery_level": 89})
 

--- a/local_examples/tmp/datatypes/hashes/dt_hash.py
+++ b/local_examples/tmp/datatypes/hashes/dt_hash.py
@@ -6,6 +6,7 @@ Code samples for Hash doc pages:
     https://redis.io/docs/latest/develop/data-types/hashes/
 """
 import redis
+import time
 
 r = redis.Redis(decode_responses=True)
 # HIDE_END
@@ -129,4 +130,74 @@ assert res14 == 1
 assert res15 == 1
 assert res16 == "3"
 assert res17 == ["1", "1"]
+# REMOVE_END
+
+# STEP_START hexpire
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+r.delete("sensor:sensor1")
+r.hset("sensor:sensor1", mapping={"air_quality": 256, "battery_level": 89})
+
+# Set a TTL of 60 seconds on two fields of the hash.
+res18 = r.hexpire("sensor:sensor1", 60, "air_quality", "battery_level")
+print(res18)
+# >>> [1, 1]
+
+# Retrieve the remaining TTL for those fields.
+res19 = r.httl("sensor:sensor1", "air_quality", "battery_level")
+print(res19)
+# >>> [60, 60]
+# (your actual values may be slightly lower)
+# STEP_END
+
+# REMOVE_START
+assert res18 == [1, 1]
+assert all(0 < ttl <= 60 for ttl in res19)
+# REMOVE_END
+
+# STEP_START hpexpire
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+r.delete("sensor:sensor1")
+r.hset("sensor:sensor1", mapping={"air_quality": 256, "battery_level": 89})
+
+# Set the TTL of the 'air_quality' field in milliseconds.
+res20 = r.hpexpire("sensor:sensor1", 60000, "air_quality")
+print(res20)
+# >>> [1]
+
+# Retrieve the remaining TTL in milliseconds.
+res21 = r.hpttl("sensor:sensor1", "air_quality")
+print(res21)
+# >>> [59994]
+# (your actual value may vary)
+# STEP_END
+
+# REMOVE_START
+assert res20 == [1]
+assert all(0 < pttl <= 60000 for pttl in res21)
+# REMOVE_END
+
+# STEP_START hexpireat
+# Recreate the sensor:sensor1 hash so this example runs on its own.
+r.delete("sensor:sensor1")
+r.hset("sensor:sensor1", mapping={"air_quality": 256, "battery_level": 89})
+
+# Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+res22 = r.hexpireat(
+    "sensor:sensor1",
+    int(time.time()) + 24 * 60 * 60,
+    "air_quality",
+)
+print(res22)
+# >>> [1]
+
+# Retrieve the expiration time as a Unix timestamp in seconds.
+res23 = r.hexpiretime("sensor:sensor1", "air_quality")
+print(res23)
+# >>> [1717668041]
+# (your actual value will vary)
+# STEP_END
+
+# REMOVE_START
+assert res22 == [1]
+assert all(ts > int(time.time()) for ts in res23)
 # REMOVE_END

--- a/local_examples/tmp/datatypes/hashes/hash_tutorial_test.go
+++ b/local_examples/tmp/datatypes/hashes/hash_tutorial_test.go
@@ -6,6 +6,7 @@ package example_commands_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -279,4 +280,136 @@ func ExampleClient_incrby_get_mget() {
 	// 1
 	// 3
 	// [1 1]
+}
+
+func ExampleClient_hexpire() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password docs
+		DB:       0,  // use default DB
+	})
+
+	// REMOVE_START
+	// start with fresh database
+	rdb.FlushDB(ctx)
+	// REMOVE_END
+
+	// STEP_START hexpire
+	// Recreate the sensor:sensor1 hash so this example runs on its own.
+	rdb.Del(ctx, "sensor:sensor1")
+	rdb.HSet(ctx, "sensor:sensor1", "air_quality", 256, "battery_level", 89)
+
+	// Set a TTL of 60 seconds on two fields of the hash.
+	res18, err := rdb.HExpire(ctx, "sensor:sensor1", 60*time.Second,
+		"air_quality", "battery_level").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(res18) // >>> [1 1]
+
+	// Retrieve the remaining TTL for those fields (returns one value per field).
+	res19, err := rdb.HTTL(ctx, "sensor:sensor1", "air_quality", "battery_level").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(len(res19)) // >>> 2
+	// STEP_END
+
+	// Output:
+	// [1 1]
+	// 2
+}
+
+func ExampleClient_hpexpire() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password docs
+		DB:       0,  // use default DB
+	})
+
+	// REMOVE_START
+	// start with fresh database
+	rdb.FlushDB(ctx)
+	// REMOVE_END
+
+	// STEP_START hpexpire
+	// Recreate the sensor:sensor1 hash so this example runs on its own.
+	rdb.Del(ctx, "sensor:sensor1")
+	rdb.HSet(ctx, "sensor:sensor1", "air_quality", 256, "battery_level", 89)
+
+	// Set the TTL of the 'air_quality' field in milliseconds.
+	res20, err := rdb.HPExpire(ctx, "sensor:sensor1", 60000*time.Millisecond,
+		"air_quality").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(res20) // >>> [1]
+
+	// Retrieve the remaining TTL in milliseconds (returns one value per field).
+	res21, err := rdb.HPTTL(ctx, "sensor:sensor1", "air_quality").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(len(res21)) // >>> 1
+	// STEP_END
+
+	// Output:
+	// [1]
+	// 1
+}
+
+func ExampleClient_hexpireat() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "", // no password docs
+		DB:       0,  // use default DB
+	})
+
+	// REMOVE_START
+	// start with fresh database
+	rdb.FlushDB(ctx)
+	// REMOVE_END
+
+	// STEP_START hexpireat
+	// Recreate the sensor:sensor1 hash so this example runs on its own.
+	rdb.Del(ctx, "sensor:sensor1")
+	rdb.HSet(ctx, "sensor:sensor1", "air_quality", 256, "battery_level", 89)
+
+	// Set the expiration of 'air_quality' to a time 24 hours from now.
+	res22, err := rdb.HExpireAt(ctx, "sensor:sensor1", time.Now().Add(24*time.Hour),
+		"air_quality").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(res22) // >>> [1]
+
+	// Retrieve the expiration time as a Unix timestamp (returns one value per field).
+	res23, err := rdb.HExpireTime(ctx, "sensor:sensor1", "air_quality").Result()
+
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(len(res23)) // >>> 1
+	// STEP_END
+
+	// Output:
+	// [1]
+	// 1
 }

--- a/local_examples/tmp/datatypes/hashes/hash_tutorial_test.go
+++ b/local_examples/tmp/datatypes/hashes/hash_tutorial_test.go
@@ -297,7 +297,6 @@ func ExampleClient_hexpire() {
 	// REMOVE_END
 
 	// STEP_START hexpire
-	// Recreate the sensor:sensor1 hash so this example runs on its own.
 	rdb.Del(ctx, "sensor:sensor1")
 	rdb.HSet(ctx, "sensor:sensor1", "air_quality", 256, "battery_level", 89)
 
@@ -341,7 +340,6 @@ func ExampleClient_hpexpire() {
 	// REMOVE_END
 
 	// STEP_START hpexpire
-	// Recreate the sensor:sensor1 hash so this example runs on its own.
 	rdb.Del(ctx, "sensor:sensor1")
 	rdb.HSet(ctx, "sensor:sensor1", "air_quality", 256, "battery_level", 89)
 
@@ -385,7 +383,6 @@ func ExampleClient_hexpireat() {
 	// REMOVE_END
 
 	// STEP_START hexpireat
-	// Recreate the sensor:sensor1 hash so this example runs on its own.
 	rdb.Del(ctx, "sensor:sensor1")
 	rdb.HSet(ctx, "sensor:sensor1", "air_quality", 256, "battery_level", 89)
 

--- a/local_examples/tmp/lettuce-async/HashExample.java
+++ b/local_examples/tmp/lettuce-async/HashExample.java
@@ -158,11 +158,96 @@ public class HashExample {
                     .toCompletableFuture();
             // STEP_END
 
+            // STEP_START hexpire
+            // Recreate the sensor:sensor1 hash so this example runs on its own.
+            Map<String, String> sensor1 = new HashMap<>();
+            sensor1.put("air_quality", "256");
+            sensor1.put("battery_level", "89");
+
+            CompletableFuture<Void> hExpire = asyncCommands.del("sensor:sensor1")
+                    .thenCompose(delRes -> asyncCommands.hset("sensor:sensor1", sensor1))
+                    // Set a TTL of 60 seconds on two fields of the hash.
+                    .thenCompose(hsetRes -> asyncCommands.hexpire("sensor:sensor1", 60, "air_quality", "battery_level"))
+                    .thenCompose(res15 -> {
+                        System.out.println(res15); // >>> [1, 1]
+                        // REMOVE_START
+                        assertThat(res15).isEqualTo(Arrays.asList(1L, 1L));
+                        // REMOVE_END
+                        // Retrieve the remaining TTL for those fields.
+                        return asyncCommands.httl("sensor:sensor1", "air_quality", "battery_level");
+                    })
+                    // REMOVE_START
+                    .thenApply(res16 -> {
+                        assertThat(res16).hasSize(2);
+                        assertThat(res16.stream().allMatch(ttl -> ttl > 0 && ttl <= 60)).isTrue();
+                        return res16;
+                    })
+                    // REMOVE_END
+                    .thenAccept(res16 -> System.out.println(res16.size()))
+                    // >>> 2
+                    .toCompletableFuture();
+            // STEP_END
+
+            // STEP_START hpexpire
+            // Recreate the sensor:sensor1 hash so this example runs on its own.
+            CompletableFuture<Void> hpExpire = hExpire
+                    .thenCompose(prev -> asyncCommands.del("sensor:sensor1"))
+                    .thenCompose(delRes -> asyncCommands.hset("sensor:sensor1", sensor1))
+                    // Set the TTL of the 'air_quality' field in milliseconds.
+                    .thenCompose(hsetRes -> asyncCommands.hpexpire("sensor:sensor1", 60000, "air_quality"))
+                    .thenCompose(res17 -> {
+                        System.out.println(res17); // >>> [1]
+                        // REMOVE_START
+                        assertThat(res17).isEqualTo(Arrays.asList(1L));
+                        // REMOVE_END
+                        // Retrieve the remaining TTL in milliseconds.
+                        return asyncCommands.hpttl("sensor:sensor1", "air_quality");
+                    })
+                    // REMOVE_START
+                    .thenApply(res18 -> {
+                        assertThat(res18).hasSize(1);
+                        assertThat(res18.stream().allMatch(pttl -> pttl > 0 && pttl <= 60000)).isTrue();
+                        return res18;
+                    })
+                    // REMOVE_END
+                    .thenAccept(res18 -> System.out.println(res18.size()))
+                    // >>> 1
+                    .toCompletableFuture();
+            // STEP_END
+
+            // STEP_START hexpireat
+            // Recreate the sensor:sensor1 hash so this example runs on its own.
+            long expireAtSeconds = System.currentTimeMillis() / 1000L + 24 * 60 * 60;
+            CompletableFuture<Void> hExpireAt = hpExpire
+                    .thenCompose(prev -> asyncCommands.del("sensor:sensor1"))
+                    .thenCompose(delRes -> asyncCommands.hset("sensor:sensor1", sensor1))
+                    // Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+                    .thenCompose(hsetRes -> asyncCommands.hexpireat("sensor:sensor1", expireAtSeconds, "air_quality"))
+                    .thenCompose(res19 -> {
+                        System.out.println(res19); // >>> [1]
+                        // REMOVE_START
+                        assertThat(res19).isEqualTo(Arrays.asList(1L));
+                        // REMOVE_END
+                        // Retrieve the expiration time as a Unix timestamp in seconds.
+                        return asyncCommands.hexpiretime("sensor:sensor1", "air_quality");
+                    })
+                    // REMOVE_START
+                    .thenApply(res20 -> {
+                        assertThat(res20).hasSize(1);
+                        assertThat(res20.get(0)).isGreaterThan(System.currentTimeMillis() / 1000L);
+                        return res20;
+                    })
+                    // REMOVE_END
+                    .thenAccept(res20 -> System.out.println(res20.size()))
+                    // >>> 1
+                    .toCompletableFuture();
+            // STEP_END
+
             CompletableFuture.allOf(
                     // REMOVE_START
                     delResult,
                     // REMOVE_END
-                    hIncrBy, incrByGetMget).join();
+                    hIncrBy, incrByGetMget, hExpireAt).join();
         } finally {
             redisClient.shutdown();
         }

--- a/local_examples/tmp/lettuce-async/HashExample.java
+++ b/local_examples/tmp/lettuce-async/HashExample.java
@@ -159,7 +159,6 @@ public class HashExample {
             // STEP_END
 
             // STEP_START hexpire
-            // Recreate the sensor:sensor1 hash so this example runs on its own.
             Map<String, String> sensor1 = new HashMap<>();
             sensor1.put("air_quality", "256");
             sensor1.put("battery_level", "89");
@@ -189,7 +188,6 @@ public class HashExample {
             // STEP_END
 
             // STEP_START hpexpire
-            // Recreate the sensor:sensor1 hash so this example runs on its own.
             CompletableFuture<Void> hpExpire = hExpire
                     .thenCompose(prev -> asyncCommands.del("sensor:sensor1"))
                     .thenCompose(delRes -> asyncCommands.hset("sensor:sensor1", sensor1))
@@ -216,7 +214,6 @@ public class HashExample {
             // STEP_END
 
             // STEP_START hexpireat
-            // Recreate the sensor:sensor1 hash so this example runs on its own.
             long expireAtSeconds = System.currentTimeMillis() / 1000L + 24 * 60 * 60;
             CompletableFuture<Void> hExpireAt = hpExpire
                     .thenCompose(prev -> asyncCommands.del("sensor:sensor1"))

--- a/local_examples/tmp/lettuce-reactive/HashExample.java
+++ b/local_examples/tmp/lettuce-reactive/HashExample.java
@@ -163,7 +163,6 @@ public class HashExample {
             Mono.when(getRides, getCrashesOwners).block();
 
             // STEP_START hexpire
-            // Recreate the sensor:sensor1 hash so this example runs on its own.
             Map<String, String> sensor1 = new HashMap<>();
             sensor1.put("air_quality", "256");
             sensor1.put("battery_level", "89");
@@ -197,7 +196,6 @@ public class HashExample {
             // STEP_END
 
             // STEP_START hpexpire
-            // Recreate the sensor:sensor1 hash so this example runs on its own.
             // Set the TTL of the 'air_quality' field in milliseconds.
             Mono<List<Long>> hpExpire = reactiveCommands.del("sensor:sensor1")
                     .then(reactiveCommands.hset("sensor:sensor1", sensor1))
@@ -227,7 +225,6 @@ public class HashExample {
             // STEP_END
 
             // STEP_START hexpireat
-            // Recreate the sensor:sensor1 hash so this example runs on its own.
             long expireAtSeconds = System.currentTimeMillis() / 1000L + 24 * 60 * 60;
 
             // Set the expiration of 'air_quality' to a Unix time 24 hours from now.

--- a/local_examples/tmp/lettuce-reactive/HashExample.java
+++ b/local_examples/tmp/lettuce-reactive/HashExample.java
@@ -161,6 +161,102 @@ public class HashExample {
             // STEP_END
 
             Mono.when(getRides, getCrashesOwners).block();
+
+            // STEP_START hexpire
+            // Recreate the sensor:sensor1 hash so this example runs on its own.
+            Map<String, String> sensor1 = new HashMap<>();
+            sensor1.put("air_quality", "256");
+            sensor1.put("battery_level", "89");
+
+            // Set a TTL of 60 seconds on two fields of the hash.
+            Mono<List<Long>> hExpire = reactiveCommands.del("sensor:sensor1")
+                    .then(reactiveCommands.hset("sensor:sensor1", sensor1))
+                    .then(reactiveCommands.hexpire("sensor:sensor1", 60, "air_quality", "battery_level").collectList())
+                    .doOnNext(result -> {
+                        System.out.println(result);
+                        // >>> [1, 1]
+                        // REMOVE_START
+                        assertThat(result).isEqualTo(Arrays.asList(1L, 1L));
+                        // REMOVE_END
+                    });
+
+            hExpire.block();
+
+            // Retrieve the remaining TTL for those fields.
+            Mono<List<Long>> hTtl = reactiveCommands.httl("sensor:sensor1", "air_quality", "battery_level")
+                    .collectList().doOnNext(result -> {
+                        System.out.println(result.size());
+                        // >>> 2
+                        // REMOVE_START
+                        assertThat(result).hasSize(2);
+                        assertThat(result.stream().allMatch(ttl -> ttl > 0 && ttl <= 60)).isTrue();
+                        // REMOVE_END
+                    });
+
+            hTtl.block();
+            // STEP_END
+
+            // STEP_START hpexpire
+            // Recreate the sensor:sensor1 hash so this example runs on its own.
+            // Set the TTL of the 'air_quality' field in milliseconds.
+            Mono<List<Long>> hpExpire = reactiveCommands.del("sensor:sensor1")
+                    .then(reactiveCommands.hset("sensor:sensor1", sensor1))
+                    .then(reactiveCommands.hpexpire("sensor:sensor1", 60000, "air_quality").collectList())
+                    .doOnNext(result -> {
+                        System.out.println(result);
+                        // >>> [1]
+                        // REMOVE_START
+                        assertThat(result).isEqualTo(Arrays.asList(1L));
+                        // REMOVE_END
+                    });
+
+            hpExpire.block();
+
+            // Retrieve the remaining TTL in milliseconds.
+            Mono<List<Long>> hpTtl = reactiveCommands.hpttl("sensor:sensor1", "air_quality")
+                    .collectList().doOnNext(result -> {
+                        System.out.println(result.size());
+                        // >>> 1
+                        // REMOVE_START
+                        assertThat(result).hasSize(1);
+                        assertThat(result.stream().allMatch(pttl -> pttl > 0 && pttl <= 60000)).isTrue();
+                        // REMOVE_END
+                    });
+
+            hpTtl.block();
+            // STEP_END
+
+            // STEP_START hexpireat
+            // Recreate the sensor:sensor1 hash so this example runs on its own.
+            long expireAtSeconds = System.currentTimeMillis() / 1000L + 24 * 60 * 60;
+
+            // Set the expiration of 'air_quality' to a Unix time 24 hours from now.
+            Mono<List<Long>> hExpireAt = reactiveCommands.del("sensor:sensor1")
+                    .then(reactiveCommands.hset("sensor:sensor1", sensor1))
+                    .then(reactiveCommands.hexpireat("sensor:sensor1", expireAtSeconds, "air_quality").collectList())
+                    .doOnNext(result -> {
+                        System.out.println(result);
+                        // >>> [1]
+                        // REMOVE_START
+                        assertThat(result).isEqualTo(Arrays.asList(1L));
+                        // REMOVE_END
+                    });
+
+            hExpireAt.block();
+
+            // Retrieve the expiration time as a Unix timestamp in seconds.
+            Mono<List<Long>> hExpireTime = reactiveCommands.hexpiretime("sensor:sensor1", "air_quality")
+                    .collectList().doOnNext(result -> {
+                        System.out.println(result.size());
+                        // >>> 1
+                        // REMOVE_START
+                        assertThat(result).hasSize(1);
+                        assertThat(result.get(0)).isGreaterThan(System.currentTimeMillis() / 1000L);
+                        // REMOVE_END
+                    });
+
+            hExpireTime.block();
+            // STEP_END
         } finally {
             redisClient.shutdown();
         }


### PR DESCRIPTION
## What

Converts the Python-only hash field expiration examples on the [hashes data-type page](https://redis.io/docs/latest/develop/data-types/hashes/#field-expiration-examples) into three tabbed `clients-example` blocks, matching the rest of the page:

- **`hexpire`** — `HEXPIRE` + `HTTL`
- **`hpexpire`** — `HPEXPIRE` + `HPTTL`
- **`hexpireat`** — `HEXPIREAT` + `HEXPIRETIME`

The old prose claimed field expiration was "not yet available" in the client libraries — that's now out of date, so the intro is rewritten too.

## How

- The three new steps are authored across the 10 `hash_tutorial` clients that support the commands (Python, Node.js, Go, Jedis, StackExchange.Redis, Lettuce async/reactive, PHP, Rust sync/async), reusing the page's existing `sensor:sensor1` narrative. Each step is self-contained (recreates the hash).
- **The released redis-rb gem (5.4.1) has no methods for the hash field expiration commands** — `hexpire`/`httl`/`hpexpire`/etc. fall through `method_missing` and send the command without the required `FIELDS` keyword, so they error at runtime. Ruby is therefore omitted from **all three** blocks via `lang_filter` (a client missing a step would otherwise render its whole file); it keeps its existing non-expiration steps.
- Signatures came from `data/command-api-mapping/` and the verified `cmds_hash` examples. Note the mapping lists redis-rb for these commands, but that reflects unreleased/fork work rather than the released gem — a gap the harness caught (see Verification).

## Verification

- ✅ Markers parse cleanly; `data/examples.json` regenerates with the new `named_steps`; full `hugo` build renders the three blocks with no errors.
- ✅ **Executed against Redis 8.8.0** via `build/example-test-harness/run.sh hash_tutorial`. All 10 expiring-client tabs pass (Python, Node.js, Go, Jedis, Lettuce async/reactive, Rust sync/async, C#/StackExchange.Redis, PHP); Ruby passes its existing steps with expiration correctly excluded. The harness surfaced two issues, both now fixed: redis-rb lacks the commands (Ruby dropped), and Predis needed `hmset`/`assertEquals(count())` in the PHP example. The C#/Go/Lettuce return-type assertions flagged as risky all passed.

Ticket: DOC-6887

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example/test harness changes only; no production runtime code. Residual risk is unverified client API assertions until examples run against Redis 7.4+.
> 
> **Overview**
> **Field expiration examples** on the hashes data-type page are reworked: outdated prose that said client support was not yet available is replaced with copy stating official libraries support it, and three Python-only snippets become tabbed `clients-example` blocks for **`hexpire`/`httl`**, **`hpexpire`/`hpttl`**, and **`hexpireat`/`hexpiretime`**, each using the shared `sensor:sensor1` setup with self-contained `DEL`/`HSET` preamble.
> 
> Matching **`STEP_START`** sections are added across the `hash_tutorial` example sources (Python, Node, Go, Jedis, Lettuce async/reactive, C#, PHP, Rust sync/async, etc.) so the docs harness can render and test the same steps. PHP examples switch multi-field hash setup from `hset` to **`hmset`** in a couple of existing steps. The **`hexpireat`** block uses **`lang_filter`** to exclude Ruby where `HEXPIREAT`/`HEXPIRETIME` are not exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5831d1741fd10ce92d05b641c9d410c8169ae21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
