### PR TITLE
DOC-6939 Add schema_version and since to the AI outputs

### DIFF
--- a/build/transform_json_sections.ts
+++ b/build/transform_json_sections.ts
@@ -47,10 +47,16 @@ interface CodeExample {
 }
 
 interface PageJsonInput {
+  // Emitted by the Hugo templates and carried through untouched. Declared so the
+  // spread below preserves them explicitly rather than by accident: schema_version is
+  // what consumers gate re-parsing on, and since is the only version information the
+  // feed carries.
+  schema_version?: number;
   id: string;
   title: string;
   url: string;
   summary: string;
+  since?: string;
   content?: string;
   tags: string[];
   last_updated: string;
@@ -60,10 +66,12 @@ interface PageJsonInput {
 type PageType = 'content' | 'index';
 
 interface PageJsonOutput {
+  schema_version?: number;
   id: string;
   title: string;
   url: string;
   summary: string;
+  since?: string;
   page_type: PageType;
   content_hash?: string;
   tags: string[];

--- a/config.toml
+++ b/config.toml
@@ -62,6 +62,17 @@ anchor = "smart"
 tagManagerId = "GTM-TKZ6J9R"
 gitHubRepo = "https://github.com/redis/docs"
 
+# Schema version for the AI-facing JSON and Markdown outputs. Emitted as
+# `schema_version` in each per-page JSON record and in the Markdown metadata block.
+#
+# Increment this ONLY when the shape of a record changes: a field added, removed or
+# renamed, or a new value entering the `role` vocabulary. It must NOT change when page
+# content changes -- consumers gate re-parsing on it, and a version that moves with
+# content is a second content hash, which they will learn to ignore.
+#
+# Changing what a field *contains* is not a shape change and does not bump this.
+aiSchemaVersion = 1
+
 # Display and sort order for client examples
 clientsExamples = ["Python", "Node.js", "ioredis", "Java-Sync", "Lettuce-Sync", "Java-Async", "Java-Reactive", "Go", "C", "C#-Sync (NRedisStack)", "C#-Async (NRedisStack)", "C#-Sync (SE.Redis)", "C#-Async (SE.Redis)", "RedisVL", "PHP", "Ruby", "Rust-Sync", "Rust-Async"]
 searchService = "/convai/api/search-service"

--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -65,16 +65,29 @@ Two consequences worth knowing if you diff the feed against the sitemap:
 - Both figures move. The feed is rebuilt at least daily and the corpus grows, so treat any
   page count as a snapshot.
 
+### Schema version
+
+Every record carries a `schema_version` integer, and the same value appears in the
+`json metadata` block of the Markdown output. It is currently **1**.
+
+It increments only when the **shape** of a record changes: a field added, removed or
+renamed, or a new value entering the [role vocabulary](#section-roles). It does **not**
+change when page content changes, and it does not change when the value inside a field
+changes without the field itself changing. Use `content_hash` to detect content changes;
+use `schema_version` to detect when your parser might need attention.
+
 ### JSON schema
 
 Each document contains:
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `schema_version` | integer | Version of the record format. See [Schema version](#schema-version). |
 | `id` | string | Unique identifier, the page's path without a file extension (for example `develop/clients/redis-py`) |
 | `title` | string | Page title |
 | `url` | string | Canonical URL |
 | `summary` | string | Short description |
+| `since` | string | Redis version the command was introduced in. Present on command pages only. |
 | `page_type` | string | `"content"` (has prose) or `"index"` (navigation only) |
 | `content_hash` | string | SHA256 hash for cache invalidation (content pages only) |
 | `sections` | array | Content split by headings with semantic roles |

--- a/layouts/_default/section.json
+++ b/layouts/_default/section.json
@@ -22,10 +22,12 @@
 {{- end -}}
 
 {
+  "schema_version": {{ site.Params.aiSchemaVersion | jsonify }},
   "id": {{ $id | jsonify }},
   "title": {{ .Title | jsonify }},
   "url": {{ .Permalink | jsonify }},
-  "summary": {{ $summary | jsonify }},
+  "summary": {{ $summary | jsonify }},{{ with .Params.since }}
+  "since": {{ . | jsonify }},{{ end }}
   "content": {{ $content | jsonify }},
   "tags": {{ $tags | jsonify }},
   "last_updated": {{ $lastUpdated | jsonify }},

--- a/layouts/_default/section.md
+++ b/layouts/_default/section.md
@@ -2,6 +2,7 @@
 
 ```json metadata
 {
+  "schema_version": {{ site.Params.aiSchemaVersion | jsonify }},
   "title": {{ .Title | jsonify }},
   "description": {{ (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace | jsonify }},
   "categories": {{ .Params.categories | jsonify }}{{ if .Params.arguments }},

--- a/layouts/_default/single.json
+++ b/layouts/_default/single.json
@@ -11,10 +11,12 @@
 {{- $lastUpdated := .Lastmod.Format "2006-01-02T15:04:05Z07:00" -}}
 
 {
+  "schema_version": {{ site.Params.aiSchemaVersion | jsonify }},
   "id": {{ $id | jsonify }},
   "title": {{ .Title | jsonify }},
   "url": {{ .Permalink | jsonify }},
-  "summary": {{ $summary | jsonify }},
+  "summary": {{ $summary | jsonify }},{{ with .Params.since }}
+  "since": {{ . | jsonify }},{{ end }}
   "content": {{ $content | jsonify }},
   "tags": {{ $tags | jsonify }},
   "last_updated": {{ $lastUpdated | jsonify }}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -2,6 +2,7 @@
 
 ```json metadata
 {
+  "schema_version": {{ site.Params.aiSchemaVersion | jsonify }},
   "title": {{ .Title | jsonify }},
   "description": {{ (.Params.description | default .Description) | plainify | replaceRE "\\s+" " " | strings.TrimSpace | jsonify }},
   "categories": {{ .Params.categories | jsonify }}{{ if .Params.arguments }},


### PR DESCRIPTION
Adds `schema_version` and `since` to the AI-facing JSON and Markdown outputs — items C1 and C3 of DOC-6939. Both were agreed with the applied AI team rather than assumed.

## C3 — `since` was their only hard blocker

Their observation 01: the Markdown metadata block carries `since` for command pages, the JSON does not, so a consumer indexing or filtering on version information could not move to the feed without dropping that filter.

It now appears in the JSON, straight from the command pages' frontmatter — on **574** records, matching exactly the 574 source files that declare it. Section pages don't gain a spurious empty field.

## C1 — `schema_version`, with the semantics that make it useful

A single integer, in every per-page JSON record and in the Markdown metadata block, currently **1**. It lives in one place — `aiSchemaVersion` in `config.toml` — so there's one value to bump rather than four templates to keep in step.

The semantics are their own definition, and they're the point of the field:

- **Increments only when the record's shape changes** — a field added, removed or renamed, or a new value entering the `role` vocabulary.
- **Never changes when content changes.** Their words: a version that moves with content is a second content hash, and they'd learn to ignore it. Use `content_hash` for content, `schema_version` for "your parser may need attention".

That distinction is written into both the config comment and the published docs, because the field is worthless without it.

**Worth stating what does *not* bump it**, since the temptation will be there: changing what a field *contains* is not a shape change. The page `id` going from a filename to a path (#3761) is a value change, so version 1 covers both that and this.

## Verification

Built and transformed the combined state, since #3761 landed first and the two had never been built together:

| | |
|---|---|
| Records | 5,733 |
| `schema_version` | `1` on all 5,733, and in the Markdown metadata block |
| Records carrying `since` | 574 (against 574 source files declaring it) |
| Distinct page ids | 5,733, 0 colliding |
| `content_hash` verifies | 5,687 / 5,687 |

`commands/set` comes out as `id='commands/set'`, `schema_version=1`, `since='1.0.0'`.

## One thing hardened beyond the ask

The transform now **declares** both fields on its input and output interfaces. They were already surviving, because the object spread carries unknown keys at runtime — but nothing said so, and a future refactor replacing the spread with explicit field copying would have silently dropped the one field consumers gate their parsing on. Declaring them makes the survival deliberate rather than incidental.

## What a reviewer should focus on

- **`schema_version` is a contract-shaped field.** Once published, consumers will gate behaviour on it, so the discipline about when it increments matters more than the field itself. The `Constraint` trailer and the config comment both state it.
- Adding the field is itself a shape change, which is the chicken-and-egg case: version 1 is defined as "the shape as of this release" rather than pretending an earlier version existed.

## Not in this PR

C4 (redirect map), C5 (splitting interface-only metadata from semantic metadata) and C6 (a machine-readable marker on the code-examples legend) are still open, as is the decision on D5 — versioned pages serving an untransformed schema at the documented URL shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive feed fields and documentation with no auth or runtime behavior changes; consumers must treat schema_version as a parser contract.
> 
> **Overview**
> Adds **`schema_version`** and **`since`** to the AI-facing per-page JSON feed and Markdown metadata, driven by a single **`aiSchemaVersion`** param in `config.toml` (currently **1**).
> 
> **`schema_version`** is documented as a shape-only contract: bump it when fields or role vocabulary change, not when page content changes (use **`content_hash`** for that). It is emitted from all four Hugo templates (`single`/`section` × JSON/Markdown).
> 
> **`since`** is added to JSON output when front matter defines it (command pages), matching what Markdown metadata already exposed, and omitted elsewhere so non-command records do not get an empty field.
> 
> Published **AI Agent Resources** docs gain a schema-version section and table rows for both fields. The NDJSON transform types in `transform_json_sections.ts` now declare **`schema_version`** and **`since`** on input/output so they survive explicit refactors, not only object spread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1cace7a545336f645a86f89983d95e59123d141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->