### PR TITLE
Document Supabase support for RDI

### DIFF
--- a/content/embeds/rdi-supported-source-versions.md
+++ b/content/embeds/rdi-supported-source-versions.md
@@ -11,4 +11,4 @@
 | AlloyDB for PostgreSQL | 14.2, 15.7 | - | 14.2, 15.7 |
 | AWS Aurora/PostgreSQL | 15 | 15 | - |
 | Neon | 14, 15, 16, 17 | - | - |
-| Snowflake (preview) | - | - | - | 
+| Snowflake (preview) | - | - | - |

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
@@ -1,5 +1,5 @@
 ---
-Title: Prepare PostgreSQL/Supabase for RDI
+Title: Prepare PostgreSQL for RDI
 aliases: /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/postgresql/
 alwaysopen: false
 categories:
@@ -7,20 +7,14 @@ categories:
 - integrate
 - rs
 - rdi
-description: Prepare PostgreSQL databases (including Supabase) to work with RDI
+description: Prepare PostgreSQL databases to work with RDI
 group: di
-linkTitle: Prepare PostgreSQL/Supabase
+linkTitle: Prepare PostgreSQL
 summary: Redis Data Integration keeps Redis in sync with the primary database in near
   real time.
 type: integration
 weight: 2
 ---
-
-{{< note >}}
-[Supabase](https://supabase.com/docs/guides/database/overview) uses PostgreSQL as
-its database engine, so the instructions below also apply to Supabase. However, RDI
-doesn't currently support cloud deployments of Supabase with AWS or GCP.
-{{< /note >}}
 
 PostgreSQL supports several
 [logical decoding plug-ins](https://wiki.postgresql.org/wiki/Logical_Decoding_Plugins)

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
@@ -62,15 +62,12 @@ The following checklist summarizes the setup:
 ## 1. Create or select a Supabase project
 
 Create a project in the [Supabase dashboard](https://supabase.com/dashboard)
-or select an existing project. In the SQL editor, check its PostgreSQL version:
+or select an existing project. You can find its PostgreSQL version in the
+Supabase dashboard or run the following query in the SQL editor:
 
 ```sql
 SELECT version();
 ```
-
-The integration was validated with hosted Supabase PostgreSQL 17.6. Other
-supported Supabase PostgreSQL versions use the same PostgreSQL connection and
-logical replication mechanism.
 
 ## 2. Configure direct network access
 

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
@@ -1,0 +1,232 @@
+---
+Title: Prepare Supabase for RDI
+alwaysopen: false
+categories:
+- docs
+- integrate
+- rs
+- rdi
+description: Prepare a hosted Supabase database to work with RDI
+group: di
+linkTitle: Prepare Supabase
+summary: Configure a hosted Supabase PostgreSQL database for snapshot and change data capture with Redis Data Integration.
+type: integration
+weight: 11
+---
+
+[Supabase](https://supabase.com/docs/guides/database/overview) is a hosted
+PostgreSQL platform. RDI supports hosted Supabase projects through the public
+direct database endpoint.
+
+{{< note >}}
+RDI supports hosted Supabase projects running an
+[RDI-supported PostgreSQL version]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs" >}}).
+The integration was validated with RDI 1.19.0 and hosted Supabase PostgreSQL
+17.6. For self-hosted Supabase deployments, follow the general
+[PostgreSQL preparation guide]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql" >}}).
+{{< /note >}}
+
+{{< note >}}
+This page describes Supabase setup for a self-managed RDI deployment. For the
+managed service, see
+[Use Supabase with RDI on Redis Cloud]({{< relref "/operate/rc/rdi/supabase" >}}).
+{{< /note >}}
+
+Supabase differs from a typical self-managed PostgreSQL source in the following
+ways:
+
+- You can't edit `postgresql.conf` or `pg_hba.conf` directly. Supabase enables
+  logical replication and manages these settings for you.
+- You must use the direct database endpoint for logical replication.
+  [Supavisor connection pooler endpoints don't support logical replication](https://supabase.com/docs/guides/database/replication/manual-replication-faq#which-connection-string-should-be-used).
+- The direct endpoint uses IPv6 unless you enable the Supabase dedicated IPv4
+  add-on. Enable the add-on if your RDI deployment can't connect over IPv6.
+- Supabase can enforce TLS and provides a CA certificate that RDI can use to
+  validate the database certificate.
+- Supabase Row Level Security (RLS) can restrict the rows visible during the
+  initial snapshot.
+
+The following checklist summarizes the setup:
+
+```checklist {id="supabaselist"}
+- [ ] [Create or select a Supabase project](#1-create-or-select-a-supabase-project)
+- [ ] [Configure direct network access](#2-configure-direct-network-access)
+- [ ] [Create a dedicated RDI role](#3-create-a-dedicated-rdi-role)
+- [ ] [Grant access to source tables](#4-grant-access-to-source-tables)
+- [ ] [Configure TLS](#5-configure-tls)
+- [ ] [Configure RDI](#6-configure-rdi)
+- [ ] [Monitor replication slots](#7-monitor-replication-slots)
+```
+
+## 1. Create or select a Supabase project
+
+Create a project in the [Supabase dashboard](https://supabase.com/dashboard)
+or select an existing project. In the SQL editor, check its PostgreSQL version:
+
+```sql
+SELECT version();
+```
+
+The integration was validated with hosted Supabase PostgreSQL 17.6. Other
+supported Supabase PostgreSQL versions use the same PostgreSQL connection and
+logical replication mechanism.
+
+## 2. Configure direct network access
+
+In the Supabase dashboard, select **Connect** and copy the **Direct
+connection** hostname. It has the following form:
+
+```text
+db.<project-ref>.supabase.co
+```
+
+Use this hostname and port `5432` for RDI. Don't use a Supavisor transaction or
+session pooler connection string.
+
+Supabase direct connections use IPv6 by default. If your RDI deployment
+doesn't have IPv6 egress, enable the
+[dedicated IPv4 add-on](https://supabase.com/docs/guides/platform/ipv4-address).
+The add-on requires a paid Supabase plan.
+
+If you enable
+[Supabase Network Restrictions](https://supabase.com/docs/guides/platform/network-restrictions),
+add the public egress address of the RDI host or cluster to the allowlist. Use
+a `/32` CIDR for an individual IPv4 address.
+
+## 3. Create a dedicated RDI role
+
+In the Supabase SQL editor, create a dedicated login for RDI. Replace the
+example name and password with your own values:
+
+```sql
+CREATE ROLE rdi_replication
+  WITH LOGIN REPLICATION PASSWORD '<strong-password>';
+```
+
+Don't use the Supabase `postgres` administrator account for the RDI
+connection.
+
+## 4. Grant access to source tables
+
+The RDI role needs to connect to the database and read every table included in
+the initial snapshot. For example:
+
+```sql
+GRANT CONNECT ON DATABASE postgres TO rdi_replication;
+
+GRANT USAGE ON SCHEMA public TO rdi_replication;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO rdi_replication;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO rdi_replication;
+```
+
+Repeat the schema grants for every schema you want RDI to capture.
+
+If RLS is enabled on a source table, the initial snapshot only contains rows
+visible to the RDI role. To capture all rows, define appropriate RLS policies
+for the role or grant `BYPASSRLS`:
+
+```sql
+ALTER ROLE rdi_replication BYPASSRLS;
+```
+
+`BYPASSRLS` applies to every table in the database. Grant it only to a
+dedicated RDI role and protect that role's credentials.
+
+### Create a publication
+
+RDI uses the PostgreSQL `pgoutput` logical decoding plug-in. As a database
+administrator, create a publication containing only the tables RDI should
+capture:
+
+```sql
+CREATE PUBLICATION rdi_publication
+  FOR TABLE public.customers, public.orders;
+```
+
+Creating the publication explicitly avoids granting table ownership or broad
+publication-creation permissions to the RDI role.
+
+By default, RDI uses `pgoutput`, a publication named `dbz_publication`, and a
+replication slot named `debezium`. These defaults also work with Supabase if
+the RDI role has permission to create the publication and manage its source
+tables. The explicit publication in this guide limits the RDI role's
+permissions and the publication's table scope.
+
+## 5. Configure TLS
+
+In the Supabase dashboard, go to
+[**Database settings** > **SSL configuration**](https://supabase.com/docs/guides/platform/ssl-enforcement):
+
+1. Enable **Enforce SSL on incoming connections**.
+1. Download the Supabase CA certificate.
+
+Store the database username, password, and CA certificate as RDI secrets:
+
+```bash
+redis-di set-secret SOURCE_DB_USERNAME rdi_replication
+redis-di set-secret SOURCE_DB_PASSWORD '<strong-password>'
+redis-di set-secret SOURCE_DB_CACERT /path/to/prod-ca-2021.crt
+```
+
+RDI verifies that the direct endpoint hostname matches the certificate.
+
+## 6. Configure RDI
+
+Add a PostgreSQL source to `config.yaml`. Replace the project reference and
+table names with your values:
+
+```yaml
+sources:
+  supabase:
+    type: cdc
+    connection:
+      type: postgresql
+      host: db.<project-ref>.supabase.co
+      port: 5432
+      database: postgres
+      user: ${SOURCE_DB_USERNAME}
+      password: ${SOURCE_DB_PASSWORD}
+    schemas:
+      - public
+    tables:
+      public.customers: {}
+      public.orders: {}
+    advanced:
+      source:
+        plugin.name: pgoutput
+        publication.name: rdi_publication
+        publication.autocreate.mode: disabled
+        slot.name: rdi_supabase
+```
+
+Use a unique replication slot name for each active pipeline that connects to
+the project.
+
+## 7. Monitor replication slots
+
+RDI creates a logical replication slot that retains write-ahead log (WAL)
+records while the pipeline is stopped or disconnected. Monitor inactive slots
+and retained WAL to prevent unexpected storage growth:
+
+```sql
+SELECT
+  slot_name,
+  active,
+  restart_lsn,
+  confirmed_flush_lsn
+FROM pg_replication_slots;
+```
+
+[Supabase requires logical replication slots to be removed](https://supabase.com/docs/guides/platform/upgrading)
+before a PostgreSQL major-version upgrade. Before upgrading:
+
+1. Stop the RDI pipeline.
+1. Record the pipeline configuration and slot name.
+1. Drop the RDI replication slot.
+1. Upgrade the Supabase project.
+1. Reset and start the RDI pipeline to create a new slot and initial snapshot.
+
+Plan for the new snapshot and monitor the pipeline until pending records return
+to zero.

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
@@ -15,8 +15,8 @@ weight: 11
 ---
 
 [Supabase](https://supabase.com/docs/guides/database/overview) is a hosted
-PostgreSQL platform. Software RDI can connect to a hosted Supabase project
-through any direct PostgreSQL endpoint that is reachable from the RDI
+PostgreSQL platform. RDI can connect to a hosted Supabase project
+through any direct PostgreSQL endpoint as long as it is reachable from the RDI
 deployment and supports logical replication.
 
 {{< note >}}
@@ -25,9 +25,6 @@ RDI supports hosted Supabase projects running an
 The integration was validated with RDI 1.19.0 and hosted Supabase PostgreSQL
 17.6. For self-hosted Supabase deployments, follow the general
 [PostgreSQL preparation guide]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql" >}}).
-{{< /note >}}
-
-{{< note >}}
 This page describes Supabase setup for a self-managed RDI deployment. For the
 managed service, see
 [Use Supabase with RDI on Redis Cloud]({{< relref "/operate/rc/rdi/supabase" >}}).
@@ -38,7 +35,7 @@ ways:
 
 - You can't edit `postgresql.conf` or `pg_hba.conf` directly. Supabase enables
   logical replication and manages these settings for you.
-- You must use the direct database endpoint for logical replication.
+- You must use the direct database endpoint for logical replication because
   [Supavisor connection pooler endpoints don't support logical replication](https://supabase.com/docs/guides/database/replication/manual-replication-faq#which-connection-string-should-be-used).
 - The direct endpoint uses IPv6 unless you enable the Supabase dedicated IPv4
   add-on. Enable the add-on if your RDI deployment can't connect over IPv6.
@@ -78,8 +75,9 @@ the **Direct connection** hostname. It has the following form:
 db.<project-ref>.supabase.co
 ```
 
-Use port `5432`. You can instead use a private hostname or address if you have
-configured private connectivity between the RDI deployment and Supabase.
+You should generally use port `5432`, but you can use a private hostname or
+address instead if you have configured private connectivity between the RDI
+deployment and Supabase.
 Don't use a Supavisor transaction or session pooler connection string because
 these endpoints don't support logical replication.
 
@@ -104,8 +102,11 @@ CREATE ROLE rdi_replication
   WITH LOGIN REPLICATION PASSWORD '<strong-password>';
 ```
 
-Don't use the Supabase `postgres` administrator account for the RDI
-connection.
+{{< warning >}}
+Don't use the Supabase `postgres` administrator account for the RDI connection.
+The RDI role's credentials provide continuous access to captured data, so grant
+the role only the permissions it needs.
+{{< /warning >}}
 
 ## 4. Grant access to source tables
 
@@ -137,9 +138,13 @@ dedicated RDI role and protect that role's credentials.
 
 ### Create a publication
 
-RDI uses the PostgreSQL `pgoutput` logical decoding plug-in. As a database
-administrator, create a publication containing only the tables RDI should
-capture:
+By default, RDI uses the PostgreSQL `pgoutput` logical decoding plug-in, a
+publication named `dbz_publication`, and a replication slot named `debezium`.
+These defaults work with Supabase if the RDI role has permission to create the
+publication and manage its source tables.
+
+It is recommended that a database administrator create a publication
+containing only the tables RDI should capture:
 
 ```sql
 CREATE PUBLICATION rdi_publication
@@ -147,13 +152,8 @@ CREATE PUBLICATION rdi_publication
 ```
 
 Creating the publication explicitly avoids granting table ownership or broad
-publication-creation permissions to the RDI role.
-
-By default, RDI uses `pgoutput`, a publication named `dbz_publication`, and a
-replication slot named `debezium`. These defaults also work with Supabase if
-the RDI role has permission to create the publication and manage its source
-tables. The explicit publication in this guide limits the RDI role's
-permissions and the publication's table scope.
+publication-creation permissions to the RDI role and limits the publication's
+table scope.
 
 ## 5. Configure TLS
 
@@ -208,8 +208,9 @@ the project.
 ## 7. Monitor replication slots
 
 RDI creates a logical replication slot that retains write-ahead log (WAL)
-records while the pipeline is stopped or disconnected. Monitor inactive slots
-and retained WAL to prevent unexpected storage growth:
+records while the pipeline is stopped or disconnected. Use a query like the
+following to monitor inactive slots and retained WAL to prevent unexpected
+storage growth:
 
 ```sql
 SELECT
@@ -229,5 +230,5 @@ before a PostgreSQL major-version upgrade. Before upgrading:
 1. Upgrade the Supabase project.
 1. Reset and start the RDI pipeline to create a new slot and initial snapshot.
 
-Plan for the new snapshot and monitor the pipeline until pending records return
-to zero.
+Allow time for the new initial snapshot to complete, and monitor the pipeline
+until pending records return to zero.

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase.md
@@ -15,8 +15,9 @@ weight: 11
 ---
 
 [Supabase](https://supabase.com/docs/guides/database/overview) is a hosted
-PostgreSQL platform. RDI supports hosted Supabase projects through the public
-direct database endpoint.
+PostgreSQL platform. Software RDI can connect to a hosted Supabase project
+through any direct PostgreSQL endpoint that is reachable from the RDI
+deployment and supports logical replication.
 
 {{< note >}}
 RDI supports hosted Supabase projects running an
@@ -73,25 +74,28 @@ logical replication mechanism.
 
 ## 2. Configure direct network access
 
-In the Supabase dashboard, select **Connect** and copy the **Direct
-connection** hostname. It has the following form:
+For a public connection, select **Connect** in the Supabase dashboard and copy
+the **Direct connection** hostname. It has the following form:
 
 ```text
 db.<project-ref>.supabase.co
 ```
 
-Use this hostname and port `5432` for RDI. Don't use a Supavisor transaction or
-session pooler connection string.
+Use port `5432`. You can instead use a private hostname or address if you have
+configured private connectivity between the RDI deployment and Supabase.
+Don't use a Supavisor transaction or session pooler connection string because
+these endpoints don't support logical replication.
 
 Supabase direct connections use IPv6 by default. If your RDI deployment
 doesn't have IPv6 egress, enable the
 [dedicated IPv4 add-on](https://supabase.com/docs/guides/platform/ipv4-address).
 The add-on requires a paid Supabase plan.
 
-If you enable
+If you use the public endpoint and enable
 [Supabase Network Restrictions](https://supabase.com/docs/guides/platform/network-restrictions),
 add the public egress address of the RDI host or cluster to the allowlist. Use
-a `/32` CIDR for an individual IPv4 address.
+a `/32` CIDR for an individual IPv4 address. For private connectivity, make
+sure the RDI host or cluster can resolve and route to the private endpoint.
 
 ## 3. Create a dedicated RDI role
 

--- a/content/operate/rc/rdi/_index.md
+++ b/content/operate/rc/rdi/_index.md
@@ -116,6 +116,7 @@ Before you can create a data pipeline, you must have:
 | MariaDB | 10.5, 11.4.3 | 10.4 to 10.11, 11.4.3 |
 | MySQL | 5.7, 8.0.x, 8.2 | 8.0.x |
 | PostgreSQL | 10, 11, 12, 13, 14, 15, 16 | 11, 12, 13, 14, 15, 16 |
+| Supabase (uses PostgreSQL) | 10, 11, 12, 13, 14, 15, 16, 17 | - |
 | AWS Aurora PostgreSQL | 15 | 15 |
 | SQL Server | 2017, 2019, 2022 | 2016, 2017, 2019, 2022 |
 | MongoDB | 6.0, 7.0, 8.0 | - |

--- a/content/operate/rc/rdi/setup.md
+++ b/content/operate/rc/rdi/setup.md
@@ -20,6 +20,7 @@ Before using the pipeline, you must first prepare your source database to use th
 See [Prepare source databases]({{<relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/">}}) to find steps for your database type:
 - [MongoDB Atlas]({{<relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/mongodb">}})
 - [Snowflake]({{<relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/snowflake">}})
+- [Supabase]({{<relref "/operate/rc/rdi/supabase">}})
 - Hosted on an AWS EC2 instance:
     - [MySQL and mariaDB]({{<relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/my-sql-mariadb">}})
     - [Oracle]({{<relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/oracle">}})

--- a/content/operate/rc/rdi/supabase.md
+++ b/content/operate/rc/rdi/supabase.md
@@ -40,7 +40,7 @@ You need:
 - An AWS Secrets Manager credentials secret and CA certificate secret shared
   with Redis Cloud.
 
-Follow [Prepare Supabase for RDI]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase" >}})
+Follow the steps in [Prepare Supabase for RDI]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase" >}})
 to create the database role, grant table access, account for Row Level
 Security, and create a publication.
 
@@ -49,10 +49,10 @@ Security, and create a publication.
 Supabase logical replication requires the direct database endpoint. Don't use
 a Supavisor transaction or session pooler endpoint.
 
-The direct endpoint uses IPv6 by default. RDI on Redis Cloud requires an IPv4
-endpoint, so enable the Supabase
-[dedicated IPv4 add-on](https://supabase.com/docs/guides/platform/ipv4-address).
-The add-on requires a paid Supabase plan.
+The direct endpoint uses IPv6 by default, but RDI on Redis Cloud requires an
+IPv4 endpoint, so you must enable the Supabase
+[dedicated IPv4 add-on](https://supabase.com/docs/guides/platform/ipv4-address)
+(you need a paid Supabase plan to do this).
 
 When you create the RDI pipeline:
 
@@ -68,7 +68,7 @@ the old addresses after the new connection succeeds.
 
 ## Configure secrets
 
-Follow [Share source database credentials]({{< relref "/operate/rc/rdi/setup#share-source-database-credentials" >}})
+Follow the steps in [Share source database credentials]({{< relref "/operate/rc/rdi/setup#share-source-database-credentials" >}})
 to create and share:
 
 - A credentials secret containing the dedicated Supabase `username` and
@@ -90,7 +90,8 @@ RDI on Redis Cloud uses TLS and validates the Supabase CA certificate.
 
 ## Configure the source
 
-Enter the following values:
+In the RDI pipeline setup flow, open the source configuration and enter the
+following values:
 
 | Field | Value |
 |:--|:--|
@@ -122,7 +123,7 @@ After deployment:
 1. Insert, update, and delete test records in Supabase.
 1. Confirm the corresponding counters increase in the pipeline metrics.
 
-Supabase logical replication slots retain write-ahead log (WAL) while a
-pipeline is stopped. Follow
+Supabase logical replication slots retain write-ahead log (WAL) while the
+pipeline is stopped. Follow the steps in
 [Monitor replication slots]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase#7-monitor-replication-slots" >}})
 to monitor retained WAL and prepare for Supabase PostgreSQL upgrades.

--- a/content/operate/rc/rdi/supabase.md
+++ b/content/operate/rc/rdi/supabase.md
@@ -1,0 +1,128 @@
+---
+Title: Use Supabase with RDI
+linkTitle: Supabase
+alwaysopen: false
+categories:
+- docs
+- operate
+- rc
+description: Connect a hosted Supabase database to RDI on Redis Cloud.
+hideListLinks: true
+weight: 7
+---
+
+You can use a hosted [Supabase](https://supabase.com/) PostgreSQL database as
+the source for an RDI pipeline on Redis Cloud. This page describes the
+Redis Cloud-specific networking, secrets, and source configuration.
+
+The integration was validated with RDI 1.19.0 and hosted Supabase PostgreSQL
+17.6. See [RDI on Redis Cloud prerequisites]({{< relref "/operate/rc/rdi#prerequisites" >}})
+for supported source versions.
+
+{{< warning >}}
+Supabase AWS PrivateLink connectivity isn't supported. Supabase shares a
+Resource Configuration through AWS Resource Access Manager and requires a
+Resource-type VPC endpoint. This differs from the AWS PrivateLink
+endpoint-service connectivity supported by RDI on Redis Cloud.
+
+Use the Supabase public direct database endpoint.
+{{< /warning >}}
+
+## Before you begin
+
+You need:
+
+- A Redis Cloud RDI workspace and target database.
+- A hosted Supabase project.
+- A dedicated Supabase role with PostgreSQL replication and table-read
+  permissions.
+- The Supabase CA certificate.
+- An AWS Secrets Manager credentials secret and CA certificate secret shared
+  with Redis Cloud.
+
+Follow [Prepare Supabase for RDI]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase" >}})
+to create the database role, grant table access, account for Row Level
+Security, and create a publication.
+
+## Configure public connectivity
+
+Supabase logical replication requires the direct database endpoint. Don't use
+a Supavisor transaction or session pooler endpoint.
+
+The direct endpoint uses IPv6 by default. RDI on Redis Cloud requires an IPv4
+endpoint, so enable the Supabase
+[dedicated IPv4 add-on](https://supabase.com/docs/guides/platform/ipv4-address).
+The add-on requires a paid Supabase plan.
+
+When you create the RDI pipeline:
+
+1. Select **PostgreSQL** as the source type.
+1. Select **Public endpoint**.
+1. Copy every **Redis Cloud outbound IP address** displayed by the setup flow.
+1. In Supabase, open **Database settings** > **Network restrictions**.
+1. Add every Redis Cloud outbound address as a `/32` CIDR.
+
+If you recreate the RDI workspace, its outbound addresses can change. Add the
+new addresses to Supabase before starting the replacement pipeline, and remove
+the old addresses after the new connection succeeds.
+
+## Configure secrets
+
+Follow [Share source database credentials]({{< relref "/operate/rc/rdi/setup#share-source-database-credentials" >}})
+to create and share:
+
+- A credentials secret containing the dedicated Supabase `username` and
+  `password`.
+- A plaintext CA certificate secret containing the certificate downloaded
+  from Supabase **Database settings** > **SSL configuration**.
+
+Encrypt both secrets with the customer-managed AWS KMS key configured for the
+RDI workspace. Use the AWS region that contains your Redis Cloud subscription.
+
+In the pipeline's **Secrets** section:
+
+1. Enter the credentials secret ARN.
+1. Select **TLS** under **Transit security**.
+1. Enter the CA certificate secret ARN.
+1. Select **Validate**.
+
+RDI on Redis Cloud uses TLS and validates the Supabase CA certificate.
+
+## Configure the source
+
+Enter the following values:
+
+| Field | Value |
+|:--|:--|
+| Source IP address / Hostname | `db.<project-ref>.supabase.co` |
+| Port | `5432` |
+| Database | `postgres` |
+
+Under **Collector properties**, set:
+
+| Property | Value |
+|:--|:--|
+| `plugin.name` | `pgoutput` |
+| `publication.name` | `rdi_publication` |
+| `publication.autocreate.mode` | `disabled` |
+| `slot.name` | A unique value, such as `rdi_supabase` |
+
+The publication name must match the publication you created in Supabase. Use a
+unique replication slot name for each active pipeline connected to the
+project.
+
+Select **Test source**. After the test succeeds, select the schemas and tables
+to capture and deploy the pipeline.
+
+## Monitor the pipeline
+
+After deployment:
+
+1. Confirm the initial snapshot reaches zero pending and rejected records.
+1. Insert, update, and delete test records in Supabase.
+1. Confirm the corresponding counters increase in the pipeline metrics.
+
+Supabase logical replication slots retain write-ahead log (WAL) while a
+pipeline is stopped. Follow
+[Monitor replication slots]({{< relref "/integrate/redis-data-integration/data-pipelines/prepare-dbs/supabase#7-monitor-replication-slots" >}})
+to monitor retained WAL and prepare for Supabase PostgreSQL upgrades.


### PR DESCRIPTION
## What changed

- Add a Software RDI guide for preparing hosted Supabase PostgreSQL, including roles, table permissions, RLS, publications, TLS secrets, `config.yaml`, slot monitoring, and upgrades.
- Add a separate RDI on Redis Cloud guide for public connectivity, workspace outbound IPs, AWS secret ARNs, Cloud source fields, and the Supabase PrivateLink limitation.
- Preserve the established supported Supabase PostgreSQL version matrix and identify PostgreSQL 17.6 as the qualification version.
- Link Supabase from the Redis Cloud source preparation and prerequisites pages.
- Remove the obsolete PostgreSQL-page note that said hosted Supabase was unsupported.

## Product scope

- `content/integrate/redis-data-integration/.../supabase.md` covers self-managed Software RDI.
- `content/operate/rc/rdi/supabase.md` covers the managed RDI service on Redis Cloud.
- The pages cross-link for database preparation, but don't mix product-specific commands or UI instructions.

## Why

RDI 1.19.0 was qualified against hosted Supabase PostgreSQL 17.6 through both self-managed RDI and RDI on Redis Cloud. Snapshot, insert/update/delete CDC, TLS, public connectivity, network restrictions, cross-account secret access, and stop/start WAL catch-up were validated. Customers need supported setup paths with clear product and PrivateLink boundaries.

## User impact

Software RDI users receive deployable SQL, secrets, and YAML guidance. Redis Cloud users receive the separate managed-service workflow using the public direct endpoint, workspace outbound addresses, and AWS Secrets Manager.

## Validation

- `git diff --check`
- Hugo `0.143.1` full build: passed (18,140 pages)
- Rendered and checked both Supabase pages
- Confirmed Cloud-only terms are absent from the Software RDI page apart from the intentional cross-link
- Confirmed Software-only commands are absent from the Redis Cloud page

The build emitted two pre-existing `REF_NOT_FOUND` warnings from `content/operate/rs/8.0/flex/_index.md`; neither is related to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security logic; risk is limited to possible doc inaccuracies or broken cross-links.
> 
> **Overview**
> Documents **hosted Supabase PostgreSQL** as a supported RDI source (qualified with RDI 1.19.0 / PostgreSQL 17.6), split across self-managed Software RDI and Redis Cloud.
> 
> Adds **`prepare-dbs/supabase.md`** for Software RDI: direct endpoint vs Supavisor, IPv4 add-on, dedicated replication role, grants/RLS/publications, TLS secrets, sample `config.yaml`, and replication-slot monitoring for upgrades. Adds **`operate/rc/rdi/supabase.md`** for Redis Cloud: public direct endpoint only (PrivateLink not supported), outbound IP allowlisting, AWS Secrets Manager TLS setup, and collector properties.
> 
> The **PostgreSQL** prep page is narrowed to generic PostgreSQL (titles/descriptions and the old “hosted Supabase unsupported” note removed). **Redis Cloud** prerequisites and setup link to Supabase; the supported-versions embed gets a minor Snowflake table formatting fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a931c659a7efaf84233bbe8d41ff3793a0fb680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->