### PR TITLE
DOC-6939 Make the page-level id unique

### DIFF
--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -43,7 +43,7 @@ Each document contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | URL slug identifier |
+| `id` | string | Unique identifier, the page's path without a file extension (for example `develop/clients/redis-py`) |
 | `title` | string | Page title |
 | `url` | string | Canonical URL |
 | `summary` | string | Short description |

--- a/layouts/_default/section.json
+++ b/layouts/_default/section.json
@@ -5,19 +5,7 @@
 {{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site "Page" .) -}}
 
 {{- /* Build the JSON object for the section itself */ -}}
-{{- /* Handle pages where .File may be nil (e.g., taxonomy pages) */ -}}
-{{- /* Also handle _index.md files where ContentBaseName is "_index" (not useful as id) */ -}}
-{{- $id := "" -}}
-{{- with .File -}}
-  {{- $baseName := .ContentBaseName -}}
-  {{- if or (not $baseName) (eq $baseName "_index") -}}
-    {{- $id = $.Title | urlize -}}
-  {{- else -}}
-    {{- $id = $baseName | urlize -}}
-  {{- end -}}
-{{- else -}}
-  {{- $id = .Title | urlize -}}
-{{- end -}}
+{{- $id := partial "page-id.html" . -}}
 {{- $summary := (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace -}}
 {{- $tags := .Params.categories | default (slice) -}}
 {{- $lastUpdated := .Lastmod.Format "2006-01-02T15:04:05Z07:00" -}}
@@ -25,19 +13,10 @@
 {{- /* Build list of child pages */ -}}
 {{- $children := slice -}}
 {{- range .Pages -}}
-  {{- $childTitle := .Title -}}
-  {{- $childId := "" -}}
-  {{- with .File -}}
-    {{- $baseName := .ContentBaseName -}}
-    {{- if or (not $baseName) (eq $baseName "_index") -}}
-      {{- $childId = $childTitle | urlize -}}
-    {{- else -}}
-      {{- $childId = $baseName | urlize -}}
-    {{- end -}}
-  {{- else -}}
-    {{- $childId = $childTitle | urlize -}}
-  {{- end -}}
-  {{- $childSummary := (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace -}}
+  {{- /* Same derivation as the page's own id, so children[].id resolves to the record
+         that page publishes */ -}}
+  {{- $childId := partial "page-id.html" . -}}
+  {{- $childSummary :=(.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace -}}
   {{- $child := dict "id" $childId "title" .Title "url" .Permalink "summary" $childSummary -}}
   {{- $children = $children | append $child -}}
 {{- end -}}

--- a/layouts/_default/single.json
+++ b/layouts/_default/single.json
@@ -5,19 +5,7 @@
 {{- $content := partial "process-markdown-content.html" (dict "RawContent" .RawContent "Site" .Site "Page" .) -}}
 
 {{- /* Build the JSON object */ -}}
-{{- /* Handle pages where .File may be nil (e.g., taxonomy pages) */ -}}
-{{- /* Also handle _index.md files where ContentBaseName is "_index" (not useful as id) */ -}}
-{{- $id := "" -}}
-{{- with .File -}}
-  {{- $baseName := .ContentBaseName -}}
-  {{- if or (not $baseName) (eq $baseName "_index") -}}
-    {{- $id = $.Title | urlize -}}
-  {{- else -}}
-    {{- $id = $baseName | urlize -}}
-  {{- end -}}
-{{- else -}}
-  {{- $id = .Title | urlize -}}
-{{- end -}}
+{{- $id := partial "page-id.html" . -}}
 {{- $summary := (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace -}}
 {{- $tags := .Params.categories | default (slice) -}}
 {{- $lastUpdated := .Lastmod.Format "2006-01-02T15:04:05Z07:00" -}}

--- a/layouts/partials/page-id.html
+++ b/layouts/partials/page-id.html
@@ -1,0 +1,41 @@
+{{- /*
+  Stable, unique id for a page record in the JSON and Markdown outputs.
+
+  Takes a Page. Returns its content path with the ".md" extension and any trailing
+  "/_index" removed, so content/develop/clients/redis-py.md becomes
+  "develop/clients/redis-py" and content/develop/clients/_index.md becomes
+  "develop/clients".
+
+  This replaces a bare filename. ContentBaseName is not unique across the corpus --
+  "message_history" named 58 different pages, "install" 42 -- so any consumer treating
+  id as a primary key silently collapsed them, with no error to notice. The content
+  path is unique by construction, because two files cannot share one path, and it is
+  stable across builds because nothing about it depends on build order. A dedup
+  suffix would not be: the page that got the plain id and the page that got "-1" could
+  swap between builds, quietly repointing anyone who had stored either.
+
+  Slashes are kept rather than flattened to hyphens. Flattening reintroduces a
+  collision risk ("a/b-c" and "a-b/c" both becoming "a-b-c") for no real gain, and the
+  path form matches how the URL is already structured.
+
+  Pages with no backing file -- generated pages, taxonomy terms -- fall back to the
+  urlized title, which is what the previous implementation did for them.
+
+  Shared by single.json, section.json and section.json's children[] entries so all
+  three agree. children[].id must equal the child page's own id or the navigation
+  graph does not resolve.
+*/ -}}
+
+{{- $id := "" -}}
+{{- with .File -}}
+  {{- /* Not ".Path | replace ..." -- piping makes .Path the LAST argument, so the
+         backslash becomes the input and every id comes out as a single backslash. */ -}}
+  {{- $path := replace .Path "\\" "/" -}}
+  {{- $path = strings.TrimSuffix ".md" $path -}}
+  {{- $path = strings.TrimSuffix "/_index" $path -}}
+  {{- $id = $path -}}
+{{- end -}}
+{{- if not $id -}}
+  {{- $id = .Title | urlize -}}
+{{- end -}}
+{{- return $id -}}


### PR DESCRIPTION
Makes the page-level `id` unique — item A4 of DOC-6939.

## The defect

`id` was the content file's base name, so it was never unique. 5,733 pages shared **2,161** ids: `message_history` named 58 different pages, `install` 42, `cli` 38. In the published feed that's 2,643 pages under 2,119 ids, so a consumer treating `id` as a primary key **silently lost about 500 pages**, with nothing to notice it by.

The applied AI team hit this and worked around it by keying on `url`. They've since confirmed they're happy to keep keying on `url` provided the `id` is genuinely unique — which turns this from a decision into an implementation.

## The fix

`id` is now the content path with the extension and any trailing `/_index` removed:

| Page | id |
|---|---|
| `content/commands/set.md` | `commands/set` |
| `content/develop/clients/redis-py.md` | `develop/clients/redis-py` |
| `content/develop/clients/_index.md` | `develop/clients` |

Unique by construction — two files can't share a path — and **stable across builds**, because nothing about it depends on processing order.

| | Before | After |
|---|---|---|
| Distinct ids | 2,161 | **5,733** |
| Colliding ids | 584, across 4,156 pages | **0** |
| `children[]` entries resolving to a page id | — | 5,717 / 5,717 |

Section ids, example ids and `content_hash` are unaffected.

## Two alternatives rejected

**Dedup suffixes** (`-1`, `-2`) would have been a smaller change, but which page gets the plain id and which gets the suffix depends on processing order — so an id could migrate between pages between builds and silently repoint anyone who had stored one. An unstable id is worse than a duplicate: a duplicate fails loudly the first time you compare counts, a migrating id doesn't fail at all.

**Flattening slashes to hyphens**, for a more conventional-looking id, reintroduces collisions — `a/b-c` and `a-b/c` both become `a-b-c`.

## Note on structure

The derivation now lives in one partial, [`layouts/partials/page-id.html`](layouts/partials/page-id.html). It was previously written out three times — `single.json`, `section.json`, and `section.json`'s `children[]` loop — and "same rule implemented twice, then drifted" has been the recurring theme of this ticket. `children[].id` in particular must equal the child page's own id or the navigation graph doesn't resolve.

## What a reviewer should focus on

- **`id` values change for every page**, not only colliding ones. It's a consumer-visible field, though the one known consumer keys on `url` and asked for this.
- The docs table row describing `id` is updated to match. That line also gets touched by #3759, in a different hunk.

## One gotcha, recorded because the tests didn't catch it

I first wrote the path normalisation as `.Path | replace "\\" "/"`. In Hugo, piping puts the piped value **last**, so that evaluates as `replace "\\" "/" .Path` — the backslash became the input and **every id came out as a single backslash**. The build passed, and the `children[]` cross-reference check reported 5,717/5,717 resolving, because everything resolved to the same wrong value. Only printing actual ids caught it. Worth knowing that a cross-reference check can be fully satisfied by uniformly wrong data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Consumer-visible breaking change to `id` on all documentation JSON records; correctness improves but any client still keying on the old basename ids must migrate (known consumer uses `url`).
> 
> **Overview**
> **Fixes duplicate `id` values** in AI/RAG JSON output by replacing filename-based ids with the page’s **content path** (extension and trailing `/_index` stripped), e.g. `develop/clients/redis-py`.
> 
> Adds shared partial **`layouts/partials/page-id.html`** and wires **`single.json`**, **`section.json`**, and **`children[].id`** through it so section navigation ids match each child page’s own record. Pages without a backing file still use a urlized title fallback.
> 
> Updates **`content/ai-agent-resources.md`** so the documented `id` field matches the new semantics. **Every page’s `id` changes** in the published feed—not only previously colliding ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f090ac64e7adfaa3058e0242562cdf02140ebc37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->