### PR TITLE
RS: Scope the OpenSSL 3.3 requirement to RHEL 9

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -113,9 +113,21 @@ The following changes affect behavior and validation in Redis Search:
 
 - Improved handling of expired records, memory constraints, and malformed fields.
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-29.md
@@ -154,9 +154,21 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 - Upgrading to this Redis Software version can cause LDAP authentication to fail with "certificate signed by unknown authority" errors if your cluster currently uses LDAP authentication. This issue will be fixed in an upcoming maintenance release.
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Deprecations
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-16-33.md
@@ -52,9 +52,21 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Supported platforms
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-23.md
@@ -149,9 +149,21 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 - `crdb_controller` is now enabled by default.
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-18-36.md
@@ -51,9 +51,21 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -95,9 +95,21 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
@@ -77,9 +77,21 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-68.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-68.md
@@ -63,9 +63,21 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/_index.md
@@ -57,9 +57,21 @@ Redis Software version 8.2.0 introduces the following breaking changes:
 
     - Existing functionality for listing, deleting, and loading modules is unchanged.
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -177,9 +177,21 @@ Redis Software version 8.2.0 introduces the following breaking changes:
 
     - Existing functionality for listing, deleting, and loading modules is unchanged.
 
-### OpenSSL version
+### OpenSSL version on RHEL 9
 
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
+On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
+
+Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
+
+The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
+
+Before you upgrade, check the OpenSSL version on each node:
+
+```sh
+openssl version
+```
+
+If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
 ### Reserved ports
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only clarification of platform-specific upgrade prerequisites; no product code or behavior changes.
> 
> **Overview**
> **OpenSSL upgrade guidance** in Redis Software 8.0.x and 8.2.x release notes is narrowed from a blanket “OpenSSL 3.3+” rule to **RHEL 9 only**, with an explicit note that other supported platforms are unchanged.
> 
> The **### OpenSSL version** heading becomes **### OpenSSL version on RHEL 9**, and the single-line requirement is replaced with RHEL-specific context: builds target the OpenSSL 3.3 runtime on recent RHEL 9 minors (with an example that RHEL 9.6 ships 3.2.2), a warning that **pre-upgrade checks do not catch** incompatible OpenSSL (upgrades can fail mid-flight and leave management services failed), and pre-upgrade steps—run `openssl version` on each node and upgrade `openssl` / `openssl-libs` to **3.3.0+** before upgrading Redis Software.
> 
> The same block is applied consistently across the 8.0 release index, multiple 8.0 maintenance/minor release note pages, and the 8.2 release index and 8.2.0-25 notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ff1d34cdff4fd08820efa7d9f123a2550a3a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->