### PR TITLE
RS/K8s: take out TODO and TBD

### DIFF
--- a/content/operate/kubernetes/7.4.6/upgrade/openshift-cli.md
+++ b/content/operate/kubernetes/7.4.6/upgrade/openshift-cli.md
@@ -28,7 +28,7 @@ Redis implements rolling updates for software upgrades in Kubernetes deployments
 
 4. When upgrading existing clusters running on RHEL7-based images, make sure to select a RHEL7-based image for the new version. See [release notes]({{< relref "/operate/kubernetes/release-notes/" >}}) for more info.
 
-5. If you want to migrate from RHEL7-based images to RHEL8-based images, you'll need to upgrade to version 7.2.4-2 with a RHEL7-based image, then you'll be able to migrate to a RHEL8-based image when upgrading to 7.2.4-**TBD**.
+5. If you want to migrate from RHEL7-based images to RHEL8-based images, you'll need to upgrade to version 7.2.4-2 with a RHEL7-based image, then you'll be able to migrate to a RHEL8-based image when upgrading to a later 7.2.4 build.
 
 ## Upgrade the operator
 

--- a/content/operate/kubernetes/8.0/networking/cluster-aware-clients.md
+++ b/content/operate/kubernetes/8.0/networking/cluster-aware-clients.md
@@ -19,7 +19,7 @@ Enabling external access for OSS Cluster API creates a separate LoadBalancer ser
 
 ## Prerequisites
 
-- RedisEnterpriseCluster (REC) running version 8.0.10-tbd or later.
+- RedisEnterpriseCluster (REC) running version 8.0.10-21 or later.
 - Proxy policy is set to `all-master-shards` or `all-nodes`.
 - Modules used by the database (if any) are bundled modules.
 - The database is not an Active-Active database.

--- a/content/operate/kubernetes/re-databases/enrich-metrics-with-tags.md
+++ b/content/operate/kubernetes/re-databases/enrich-metrics-with-tags.md
@@ -74,15 +74,6 @@ Tag key allowlist entries (`metricsTagKeysExposed`) must follow these rules:
 - Duplicate keys are rejected. The operator rejects the resource if the same key appears more than once, ignoring case.
 - A maximum of 50 keys is allowed.
 
-<!-- REVIEWER QUESTION: are these allowlist key rules correct for 8.2.0? The "lowercased" and "may contain
-     spaces, -, ., +, @, :" bullets above come from the v8.2.0-8 CRD field comment, but the metrics discussion
-     indicates the cluster tightened validation to the Prometheus label regex [a-zA-Z_][a-zA-Z0-9_]* (no
-     hyphens/spaces/dots, and lowercasing removed, so mixed case is allowed). If the regex form is right, these two
-     bullets need rewriting.
-
-     REVIEWER QUESTION: for keySizeBuckets / keyItemsBuckets, what are the valid units/suffixes (does "128M" mean
-     megabytes and "1M" mean one million items?) and must the boundaries be in ascending order? -->
-
 ## Tag a database
 
 Set tags on a Redis Enterprise database (REDB) with `spec.tags`, a set of key-value pairs:
@@ -137,16 +128,6 @@ When you upgrade to a release with this feature, `status.managedTags` starts emp
 {{< /note >}}
 
 ## View tagged metrics in Prometheus
-
-<!-- REVIEWER QUESTIONS for this section (needed before it can be written):
-
-     Endpoint: are exposed tags (and the key-distribution histogram metrics) available on the /v2 metrics endpoint
-     only, or also on the legacy v1 / port-8070 stream? The discussion points to /v2. If it's /v2-only, the
-     connect-prometheus-operator cross-link below is the v1 path and is wrong for this feature.
-
-     Label model: confirm that exposed tags appear on a single db_tags metric queried via PromQL joins, not as a
-     label on every DB metric. Please provide the exact db_tags metric name, its label set, and a canonical PromQL
-     join example. Label names must match the Prometheus regex [a-zA-Z_][a-zA-Z0-9_]*. -->
 
 For instructions on connecting Prometheus to Redis Enterprise for Kubernetes, see [Export metrics to Prometheus]({{< relref "/operate/kubernetes/re-clusters/connect-prometheus-operator" >}}).
 

--- a/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026.md
+++ b/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 8.2.0-12 (July 2026) release notes
 weight: 27
 ---
 
