### PR TITLE
RS: fix link warnings

### DIFF
--- a/content/operate/rs/8.0/flex/_index.md
+++ b/content/operate/rs/8.0/flex/_index.md
@@ -65,7 +65,7 @@ Flex does not replace long-term data persistence. For workloads that require dur
 
 ## Flex and Auto Tiering
 
-Flex replaces [Auto Tiering]({{< relref "/operate/rs/8.0/7.22/databases/auto-tiering" >}}) (formerly known as Redis on Flash). Redis Software selects the implementation based on your Redis version:
+Flex replaces [Auto Tiering]({{< relref "/operate/rs/7.22/databases/auto-tiering" >}}) (formerly known as Redis on Flash). Redis Software selects the implementation based on your Redis version:
 
 | Redis database version | Flex | Auto Tiering |
 |------------------------|------|--------------|
@@ -73,7 +73,7 @@ Flex replaces [Auto Tiering]({{< relref "/operate/rs/8.0/7.22/databases/auto-tie
 | 7.4 | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span>|
 | 7.2 and earlier | <span title="Not supported">&#x274c;</span> | <span title="Supported">&#x2705;</span> |
 
-For Redis Software version 7.22.2-22 or earlier, see [Auto Tiering]({{< relref "/operate/rs/8.0/7.22/databases/auto-tiering" >}}).
+For Redis Software version 7.22.2-22 or earlier, see [Auto Tiering]({{< relref "/operate/rs/7.22/databases/auto-tiering" >}}).
 
 ### Differences between Flex and Auto Tiering
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only link path correction with no runtime or security impact.
> 
> **Overview**
> Corrects two broken **Auto Tiering** links on the Redis Software 8.0 Flex overview so Hugo `relref` targets match the rest of the RS docs.
> 
> Both references change from `/operate/rs/8.0/7.22/databases/auto-tiering` to `/operate/rs/7.22/databases/auto-tiering` (intro paragraph and the note for Redis Software 7.22.2-22 or earlier).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4987ffbc551042edcf80876b7d14585a53f0eb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->