### PR TITLE
DOC-6939 Stop publishing HTML-commented content to the AI outputs

### DIFF
--- a/layouts/partials/process-markdown-content.html
+++ b/layouts/partials/process-markdown-content.html
@@ -16,6 +16,30 @@
 {{- $content := .RawContent -}}
 {{- $visited := .Visited | default (slice) -}}
 
+{{- /* Drop HTML-comment blocks before anything else looks at the content.
+
+       Hugo is configured with unsafe = true, so a comment passes through to the rendered
+       HTML and is invisible to readers -- which is how authors park prose that should not
+       be published yet. Nothing downstream of here knew that, so the commented text was
+       reaching the JSON feed as real section content and the Markdown output as real body
+       text: we were publishing to AI consumers exactly what we withhold from readers. On
+       develop/clients/observability that was a whole "Tracing overview" section, kept
+       because the explanation is good but the clients do not support tracing yet.
+
+       The open delimiter must be at the start of a line. That is what separates an author's
+       block comment from a comment inside a code example -- a Maven snippet carries
+       "</version> <!-- Check for the latest version -->" mid-line, and stripping that would
+       damage the sample. Measured over the whole corpus, the line-anchored form removes 48
+       comments totalling about 19,200 characters and never matches inside a fenced code
+       block, where the unanchored form would have hit 9. The residual is inline comments,
+       which are small and usually part of a code sample anyway.
+
+       Known limit: a block comment written at column 0 *inside* a fenced code block would
+       still be stripped. None exists today. Both the literal and entity-escaped forms are
+       matched, because RawContent arrives escaped in some contexts. */ -}}
+{{- $content = $content | replaceRE "(?ms)^<!--.*?-->" "" -}}
+{{- $content = $content | replaceRE "(?ms)^&lt;!--.*?--&gt;" "" -}}
+
 {{- /* Expand embed-md shortcodes before other transforms so embedded content can be processed too. */ -}}
 {{- $content = partial "markdown-embed-md.html" (dict "RawContent" $content "Page" .Page "Visited" $visited) -}}
 {{- /* Split wide table-scrollable blocks for AI-facing Markdown output only. */ -}}

--- a/layouts/partials/toc-from-markdown.html
+++ b/layouts/partials/toc-from-markdown.html
@@ -25,6 +25,15 @@
        what counts as code and their ids stay in step. */ -}}
 {{- $content = $content | replaceRE "(?s)```.*?```" "" -}}
 
+{{- /* Drop HTML-comment blocks too, so prose an author has parked does not appear in the
+       navigation. develop/clients/observability comments out a whole "Tracing overview"
+       section, which was published here as a real entry pointing at an anchor that does
+       not exist on the page, because Hugo renders no heading for commented-out text.
+       Line-anchored open delimiter, matching process-markdown-content.html -- change the
+       two together. Safe to run after the code strip above, which has already removed any
+       comment living inside a code sample. */ -}}
+{{- $content = $content | replaceRE "(?ms)^<!--.*?-->" "" -}}
+
 {{- /* Find all ## and ### headers in the raw markdown */ -}}
 {{- /* Pattern matches lines starting with ## or ### followed by space and title */ -}}
 {{- $headerPattern := `(?m)^(#{2,3}) +(.+)$` -}}


### PR DESCRIPTION
Stops content inside HTML comments reaching the JSON feed and the per-page Markdown — item D4 of DOC-6939.

## The defect

Hugo runs with `unsafe = true`, so an HTML comment passes straight through to the rendered page. It's invisible to readers, which is exactly how authors park prose that shouldn't be published yet. Nothing in the AI output path knew that, so commented text was being treated as publishable content.

**We were publishing to AI consumers exactly what we withhold from readers.** That's worse than a formatting defect — an assistant can cite a feature as documented when we have deliberately not documented it.

The case that surfaced it is `develop/clients/observability`, where a comment holds an entire "Tracing overview" section, kept because the explanation is good but the clients don't support tracing yet:

