### PR TITLE
Remove upgrade procedure of EoL versions

### DIFF
--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-cluster.md
@@ -230,8 +230,6 @@ To perform a rolling upgrade of the cluster, use one of the following methods:
 
 After all nodes are upgraded, the cluster is fully upgraded. Certain features introduced in the new version of Redis Software only become available after upgrading the entire cluster.
 
-After upgrading from version 6.0.x to 6.2.x, restart `cnm_exec` on each cluster node to enable more advanced state machine handling capabilities:
-
 ```sh
 supervisorctl restart cnm_exec
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Removes the **After cluster upgrade** note that told readers upgrading from **6.0.x to 6.2.x** to run `supervisorctl restart cnm_exec` on each node for advanced state machine handling—part of dropping end-of-life version upgrade procedures from the docs.
> 
> The `cnm_exec` restart snippet may still appear in `upgrade-cluster.md` without that version-specific lead-in; confirm whether the block should be removed entirely or reworded for supported paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f78390b224257702851870b1d7b4c62321e61f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->