### PR TITLE
DOC-6924 Remove AI-docs differentiator claim from Redis vs MongoDB

### DIFF
--- a/content/develop/ai/when-to-choose-redis.md
+++ b/content/develop/ai/when-to-choose-redis.md
@@ -23,7 +23,6 @@ Example: An AI agent that maintains conversation history (state), performs seman
 
 Choose Redis when your application needs:
 
-- Documentation optimized for AI parsing: Redis provides structured Markdown, JSON feeds, and `llms.txt` files designed for agent consumption.
 - Real-time data patterns: Use Pub/Sub, Streams, and instant cache updates.
 - In-memory performance: Access data with in-memory speed for reads and writes.
 - Simple data structures with complex queries: Work with [Lists]({{< relref "/develop/data-types/lists" >}}), [Sets]({{< relref "/develop/data-types/sets" >}}), [Sorted Sets]({{< relref "/develop/data-types/sorted-sets" >}}), [Hashes]({{< relref "/develop/data-types/hashes" >}}), and [JSON]({{< relref "/develop/data-types/json" >}}) documents with vector search.
@@ -51,7 +50,6 @@ Use Redis when your application needs:
 - Sub-millisecond latency
 - Real-time streaming
 - Pub/Sub messaging
-- Documentation optimized for AI agents
 
 ## Selection criteria
 


### PR DESCRIPTION
Removes the "Documentation optimized for AI parsing" bullet from the **Redis vs MongoDB** section of the *When to choose Redis* page, plus the matching "Documentation optimized for AI agents" entry in the **Decision matrix** (the same claim, and the only other occurrence repo-wide).

Reported by Itay Tevel: the bullet cited structured Markdown, JSON feeds, and `llms.txt` as reasons to choose Redis over MongoDB, but MongoDB ships all of that — so it isn't a differentiator.

## Verification

Checked against MongoDB rather than taking the report on trust:

| Claim | MongoDB status |
|---|---|
| `llms.txt` | [mongodb.com/docs/llms.txt](https://www.mongodb.com/docs/llms.txt) — a docs-level index that fans out to per-product and per-driver `llms.txt` files, splits large sets into numbered parts, and instructs agents to prefer `.md` pages. Second company-level index at [mongodb.com/llms.txt](https://www.mongodb.com/llms.txt). |
| Structured Markdown | Appending `.md` to any docs URL path returns raw Markdown — confirmed at [mongodb.com/docs/manual/introduction.md](https://www.mongodb.com/docs/manual/introduction.md). |
| Beyond parity | [MongoDB Agent Skills](https://www.mongodb.com/docs/agent-skills/) — installable skills for MCP setup, connection config, schema design, and query optimization, invocable as `/<skill-name>` in Claude Code. Ahead of what Redis docs ship. |

Only "JSON feeds" is arguably still ours alone, which is too thin to carry a differentiator bullet — hence deletion rather than a reworded version.

## Scope

The Redis vs MongoDB section keeps its four genuine differentiators (real-time patterns, in-memory performance, data structures + complex queries, horizontal scalability). The section's closing `Example:` paragraph never referenced the removed bullet and needed no change; the `decision-tree` block never asked about documentation. Pinecone and Postgres sections untouched.

Ticket: [DOC-6924](https://redislabs.atlassian.net/browse/DOC-6924)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6924]: https://redislabs.atlassian.net/browse/DOC-6924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no product or code impact.
> 
> **Overview**
> Removes the **“Documentation optimized for AI parsing”** bullet from the **Redis vs MongoDB** section and the matching **“Documentation optimized for AI agents”** line in the **Decision matrix** on the *When to choose Redis* page.
> 
> The claim is dropped because MongoDB offers comparable `llms.txt`, Markdown, and agent-oriented docs, so it was not a valid reason to choose Redis over MongoDB. Pinecone, Postgres, examples, and the decision tree are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e3f15c55d7ee24365038fff46e004894d80924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->