| Artifact | Before | After |
|---|---|---|
| Rendered page | Hidden inside an HTML comment ✓ | unchanged ✓ |
| `sections[]` in the feed | A real section, 1,610 chars of prose | **gone** |
| Per-page Markdown | Present | **gone** |
| Metadata TOC | Present, pointing at a non-existent anchor | **gone** |

Across the corpus, **56 files carry HTML comments totalling about 22,000 characters**. Only 2 of those comments contain a heading, which is why just one showed up in an anchor-parity check — the other 54 leak their prose into whatever section encloses them, invisible to any id-based metric.

## The fix, and why it's line-anchored

A line-anchored strip in `process-markdown-content.html` (the choke point feeding both the JSON `content` field and the Markdown output) and in `toc-from-markdown.html` (which reads `.RawContent` directly).

**The open delimiter must be at the start of a line, and that's load-bearing.** HTML comments legitimately appear inside code examples — the Lettuce pages carry a Maven snippet with `</version> <!-- Check for the latest version on Maven Central -->` mid-line, and stripping that damages a sample a reader sees. Column-0 is what separates an author's parked block from a comment inside a code sample:

| Pattern | Removes | Matches *inside* a fenced code block |
|---|---|---|
| Unanchored `(?s)<!--.*?-->` | 214 comments / 24,560 chars | **9** |
| Line-anchored `(?ms)^<!--.*?-->` | 48 comments / 19,232 chars | **0** |

Both the literal and entity-escaped forms are matched, because `.RawContent` arrives escaped in some contexts.

## Verification

Built before and after, comparing every page's `content` field:

- **5,706 pages byte-identical**
- **27 shrank**, and every one of the 27 is explained by having a line-anchored comment
- **0 grew**, 0 changed pages unexplained
- Zero line-anchored comments survive into `sections[]` or the `.md` output
- Duplicate section ids 0, duplicate example ids 0, `content_hash` verifies 5,687/5,687

## What a reviewer should focus on

- **The rendered site is untouched.** `process-markdown-content.html` feeds only the JSON and Markdown output formats, not the HTML, so nothing readers see changes.
- 27 pages lose content from their AI outputs. That's the intent, but it is content removal, so the byte-diff above is the thing to trust.
- If the anchoring is ever relaxed, it will start eating comments out of code samples at 9 known sites.

## Deliberately not fixed in the content

The comment on `observability.md` is a legitimate authoring choice — good prose held back until the clients catch up. Removing it would have fixed one page and left 55. The defect is that our pipeline treated invisible content as publishable.

## Not in this PR

- **Inline comments**, about 2,800 characters, still reach the outputs. Almost all of it is part of a code sample and belongs there.
- A block comment written at column 0 *inside* a fenced code block would still be stripped. None exists today.

## Relationship to #3757

Independent. #3757 (D3 + C7) changes how titles and ids are derived; this changes what content is considered publishable. Both edit `toc-from-markdown.html` but in different regions — line ~27 here against lines 47+ there — so they merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Intentional content removal from JSON/Markdown for ~27 pages; wrong regex anchoring could damage code samples, but rendered site HTML is out of scope.
> 
> **Overview**
> **Stops author-parked HTML comment blocks from being treated as publishable content** in the JSON feed, per-page Markdown, and metadata TOC—while leaving the normal Hugo HTML site unchanged.
> 
> `process-markdown-content.html` now removes line-anchored `<!-- ... -->` blocks (and entity-escaped equivalents) **before** embeds, shortcodes, and other transforms, so `sections[]` / body text no longer include prose that readers never see (e.g. a commented-out “Tracing overview” on observability). The pattern requires the opening delimiter at **column 0** so mid-line comments inside code samples (Maven snippets, etc.) are not stripped.
> 
> `toc-from-markdown.html` applies the same line-anchored strip after fenced code blocks are removed, so commented headings do not appear as TOC entries with dead anchors.
> 
> **Scope:** ~27 AI-facing pages shrink by design; inline comments and rendered HTML are unaffected. Relaxing line anchoring would risk stripping comments inside fenced code at known sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c4e6085f21496f5d2fa8a7a87e1e80a9d145dd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->