### PR TITLE
DOC-6939 Document feed coverage and the section role vocabulary

### DIFF
--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -37,6 +37,34 @@ Each documentation page has a corresponding JSON file at the same URL with `/ind
 - Page: `https://redis.io/docs/latest/commands/set/`
 - JSON: `https://redis.io/docs/latest/commands/set/index.json`
 
+### What the feeds cover
+
+The feeds contain one record for every documentation page. They deliberately do **not**
+contain the taxonomy pages that appear in
+[sitemap.xml](https://redis.io/docs/latest/sitemap.xml), so a straight comparison of the two
+shows the sitemap with more URLs.
+
+The excluded pages are:
+
+- the `categories/` listing and each `categories/<name>` page
+- the `tags/` listing and each `tags/<name>` page
+- the documentation home page
+
+These are generated index pages that list other pages. They carry no documentation prose of
+their own, so a record for them would add navigation noise without adding content. The
+exclusion is a consequence of how the output formats are configured rather than a filter
+applied afterwards: JSON and Markdown are produced for Hugo's `section` and `page` kinds
+only, and taxonomy, term and home pages are none of those.
+
+Two consequences worth knowing if you diff the feed against the sitemap:
+
+- Pages excluded from Hugo's page lists with `_build.list: never` are **absent from the
+  sitemap but present in the feeds**, because they are still built and rendered. They are
+  real documentation pages, usually reference material reached by direct link rather than by
+  browsing.
+- Both figures move. The feed is rebuilt at least daily and the corpus grows, so treat any
+  page count as a snapshot.
+
 ### JSON schema
 
 Each document contains:
@@ -54,9 +82,11 @@ Each document contains:
 | `children` | array | Child pages (index pages only) |
 
 Each **section** contains:
-- `id`: Slugified heading
+- `id`: Slugified heading, matching the heading's anchor on the rendered page, so
+  `<url>#<section id>` links to that section
 - `title`: Original heading text
-- `role`: Semantic role (`overview`, `syntax`, `example`, `parameters`, `returns`, etc.)
+- `role`: Semantic role, assigned from the heading text. See
+  [Section roles](#section-roles) for the current values.
 - `text`: Section content (code blocks replaced with `[code example]` placeholder)
 
 Each **example** contains:
@@ -64,6 +94,40 @@ Each **example** contains:
 - `language`: Language from code fence (`python`, `go`, `plaintext`, etc.)
 - `code`: The code content
 - `section_id`: Which section this example came from
+
+### Section roles
+
+Each section carries a `role`, derived from its heading text. These are the values currently
+in use:
+
+| Role | Assigned when the heading begins with |
+|------|----------------------------------------|
+| `overview` | `overview`, `introduction`, `about`, `description` |
+| `syntax` | `syntax`, `usage`, `command`, `signature` |
+| `example` | `example`, `demo`, `sample`, `code example` |
+| `parameters` | `option`, `parameter`, `argument`, `flag` |
+| `returns` | `return`, `response`, `output`, `result` |
+| `errors` | `error`, `exception`, `troubleshoot` |
+| `performance` | `performance`, `complexity`, `benchmark` |
+| `limits` | `limit`, `constraint`, `restriction` |
+| `related` | `see also`, `related`, `learn more`, `reference` |
+| `setup` | `install`, `setup`, `getting started`, `quickstart` |
+| `configuration` | `configur`, `setting` |
+| `security` | `security`, `auth`, `permission`, `acl` |
+| `history` | `history`, `changelog`, `version history` |
+| `compatibility` | `compatib`, `support`, `version` |
+| `content` | none of the above |
+
+The table is in priority order and the first match wins, which matters where the patterns
+overlap: a heading of "Version history" is `history` rather than `compatibility`, because
+`history` is tested first.
+
+A page's introductory text, before its first heading, is also given the `overview` role.
+
+{{< note >}}This vocabulary is descriptive, not a contract. It reflects the values produced
+today and may gain entries, or change how a heading maps to a role, without notice. If you
+filter or rank on `role`, treat an unrecognized value as `content` rather than discarding the
+section, and do not assume a value you rely on will keep its current name.{{< /note >}}
 
 ### Verifying content_hash
 


### PR DESCRIPTION
Documents feed coverage and the section `role` vocabulary on the AI agent resources page — items B2 and B3 of DOC-6939. Documentation only: no output format changes, no build changes.

## Why

Two of the applied AI team's findings were "you don't explain this" rather than "this is broken":

- **Their observation 08** — the feed has 27 fewer URLs than `sitemap.xml` and nothing says why, so anyone diffing the two derives an unexplained shortfall.
- **Their observation 06** — `role` is documented as five examples followed by "etc.", and they flagged that filtering or ranking on an uncontracted vocabulary breaks silently if a value is ever renamed.

## What's added

**A "What the feeds cover" section.** It explains the exclusion as what it actually is rather than as a skip list: JSON and Markdown are configured for Hugo's `section` and `page` kinds only, so taxonomy listings, term pages and the home page produce no JSON and therefore no record. There is no filter to document — which is why the difference couldn't be explained by describing one.

It also covers the asymmetry running the *other* way, which the assessment spotted but couldn't account for: a page carrying `_build.list: never` is dropped from Hugo's page collections, and the sitemap is generated from those collections, but the page is still rendered — so it has JSON and reaches the feed while being absent from the sitemap. `integrate/redis-data-integration/reference/data-transformation/cache` is the current example. It's genuine reference material reached by direct link, so publishing it is correct; only the mismatch needed explaining.

**A "Section roles" section.** All fifteen values, with the trigger words for each, in the order the patterns are tested — because first match wins and the patterns overlap. A heading of "Version history" is `history` rather than `compatibility` purely because `history` is tested first, which looks like a bug from outside if you don't know the order.

The stability caveat is explicit and phrased as guidance rather than a promise: **treat an unrecognized role as `content` rather than discarding the section.** We can't offer a contract on these names until there's a `schema_version` to signal a change, which remains open as ticket item C1.

The `sections[].id` description now also states that the id matches the heading's anchor on the rendered page, so `<url>#<section id>` resolves. That became true with #3757 and is worth saying out loud.

## Verification

- **The documented vocabulary matches the feed exactly** — fifteen values documented, fifteen emitted across the corpus, nothing in one set and not the other. Verified against built output rather than transcribed from `ROLE_PATTERNS`.
- The role table's order and trigger words check out line-by-line against `ROLE_PATTERNS` in `build/transform_json_sections.ts`.
- Both new sections reach the JSON and Markdown outputs, not just the rendered page.

## One wrinkle worth knowing

This page is documentation *about* the feed that also appears *in* the feed, so a caveat written inside a `{{< note >}}` has to survive the AI-output path. It does — the catch-all shortcode strip removes the `{{< >}}` delimiters but keeps the text between them — and I confirmed the caveat text is present in the JSON `content` rather than assuming it.

## Follow-up this doesn't do

The commit carries a `Constraint` trailer recording that the published table is now the vocabulary consumers filter on, so a future change to `ROLE_PATTERNS` has to update this page or we publish a vocabulary the feed no longer uses. A build-time check would be better than a trailer; not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no build, output format, or runtime behavior changes.
> 
> **Overview**
> **Documentation-only** updates to the AI agent resources page so feed consumers can reconcile URLs with `sitemap.xml` and use `sections[].role` safely.
> 
> Adds **What the feeds cover**, explaining why the NDJSON corpus has fewer URLs than the sitemap (JSON/Markdown only for Hugo `section`/`page` kinds—no taxonomy, term, or home records) and the reverse case where `_build.list: never` pages appear in feeds but not the sitemap, plus a note that counts are snapshots.
> 
> Adds **Section roles** with all fifteen `role` values, trigger heading prefixes, and priority order (first match wins). The JSON schema now states that `sections[].id` matches on-page heading anchors for `#` links, and includes a note that roles are descriptive—not a stable contract—and unknown values should be treated as `content`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0306759d05977f505c84847986fa6821f2d6187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->