### PR TITLE
Fix copy-to-clipboard button position on short code blocks

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1225,7 +1225,9 @@ a[href*="#no-click"], img[src*="#no-click"] {
 /* Copy button wrapper positioning */
 .copy-button-wrapper {
   position: absolute;
-  top: 24px;
+  /* Keep the inset smaller than the button height (32px) so the button stays
+     inside the top-right corner of single-line code blocks (~56px tall). */
+  top: 10px;
   right: 10px;
   z-index: 1;
   display: flex;


### PR DESCRIPTION
The button is injected as a 32px-tall absolutely positioned element, but .copy-button-wrapper pinned it at top: 24px. A single-line code block is only 56px tall (16px padding + 24px line + 16px padding), so 24 + 32 = 56 put the button flush against the bottom edge, covering the rounded bottom-right corner. On multi-line blocks it sat level with the second line rather than in the corner.

Use top: 10px, symmetric with the existing right: 10px and consistent
with the <=768px overrides, which already used top: 8px.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS positioning tweak for documentation UI; no logic, auth, or data changes.
> 
> **Overview**
> Adjusts **`.copy-button-wrapper`** positioning so the copy-to-clipboard control sits in the top-right corner of code blocks instead of overlapping the bottom edge or aligning with the second line on taller blocks.
> 
> Changes **`top` from `24px` to `10px`**, matching the existing **`right: 10px`** inset and aligning with the mobile breakpoint rules that already use **`top: 8px`**. A short comment documents the sizing constraint (32px button vs ~56px single-line block height).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 069679261811603c38911244da129d149b7a6f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->