### PR TITLE
RS: fix fips wording

### DIFF
--- a/content/operate/kubernetes/security/fips.md
+++ b/content/operate/kubernetes/security/fips.md
@@ -19,7 +19,7 @@ When you enable FIPS mode, the operator deploys a FIPS-compatible image in place
 FIPS compliance depends on the underlying platform, not only on Redis:
 
 - **FIPS-configured nodes.** A container runs in FIPS mode only if the host node is configured for FIPS. On OpenShift, the cluster must be installed in FIPS mode. Redis does not configure the host; this is the responsibility of your platform.
-- **amd64 architecture.** The FIPS-compatible Redis Enterprise image is built for `amd64` only. There is no arm64 FIPS image.
+- **amd64 architecture.** The FIPS-compatible Redis Software image is built for `amd64` only. There is no arm64 FIPS image.
 
 ## Enable FIPS mode
 

--- a/content/operate/kubernetes/security/fips.md
+++ b/content/operate/kubernetes/security/fips.md
@@ -10,7 +10,7 @@ linkTitle: FIPS compliance
 weight: 60
 ---
 
-You can run your Redis Software for Kubernetes cluster in FIPS 140-3 compliance mode, where cryptographic operations use validated, FIPS-approved algorithms. FIPS mode is available starting with operator version 8.2.0.
+You can run your Redis Software for Kubernetes cluster in FIPS 140-3 compliance mode, which uses cryptographic libraries based on FIPS 140-3 validated modules and enables the use of FIPS-approved cryptographic algorithms. FIPS mode is available starting with operator version 8.2.0.
 
 When you enable FIPS mode, the operator deploys a FIPS-compatible image in place of the standard one.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -49,9 +49,9 @@ For more information, see [Audit events]({{<relref "/operate/rs/security/audit-e
 
 ### FIPS 140-3 support
 
-Redis supports deployments on RHEL 9 VMs using cryptographic libraries based on FIPS 140-3 validated modules, enabling the use of FIPS-approved cryptographic algorithms in supported environments.
+Redis Software supports deployments on RHEL 9 VMs and RHEL 9 containerized Redis on GKE using cryptographic libraries based on FIPS 140-3 validated modules, enabling the use of FIPS-approved cryptographic algorithms in supported environments.
 
-- Install Redis Software on a RHEL 9 host that has FIPS mode enabled. See [Supported platforms](#supported-platforms) for the platforms validated for FIPS mode.
+- Install Redis Software on a RHEL 9 host that has FIPS mode enabled. See [Supported platforms](#supported-platforms) for the platforms that support FIPS mode.
 
 - In FIPS mode, Redis Software uses only FIPS-approved cryptographic algorithms and cipher suites; non-approved ciphers and algorithms are blocked.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Markdown-only copy changes with no code, configuration, or security behavior impact.
> 
> **Overview**
> Documentation-only edits align **FIPS 140-3** phrasing with the validated-modules / FIPS-approved-algorithms framing used elsewhere.
> 
> In `content/operate/kubernetes/security/fips.md`, the intro now describes FIPS mode in terms of **cryptographic libraries based on FIPS 140-3 validated modules** (replacing the shorter “validated, FIPS-approved algorithms” line), and the **amd64** prerequisite refers to the **Redis Software** FIPS image instead of **Redis Enterprise**.
> 
> In `content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md`, the FIPS section names **Redis Software** (not generic “Redis”), adds **RHEL 9 containerized Redis on GKE** as a supported deployment, and changes the supported-platforms bullet from “validated for FIPS mode” to **platforms that support FIPS mode**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fd2ec0e78135ac56df5c0bda81192f00bce2ab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->