### PR TITLE
AI: Update .agents/skills/generate-tce-examples

### DIFF
--- a/.agents/skills/generate-tce-examples/SKILL.md
+++ b/.agents/skills/generate-tce-examples/SKILL.md
@@ -346,7 +346,7 @@ Follow the conventions in `for-ais-only/tcedocs/SPECIFICATION.md` and the `*_TES
 
 Use this checklist before completing:
 
-- [ ] All 10 client examples implemented
+- [ ] All 12 client examples implemented (one per directory in `assets/`)
 - [ ] Client-specific method signatures used correctly (from API mapping)
 - [ ] TCE markers properly placed
 - [ ] Expected output comments included (`// >>> value`)
@@ -370,7 +370,7 @@ The `assets/` directory contains reference implementations for each client:
 │   └── sample_test.js
 ├── jedis/
 │   ├── JEDIS_TEST_PATTERNS.md
-│   └── src/test/java/...
+│   └── SampleTest.java
 ├── lettuce-async/
 │   └── ...
 ├── lettuce-reactive/
@@ -394,6 +394,19 @@ The `assets/` directory contains reference implementations for each client:
 ```
 
 **Always consult** the `*_TEST_PATTERNS.md` file for each language before writing code.
+
+### Using the Samples as Templates
+
+Each `sample_test.*` file opens with a ~18-line banner comment explaining the
+markers. **Do not copy that banner into a generated example.** Comment lines that
+are not inside a `HIDE` or `REMOVE` block are published verbatim, so the banner
+would appear in the rendered documentation. Every real example starts directly
+with `// EXAMPLE: <name>` on line 1 (optionally followed by `BINDER_ID` on
+line 2).
+
+The samples also demonstrate several unrelated steps in one file to show the
+range of patterns. A generated example normally covers one command page, so take
+the structure and conventions from the sample, not its step list.
 
 ## Client Language Quick Reference
 
