### PR TITLE
Allow slashes in branch name

### DIFF
--- a/.github/workflows/autocomment_staging_links.yaml
+++ b/.github/workflows/autocomment_staging_links.yaml
@@ -51,8 +51,8 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             $FILES_URL \
-              | jq -r --arg prefix $BRANCH_NAME/ '.[] | select(((.filename | test("content/(?!.*embed).*\\.md")) and .status != "removed")) | ($prefix + .filename)' \
-              | sed -E -e 's|(^[^/]+/)([^/]+/)|\1|' -e 's|^|https://redis.io/docs/staging/|' -e 's|(\/_?index)?\.md|\/|' \
+              | jq -r --arg prefix "$BRANCH_NAME/" '.[] | select(((.filename | test("content/(?!.*embed).*\\.md")) and .status != "removed")) | ($prefix + (.filename | sub("^content/"; "")))' \
+              | sed -E -e 's|^|https://redis.io/docs/staging/|' -e 's|(\/_?index)?\.md|\/|' \
               | sort \
               | uniq)
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
       env:
         BRANCH_NAME: ${{ github.ref_name }}
       run: |
-        if [[ "$BRANCH_NAME" =~ ^[a-zA-Z0-9_.-]+$ ]]; then
+        if [[ "$BRANCH_NAME" =~ ^[a-zA-Z0-9_./-]+$ ]]; then
           echo "The branch name $BRANCH_NAME is valid."
         else
           echo "ERROR: Invalid branch name $BRANCH_NAME!"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small GitHub Actions workflow-only changes with no auth, data, or application runtime impact.
> 
> **Overview**
> **Docs CI** now accepts branch names that include `/` by extending the `build_docs` branch-name regex in `main.yml`.
> 
> The **PR staging-links autocomment** workflow is updated so those branches still get correct URLs: `jq` uses a quoted branch prefix, strips the `content/` prefix from changed markdown paths, and drops the old `sed` step that incorrectly collapsed the first path segment when the branch name contained slashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62ab16e04ba4409e8da21f0a68d6b133d6140e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->