### PR TITLE
K8s: RBAC yaml examples [PARKED]

### DIFF
--- a/content/embeds/k8s/reacl.md
+++ b/content/embeds/k8s/reacl.md
@@ -1,0 +1,11 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseACL
+metadata:
+  name: read-only
+  labels:
+    app: redis-enterprise
+spec:
+  # Example ACL expression granting read-only access to all keys.
+  acl: +@read ~*
+```

--- a/content/embeds/k8s/reacl_full_access.md
+++ b/content/embeds/k8s/reacl_full_access.md
@@ -1,0 +1,11 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseACL
+metadata:
+  name: full-access
+  labels:
+    app: redis-enterprise
+spec:
+  # Example ACL expression granting full access to all keys.
+  acl: +@all ~*
+```

--- a/content/embeds/k8s/recrole.md
+++ b/content/embeds/k8s/recrole.md
@@ -1,0 +1,18 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseClusterRole
+metadata:
+  name: cluster-admin
+  labels:
+    app: redis-enterprise
+spec:
+  # One of: 
+  # Admin, UserManager, ClusterMember, ClusterViewer,
+  # DBMember, DBViewer, None.
+  managementRole: Admin
+
+  # An optional ACL that applies to all databases in the cluster.
+  acl:
+    kind: RedisEnterpriseACL
+    name: full-access
+```

--- a/content/embeds/k8s/recrolebinding.md
+++ b/content/embeds/k8s/recrolebinding.md
@@ -1,0 +1,19 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseClusterRoleBinding
+metadata:
+  name: cluster-admin
+  labels:
+    app: redis-enterprise
+spec:
+  # A reference to a RedisEnterpriseClusterRole object.
+  roleRef:
+    kind: RedisEnterpriseClusterRole
+    name: cluster-admin
+
+  # A reference to one or more RedisEnterpriseUser objects,
+  # or other kinds of subjects.
+  subjects:
+  - kind: RedisEnterpriseUser
+    name: some-admin-user
+```

--- a/content/embeds/k8s/rerole.md
+++ b/content/embeds/k8s/rerole.md
@@ -1,0 +1,22 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseRole
+metadata:
+  name: db-reader
+  labels:
+    app: redis-enterprise
+spec:
+  # One of: 
+  # DBMember, DBViewer, None.
+  managementRole: DBViewer
+
+  # The scopes (databases) for which this role grants dataplane access to.
+  scopes:
+  - kind: RedisEnterpriseDatabase
+    name: redb
+
+  # The dataplane permissions (ACL) granted by this role.
+  acl:
+    kind: RedisEnterpriseACL
+    name: read-only
+```

--- a/content/embeds/k8s/rerolebinding.md
+++ b/content/embeds/k8s/rerolebinding.md
@@ -1,0 +1,19 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseRoleBinding
+metadata:
+  name: db-reader
+  labels:
+    app: redis-enterprise
+spec:
+  # A reference to a RedisEnterpriseRole object.
+  roleRef:
+    kind: RedisEnterpriseRole
+    name: db-reader
+
+  # A reference to one or more RedisEnterpriseUser objects,
+  # or other kinds of subjects.
+  subjects:
+  - kind: RedisEnterpriseUser
+    name: some-db-user
+```

