### PR TITLE
DOC-6918 Fix "openTryItCli is not defined" on redis-cli shortcode pages

### DIFF
--- a/layouts/shortcodes/redis-cli.html
+++ b/layouts/shortcodes/redis-cli.html
@@ -34,24 +34,9 @@
   {{- printf "<div class=\"redis-cli redis-cli-static overflow-y-auto max-h-80\"><pre>%s</pre></div>" (htmlEscape (trim .Inner " \n\t\r")) | safeHTML -}}
 {{- end -}}
 {{- if $commands -}}
-<script>
-  window._tryItCommands = window._tryItCommands || {};
-  window._tryItCommands['{{ $id }}'] = {{ $commands | jsonify | safeJS }};
-  window.openTryItCli = window.openTryItCli || function(button) {
-    const codetabsId = button.getAttribute('data-codetabs-id');
-    const commands = window._tryItCommands[codetabsId];
-    if (!commands || !commands.length) return;
-    const json = JSON.stringify(commands);
-    const b64 = btoa(unescape(encodeURIComponent(json)))
-      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-    // Attribution: which docs page + snippet launched this run. snippet is the
-    // codetabs id (stable, already on the button); source is the page path.
-    // Kept out of the base64 so the backend can read them without decoding.
-    const source = button.getAttribute('data-tryit-source') || '';
-    let url = 'https://redis.io/cli?commands=' + b64 + '&autorun=true'
-      + '&snippet=' + encodeURIComponent(codetabsId);
-    if (source) url += '&source=' + encodeURIComponent(source);
-    window.open(url, '_blank', 'noopener,noreferrer');
-  };
-</script>
+{{- /* One line, no "//" comments. This shortcode is called with percent
+       delimiters, so Goldmark re-parses its output; html/template strips JS
+       comments to whitespace-only lines, which end the HTML block and turn the
+       rest of the script into a <pre><code> block. See DOC-6918. */ -}}
+<script>window._tryItCommands = window._tryItCommands || {}; window._tryItCommands['{{ $id }}'] = {{ $commands | jsonify | safeJS }}; window.openTryItCli = window.openTryItCli || function(button) { const codetabsId = button.getAttribute('data-codetabs-id'); const commands = window._tryItCommands[codetabsId]; if (!commands || !commands.length) return; const json = JSON.stringify(commands); const b64 = btoa(unescape(encodeURIComponent(json))).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, ''); const source = button.getAttribute('data-tryit-source') || ''; let url = 'https://redis.io/cli?commands=' + b64 + '&autorun=true' + '&snippet=' + encodeURIComponent(codetabsId); if (source) url += '&source=' + encodeURIComponent(source); window.open(url, '_blank', 'noopener,noreferrer'); };</script>
 {{- end -}}


### PR DESCRIPTION
The Try it button threw "openTryItCli is not defined" on every page whose example block is rendered by the redis-cli shortcode -- 164 pages, all under content/commands/ (e.g. scard, append, armset).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only shortcode output change; behavior of Try it is restored without touching auth, APIs, or data paths.
> 
> **Overview**
> Fixes **Try it** failing with `openTryItCli is not defined` on command docs that use the `redis-cli` shortcode (e.g. under `content/commands/`).
> 
> The inline script that registers `window._tryItCommands` and defines `openTryItCli` is now emitted as **one line with no `//` comments**. With percent-delimited shortcodes, Goldmark re-parses the shortcode output; `html/template` strips JS comments into blank lines, which ends the HTML block and leaves the script body as visible `<pre><code>` instead of executable JavaScript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9700f76db3c6a8d244e6ea627cd59278cc714cbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->