### PR TITLE
DOC-6886: Add version release model section and align OSS version tab…

### DIFF
--- a/content/operate/oss_and_stack/install/version-mgmt.md
+++ b/content/operate/oss_and_stack/install/version-mgmt.md
@@ -21,19 +21,26 @@ Redis uses a **MAJOR.MINOR.PATCH** versioning scheme:
 - **Minor versions**: New features and improvements within a major version (for example, 8.2 → 8.4 → 8.6 → 8.8).
 - **Patch versions**: Bug fixes and security updates (for example, 8.6.1 → 8.6.2).
 
+## Version release model
+
+Redis uses two release types within a major version:
+
+- **Standard releases** are the first release in a major version series (for example, 8.0) and intermediate minor releases (for example, 8.4, 8.6). These releases receive security updates and critical bug fixes for 6 months after the following minor version is released.
+- **Extended releases** are the second minor release in a major version series (for example, 8.2) and the final minor release in a series. These releases receive security updates and critical bug fixes for 5 years after their release date.
+
 ## Supported versions
 
 {{< note >}}
 **We strongly recommend using the latest available version** to benefit from the newest features, performance improvements, and security updates.
 {{< /note >}}
 
-| Version | Status | EOL Date |
-|---------|--------|----------|
-| **Redis 8.8** | GA | TBD |
-| **Redis 8.6** | GA | TBD |
-| **Redis 8.4** | GA | TBD |
-| **Redis 8.2** | GA | September 1, 2030 |
-| **Redis 8.0** | GA | December 1, 2026 |
-| **Redis 7.4** | GA | December 1, 2029 |
-| **Redis 7.2** | GA | December 1, 2029 |
-| **Redis 6.2** | GA | April 1, 2027 |
+| Version | Release type | Status | EOL Date |
+|---------|--------------|--------|----------|
+| **Redis 8.8** | Standard | GA | TBD |
+| **Redis 8.6** | Standard | GA | TBD |
+| **Redis 8.4** | Standard | GA | TBD |
+| **Redis 8.2** | Extended | GA | September 1, 2030 |
+| **Redis 8.0** | Standard | GA | December 1, 2026 |
+| **Redis 7.4** | Extended | GA | December 1, 2029 |
+| **Redis 7.2** | Extended | GA | December 1, 2029 |
+| **Redis 6.2** | Extended | GA | April 1, 2027 |


### PR DESCRIPTION
…le with Cloud

Adds Standard/Extended release type descriptions with maintenance period details. Adds Release type column to the supported versions table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to version-mgmt.md with no runtime or security impact.
> 
> **Overview**
> Documents **Standard** vs **Extended** Redis minor releases on the OSS **Version management** page, including how long each type receives security and critical bugfix support.
> 
> Adds a **Version release model** section (6-month post-successor support for Standard; 5-year support from release date for Extended) and a **Release type** column on the supported versions table so each listed GA version is labeled Standard or Extended, matching the Cloud version table per DOC-6886.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693463d5dca72e024554a7c805ac3f2e76992410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->