-Redis Enterprise for Kubernetes 8.2.0-12 is a feature release that supports [Redis Software 8.2.0]({{<relref "/operate/rs/release-notes/" >}})<!-- TODO: retarget to /operate/rs/release-notes/rs-8-2-releases/ after syncing main into this branch — RS 8.2.0 notes are on main but not yet on this branch --> and includes new features, bug fixes, and enhancements.
+Redis Enterprise for Kubernetes 8.2.0-12 is a feature release that supports [Redis Software 8.2.0]({{< relref "/operate/rs/release-notes/rs-8-2-releases/" >}}) and includes new features, bug fixes, and enhancements.
 
 ## Highlights
 

--- a/content/operate/kubernetes/release-notes/8-2-0-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-2-0-releases/_index.md
@@ -23,8 +23,6 @@ Redis Enterprise for Kubernetes is compatible with [CNCF-conformant](https://www
 
 The following table shows supported Kubernetes versions at the time of this release. For a list of platforms tested with this release, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/reference/supported_k8s_distributions" >}}).
 
-<!-- TODO (DOC-6703): add the full tested-platform list. -->
-
 | Kubernetes | **Redis <nobr>8.2.0</nobr>** |
 |---|---|
 | 1.36 | Supported |

--- a/content/operate/rs/7.22/databases/active-active/create.md
+++ b/content/operate/rs/7.22/databases/active-active/create.md
@@ -221,7 +221,6 @@ Active-Active databases support append-only file (AOF) persistence only. Snapsho
     
 To enable causal consistency for an existing Active-Active database, use the REST API.
 
-<!-- Also in getting-started-crdbs.md -->
 ## Test Active-Active database connections
 
 With the Redis database created, you are ready to connect to your database. See [Connect to Active-Active databases]({{< relref "/operate/rs/7.22/databases/active-active/connect.md" >}}) for tutorials and examples of multiple connection methods.

--- a/content/operate/rs/7.22/databases/active-active/develop/app-failover-active-active.md
+++ b/content/operate/rs/7.22/databases/active-active/develop/app-failover-active-active.md
@@ -76,10 +76,6 @@ It's best if your application doesn't read its own recent writes. Those writes c
 1. Lost forever, if the local replica has an event such as a double failure or loss of persistent files.
 1. Temporarily unavailable, but will be available at a later time if the local replica's failure is temporary.
 
-<!--- {{< note >}}
-Sample code that maps a hash slot to a key name can be found in this Python script.
-{{< /note >}} --->
-
 ## Failback decision
 
 Your application can use the same checks described above to continue monitoring the state of the failed replica after failover.

--- a/content/operate/rs/7.4/databases/active-active/develop/app-failover-active-active.md
+++ b/content/operate/rs/7.4/databases/active-active/develop/app-failover-active-active.md
@@ -76,10 +76,6 @@ It's best if your application doesn't read its own recent writes. Those writes c
 1. Lost forever, if the local replica has an event such as a double failure or loss of persistent files.
 1. Temporarily unavailable, but will be available at a later time if the local replica's failure is temporary.
 
-<!--- {{< note >}}
-Sample code that maps a hash slot to a key name can be found in this Python script.
-{{< /note >}} --->
-
 ## Failback decision
 
 Your application can use the same checks described above to continue monitoring the state of the failed replica after failover.

--- a/content/operate/rs/7.8/databases/active-active/develop/app-failover-active-active.md
+++ b/content/operate/rs/7.8/databases/active-active/develop/app-failover-active-active.md
@@ -76,10 +76,6 @@ It's best if your application doesn't read its own recent writes. Those writes c
 1. Lost forever, if the local replica has an event such as a double failure or loss of persistent files.
 1. Temporarily unavailable, but will be available at a later time if the local replica's failure is temporary.
 
-<!--- {{< note >}}
-Sample code that maps a hash slot to a key name can be found in this Python script.
-{{< /note >}} --->
-
 ## Failback decision
 
 Your application can use the same checks described above to continue monitoring the state of the failed replica after failover.

--- a/content/operate/rs/8.0/databases/active-active/develop/app-failover-active-active.md
+++ b/content/operate/rs/8.0/databases/active-active/develop/app-failover-active-active.md
@@ -82,10 +82,6 @@ It's best if your application doesn't read its own recent writes. Those writes c
 1. Lost forever, if the local replica has an event such as a double failure or loss of persistent files.
 1. Temporarily unavailable, but will be available at a later time if the local replica's failure is temporary.
 
-<!--- {{< note >}}
-Sample code that maps a hash slot to a key name can be found in this Python script.
-{{< /note >}} --->
-
 ## Failback decision
 
 Your application can use the same checks described above to continue monitoring the state of the failed replica after failover.

--- a/content/operate/rs/databases/active-active/develop/app-failover-active-active.md
+++ b/content/operate/rs/databases/active-active/develop/app-failover-active-active.md
@@ -81,10 +81,6 @@ It's best if your application doesn't read its own recent writes. Those writes c
 1. Lost forever, if the local replica has an event such as a double failure or loss of persistent files.
 1. Temporarily unavailable, but will be available at a later time if the local replica's failure is temporary.
 
-<!--- {{< note >}}
-Sample code that maps a hash slot to a key name can be found in this Python script.
-{{< /note >}} --->
-
 ## Failback decision
 
 Your application can use the same checks described above to continue monitoring the state of the failed replica after failover.

--- a/content/operate/rs/release-notes/rs-6-0-8-september-2020.md
+++ b/content/operate/rs/release-notes/rs-6-0-8-september-2020.md
@@ -75,8 +75,8 @@ With build 6.0.8-32:
 -RS81463 - A shard may crash when resharding an Active-Active database with Auto Tiering . Specifically, the shard will crash when volatile keys or Active-Active tombstone keys reside in Flash memory.
 
 ### Active-Active databases
-- RS44656 - A bug causing TLS mode for clients connections to toggle between ‘all communication’ to ‘for crdb communication only’ when performing a global configuration change. ***TBD***
-- RS51359 - Active-Active databases, using replication and Append Only File (AOF) for [Database persistence]({{< relref "/operate/rs/databases/configure/database-persistence.md" >}}), are suffering from memory leaks on replica shards, causing them to grow bigger than the master shards. Customers are advised to upgrade to RS 6.0.12 ***TBD***. Meanwhile you can use snapshots for database persistence or restart the replica shards ***TBD***.
+- RS44656 - A bug causing TLS mode for clients connections to toggle between ‘all communication’ to ‘for crdb communication only’ when performing a global configuration change.
+- RS51359 - Active-Active databases, using replication and Append Only File (AOF) for [Database persistence]({{< relref "/operate/rs/databases/configure/database-persistence.md" >}}), are suffering from memory leaks on replica shards, causing them to grow bigger than the master shards. Customers are advised to upgrade to RS 6.0.12. Meanwhile you can use snapshots for database persistence or restart the replica shards.
 
 ### Installation limitations
 

--- a/content/operate/rs/release-notes/rs-6-0-may-2020.md
+++ b/content/operate/rs/release-notes/rs-6-0-may-2020.md
@@ -113,7 +113,7 @@ To use the updated modules with a database, you must [upgrade the module on the 
 -RS81463 - A shard may crash when resharding an Active-Active database with Auto Tiering . Specifically, the shard will crash when volatile keys or Active-Active tombstone keys reside in Flash memory.
 
 ### Active-Active databases
-- RS51359 - Active-Active databases, using replication and Append Only File (AOF) for [database persistence]({{< relref "/operate/rs/databases/configure/database-persistence.md" >}}), are suffering from memory leaks on replica shards, causing them to grow bigger than the master shards. Customers are advised to upgrade to RS 6.0.12 ***TBD***. Meanwhile you can use snapshots for database persistence or restart the replica shards ***TBD***.
+- RS51359 - Active-Active databases, using replication and Append Only File (AOF) for [database persistence]({{< relref "/operate/rs/databases/configure/database-persistence.md" >}}), are suffering from memory leaks on replica shards, causing them to grow bigger than the master shards. Customers are advised to upgrade to RS 6.0.12. Meanwhile you can use snapshots for database persistence or restart the replica shards.
 
 ### Installation limitations
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -51,8 +51,6 @@ For more information, see [Audit events]({{<relref "/operate/rs/security/audit-e
 
 Redis supports deployments on RHEL 9 VMs using cryptographic libraries based on FIPS 140-3 validated modules, enabling the use of FIPS-approved cryptographic algorithms in supported environments.
 
-<!-- FIPS support for RHEL 9 containerized Redis on GKE is documented in the Redis Software for Kubernetes (Duckburg) release notes. -->
-
 - Install Redis Software on a RHEL 9 host that has FIPS mode enabled. See [Supported platforms](#supported-platforms) for the platforms validated for FIPS mode.
 
 - In FIPS mode, Redis Software uses only FIPS-approved cryptographic algorithms and cipher suites; non-approved ciphers and algorithms are blocked.
@@ -63,7 +61,7 @@ For FIPS-mode limitations, see [Increased memory usage in FIPS mode](#increased-
 
 ### Enhancements
 
-- **Disable Basic authentication for the REST API.** You can now disable Basic and Digest authentication for the cluster management REST API using the new `control_plane_basic_authentication` cluster setting. Basic authentication remains enabled by default; when you disable it, the cluster rejects Basic and Digest authentication on inbound REST API requests. Configure it with [`rladmin tune cluster`]({{<relref "/operate/rs/references/cli-utilities/rladmin/tune">}}) or an [update cluster settings]({{<relref "/operate/rs/references/rest-api/requests/cluster#put-cluster">}}) REST API request. See [Disable basic authentication for the REST API]({{<relref "/operate/rs/security/access-control/disable-basic-authentication">}}).
+- **Disable Basic authentication for the REST API.** You can now disable Basic and Digest authentication for the cluster management REST API using the new `control_plane_basic_authentication` cluster setting. Basic authentication remains enabled by default; when you disable it, the cluster rejects Basic and Digest authentication on inbound REST API requests. Configure it with [`rladmin tune cluster`]({{<relref "/operate/rs/references/cli-utilities/rladmin/tune">}}) or an [update cluster settings]({{<relref "/operate/rs/references/rest-api/requests/cluster#put-cluster">}}) REST API request. Cluster join and Active-Active (CRDB) management operations support certificate credentials when Basic and Digest authentication are disabled or unavailable. See [Disable basic authentication for the REST API]({{<relref "/operate/rs/security/access-control/disable-basic-authentication">}}).
 
 - **Expose database tags in metrics.** You can now expose selected [database tags]({{<relref "/operate/rs/databases/configure/db-tags">}}) as labels in [v2 metrics]({{<relref "/operate/rs/monitoring/metrics_stream_engine/prometheus-metrics-v2">}}) through a new `db_tags` metric, so you can group, filter, and alert on database metrics by your own tags. Enable it in the cluster's metrics configuration using the `expose_db_tags` and `metrics_tag_keys_exposed` settings.
 

--- a/content/operate/rs/security/access-control/disable-basic-authentication.md
+++ b/content/operate/rs/security/access-control/disable-basic-authentication.md
@@ -18,8 +18,6 @@ When you disable basic authentication, the cluster rejects Basic and Digest auth
 This setting applies only to the cluster management REST API. It does not change how clients authenticate to databases.
 {{</note>}}
 
-<!-- TODO(confirm — RED-201786 / Iren Friedland + Aharon): does the Cluster Manager UI still work when basic authentication is disabled, or does it also require certificate/JWT auth? Source (cluster schema @ v8.2.0-26) only states inbound REST API requests reject Basic/Digest. Confirm UI impact before GA. -->
-
 ## Before you begin
 
 {{<warning>}}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only editorial changes with no application or infrastructure code; risk is limited to possible doc accuracy if removed TODOs hid unresolved facts.
> 
> **Overview**
> Cleans up **Redis Software** and **Redis Enterprise for Kubernetes** docs by removing internal **TODO**, **TBD**, and reviewer-comment blocks, and applying a few concrete wording/link fixes.
> 
> **Substantive reader-facing updates:** OpenShift upgrade guidance now points RHEL7→RHEL8 migration at **a later 7.2.4 build** instead of a TBD build; OSS Cluster API prerequisites use **REC 8.0.10-21** instead of `8.0.10-tbd`; K8s **8.2.0-12** release notes link to the **RS 8.2.0** release-notes index; RS **8.2.0-25** notes clarify that **cluster join** and **Active-Active (CRDB)** management support **certificate credentials** when Basic/Digest REST auth is disabled. Legacy RS **6.0** known-limitation text drops `***TBD***` while keeping the **upgrade to RS 6.0.12** guidance.
> 
> **Removed without replacing:** reviewer questions on **enrich-metrics-with-tags** (allowlist/Prometheus), a **disable-basic-authentication** UI TODO, **8.2.0** supported-distributions TODO, commented failover Python-sample notes across Active-Active app-failover pages, and a stray HTML comment on Active-Active create.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a175025bdff6c51232666fc4538ea68824ae683b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->