@@ -563,15 +576,21 @@ public class CmdsHashExample
 // REMOVE_END
 {
     // REMOVE_START
-    public CmdsHashExample(RedisFixture fixture) : base(fixture) { }
+    public CmdsHashExample(EndpointsFixture fixture) : base(fixture) { }
 
     [Fact]
-    public void run()
+    // REMOVE_END
+    public void Run()
     {
-        SkipIfTargetConnectionDoesNotExist();
-        var muxer = GetConnection();
-        var db = GetCleanDatabase(muxer);
+        // REMOVE_START
+        SkipIfTargetConnectionDoesNotExist(EndpointsFixture.Env.Standalone);
+        var _ = GetCleanDatabase(EndpointsFixture.Env.Standalone);
         // REMOVE_END
+
+        // STEP_START connect
+        var muxer = ConnectionMultiplexer.Connect("localhost:6379");
+        var db = muxer.GetDatabase();
+        // STEP_END
 
         // STEP_START hmget
         db.HashSet("myhash", new HashEntry[] {
@@ -589,48 +608,51 @@ public class CmdsHashExample
 
         // HIDE_START
         muxer.Close();
-        // HIDE_END
     }
 }
+// HIDE_END
 ```
 
 ### PHP (Predis)
 
 ```php
 // EXAMPLE: cmds_hash
-<?php
 // BINDER_ID php-sample
+<?php
 
-use PHPUnit\Framework\TestCase;
+require 'vendor/autoload.php';
+
 use Predis\Client as PredisClient;
 
 class CmdHashTest
 // REMOVE_START
-extends TestCase
+extends PredisTestCase
 // REMOVE_END
 {
     public function testHmget(): void
     {
-        $redis = new PredisClient([
-            'scheme' => 'tcp',
-            'host'   => '127.0.0.1',
-            'port'   => 6379,
+        $r = new PredisClient([
+            'scheme'   => 'tcp',
+            'host'     => '127.0.0.1',
+            'port'     => 6379,
+            'password' => '',
+            'database' => 0,
         ]);
 
         // REMOVE_START
-        $redis->del('myhash');
+        $r->del('myhash');
         // REMOVE_END
 
         // STEP_START hmget
-        $redis->hset('myhash', 'field1', 'value1');
-        $redis->hset('myhash', 'field2', 'value2');
-        $result = $redis->hmget('myhash', ['field1', 'field2', 'nofield']);
+        $r->hset('myhash', 'field1', 'value1');
+        $r->hset('myhash', 'field2', 'value2');
+        $result = $r->hmget('myhash', ['field1', 'field2', 'nofield']);
         echo json_encode($result) . PHP_EOL; // >>> ["value1","value2",null]
         // STEP_END
 
         // REMOVE_START
         $this->assertEquals(['value1', 'value2', null], $result);
-        $redis->del('myhash');
+        $r->del('myhash');
         // REMOVE_END
     }
 }

--- a/.agents/skills/generate-tce-examples/assets/go-redis/GO_REDIS_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/go-redis/GO_REDIS_TEST_PATTERNS.md
@@ -18,6 +18,7 @@ These test files serve dual purposes:
 | Marker | Purpose |
 |--------|---------|
 | `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
 | `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
 | `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
 | `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |

--- a/.agents/skills/generate-tce-examples/assets/go-redis/sample_test.go
+++ b/.agents/skills/generate-tce-examples/assets/go-redis/sample_test.go
@@ -32,7 +32,7 @@ import (
 
 func ExampleClient_string_ops() {
 	ctx := context.Background()
-	
+
 	rdb := redis.NewClient(&redis.Options{
 		Addr:     "localhost:6379",
 		Password: "",
@@ -41,7 +41,6 @@ func ExampleClient_string_ops() {
 
 	// REMOVE_START
 	// start with fresh database
-	rdb.FlushDB(ctx)
 	errFlush := rdb.FlushDB(ctx).Err() // Clear the database before each test
 	if errFlush != nil {
 		panic(errFlush)
@@ -164,4 +163,45 @@ func ExampleClient_hash_tutorial() {
 	// 4
 	// Deimos
 	// 4972
+}
+
+func ExampleClient_hincrby() {
+	ctx := context.Background()
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "",
+		DB:       0,
+	})
+
+	// REMOVE_START
+	// start with fresh database
+	rdb.FlushDB(ctx)
+	rdb.Del(ctx, "bike:1:stats")
+	// REMOVE_END
+
+	// STEP_START hincrby
+	res1, err := rdb.HIncrBy(ctx, "bike:1:stats", "rides", 1).Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res1) // >>> 1
+
+	res2, err := rdb.HIncrBy(ctx, "bike:1:stats", "rides", 1).Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res2) // >>> 2
+
+	res3, err := rdb.HIncrBy(ctx, "bike:1:stats", "crashes", 1).Result()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res3) // >>> 1
+	// STEP_END
+
+	// Output:
+	// 1
+	// 2
+	// 1
 }

--- a/.agents/skills/generate-tce-examples/assets/hiredis/HIREDIS_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/hiredis/HIREDIS_TEST_PATTERNS.md
@@ -17,6 +17,7 @@ These test files serve dual purposes:
 | Marker | Purpose |
 |--------|---------|
 | `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
 | `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
 | `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
 | `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
@@ -51,7 +52,8 @@ int main(int argc, char **argv) {
     // STEP_END
 
     // REMOVE_START
-    redisCommand(c, "DEL mykey");
+    redisReply *del_reply = redisCommand(c, "DEL mykey");
+    freeReplyObject(del_reply);
     // REMOVE_END
 
     // STEP_START string_ops
@@ -181,6 +183,17 @@ cc sample_test.c $(pkg-config --cflags --libs hiredis) -o sample_test
 redisReply *reply = redisCommand(c, "GET key");
 // ... use reply ...
 freeReplyObject(reply);  // Always free!
+```
+
+This applies to cleanup commands inside REMOVE blocks too, even though their
+result is never read — bind the reply and free it rather than discarding the
+return value of `redisCommand`:
+
+```c
+// REMOVE_START
+redisReply *del_reply = redisCommand(c, "DEL mykey");
+freeReplyObject(del_reply);
+// REMOVE_END
 ```
 
 ## Installing hiredis

--- a/.agents/skills/generate-tce-examples/assets/ioredis/sample_test.js
+++ b/.agents/skills/generate-tce-examples/assets/ioredis/sample_test.js
@@ -93,7 +93,14 @@ console.log(res8); // >>> 4972
 
 const res9 = await redis.hgetall('bike:1');
 console.log(JSON.stringify(res9, null, 2));
-// >>> { model: 'Deimos', brand: 'Ergonom', type: 'Enduro bikes', price: '4972' }
+/* >>>
+{
+  "model": "Deimos",
+  "brand": "Ergonom",
+  "type": "Enduro bikes",
+  "price": "4972"
+}
+*/
 // STEP_END
 
 // REMOVE_START

--- a/.agents/skills/generate-tce-examples/assets/jedis/JEDIS_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/jedis/JEDIS_TEST_PATTERNS.md
@@ -11,7 +11,10 @@ These test files serve dual purposes:
 ## File Locations
 
 - **Original tests**: `/path/to/jedis/src/test/java/io/redis/examples/*.java`
-- **Sample template**: `src/test/java/io/redis/examples/SampleTest.java` (in this directory)
+- **Sample template**: `SampleTest.java` (in this directory)
+- **Generated examples**: must go under
+  `src/test/java/io/redis/examples/` in the examples project — Maven only
+  discovers tests there.
 
 ## Marker Reference
 
@@ -25,89 +28,121 @@ These test files serve dual purposes:
 
 ## File Structure Template
 
+The class declaration, `@Test`, the method signature and the connection setup
+are wrapped in one **HIDE** block so the published example reads as a plain
+sequence of statements. The closing `jedis.close()` and the closing braces are
+wrapped in a second HIDE block at the end.
+
 ```java
 // EXAMPLE: example_name
 // REMOVE_START
 package io.redis.examples;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 // REMOVE_END
+
+// Imports the reader needs stay visible.
+import java.util.HashMap;
+import java.util.Map;
 
 // HIDE_START
 import redis.clients.jedis.RedisClient;
-
-import java.util.HashMap;
-import java.util.Map;
 // HIDE_END
 
+// HIDE_START
 public class SampleTest {
 
-    // REMOVE_START
     @Test
-    // REMOVE_END
     public void run() {
-        // HIDE_START
         RedisClient jedis = RedisClient.create("redis://localhost:6379");
-        // HIDE_END
 
         // REMOVE_START
+        // Clean up any existing data before tests
         jedis.del("mykey");
         // REMOVE_END
+// HIDE_END
 
         // STEP_START operation_name
         String res = jedis.set("mykey", "Hello");
-        System.out.println(res); // >>> OK
+        System.out.println(res);    // >>> OK
 
         String value = jedis.get("mykey");
-        System.out.println(value); // >>> Hello
+        System.out.println(value);    // >>> Hello
         // STEP_END
-
         // REMOVE_START
         assertEquals("OK", res);
         assertEquals("Hello", value);
         jedis.del("mykey");
-        jedis.close();
         // REMOVE_END
+
+// HIDE_START
+        jedis.close();
     }
 }
+// HIDE_END
 ```
+
+Note that a REMOVE block nested inside a HIDE block is legal and is used above —
+the two markers track independent state in the build.
+
+`@Test` is stripped from the rendered output automatically, so it does not
+strictly need its own marker here; it sits inside the HIDE block along with the
+rest of the scaffolding.
 
 ## Key Patterns
 
 ### 1. Package and Imports
+
+Three tiers, and the distinction matters:
+
 ```java
+// Test-only — REMOVE, never shown to the reader
 // REMOVE_START
 package io.redis.examples;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 // REMOVE_END
 
-// HIDE_START
-import redis.clients.jedis.UnifiedJedis;
+// Needed to understand the example — left visible
 import java.util.HashMap;
 import java.util.Map;
+
+// Client import — HIDE, available behind the eye button
+// HIDE_START
+import redis.clients.jedis.RedisClient;
 // HIDE_END
 ```
 
-### 2. Connection Setup (in HIDE block)
+> **Do not leave the `import static ...Assertions.*` lines unmarked.** They are
+> test-only scaffolding; if they fall outside both a HIDE and a REMOVE block they
+> are published verbatim into the documentation, where nothing references them.
+
+### 2. Connection Setup
+
+The client is `RedisClient` (not `UnifiedJedis`), created inside the opening HIDE
+block:
+
 ```java
-// HIDE_START
 RedisClient jedis = RedisClient.create("redis://localhost:6379");
-// HIDE_END
 ```
 
 ### 3. Assertions (in REMOVE blocks)
+
 ```java
 // REMOVE_START
 assertEquals("OK", res);
 assertEquals("Hello", value);
 assertEquals(3, map.size());
 jedis.del("mykey");
-jedis.close();
 // REMOVE_END
 ```
+
+`jedis.close()` belongs in the final HIDE block, not in a REMOVE block — the
+connection must still be closed when the file is read as documentation.
 
 ### 4. Console Output Comments
 ```java
@@ -141,13 +176,14 @@ Maven requires test files to be in a specific directory structure:
 examples/jedis/
 ├── pom.xml
 ├── JEDIS_TEST_PATTERNS.md
+├── SampleTest.java             # this template (reference only)
 └── src/
     └── test/
         └── java/
             └── io/
                 └── redis/
                     └── examples/
-                        └── SampleTest.java
+                        └── CmdsHashExample.java   # generated examples go here
 ```
 
 ## Running Tests
@@ -211,5 +247,5 @@ mvn test -Dtest=SampleTest#run
 
 ## See Also
 
-- Sample template: `src/test/java/io/redis/examples/SampleTest.java` (in this directory)
+- Sample template: `SampleTest.java` (in this directory)
 - Hash commands: `/path/to/jedis/src/test/java/io/redis/examples/CmdsHashExample.java`

--- a/.agents/skills/generate-tce-examples/assets/jedis/SampleTest.java
+++ b/.agents/skills/generate-tce-examples/assets/jedis/SampleTest.java
@@ -21,17 +21,17 @@
 package io.redis.examples;
 
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 // REMOVE_END
 
+// Imports that the reader needs stay visible.
 import java.util.HashMap;
 import java.util.Map;
 
 // HIDE_START
 import redis.clients.jedis.RedisClient;
 // HIDE_END
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 // HIDE_START
 public class SampleTest {

--- a/.agents/skills/generate-tce-examples/assets/lettuce-async/LETTUCE_ASYNC_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/lettuce-async/LETTUCE_ASYNC_TEST_PATTERNS.md
@@ -11,13 +11,17 @@ These test files serve dual purposes:
 ## File Locations
 
 - **Original tests**: `/path/to/lettuce/src/test/java/io/redis/examples/async/*.java`
-- **Sample template**: `src/test/java/io/redis/examples/async/SampleTest.java` (in this directory)
+- **Sample template**: `SampleTest.java` (in this directory)
+- **Generated examples**: must go under
+  `src/test/java/io/redis/examples/async/` in the examples project — Maven only
+  discovers tests there.
 
 ## Marker Reference
 
 | Marker | Purpose |
 |--------|---------|
 | `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
 | `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
 | `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
 | `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
@@ -52,7 +56,7 @@ public class SampleTest {
             RedisAsyncCommands<String, String> asyncCommands = connection.async();
 
             // REMOVE_START
-            asyncCommands.del("mykey").get();
+            asyncCommands.del("mykey").toCompletableFuture().join();
             // REMOVE_END
 
             // STEP_START operation_name
@@ -111,7 +115,35 @@ chain.join(); // Wait for completion
 // REMOVE_START
 assertThat(result.join()).isEqualTo("Hello");
 assertThat(map).hasSize(3);
-asyncCommands.del("mykey").get();
+asyncCommands.del("mykey").toCompletableFuture().join();
+// REMOVE_END
+```
+
+Use `.toCompletableFuture().join()` rather than `RedisFuture.get()`. `get()`
+throws checked `InterruptedException`/`ExecutionException`, which will not
+compile in a `run()` method that declares no `throws` clause.
+
+Assertions inside a `thenCompose`/`thenAccept` lambda go in a REMOVE block
+around the assertion line only, leaving the surrounding chain visible:
+
+```java
+.thenCompose(res1 -> {
+    System.out.println(res1); // >>> OK
+    // REMOVE_START
+    assertThat(res1).isEqualTo("OK");
+    // REMOVE_END
+    return asyncCommands.get("mykey");
+})
+```
+
+When a whole chain stage exists purely to assert, wrap the entire stage:
+
+```java
+// REMOVE_START
+.thenApply(res -> {
+    assertThat(res.get("field1")).isEqualTo("value1");
+    return res;
+})
 // REMOVE_END
 ```
 
@@ -146,6 +178,7 @@ Maven requires test files to be in a specific directory structure:
 examples/lettuce-async/
 ├── pom.xml
 ├── LETTUCE_ASYNC_TEST_PATTERNS.md
+├── SampleTest.java                 # this template (reference only)
 └── src/
     └── test/
         └── java/
@@ -153,7 +186,7 @@ examples/lettuce-async/
                 └── redis/
                     └── examples/
                         └── async/
-                            └── SampleTest.java
+                            └── CmdsHashExample.java   # generated examples here
 ```
 
 ## Running Tests
@@ -223,5 +256,6 @@ mvn test -Dtest=SampleTest#run
 
 ## See Also
 
-- Sample template: `src/test/java/io/redis/examples/async/SampleTest.java` (in this directory)
+- Sample template: `SampleTest.java` (in this directory)
 - Hash commands: `/path/to/lettuce/src/test/java/io/redis/examples/async/HashExample.java`
+- Reactive counterpart: `../lettuce-reactive/LETTUCE_REACTIVE_TEST_PATTERNS.md`

--- a/.agents/skills/generate-tce-examples/assets/lettuce-async/SampleTest.java
+++ b/.agents/skills/generate-tce-examples/assets/lettuce-async/SampleTest.java
@@ -35,7 +35,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SampleTest {
 
+    // REMOVE_START
     @Test
+    // REMOVE_END
     public void run() {
         RedisClient redisClient = RedisClient.create("redis://localhost:6379");
 

--- a/.agents/skills/generate-tce-examples/assets/lettuce-reactive/LETTUCE_REACTIVE_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/lettuce-reactive/LETTUCE_REACTIVE_TEST_PATTERNS.md
@@ -11,13 +11,17 @@ These test files serve dual purposes:
 ## File Locations
 
 - **Original tests**: `/path/to/lettuce/src/test/java/io/redis/examples/reactive/*.java`
-- **Sample template**: `src/test/java/io/redis/examples/reactive/SampleTest.java` (in this directory)
+- **Sample template**: `SampleTest.java` (in this directory)
+- **Generated examples**: must go under
+  `src/test/java/io/redis/examples/reactive/` in the examples project — Maven
+  only discovers tests there.
 
 ## Marker Reference
 
 | Marker | Purpose |
 |--------|---------|
 | `// EXAMPLE: <name>` | Identifies example name (matches docs folder) |
+| `// BINDER_ID <id>` | Optional identifier for online code runners |
 | `// HIDE_START` / `// HIDE_END` | Code hidden from docs but still executed |
 | `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
 | `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
@@ -162,6 +166,7 @@ Maven requires test files to be in a specific directory structure:
 examples/lettuce-reactive/
 ├── pom.xml
 ├── LETTUCE_REACTIVE_TEST_PATTERNS.md
+├── SampleTest.java                 # this template (reference only)
 └── src/
     └── test/
         └── java/
@@ -169,7 +174,7 @@ examples/lettuce-reactive/
                 └── redis/
                     └── examples/
                         └── reactive/
-                            └── SampleTest.java
+                            └── CmdsHashExample.java   # generated examples here
 ```
 
 ## Running Tests
@@ -244,5 +249,6 @@ mvn test -Dtest=SampleTest#run
 
 ## See Also
 
-- Sample template: `src/test/java/io/redis/examples/reactive/SampleTest.java` (in this directory)
+- Sample template: `SampleTest.java` (in this directory)
 - Hash commands: `/path/to/lettuce/src/test/java/io/redis/examples/reactive/HashExample.java`
+- Async counterpart: `../lettuce-async/LETTUCE_ASYNC_TEST_PATTERNS.md`

--- a/.agents/skills/generate-tce-examples/assets/nredisstack/NREDISSTACK_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/nredisstack/NREDISSTACK_TEST_PATTERNS.md
@@ -70,11 +70,11 @@ public class ExampleClassName
 
         // REMOVE_START
         // Test setup/cleanup (completely removed from docs)
-        db.KeyDelete(["mykey", "user:1", "user:2"]);
+        db.KeyDelete(["mykey", "user:1", "user:2", "bike:1", "bike:1:stats"]);
         try { ft.DropIndex("idx:users"); } catch { }
         // REMOVE_END
 
-        // STEP_START basic_string_ops
+        // STEP_START string_ops
         bool setResult = db.StringSet("mykey", "Hello");
         Console.WriteLine(setResult);  // >>> True
 
@@ -91,7 +91,15 @@ public class ExampleClassName
         muxer.Close();
     }
 }
+// HIDE_END
 ```
+
+> **⚠️ Every `HIDE_START` must have a matching `HIDE_END`.** An unclosed hide
+> anchor makes the build abort the example with
+> `Unclosed hidden anchor ... - aborting`, and the example silently produces no
+> output. The same rule applies to `REMOVE_START`/`REMOVE_END` and
+> `STEP_START`/`STEP_END`. Note that the closing braces of the method and class
+> belong *inside* the final hide block, as shown above.
 
 ## Module Command Interfaces
 

--- a/.agents/skills/generate-tce-examples/assets/nredisstack/nredisstack_sample_test.cs
+++ b/.agents/skills/generate-tce-examples/assets/nredisstack/nredisstack_sample_test.cs
@@ -58,11 +58,11 @@ public class ExampleClassName
 
         // REMOVE_START
         // Test setup/cleanup (completely removed from docs)
-        db.KeyDelete(["mykey", "user:1", "user:2"]);
+        db.KeyDelete(["mykey", "user:1", "user:2", "bike:1", "bike:1:stats"]);
         try { ft.DropIndex("idx:users"); } catch { }
         // REMOVE_END
 
-        // STEP_START basic_string_ops
+        // STEP_START string_ops
         bool setResult = db.StringSet("mykey", "Hello");
         Console.WriteLine(setResult);  // >>> True
 
@@ -93,6 +93,51 @@ public class ExampleClassName
         // REMOVE_START
         Assert.Equal("Alice", name);
         Assert.Equal(3, allFields.Length);
+        // REMOVE_END
+
+        // STEP_START hash_tutorial
+        // Tutorial-style example with bike data
+        db.HashSet("bike:1", [
+            new("model", "Deimos"),
+            new("brand", "Ergonom"),
+            new("type", "Enduro bikes"),
+            new("price", "4972")
+        ]);
+
+        var model = db.HashGet("bike:1", "model");
+        Console.WriteLine(model);  // >>> Deimos
+
+        var price = db.HashGet("bike:1", "price");
+        Console.WriteLine(price);  // >>> 4972
+
+        var bikeFields = db.HashGetAll("bike:1");
+        Console.WriteLine(string.Join(", ", bikeFields.Select(f => $"{f.Name}={f.Value}")));
+        // >>> model=Deimos, brand=Ergonom, type=Enduro bikes, price=4972
+        // STEP_END
+
+        // REMOVE_START
+        Assert.Equal("Deimos", model);
+        Assert.Equal("4972", price);
+        Assert.Equal(4, bikeFields.Length);
+        // REMOVE_END
+
+        // STEP_START hincrby
+        // Numeric operations on hash fields
+        long rides1 = db.HashIncrement("bike:1:stats", "rides", 1);
+        Console.WriteLine(rides1);   // >>> 1
+
+        long rides2 = db.HashIncrement("bike:1:stats", "rides", 1);
+        Console.WriteLine(rides2);   // >>> 2
+
+        long crashes = db.HashIncrement("bike:1:stats", "crashes", 1);
+        Console.WriteLine(crashes);  // >>> 1
+        // STEP_END
+
+        // REMOVE_START
+        Assert.Equal(1, rides1);
+        Assert.Equal(2, rides2);
+        Assert.Equal(1, crashes);
+        db.KeyDelete(["bike:1", "bike:1:stats"]);
         // REMOVE_END
 
         // STEP_START json_ops
@@ -154,3 +199,4 @@ public class ExampleClassName
         muxer.Close();
     }
 }
+// HIDE_END

--- a/.agents/skills/generate-tce-examples/assets/predis/PREDIS_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/predis/PREDIS_TEST_PATTERNS.md
@@ -24,42 +24,50 @@ These test files serve dual purposes:
 
 ## File Structure Template
 
+Note the marker ordering at the top: `EXAMPLE:` is line 1 and `BINDER_ID` is
+line 2, both **before** the `<?php` tag. Everything after `<?php` is a normal PHP
+comment; anything before it would be echoed as raw output when the file runs.
+
 ```php
 // EXAMPLE: example_name
-<?php
 // BINDER_ID php-sample
+<?php
 
-use PHPUnit\Framework\TestCase;
+require 'vendor/autoload.php';
+
 use Predis\Client as PredisClient;
 
 class SampleTest
 // REMOVE_START
-extends TestCase
+extends PredisTestCase
 // REMOVE_END
 {
     public function testSampleExample(): void
     {
-        $redis = new PredisClient([
-            'scheme' => 'tcp',
-            'host'   => '127.0.0.1',
-            'port'   => 6379,
+        $r = new PredisClient([
+            'scheme'   => 'tcp',
+            'host'     => '127.0.0.1',
+            'port'     => 6379,
+            'password' => '',
+            'database' => 0,
         ]);
+
         // REMOVE_START
-        $redis->del('mykey');
+        $r->del('mykey');
         // REMOVE_END
 
         // STEP_START string_ops
-        $res = $redis->set('mykey', 'Hello');
+        $res = $r->set('mykey', 'Hello');
         echo $res . PHP_EOL; // >>> OK
 
-        $value = $redis->get('mykey');
+        $value = $r->get('mykey');
         echo $value . PHP_EOL; // >>> Hello
         // STEP_END
 
         // REMOVE_START
         $this->assertEquals('OK', $res);
         $this->assertEquals('Hello', $value);
-        $redis->del('mykey');
+        $r->del('mykey');
         // REMOVE_END
     }
 }
@@ -68,13 +76,20 @@ extends TestCase
 ## Key Patterns
 
 ### 1. Imports and Test Class
+
+The autoloader is required at the top, and the class extends `PredisTestCase`
+(the examples project's base class) inside a REMOVE block. There is no
+`use PHPUnit\Framework\TestCase;` import — `PredisTestCase` supplies the PHPUnit
+base:
+
 ```php
-use PHPUnit\Framework\TestCase;
+require 'vendor/autoload.php';
+
 use Predis\Client as PredisClient;
 
 class SampleTest
 // REMOVE_START
-extends TestCase
+extends PredisTestCase
 // REMOVE_END
 {
     public function testSampleExample(): void
@@ -82,11 +97,16 @@ extends TestCase
 ```
 
 ### 2. Connection Setup
+
+The client variable is `$r`:
+
 ```php
-$redis = new PredisClient([
-    'scheme' => 'tcp',
-    'host'   => '127.0.0.1',
-    'port'   => 6379,
+$r = new PredisClient([
+    'scheme'   => 'tcp',
+    'host'     => '127.0.0.1',
+    'port'     => 6379,
+    'password' => '',
+    'database' => 0,
 ]);
 ```
 
@@ -96,7 +116,7 @@ $redis = new PredisClient([
 $this->assertEquals('OK', $res);
 $this->assertEquals('Hello', $value);
 $this->assertCount(3, $all);
-$redis->del('mykey');
+$r->del('mykey');
 // REMOVE_END
 ```
 
@@ -109,20 +129,20 @@ echo json_encode($all) . PHP_EOL;
 // >>> {"field1":"value1","field2":"value2"}
 ```
 
-### 6. Hash Operations
+### 5. Hash Operations
 ```php
-// Single field
-$redis->hset('myhash', 'field1', 'value1');
+// Single field — returns the number of new fields
+$r->hset('myhash', 'field1', 'value1');
 
-// Multiple fields
-$redis->hmset('myhash', [
+// Multiple fields — returns the status string "OK"
+$r->hmset('myhash', [
     'field2' => 'value2',
     'field3' => 'value3',
 ]);
 
 // Get operations
-$value = $redis->hget('myhash', 'field1');
-$all = $redis->hgetall('myhash');
+$value = $r->hget('myhash', 'field1');
+$all = $r->hgetall('myhash');
 ```
 
 ## Setup

--- a/.agents/skills/generate-tce-examples/assets/predis/SampleTest.php
+++ b/.agents/skills/generate-tce-examples/assets/predis/SampleTest.php
@@ -1,4 +1,5 @@
 // EXAMPLE: sample_example
+// BINDER_ID php-sample
 <?php
 // =============================================================================
 // CANONICAL PREDIS TEST FILE TEMPLATE
@@ -18,59 +19,60 @@
 // RUN: phpunit SampleTest.php
 // =============================================================================
 
-// BINDER_ID php-sample
+require 'vendor/autoload.php';
 
-use PHPUnit\Framework\TestCase;
 use Predis\Client as PredisClient;
 
 class SampleTest
 // REMOVE_START
-extends TestCase
+extends PredisTestCase
 // REMOVE_END
 {
     public function testSampleExample(): void
     {
-        $redis = new PredisClient([
-            'scheme' => 'tcp',
-            'host'   => '127.0.0.1',
-            'port'   => 6379,
+        $r = new PredisClient([
+            'scheme'   => 'tcp',
+            'host'     => '127.0.0.1',
+            'port'     => 6379,
+            'password' => '',
+            'database' => 0,
         ]);
 
         // REMOVE_START
         // Clean up any existing data before tests
-        $redis->del('mykey', 'myhash', 'bike:1', 'bike:1:stats');
+        $r->del('mykey', 'myhash', 'bike:1', 'bike:1:stats');
         // REMOVE_END
 
         // STEP_START string_ops
         // Basic string SET/GET operations
-        $res1 = $redis->set('mykey', 'Hello');
+        $res1 = $r->set('mykey', 'Hello');
         echo $res1 . PHP_EOL; // >>> OK
 
-        $res2 = $redis->get('mykey');
+        $res2 = $r->get('mykey');
         echo $res2 . PHP_EOL; // >>> Hello
         // STEP_END
 
         // REMOVE_START
         $this->assertEquals('OK', $res1);
         $this->assertEquals('Hello', $res2);
-        $redis->del('mykey');
+        $r->del('mykey');
         // REMOVE_END
 
         // STEP_START hash_ops
         // Hash operations: HSET, HGET, HGETALL
-        $res3 = $redis->hset('myhash', 'field1', 'value1');
+        $res3 = $r->hset('myhash', 'field1', 'value1');
         echo $res3 . PHP_EOL; // >>> 1
 
-        $res4 = $redis->hmset('myhash', [
+        $res4 = $r->hmset('myhash', [
             'field2' => 'value2',
             'field3' => 'value3'
         ]);
         echo $res4 . PHP_EOL; // >>> OK
 
-        $res5 = $redis->hget('myhash', 'field1');
+        $res5 = $r->hget('myhash', 'field1');
         echo $res5 . PHP_EOL; // >>> value1
 
-        $res6 = $redis->hgetall('myhash');
+        $res6 = $r->hgetall('myhash');
         echo json_encode($res6) . PHP_EOL;
         // >>> {"field1":"value1","field2":"value2","field3":"value3"}
         // STEP_END
@@ -80,7 +82,7 @@ extends TestCase
         $this->assertEquals('OK', $res4);
         $this->assertEquals('value1', $res5);
         $this->assertEquals('value1', $res6['field1']);
-        $redis->del('myhash');
+        $r->del('myhash');
         // REMOVE_END
 
         // STEP_START hash_tutorial
@@ -92,16 +94,16 @@ extends TestCase
             'price' => '4972'
         ];
 
-        $res7 = $redis->hmset('bike:1', $bike1);
+        $res7 = $r->hmset('bike:1', $bike1);
         echo $res7 . PHP_EOL; // >>> OK
 
-        $res8 = $redis->hget('bike:1', 'model');
+        $res8 = $r->hget('bike:1', 'model');
         echo $res8 . PHP_EOL; // >>> Deimos
 
-        $res9 = $redis->hget('bike:1', 'price');
+        $res9 = $r->hget('bike:1', 'price');
         echo $res9 . PHP_EOL; // >>> 4972
 
-        $res10 = $redis->hgetall('bike:1');
+        $res10 = $r->hgetall('bike:1');
         echo json_encode($res10) . PHP_EOL;
         // >>> {"model":"Deimos","brand":"Ergonom","type":"Enduro bikes","price":"4972"}
         // STEP_END
@@ -111,20 +113,20 @@ extends TestCase
         $this->assertEquals('Deimos', $res8);
         $this->assertEquals('4972', $res9);
         $this->assertEquals('Deimos', $res10['model']);
-        $redis->del('bike:1');
+        $r->del('bike:1');
         // REMOVE_END
 
         // STEP_START hincrby
         // Numeric operations on hash fields
-        $redis->hset('bike:1:stats', 'rides', 0);
+        $r->hset('bike:1:stats', 'rides', 0);
 
-        $res11 = $redis->hincrby('bike:1:stats', 'rides', 1);
+        $res11 = $r->hincrby('bike:1:stats', 'rides', 1);
         echo $res11 . PHP_EOL; // >>> 1
 
-        $res12 = $redis->hincrby('bike:1:stats', 'rides', 1);
+        $res12 = $r->hincrby('bike:1:stats', 'rides', 1);
         echo $res12 . PHP_EOL; // >>> 2
 
-        $res13 = $redis->hincrby('bike:1:stats', 'crashes', 1);
+        $res13 = $r->hincrby('bike:1:stats', 'crashes', 1);
         echo $res13 . PHP_EOL; // >>> 1
         // STEP_END
 
@@ -132,7 +134,7 @@ extends TestCase
         $this->assertEquals(1, $res11);
         $this->assertEquals(2, $res12);
         $this->assertEquals(1, $res13);
-        $redis->del('bike:1:stats');
+        $r->del('bike:1:stats');
         // REMOVE_END
     }
 }

--- a/.agents/skills/generate-tce-examples/assets/rust-async/RUST_ASYNC_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/rust-async/RUST_ASYNC_TEST_PATTERNS.md
@@ -10,7 +10,10 @@ These test files serve dual purposes:
 
 ## File Locations
 
-- **Sample template**: `tests/sample_test.rs` (in this directory)
+- **Sample template**: `sample_test.rs` (in this directory)
+- **Generated examples**: must go in the project's `tests/` subdirectory
+  (e.g. `rust-async/tests/cmds_hash.rs`), never the project root — Cargo only
+  discovers integration tests there.
 
 ## Marker Reference
 
@@ -21,124 +24,225 @@ These test files serve dual purposes:
 | `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
 | `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
 
+Every `*_START` marker must have a matching `*_END`. An unclosed anchor makes the
+build abort the example, which then silently produces no output.
+
+The `BINDER_ID` marker is valid for every language but is not used for Rust
+examples — none of the published Rust examples set it.
+
+## What the Build Strips Automatically
+
+This matters for Rust, because it means the test scaffolding does **not** need
+marker wrapping:
+
+| Construct | Stripped from docs? |
+|-----------|---------------------|
+| `#[cfg(test)]` | ✅ Yes — automatic |
+| `#[tokio::test]` | ✅ Yes — automatic |
+| `#[test]` | ✅ Yes — automatic |
+| `mod <name>_tests {` | ❌ No — appears in docs |
+| `use redis::AsyncCommands;` | ❌ No — appears in docs |
+| Closing `}` braces | ❌ No — appear in docs |
+
+The attributes are removed by the build's test-marker pass, so leave them
+unmarked. Do **not** wrap the module in `REMOVE_START`/`REMOVE_END` — the
+published examples deliberately show `mod ... { use redis::AsyncCommands; ... }`
+so readers can see the imports.
+
 ## File Structure Template
 
 ```rust
 // EXAMPLE: example_name
-
-// HIDE_START
-use redis::AsyncCommands;
-// HIDE_END
-
-// REMOVE_START
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod example_name_tests {
+    use redis::AsyncCommands;
+    use std::collections::HashMap;
 
     #[tokio::test]
-    async fn test_run() {
-// REMOVE_END
-        // STEP_START connect
-        let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-        let mut con = client.get_multiplexed_async_connection().await.unwrap();
-        // STEP_END
+    async fn run() {
+        let client = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => client,
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
+
+        let mut r = match client.get_multiplexed_async_connection().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                println!("Failed to connect to Redis: {e}");
+                return;
+            }
+        };
 
         // REMOVE_START
-        let _: () = redis::cmd("DEL").arg("mykey").query_async(&mut con).await.unwrap();
+        // Clean up any existing data before tests
+        let _: () = r.del("mykey").await.unwrap();
         // REMOVE_END
 
-        // STEP_START string_ops
-        let _: () = con.set("mykey", "Hello").await.unwrap();
-        println!("SET mykey Hello: OK"); // >>> OK
+        // STEP_START operation_name
+        if let Ok(res1) = r.set("mykey", "Hello").await {
+            let res1: String = res1;
+            println!("{res1}"); // >>> OK
+            // REMOVE_START
+            assert_eq!(res1, "OK");
+            // REMOVE_END
+        }
 
-        let value: String = con.get("mykey").await.unwrap();
-        println!("GET mykey: {}", value); // >>> Hello
+        match r.get("mykey").await {
+            Ok(res2) => {
+                let res2: String = res2;
+                println!("{res2}"); // >>> Hello
+                // REMOVE_START
+                assert_eq!(res2, "Hello");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
         // STEP_END
 
         // REMOVE_START
-        assert_eq!(value, "Hello");
-        let _: () = redis::cmd("DEL").arg("mykey").query_async(&mut con).await.unwrap();
-// REMOVE_END
-// REMOVE_START
+        let _: () = r.del("mykey").await.unwrap();
+        // REMOVE_END
     }
 }
-// REMOVE_END
+```
+
+The nested single-expression form used by `sample_test.rs` is equally valid:
+
+```rust
+let mut r = match redis::Client::open("redis://127.0.0.1") {
+    Ok(client) => match client.get_multiplexed_async_connection().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            println!("Failed to connect to Redis: {e}");
+            return;
+        }
+    },
+    Err(e) => {
+        println!("Failed to create Redis client: {e}");
+        return;
+    }
+};
 ```
 
 ## Key Patterns
 
-### 1. Imports (in HIDE block)
-```rust
-// HIDE_START
-use redis::AsyncCommands;
-// HIDE_END
-```
+### 1. Module and Imports (unmarked)
 
-### 2. Async Test Structure (in REMOVE blocks)
+The module wrapper and its imports are part of the published example. Name the
+module after the example, suffixed with `_tests`:
+
 ```rust
-// REMOVE_START
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod cmds_hash_tests {
+    use redis::AsyncCommands;
+    use std::collections::HashMap;  // only when the example needs it
+```
 
+### 2. Test Function
+
+Always named `run`, always `#[tokio::test]` + `async fn`:
+
+```rust
     #[tokio::test]
-    async fn test_run() {
-// REMOVE_END
-        // ... async code ...
-// REMOVE_START
+    async fn run() {
+```
+
+### 3. Connection Setup (unmarked, not a step)
+
+The connection cascade is shown in the docs but is not wrapped in a
+`STEP_START` block — steps begin at the first Redis command. It returns early
+rather than panicking, so a missing server skips the example instead of failing
+the suite. The connection variable is named `r`.
+
+### 4. Command Results: `match` or `if let Ok`, not `unwrap()`
+
+Use `match` when you need an error arm, `if let Ok(...)` when you don't. Bind
+the concrete type on the first line of the `Ok` arm — this is how redis-rs is
+told what to deserialize into:
+
+```rust
+match r.hget("myhash", "field1").await {
+    Ok(res5) => {
+        let res5: String = res5;
+        println!("{res5}"); // >>> value1
+        // REMOVE_START
+        assert_eq!(res5, "value1");
+        // REMOVE_END
     }
+    Err(e) => println!("Error: {e}"),
 }
-// REMOVE_END
+
+if let Ok(res3) = r.hset("myhash", "field1", "value1").await {
+    let res3: i32 = res3;
+    println!("{res3}"); // >>> 1
+}
 ```
 
-### 3. Async Connection Setup
-```rust
-// STEP_START connect
-let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-let mut con = client.get_multiplexed_async_connection().await.unwrap();
-// STEP_END
-```
-
-### 4. Async Operations
-```rust
-// All operations use .await
-let _: () = con.set("key", "value").await.unwrap();
-let value: String = con.get("key").await.unwrap();
-```
+Avoid `.unwrap()` in the visible example code. It is fine inside REMOVE blocks.
 
 ### 5. Assertions (in REMOVE blocks)
+
+Assertions live inside the `Ok` arm, wrapped in `REMOVE_START`/`REMOVE_END`, so
+they execute in tests but never appear in the docs:
+
 ```rust
 // REMOVE_START
-assert_eq!(value, "Hello");
-let _: () = redis::cmd("DEL").arg("mykey").query_async(&mut con).await.unwrap();
+assert_eq!(res6.get("field1"), Some(&"value1".to_string()));
 // REMOVE_END
 ```
 
-### 6. Hash Operations (Async)
+### 6. Console Output Comments
+
+Print the bound variable and annotate the real output. Never hardcode a literal
+in the `println!` just to make the comment true:
+
 ```rust
-// Single field
-let _: () = con.hset("myhash", "field1", "value1").await.unwrap();
-
-// Multiple fields
-let _: () = con.hset_multiple("myhash", &[
-    ("field2", "value2"),
-    ("field3", "value3"),
-]).await.unwrap();
-
-// Get operations
-let value: String = con.hget("myhash", "field1").await.unwrap();
-let all: std::collections::HashMap<String, String> = con.hgetall("myhash").await.unwrap();
+println!("{res1}");                   // >>> OK
+println!("{:?}", res6.get("field1")); // >>> Some("value1")
 ```
 
-### 7. Raw Commands (Async)
+### 7. Cleanup (in REMOVE blocks)
+
+Cleanup runs inside REMOVE blocks, where `.unwrap()` is acceptable:
+
 ```rust
-let _: () = redis::cmd("DEL")
-    .arg("key1")
-    .arg("key2")
-    .query_async(&mut con)
-    .await
-    .unwrap();
+// REMOVE_START
+let _: () = r.del("mykey").await.unwrap();
+let _: () = r.del(&["bike:1", "bike:1:stats"]).await.unwrap();
+// REMOVE_END
 ```
+
+### 8. Hash Operations (Async)
+
+```rust
+// Single field — returns the number of new fields
+if let Ok(res) = r.hset("myhash", "field1", "value1").await {
+    let res: i32 = res;
+    println!("{res}"); // >>> 1
+}
+
+// Multiple fields — returns "OK"
+let hash_fields = vec![("field2", "value2"), ("field3", "value3")];
+if let Ok(res) = r.hset_multiple("myhash", &hash_fields).await {
+    let res: String = res;
+    println!("{res}"); // >>> OK
+}
+
+// Get all
+match r.hgetall("myhash").await {
+    Ok(res) => {
+        let res: HashMap<String, String> = res;
+        println!("{:?}", res.get("field1")); // >>> Some("value1")
+    }
+    Err(e) => println!("Error: {e}"),
+}
+```
+
+Note that `hset` returns an integer count while `hset_multiple` returns the
+status string `OK` — a common source of wrong output comments.
 
 ## Sync vs Async Comparison
 
@@ -146,20 +250,22 @@ let _: () = redis::cmd("DEL")
 |--------|------|-------|
 | Import | `use redis::Commands;` | `use redis::AsyncCommands;` |
 | Test attr | `#[test]` | `#[tokio::test]` |
-| Connection | `get_connection()` | `get_multiplexed_async_connection().await` |
-| Operations | `con.set(...).unwrap()` | `con.set(...).await.unwrap()` |
-| Raw cmd | `.query(&mut con)` | `.query_async(&mut con).await` |
+| Test fn | `fn run()` | `async fn run()` |
+| Connection | `client.get_connection()` | `client.get_multiplexed_async_connection().await` |
+| Operations | `r.set(...)` | `r.set(...).await` |
+| Cleanup discard | `let _: Result<i32, _> = r.del("k");` | `let _: () = r.del("k").await.unwrap();` |
 
 ## Directory Structure
 
-Cargo requires test files to be in a specific location:
+Cargo requires integration tests to live under `tests/`:
 
 ```
 examples/rust-async/
 ├── Cargo.toml
 ├── RUST_ASYNC_TEST_PATTERNS.md
+├── sample_test.rs          # this template (reference only)
 └── tests/
-    └── sample_test.rs
+    └── cmds_hash.rs        # generated examples go here
 ```
 
 ## Running Tests
@@ -171,12 +277,15 @@ cargo build
 # Run all tests
 cargo test
 
-# Run specific test
-cargo test test_run
+# Run a single example's test
+cargo test run
 
-# Run with output
+# Run with output visible
 cargo test -- --nocapture
 ```
+
+Because every example's test function is named `run`, `cargo test run` matches
+all of them; use `cargo test --test cmds_hash` to target one file.
 
 ## Cargo.toml
 
@@ -196,11 +305,13 @@ tokio = { version = "1", features = ["full"] }
 
 ## API Notes
 
-- Use `redis::AsyncCommands` trait for convenient async methods
-- Requires `tokio-comp` feature in redis crate
-- Use `get_multiplexed_async_connection()` for async connection
+- Use the `redis::AsyncCommands` trait for convenient async methods
+- Requires the `tokio-comp` feature in the redis crate
+- Use `get_multiplexed_async_connection()` for the connection
 - All operations require `.await`
+- Type annotations are required so redis-rs knows what to deserialize into
 
 ## See Also
 
-- Sample template: `tests/sample_test.rs` (in this directory)
+- Sample template: `sample_test.rs` (in this directory)
+- Sync counterpart: `../rust-sync/RUST_SYNC_TEST_PATTERNS.md`

--- a/.agents/skills/generate-tce-examples/assets/rust-async/sample_test.rs
+++ b/.agents/skills/generate-tce-examples/assets/rust-async/sample_test.rs
@@ -153,6 +153,33 @@ mod sample_async_tests {
         }
         // STEP_END
 
+        // STEP_START hincrby
+        // Numeric operations on hash fields (async)
+        if let Ok(res10) = r.hincr("bike:1:stats", "rides", 1).await {
+            let res10: i32 = res10;
+            println!("{res10}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res10, 1);
+            // REMOVE_END
+        }
+
+        if let Ok(res11) = r.hincr("bike:1:stats", "rides", 1).await {
+            let res11: i32 = res11;
+            println!("{res11}"); // >>> 2
+            // REMOVE_START
+            assert_eq!(res11, 2);
+            // REMOVE_END
+        }
+
+        if let Ok(res12) = r.hincr("bike:1:stats", "crashes", 1).await {
+            let res12: i32 = res12;
+            println!("{res12}"); // >>> 1
+            // REMOVE_START
+            assert_eq!(res12, 1);
+            // REMOVE_END
+        }
+        // STEP_END
+
         // REMOVE_START
         let _: () = r.del(&["bike:1", "bike:1:stats"]).await.unwrap();
         // REMOVE_END

--- a/.agents/skills/generate-tce-examples/assets/rust-sync/RUST_SYNC_TEST_PATTERNS.md
+++ b/.agents/skills/generate-tce-examples/assets/rust-sync/RUST_SYNC_TEST_PATTERNS.md
@@ -10,7 +10,10 @@ These test files serve dual purposes:
 
 ## File Locations
 
-- **Sample template**: `tests/sample_test.rs` (in this directory)
+- **Sample template**: `sample_test.rs` (in this directory)
+- **Generated examples**: must go in the project's `tests/` subdirectory
+  (e.g. `rust-sync/tests/cmds_hash.rs`), never the project root — Cargo only
+  discovers integration tests there.
 
 ## Marker Reference
 
@@ -21,135 +24,234 @@ These test files serve dual purposes:
 | `// REMOVE_START` / `// REMOVE_END` | Code completely removed from docs |
 | `// STEP_START <name>` / `// STEP_END` | Named section for targeted doc inclusion |
 
+Every `*_START` marker must have a matching `*_END`. An unclosed anchor makes the
+build abort the example, which then silently produces no output.
+
+The `BINDER_ID` marker is valid for every language but is not used for Rust
+examples — none of the published Rust examples set it.
+
+## What the Build Strips Automatically
+
+This matters for Rust, because it means the test scaffolding does **not** need
+marker wrapping:
+
+| Construct | Stripped from docs? |
+|-----------|---------------------|
+| `#[cfg(test)]` | ✅ Yes — automatic |
+| `#[test]` | ✅ Yes — automatic |
+| `#[tokio::test]` | ✅ Yes — automatic |
+| `mod <name>_tests {` | ❌ No — appears in docs |
+| `use redis::Commands;` | ❌ No — appears in docs |
+| Closing `}` braces | ❌ No — appear in docs |
+
+The three attributes are removed by the build's test-marker pass, so leave them
+unmarked. Do **not** wrap the module in `REMOVE_START`/`REMOVE_END` — the
+published examples deliberately show `mod ... { use redis::Commands; ... }` so
+readers can see the imports.
+
 ## File Structure Template
 
 ```rust
 // EXAMPLE: example_name
-
-// HIDE_START
-use redis::Commands;
-// HIDE_END
-
-// REMOVE_START
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod example_name_tests {
+    use redis::Commands;
+    use std::collections::HashMap;
 
     #[test]
-    fn test_run() {
-// REMOVE_END
-        // STEP_START connect
-        let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-        let mut con = client.get_connection().unwrap();
-        // STEP_END
+    fn run() {
+        let mut r = match redis::Client::open("redis://127.0.0.1") {
+            Ok(client) => match client.get_connection() {
+                Ok(conn) => conn,
+                Err(e) => {
+                    println!("Failed to connect to Redis: {e}");
+                    return;
+                }
+            },
+            Err(e) => {
+                println!("Failed to create Redis client: {e}");
+                return;
+            }
+        };
 
         // REMOVE_START
-        let _: () = redis::cmd("DEL").arg("mykey").query(&mut con).unwrap();
+        // Clean up any existing data before tests
+        let _: Result<i32, _> = r.del("mykey");
         // REMOVE_END
 
-        // STEP_START string_ops
-        let _: () = con.set("mykey", "Hello").unwrap();
-        println!("SET mykey Hello: OK"); // >>> OK
+        // STEP_START operation_name
+        match r.set("mykey", "Hello") {
+            Ok(res1) => {
+                let res1: String = res1;
+                println!("{res1}"); // >>> OK
+                // REMOVE_START
+                assert_eq!(res1, "OK");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
 
-        let value: String = con.get("mykey").unwrap();
-        println!("GET mykey: {}", value); // >>> Hello
+        match r.get("mykey") {
+            Ok(res2) => {
+                let res2: String = res2;
+                println!("{res2}"); // >>> Hello
+                // REMOVE_START
+                assert_eq!(res2, "Hello");
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
         // STEP_END
 
         // REMOVE_START
-        assert_eq!(value, "Hello");
-        let _: () = redis::cmd("DEL").arg("mykey").query(&mut con).unwrap();
-// REMOVE_END
-// REMOVE_START
+        let _: Result<i32, _> = r.del("mykey");
+        // REMOVE_END
     }
 }
-// REMOVE_END
 ```
 
 ## Key Patterns
 
-### 1. Imports (in HIDE block)
-```rust
-// HIDE_START
-use redis::Commands;
-// HIDE_END
-```
+### 1. Module and Imports (unmarked)
 
-### 2. Test Module Structure (in REMOVE blocks)
+The module wrapper and its imports are part of the published example. Name the
+module after the example, suffixed with `_tests`:
+
 ```rust
-// REMOVE_START
 #[cfg(test)]
-mod tests {
-    use super::*;
+mod cmds_hash_tests {
+    use redis::Commands;
+    use std::collections::HashMap;  // only when the example needs it
+```
 
+### 2. Test Function
+
+Always named `run`, always `#[test]`:
+
+```rust
     #[test]
-    fn test_run() {
-// REMOVE_END
-        // ... code ...
-// REMOVE_START
+    fn run() {
+```
+
+### 3. Connection Setup (unmarked, not a step)
+
+The connection cascade is shown in the docs but is not wrapped in a
+`STEP_START` block — steps begin at the first Redis command. It returns early
+rather than panicking, so a missing server skips the example instead of failing
+the suite:
+
+```rust
+let mut r = match redis::Client::open("redis://127.0.0.1") {
+    Ok(client) => match client.get_connection() {
+        Ok(conn) => conn,
+        Err(e) => {
+            println!("Failed to connect to Redis: {e}");
+            return;
+        }
+    },
+    Err(e) => {
+        println!("Failed to create Redis client: {e}");
+        return;
     }
-}
-// REMOVE_END
+};
 ```
 
-### 3. Connection Setup
+The connection variable is named `r`.
+
+### 4. Command Results: `match`, not `unwrap()`
+
+Every command is handled with `match` (or `if let Ok(...)` when there is no
+assertion to make), binding a numbered result variable. Bind the concrete type
+on the first line of the `Ok` arm — this is how redis-rs is told what to
+deserialize into:
+
 ```rust
-// STEP_START connect
-let client = redis::Client::open("redis://127.0.0.1/").unwrap();
-let mut con = client.get_connection().unwrap();
-// STEP_END
+match r.hget("myhash", "field1") {
+    Ok(res5) => {
+        let res5: String = res5;
+        println!("{res5}"); // >>> value1
+        // REMOVE_START
+        assert_eq!(res5, "value1");
+        // REMOVE_END
+    }
+    Err(e) => println!("Error: {e}"),
+}
 ```
 
-### 4. Assertions (in REMOVE blocks)
+Avoid `.unwrap()` in the visible example code.
+
+### 5. Assertions (in REMOVE blocks)
+
+Assertions live inside the `Ok` arm, wrapped in `REMOVE_START`/`REMOVE_END`, so
+they execute in tests but never appear in the docs:
+
 ```rust
 // REMOVE_START
-assert_eq!(value, "Hello");
-assert_eq!(count, 3);
-let _: () = redis::cmd("DEL").arg("mykey").query(&mut con).unwrap();
+assert_eq!(res6.get("field1"), Some(&"value1".to_string()));
 // REMOVE_END
 ```
 
-### 5. Console Output Comments
+### 6. Console Output Comments
+
+Print the bound variable and annotate the real output. Never hardcode a literal
+in the `println!` just to make the comment true:
+
 ```rust
-println!("SET mykey Hello: OK"); // >>> OK
-println!("GET mykey: {}", value); // >>> Hello
+println!("{res1}");              // >>> OK
+println!("{:?}", res6.get("field1")); // >>> Some("value1")
 ```
 
-### 6. Hash Operations
+### 7. Cleanup (in REMOVE blocks)
+
+Use the typed-discard form of `del`, not raw `redis::cmd`:
+
 ```rust
-// Single field
-let _: () = con.hset("myhash", "field1", "value1").unwrap();
-
-// Multiple fields
-let _: () = con.hset_multiple("myhash", &[
-    ("field2", "value2"),
-    ("field3", "value3"),
-]).unwrap();
-
-// Get operations
-let value: String = con.hget("myhash", "field1").unwrap();
-let all: std::collections::HashMap<String, String> = con.hgetall("myhash").unwrap();
+// REMOVE_START
+let _: Result<i32, _> = r.del("mykey");
+let _: Result<i32, _> = r.del(&["bike:1", "bike:1:stats"]);
+// REMOVE_END
 ```
 
-### 7. Type Annotations
-```rust
-// Explicit type for set operations (returns nothing)
-let _: () = con.set("key", "value").unwrap();
+### 8. Hash Operations
 
-// Explicit type for get operations
-let value: String = con.get("key").unwrap();
-let count: i64 = con.hlen("myhash").unwrap();
+```rust
+// Single field — returns the number of new fields
+match r.hset("myhash", "field1", "value1") {
+    Ok(res) => { let res: i32 = res; println!("{res}"); } // >>> 1
+    Err(e) => println!("Error: {e}"),
+}
+
+// Multiple fields — returns "OK"
+let hash_fields = vec![("field2", "value2"), ("field3", "value3")];
+match r.hset_multiple("myhash", &hash_fields) {
+    Ok(res) => { let res: String = res; println!("{res}"); } // >>> OK
+    Err(e) => println!("Error: {e}"),
+}
+
+// Get all
+match r.hgetall("myhash") {
+    Ok(res) => {
+        let res: HashMap<String, String> = res;
+        println!("{:?}", res.get("field1")); // >>> Some("value1")
+    }
+    Err(e) => println!("Error: {e}"),
+}
 ```
+
+Note that `hset` returns an integer count while `hset_multiple` returns the
+status string `OK` — a common source of wrong output comments.
 
 ## Directory Structure
 
-Cargo requires test files to be in a specific location:
+Cargo requires integration tests to live under `tests/`:
 
 ```
 examples/rust-sync/
 ├── Cargo.toml
 ├── RUST_SYNC_TEST_PATTERNS.md
+├── sample_test.rs          # this template (reference only)
 └── tests/
-    └── sample_test.rs
+    └── cmds_hash.rs        # generated examples go here
 ```
 
 ## Running Tests
@@ -161,12 +263,15 @@ cargo build
 # Run all tests
 cargo test
 
-# Run specific test
-cargo test test_run
+# Run a single example's test
+cargo test run
 
-# Run with output
+# Run with output visible
 cargo test -- --nocapture
 ```
+
+Because every example's test function is named `run`, `cargo test run` matches
+all of them; use `cargo test --test cmds_hash` to target one file.
 
 ## Cargo.toml
 
@@ -185,11 +290,12 @@ redis = "1.0"
 
 ## API Notes
 
-- Use `redis::Commands` trait for convenient methods
-- All operations return `RedisResult<T>`, use `.unwrap()` for examples
-- Type annotations required for return values
-- Connection is mutable (`&mut con`)
+- Use the `redis::Commands` trait for convenient methods
+- All operations return `RedisResult<T>`; handle with `match`, not `.unwrap()`
+- Type annotations are required so redis-rs knows what to deserialize into
+- The connection is mutable (`let mut r`)
 
 ## See Also
 
-- Sample template: `tests/sample_test.rs` (in this directory)
+- Sample template: `sample_test.rs` (in this directory)
+- Async counterpart: `../rust-async/RUST_ASYNC_TEST_PATTERNS.md`

--- a/.agents/skills/generate-tce-examples/assets/rust-sync/sample_test.rs
+++ b/.agents/skills/generate-tce-examples/assets/rust-sync/sample_test.rs
@@ -164,6 +164,42 @@ mod sample_tests {
         }
         // STEP_END
 
+        // STEP_START hincrby
+        // Numeric operations on hash fields
+        match r.hincr("bike:1:stats", "rides", 1) {
+            Ok(res10) => {
+                let res10: i32 = res10;
+                println!("{res10}"); // >>> 1
+                // REMOVE_START
+                assert_eq!(res10, 1);
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hincr("bike:1:stats", "rides", 1) {
+            Ok(res11) => {
+                let res11: i32 = res11;
+                println!("{res11}"); // >>> 2
+                // REMOVE_START
+                assert_eq!(res11, 2);
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+
+        match r.hincr("bike:1:stats", "crashes", 1) {
+            Ok(res12) => {
+                let res12: i32 = res12;
+                println!("{res12}"); // >>> 1
+                // REMOVE_START
+                assert_eq!(res12, 1);
+                // REMOVE_END
+            }
+            Err(e) => println!("Error: {e}"),
+        }
+        // STEP_END
+
         // REMOVE_START
         let _: Result<i32, _> = r.del(&["bike:1", "bike:1:stats"]);
         // REMOVE_END


### PR DESCRIPTION
A bit of house cleaning before I re-work this skill; some of the `.../assets/...` files will be reused in the new skill.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill template changes only; no production services or user-facing site behavior unless someone relies on the old skill text.
> 
> **Overview**
> Refreshes the **generate-tce-examples** agent skill before a larger rework, focusing on `assets/` templates and `*_TEST_PATTERNS.md` guides rather than runtime docs code.
> 
> **SKILL.md** bumps the validation checklist from 10 to **12 client examples** (one per `assets/` directory), documents how to use samples without copying banner comments into published examples, and aligns embedded snippets for **NRedisStack** (`EndpointsFixture`, explicit connect step, `HIDE_END`), **Predis** (`PredisTestCase`, `$r`, marker order before `<?php>`), and related clients.
> 
> **Per-language pattern and sample updates** tighten TCE marker rules and realistic test style: **Jedis** (HIDE-wrapped scaffolding, `RedisClient`, Maven output paths), **Lettuce async** (`.toCompletableFuture().join()` instead of `get()`, assertion placement in chains), **Predis** / **hiredis** (cleanup and reply freeing), **NRedisStack** (required `HIDE_END`, extra hash/`hincrby` steps in the sample), **go-redis** (flush error handling, `hincrby` example), **ioredis** (multi-line expected output comments), and **rust-sync/async** (large rewrite: what the build auto-strips, `match`/`if let` instead of visible `unwrap`, `tests/` placement, `hincrby` samples).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bac5a2a54f4e9ed9fd815ec577ad9ae6051415b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->