--- a/content/embeds/k8s/reuser.md
+++ b/content/embeds/k8s/reuser.md
@@ -1,0 +1,19 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseUser
+metadata:
+  name: some-db-user
+  labels:
+    app: redis-enterprise
+spec:
+  # The email address for the user.
+  email: some-db-user@example.com
+
+  # The username associated with the user.
+  username: some-db-user
+
+  # Names of one or more secrets holding the user's password.
+  # Each secret must have a key named 'password'.
+  passwordSecrets:
+  - name: some-db-user-secret
+```

--- a/content/embeds/k8s/reuser_admin.md
+++ b/content/embeds/k8s/reuser_admin.md
@@ -1,0 +1,19 @@
+```yaml
+apiVersion: app.redislabs.com/v1alpha1
+kind: RedisEnterpriseUser
+metadata:
+  name: some-admin-user
+  labels:
+    app: redis-enterprise
+spec:
+  # The email address for the user.
+  email: some-admin-user@example.com
+
+  # The username associated with the user.
+  username: some-admin-user
+
+  # Names of one or more secrets holding the user's password.
+  # Each secret must have a key named 'password'.
+  passwordSecrets:
+  - name: some-admin-user-secret
+```

--- a/content/operate/kubernetes/reference/yaml/_index.md
+++ b/content/operate/kubernetes/reference/yaml/_index.md
@@ -72,6 +72,7 @@ kubectl get events --sort-by=.metadata.creationTimestamp
 - [Rack awareness examples]({{< relref "/operate/kubernetes/reference/yaml/rack-awareness" >}}) - Rack-aware cluster configuration and required RBAC
 - [Active-Active examples]({{< relref "/operate/kubernetes/reference/yaml/active-active" >}}) - Multi-cluster Active-Active database setup
 - [Multi-namespace examples]({{< relref "/operate/kubernetes/reference/yaml/multi-namespace" >}}) - Cross-namespace operator and cluster configurations
+- [Access control examples]({{< relref "/operate/kubernetes/reference/yaml/access-control" >}}) - Users, roles, role bindings, and ACLs for role-based access control
 - [Log collector RBAC examples]({{< relref "/operate/kubernetes/reference/yaml/log-collector-rbac" >}}) - RBAC permissions for log collection in restricted and all modes
 
 ## Best practices

--- a/content/operate/kubernetes/reference/yaml/access-control.md
+++ b/content/operate/kubernetes/reference/yaml/access-control.md
@@ -1,0 +1,145 @@
+---
+Title: Access control examples
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: YAML examples for managing Redis Software users, roles, role bindings, and ACLs with custom resources.
+linkTitle: Access control
+weight: 50
+---
+
+This page provides YAML examples for role-based access control (RBAC) in Redis Software for Kubernetes. These custom resources let you manage users, roles, and data access permissions declaratively, instead of configuring them through the Redis Software admin console or REST API.
+
+For task instructions, see [Access control]({{< relref "/operate/kubernetes/security/access-control" >}}).
+
+## Applying the configuration
+
+Apply these resources in dependency order. Roles reference ACLs and databases, and bindings reference roles and users, so a resource that points at something not yet created stays unreconciled until it exists.
+
+1. ACLs and users, in any order
+2. Roles and cluster roles
+3. Role bindings and cluster role bindings
+
+```sh
+kubectl apply -f <filename>
+```
+
+The examples on this page form one working configuration. Together they grant a read-only user access to a single database, and an admin user full access to the cluster:
+
+| Resource | Name | Grants |
+|---|---|---|
+| `RedisEnterpriseACL` | `read-only` | Read commands on all keys |
+| `RedisEnterpriseACL` | `full-access` | All commands on all keys |
+| `RedisEnterpriseUser` | `some-db-user` | — |
+| `RedisEnterpriseUser` | `some-admin-user` | — |
+| `RedisEnterpriseRole` | `db-reader` | `DBViewer` on database `redb`, with the `read-only` ACL |
+| `RedisEnterpriseClusterRole` | `cluster-admin` | `Admin` across the cluster, with the `full-access` ACL |
+| `RedisEnterpriseRoleBinding` | `db-reader` | Binds `db-reader` to `some-db-user` |
+| `RedisEnterpriseClusterRoleBinding` | `cluster-admin` | Binds `cluster-admin` to `some-admin-user` |
+
+The role example scopes access to a database named `redb`, which the [basic deployment examples]({{< relref "/operate/kubernetes/reference/yaml/basic-deployment" >}}) create. Change the name to match your own database.
+
+## ACL examples
+
+A RedisEnterpriseACL defines data access permissions using [Redis ACL syntax]({{< relref "/operate/oss_and_stack/management/security/acl" >}}). Roles reference an ACL to grant those permissions to their subjects.
+
+`redis-enterprise-acl.yaml` grants read-only access to all keys.
+
+{{<embed-yaml "k8s/reacl.md" "redis-enterprise-acl.yaml">}}
+
+`redis-enterprise-acl-full-access.yaml` grants all commands on all keys.
+
+{{<embed-yaml "k8s/reacl_full_access.md" "redis-enterprise-acl-full-access.yaml">}}
+
+### REACL configuration
+
+- [spec.acl]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_acl_api#spec" >}}): The ACL expression that defines which commands and keys the ACL permits
+
+## User examples
+
+A RedisEnterpriseUser creates a user in the Redis Software cluster. The user has no permissions until a role binding assigns a role to it.
+
+`redis-enterprise-user.yaml` creates the database user.
+
+{{<embed-yaml "k8s/reuser.md" "redis-enterprise-user.yaml">}}
+
+`redis-enterprise-user-admin.yaml` creates the admin user.
+
+{{<embed-yaml "k8s/reuser_admin.md" "redis-enterprise-user-admin.yaml">}}
+
+### REUSER configuration
+
+- [spec.username]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_user_api#spec" >}}): The username used to connect to a database or sign in to Redis Software. Must be unique within the cluster. If you omit it, the operator assigns a default username, reported in the resource's status.
+- [spec.email]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_user_api#spec" >}}): The user's email address. Optional.
+- [spec.passwordSecrets]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_user_api#specpasswordsecrets" >}}): One or more secrets holding the user's password. Each secret must have a key named `password`.
+
+Create the referenced secret before you apply the user. When a binding's `subjects` list refers to this user, it uses the resource name in `metadata.name`, not `spec.username`.
+
+## Role examples
+
+A RedisEnterpriseRole grants database-scoped permissions. It combines a management role, the databases it applies to, and an optional ACL for data access.
+
+`redis-enterprise-role.yaml` grants read-only access to a single database.
+
+{{<embed-yaml "k8s/rerole.md" "redis-enterprise-role.yaml">}}
+
+### REROLE configuration
+
+- [spec.managementRole]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_api#spec" >}}): The management permissions this role grants. RedisEnterpriseRole supports only database-scoped roles: `DBMember`, `DBViewer`, or `None`. Defaults to `None` if omitted.
+- [spec.scopes]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_api#specscopes" >}}): The databases this role applies to. Reference them by name, or select them with a label selector.
+- [spec.acl]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_api#specacl" >}}): The data access permissions the role grants within those databases
+
+## Cluster role examples
+
+A RedisEnterpriseClusterRole grants permissions across the whole cluster rather than specific databases. Its ACL, if set, applies to every database in the cluster.
+
+`redis-enterprise-cluster-role.yaml` grants full administrative access.
+
+{{<embed-yaml "k8s/recrole.md" "redis-enterprise-cluster-role.yaml">}}
+
+### RECROLE configuration
+
+- [spec.managementRole]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_api#spec" >}}): The management permissions this role grants. Cluster roles support the full set: `Admin`, `UserManager`, `ClusterMember`, `ClusterViewer`, `DBMember`, `DBViewer`, or `None`. Defaults to `None` if omitted.
+- [spec.acl]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_api#specacl" >}}): The data access permissions the role grants across all databases in the cluster. Optional.
+
+## Role binding examples
+
+A RedisEnterpriseRoleBinding assigns a RedisEnterpriseRole to one or more subjects.
+
+`redis-enterprise-role-binding.yaml` binds the `db-reader` role to the database user.
+
+{{<embed-yaml "k8s/rerolebinding.md" "redis-enterprise-role-binding.yaml">}}
+
+### REROLEBINDING configuration
+
+- [spec.roleRef]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_binding_api#specroleref" >}}): The RedisEnterpriseRole this binding assigns
+- [spec.subjects]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_binding_api#specsubjects" >}}): The users the role is assigned to, referenced by resource name
+
+## Cluster role binding examples
+
+A RedisEnterpriseClusterRoleBinding assigns a RedisEnterpriseClusterRole to one or more subjects.
+
+`redis-enterprise-cluster-role-binding.yaml` binds the `cluster-admin` role to the admin user.
+
+{{<embed-yaml "k8s/recrolebinding.md" "redis-enterprise-cluster-role-binding.yaml">}}
+
+### RECROLEBINDING configuration
+
+- [spec.roleRef]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_binding_api#specroleref" >}}): The RedisEnterpriseClusterRole this binding assigns
+- [spec.subjects]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_binding_api#specsubjects" >}}): The users the role is assigned to, referenced by resource name
+
+## Related documentation
+
+- [Access control]({{< relref "/operate/kubernetes/security/access-control" >}})
+- [Manage users]({{< relref "/operate/kubernetes/security/access-control/manage-users" >}})
+- [Manage roles]({{< relref "/operate/kubernetes/security/access-control/manage-roles" >}})
+- [Manage ACLs]({{< relref "/operate/kubernetes/security/access-control/manage-acls" >}})
+- [Manage bindings]({{< relref "/operate/kubernetes/security/access-control/manage-bindings" >}})
+- [REACL API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_acl_api" >}})
+- [REUSER API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_user_api" >}})
+- [REROLE API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_api" >}})
+- [RECROLE API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_api" >}})
+- [REROLEBINDING API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_role_binding_api" >}})
+- [RECROLEBINDING API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_role_binding_api" >}})

--- a/content/operate/kubernetes/reference/yaml/log-collector-rbac.md
+++ b/content/operate/kubernetes/reference/yaml/log-collector-rbac.md
@@ -7,7 +7,7 @@ categories:
 - kubernetes
 description: YAML examples for configuring RBAC permissions for the Redis Enterprise log collector tool in `restricted` and `all` modes.
 linkTitle: Log collector RBAC
-weight: 50
+weight: 60
 ---
 
 This page provides YAML examples for configuring RBAC permissions for the Redis Enterprise log collector tool. The log collector requires different permission levels depending on the collection mode you choose.


### PR DESCRIPTION
Adds a YAML examples page for RBAC access control, covering all six RBAC custom resources (REACL, REUSER, REROLE, RECROLE, REROLEBINDING, RECROLEBINDING).

The `reference/yaml/` section is the established home for generated CRD example embeds — no API reference page carries examples, so this follows the existing pattern rather than making the RBAC reference pages an exception.

**Changes**
- New page `reference/yaml/access-control.md` (weight 50), structured in dependency order: ACLs → users → roles → cluster roles → role bindings → cluster role bindings.
- Eight embeds in `content/embeds/k8s/`, generated with the sync workflow's own `formatYamlSnippet` function so they are byte-identical to what the next API sync will emit.
- `reference/yaml/_index.md` — added to the example-categories list.
- `log-collector-rbac.md` — weight 50 → 60 to make room.

**Not in this PR, deliberately:** the eight `formatYamlSnippet` lines for `.github/workflows/k8s_apis_sync.yaml`. See the manifest checklist — landing them before the upstream change ships would silently corrupt the embeds.

---

> ## ⛔ Do not merge yet
>
> This page's examples depend on **[redis-enterprise-operator#6768](https://github.com/redislabsdev/redis-enterprise-operator/pull/6768)**, which is open and unmerged. That PR makes the RBAC example manifests reference resources that actually exist; before it, four cross-references dangle (`some-db`, `some-db-user`, `some-admin-user`, `full-access`), and two of the files embedded here don't exist upstream at all.
>
> Merging to `main` auto-publishes. Hold until #6768 has merged **and** shipped in a released operator tag.

<!-- park-manifest -->
## Park manifest

Ticket: DOC-6865
Parked at: 2026-07-28
Trigger to pick up: operator PR redislabsdev/redis-enterprise-operator#6768 **merged** into `master` **and** present in a released operator tag newer than `v8.2.0-12` — testably, a tag where `deploy/examples/v1alpha1/reacl_full_access.yaml` and `reuser_admin.yaml` both exist.
Labels: parked, do not merge yet

### Pinned sources (state observed at park time)

| Source | URL | State at park time | Re-fetch |
|---|---|---|---|
| Operator PR (the blocker) | https://github.com/redislabsdev/redis-enterprise-operator/pull/6768 | `state: open`, `merged: false`, `draft: false`, `head_sha: 45a6f85e2a49385f350927724510ffb1a2d4aa67`, `base: master`, `milestone: null`, `mergeable_state: blocked`, `changed_files: 5`, `updated_at: 2026-07-28T19:49:25Z` | `gh api repos/RedisLabsDev/redis-enterprise-operator/pulls/6768 --jq '{state, merged, head_sha: .head.sha, base: .base.ref, milestone: .milestone.title, updated_at}'` |
| Operator released baseline | tag `v8.2.0-12` (Duckburg GA) | Newest `v8.2.*` tag at park time. Contains the **pre-fix** examples with the four dangling references. | `git -C <operator> fetch --tags && git tag \| grep -E '^v8\.2\.' \| sort -V \| tail -1` |

**Example-file blob SHAs at `v8.2.0-12`** — the pre-change baseline. On unpark, diff the shipped tag's files against these; any row that changed needs its embed regenerated.

| File (`deploy/examples/v1alpha1/`) | blob SHA at `v8.2.0-12` |
|---|---|
| `reacl.yaml` | `1d4022de7513866f4eefadecd2ff88c06c3ebe02` |
| `reacl_full_access.yaml` | **absent** (added by #6768) |
| `reuser.yaml` | `e9bdb984a9231236a1a745efe356e9c535fcfa5d` (modified by #6768) |
| `reuser_admin.yaml` | **absent** (added by #6768) |
| `rerole.yaml` | `ebe22de6726d2faf56cb388c0d5adf1a908faa71` (modified by #6768) |
| `recrole.yaml` | `ee92bba9c4e32c54f2f3f43d8fb114573d3863b6` (unchanged by #6768) |
| `rerolebinding.yaml` | `bbc9dbb4c6126a03e2ba30ac82dc629daa99392c` (unchanged by #6768) |
| `recrolebinding.yaml` | `e9146383d267582381241e0b2c609334d2c42c90` (unchanged by #6768) |

Re-fetch a single blob: `git -C <operator> rev-parse <tag>:deploy/examples/v1alpha1/<file>`

### Observed shape the page assumes

Two different confidence levels apply here, and conflating them would mislead unpark.

**CRD field shape and semantics — HIGH.** All six RBAC CRDs are GA in Duckburg 8.2.0; nothing on this page documents unreleased behavior. Verified directly against `deploy/crds/*_crd.yaml` at `v8.2.0-12` and the generated API reference pages:
- `RedisEnterpriseRole.spec.managementRole` enum is database-scoped only: `DBMember`, `DBViewer`, `None`; defaults to `None` when omitted.
- `RedisEnterpriseClusterRole.spec.managementRole` enum is the full set: `Admin`, `ClusterMember`, `ClusterViewer`, `DBMember`, `DBViewer`, `UserManager`, `None`.
- `RedisEnterpriseUser.spec` has **no required fields**; `email` and `username` are both optional, and an omitted username is assigned by the operator and surfaced in status.
- Bindings reference users by resource name (`metadata.name`), not `spec.username`.
- Anchors used in field links (`#spec`, `#specacl`, `#specscopes`, `#specroleref`, `#specsubjects`, `#specpasswordsecrets`) all exist on the generated pages; `npx hugo` exits 0.

**Example manifest content (names, filenames, values) — LOW.** #6768 is unmerged and its content has already shifted once during drafting (user emails changed from `@some-company.com` to `@example.com`, and a `password`-key comment was added). Specifically provisional:
- Filenames `reacl_full_access.yaml` and `reuser_admin.yaml` — the embed filenames and the future workflow lines both hard-code these.
- Resource names `full-access`, `some-db-user`, `some-admin-user`, and `rerole`'s scope target `redb`.
- The `+@all ~*` ACL expression (the integration suite uses the equivalent `~* +@all`).

**Deliberate decision — no `bannerText` on the page.** The park skill suggests a "not yet released / subject to change" banner, and this page intentionally does not have one. Every manifest embedded here is valid against the current GA release, and all six CRDs shipped in 8.2.0 — what's pending is only whether the operator repo ships two of them as example *files*. A "not yet released" banner would misinform readers about GA functionality and conflicts with documenting current behavior only. Do not add one on unpark.

### Re-check checklist

Note: the branch's single commit carries no `/reflect` trailers (no body), so this checklist is seeded from the drafting analysis rather than harvested trailers.

- [ ] **HIGHEST RISK** — Add the eight `formatYamlSnippet` lines to `.github/workflows/k8s_apis_sync.yaml`, and **only** once the change is in a released tag. The step has no `set -e`, so `formatYamlSnippet` on a missing file **exits 0 and writes an empty ```yaml fence**. Landing the lines early would blank `reacl_full_access.md` and `reuser_admin.md`, and revert `reuser.md`/`rerole.md` to the dangling names — with CI green.
- [ ] **HIGH RISK** — Re-diff all eight embeds in `content/embeds/k8s/` against the shipped tag. If any blob SHA differs from the table above (beyond the predicted changes), regenerate that embed with the workflow's `formatYamlSnippet`, not by hand.
- [ ] **HIGH RISK** — Confirm #6768 merged without renaming `reacl_full_access.yaml` or `reuser_admin.yaml`. Both embed filenames and the workflow lines hard-code them.
- [ ] **HIGH RISK — open SME question (@zcahana, asked in `#docs-k8s` 2026-07-28).** Does Redis Software reject creating a `redis_acl` whose rule duplicates a built-in ACL? The new `full-access` example uses `+@all ~*`, which matches the built-in Full Access. Not verifiable without a live cluster. **If it does reject:** the fix widens beyond #6768 — the pre-existing `read-only` example (`+@read ~*`) has the same problem, and on the docs side this page's prose plus the `reacl.md` and `reacl_full_access.md` embeds all change. Resolve before unparking.
- [ ] Confirm the four previously-dangling references resolve in the shipped examples: `rerole` → `redb` + `read-only`; `recrole` → `full-access`; `rerolebinding` → `some-db-user`; `recrolebinding` → `some-admin-user`.
- [ ] Confirm user emails are still `@example.com` (already changed once mid-draft).
- [ ] Verify the OLM CSV `alm-examples` still matches `deploy/examples/` — no tooling syncs the two, and that drift is the root cause of the original bug. Note `redb.yaml` sets `replication: false` while the CSV sets `replication: true`; pre-existing, left alone.
- [ ] Re-verify the page's dependency/apply-order claim and the cross-reference summary table against the shipped examples.
- [ ] Re-run `npx hugo` — confirm exit 0, all eight embeds render, and no empty code fences.
- [ ] Check whether the operator team asked for a `RED` ticket on #6768; if so, note it on DOC-6865.
- [ ] Decide separately whether the 22 hand-authored YAML blocks in `security/access-control/` should switch to these embeds. Out of scope here; they're pedagogically sequenced for their procedures and may be better hand-maintained.

### On unpark, then

Run `/unpark 3724`. It re-fetches each pinned source, diffs against the snapshots above, reports what changed versus what was predicted, reconciles the docs, and then takes this PR through the normal `/reflect` → `/finalize` pipeline. `/finalize` is **deferred** until then — the episodic notes must survive until the source settles. The `do not merge yet` guard holds until `/finalize` completes.
<!-- /park-manifest -->

