### PR TITLE
Document Supabase support for RDI

### DIFF
--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -11,4 +11,4 @@
 | AlloyDB for PostgreSQL | 14.2, 15.7 | - | 14.2, 15.7 |
 | AWS Aurora/PostgreSQL | 15 | 15 | - |
 | Neon | 14, 15, 16, 17 | - | - |
-| Snowflake (preview) | - | - | - | 
+| Snowflake (preview) | - | - | - |

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
@@ -1,5 +1,5 @@
 ---
-Title: Prepare PostgreSQL/Supabase for RDI
+Title: Prepare PostgreSQL for RDI
 aliases: /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/postgresql/
 alwaysopen: false
 categories:
@@ -7,20 +7,14 @@ categories:
 - integrate
 - rs
 - rdi
-description: Prepare PostgreSQL databases (including Supabase) to work with RDI
+description: Prepare PostgreSQL databases to work with RDI
 group: di
-linkTitle: Prepare PostgreSQL/Supabase
+linkTitle: Prepare PostgreSQL
 summary: Redis Data Integration keeps Redis in sync with the primary database in near
   real time.
 type: integration
 weight: 2
 ---
-
-{{< note >}}
-[Supabase](https://supabase.com/docs/guides/database/overview) uses PostgreSQL as
-its database engine, so the instructions below also apply to Supabase. However, RDI
-doesn't currently support cloud deployments of Supabase with AWS or GCP.
-{{< /note >}}
 
 PostgreSQL supports several
 [logical decoding plug-ins](https://wiki.postgresql.org/wiki/Logical_Decoding_Plugins)

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
@@ -1,0 +1,269 @@
+---
+Title: Prepare Supabase for RDI
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+- rdi
+description: Prepare a hosted Supabase database to work with RDI
+group: di
+linkTitle: Prepare Supabase
+summary: Configure a hosted Supabase PostgreSQL database for snapshot and change data capture with Redis Data Integration.
+type: integration
+weight: 11
+---
+
+[Supabase](https://supabase.com/docs/guides/database/overview) is a hosted
+PostgreSQL platform. RDI supports hosted Supabase projects through the public
+direct database endpoint.
+
+{{< note >}}
+RDI supports hosted Supabase projects running an
+[RDI-supported PostgreSQL version]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs" >}}).
+The integration was validated with RDI 1.19.0 and hosted Supabase PostgreSQL
+17.6. For self-hosted Supabase deployments, follow the general
+[PostgreSQL preparation guide]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql" >}}).
+{{< /note >}}
+
+Supabase differs from a typical self-managed PostgreSQL source in the following
+ways:
+
+- You can't edit `postgresql.conf` or `pg_hba.conf` directly. Supabase enables
+  logical replication and manages these settings for you.
+- You must use the direct database endpoint for logical replication.
+  [Supavisor connection pooler endpoints don't support logical replication](https://supabase.com/docs/guides/database/replication/manual-replication-faq#which-connection-string-should-be-used).
+- The direct endpoint uses IPv6 unless you enable the Supabase dedicated IPv4
+  add-on. Enable the add-on if your RDI deployment can't connect over IPv6.
+- Supabase can enforce TLS and provides a CA certificate that RDI can use to
+  validate the database certificate.
+- Supabase Row Level Security (RLS) can restrict the rows visible during the
+  initial snapshot.
+
+Supabase AWS PrivateLink connectivity is not currently supported. Supabase
+shares a Resource Configuration through AWS Resource Access Manager and
+requires a Resource-type VPC endpoint. This differs from the AWS PrivateLink
+endpoint-service connectivity supported by Redis Cloud. Use the public direct
+database endpoint instead.
+
+The following checklist summarizes the setup:
+
+```checklist {id="supabaselist"}
+- [ ] [Create or select a Supabase project](#1-create-or-select-a-supabase-project)
+- [ ] [Configure direct network access](#2-configure-direct-network-access)
+- [ ] [Create a dedicated RDI role](#3-create-a-dedicated-rdi-role)
+- [ ] [Grant access to source tables](#4-grant-access-to-source-tables)
+- [ ] [Configure TLS](#5-configure-tls)
+- [ ] [Configure RDI](#6-configure-rdi)
+- [ ] [Monitor replication slots](#7-monitor-replication-slots)
+```
+
+## 1. Create or select a Supabase project
+
+Create a project in the [Supabase dashboard](https://supabase.com/dashboard)
+or select an existing project. In the SQL editor, check its PostgreSQL version:
+
+```sql
+SELECT version();
+```
+
+The integration was validated with hosted Supabase PostgreSQL 17.6. Other
+supported Supabase PostgreSQL versions use the same PostgreSQL connection and
+logical replication mechanism.
+
+## 2. Configure direct network access
+
+In the Supabase dashboard, select **Connect** and copy the **Direct
+connection** hostname. It has the following form:
+
+```text
+db.<project-ref>.supabase.co
+```
+
+Use this hostname and port `5432` for RDI. Don't use a Supavisor transaction or
+session pooler connection string.
+
+Supabase direct connections use IPv6 by default. If your RDI deployment
+doesn't have IPv6 egress, enable the
+[dedicated IPv4 add-on](https://supabase.com/docs/guides/platform/ipv4-address).
+The add-on requires a paid Supabase plan.
+
+If you enable
+[Supabase Network Restrictions](https://supabase.com/docs/guides/platform/network-restrictions),
+add every RDI connector egress address to the allowlist:
+
+- For Redis Cloud, copy all **Redis Cloud outbound IP addresses** displayed
+  when you select **Public endpoint** during pipeline setup.
+- For a self-managed RDI installation, add the public egress address of the
+  RDI host or cluster.
+
+Use `/32` CIDRs for individual IPv4 addresses. If you recreate a Redis Cloud
+RDI workspace, check its outbound addresses and update the Supabase allowlist
+before starting the new pipeline.
+
+## 3. Create a dedicated RDI role
+
+In the Supabase SQL editor, create a dedicated login for RDI. Replace the
+example name and password with your own values:
+
+```sql
+CREATE ROLE rdi_replication
+  WITH LOGIN REPLICATION PASSWORD '<strong-password>';
+```
+
+Don't use the Supabase `postgres` administrator account for the RDI
+connection.
+
+## 4. Grant access to source tables
+
+The RDI role needs to connect to the database and read every table included in
+the initial snapshot. For example:
+
+```sql
+GRANT CONNECT ON DATABASE postgres TO rdi_replication;
+
+GRANT USAGE ON SCHEMA public TO rdi_replication;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO rdi_replication;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO rdi_replication;
+```
+
+Repeat the schema grants for every schema you want RDI to capture.
+
+If RLS is enabled on a source table, the initial snapshot only contains rows
+visible to the RDI role. To capture all rows, define appropriate RLS policies
+for the role or grant `BYPASSRLS`:
+
+```sql
+ALTER ROLE rdi_replication BYPASSRLS;
+```
+
+`BYPASSRLS` applies to every table in the database. Grant it only to a
+dedicated RDI role and protect that role's credentials.
+
+### Create a publication
+
+RDI uses the PostgreSQL `pgoutput` logical decoding plug-in. As a database
+administrator, create a publication containing only the tables RDI should
+capture:
+
+```sql
+CREATE PUBLICATION rdi_publication
+  FOR TABLE public.customers, public.orders;
+```
+
+Creating the publication explicitly avoids granting table ownership or broad
+publication-creation permissions to the RDI role.
+
+By default, RDI uses `pgoutput`, a publication named `dbz_publication`, and a
+replication slot named `debezium`. These defaults also work with Supabase if
+the RDI role has permission to create the publication and manage its source
+tables. The explicit publication in this guide limits the RDI role's
+permissions and the publication's table scope.
+
+## 5. Configure TLS
+
+In the Supabase dashboard, go to
+[**Database settings** > **SSL configuration**](https://supabase.com/docs/guides/platform/ssl-enforcement):
+
+1. Enable **Enforce SSL on incoming connections**.
+1. Download the Supabase CA certificate.
+
+For self-managed RDI, store the database username, password, and CA certificate
+as RDI secrets:
+
+```bash
+redis-di set-secret SOURCE_DB_USERNAME rdi_replication
+redis-di set-secret SOURCE_DB_PASSWORD '<strong-password>'
+redis-di set-secret SOURCE_DB_CACERT /path/to/prod-ca-2021.crt
+```
+
+For Redis Cloud, create an AWS Secrets Manager credentials secret containing
+the `username` and `password`, and a separate plaintext secret containing the
+CA certificate. Follow
+[Share source database credentials]({{< relref "/operate/rc/rdi/setup#share-source-database-credentials" >}})
+to encrypt and share both secrets with Redis Cloud.
+
+Redis Cloud uses TLS with CA validation for this connection. Self-managed RDI
+also verifies that the direct endpoint hostname matches the certificate.
+
+## 6. Configure RDI
+
+### Self-managed RDI
+
+Add a PostgreSQL source to `config.yaml`. Replace the project reference and
+table names with your values:
+
+```yaml
+sources:
+  supabase:
+    type: cdc
+    connection:
+      type: postgresql
+      host: db.<project-ref>.supabase.co
+      port: 5432
+      database: postgres
+      user: ${SOURCE_DB_USERNAME}
+      password: ${SOURCE_DB_PASSWORD}
+    schemas:
+      - public
+    tables:
+      public.customers: {}
+      public.orders: {}
+    advanced:
+      source:
+        plugin.name: pgoutput
+        publication.name: rdi_publication
+        publication.autocreate.mode: disabled
+        slot.name: rdi_supabase
+```
+
+Use a unique replication slot name for each active pipeline that connects to
+the project.
+
+### Redis Cloud
+
+When you create the Redis Cloud RDI pipeline:
+
+1. Select **PostgreSQL** as the source type.
+1. Select **Public endpoint**.
+1. Enter the direct endpoint hostname
+   `db.<project-ref>.supabase.co`.
+1. Enter the credentials secret ARN.
+1. Select **TLS** and enter the CA certificate secret ARN.
+1. Set the port to `5432` and the database to `postgres`.
+1. Under **Collector properties**, set:
+   - `plugin.name` to `pgoutput`
+   - `publication.name` to `rdi_publication`
+   - `publication.autocreate.mode` to `disabled`
+   - `slot.name` to a unique value such as `rdi_supabase`
+1. Select the schemas and tables to capture, validate the source, and start
+   the pipeline.
+
+## 7. Monitor replication slots
+
+RDI creates a logical replication slot that retains write-ahead log (WAL)
+records while the pipeline is stopped or disconnected. Monitor inactive slots
+and retained WAL to prevent unexpected storage growth:
+
+```sql
+SELECT
+  slot_name,
+  active,
+  restart_lsn,
+  confirmed_flush_lsn
+FROM pg_replication_slots;
+```
+
+[Supabase requires logical replication slots to be removed](https://supabase.com/docs/guides/platform/upgrading)
+before a PostgreSQL major-version upgrade. Before upgrading:
+
+1. Stop the RDI pipeline.
+1. Record the pipeline configuration and slot name.
+1. Drop the RDI replication slot.
+1. Upgrade the Supabase project.
+1. Reset and start the RDI pipeline to create a new slot and initial snapshot.
+
+Plan for the new snapshot and monitor the pipeline until pending records return
+to zero.


### PR DESCRIPTION
## What changed

- Add a dedicated guide for preparing hosted Supabase PostgreSQL as an RDI source.
- Document the supported hosted Supabase version (PostgreSQL 17).
- Cover direct-endpoint networking, IPv4 requirements, network restrictions, replication-role permissions, RLS, publications, TLS, self-managed RDI configuration, Redis Cloud setup, replication-slot monitoring, and major-version upgrades.
- Clarify that Supabase AWS PrivateLink uses an unsupported AWS RAM Resource Configuration/Resource endpoint flow.
- Remove the obsolete PostgreSQL-page note that said hosted Supabase was unsupported.

## Why

RDI 1.19.0 was qualified against hosted Supabase PostgreSQL 17.6 through both self-managed RDI and Redis Cloud RDI. Snapshot, insert/update/delete CDC, TLS, public connectivity, network restrictions, cross-account secret access, and stop/start WAL catch-up were validated. Customers need a supported setup path and clear boundaries.

## User impact

Customers can configure Supabase as a PostgreSQL source using the public direct endpoint and understand the required privileges and networking. The guide explicitly distinguishes supported public connectivity from the currently unsupported Supabase PrivateLink architecture.

## Validation

- `git diff --cached --check`
- Hugo `0.143.1` full build: passed (18,137 pages)
- Rendered the new Supabase page and verified its key sections and internal references

The build emitted two pre-existing `REF_NOT_FOUND` warnings from `content/operate/rs/8.0/flex/_index.md`; neither is related to this change.
