### PR TITLE
K8s: 8.2.0-13 release notes

### DIFF
--- a/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026.md
+++ b/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026.md
@@ -7,11 +7,11 @@ categories:
 description: Feature release with Redis Enterprise RBAC custom resource definitions, REDB metric enrichment through tags, and Redis Software 8.2.0.
 hideListLinks: true
 linkTitle: 8.2.0-12 (July 2026)
-title: Redis Enterprise for Kubernetes 8.2.0-12 (July 2026) release notes
+title: Redis Software for Kubernetes 8.2.0-12 (July 2026) release notes
 weight: 27
 ---
 
-Redis Enterprise for Kubernetes 8.2.0-12 is a feature release that supports [Redis Software 8.2.0]({{< relref "/operate/rs/release-notes/rs-8-2-releases/" >}}) and includes new features, bug fixes, and enhancements.
+Redis Software for Kubernetes 8.2.0-12 is a feature release that supports [Redis Software 8.2.0]({{< relref "/operate/rs/release-notes/rs-8-2-releases/" >}}) and includes new features, bug fixes, and enhancements.
 
 ## Highlights
 
@@ -64,7 +64,7 @@ This release adds the RBAC custom resource definitions and new fields for access
 
 ## Supported distributions
 
-Redis Enterprise for Kubernetes is compatible with [CNCF-conformant](https://www.cncf.io/training/certification/software-conformance/) Kubernetes platforms. The operator follows standard Kubernetes APIs and practices and is designed to run consistently across certified Kubernetes environments.
+Redis Software for Kubernetes is compatible with [CNCF-conformant](https://www.cncf.io/training/certification/software-conformance/) Kubernetes platforms. The operator follows standard Kubernetes APIs and practices and is designed to run consistently across certified Kubernetes environments.
 
 The following table shows supported Kubernetes versions at the time of this release. For a list of platforms tested with this release, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/reference/supported_k8s_distributions" >}}).
 

--- a/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-13-august2026.md
+++ b/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-13-august2026.md
@@ -1,0 +1,43 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: This is a maintenance release to support Redis Software version 8.2.0-46.
+hideListLinks: true
+linkTitle: 8.2.0-13 (August 2026)
+title: Redis Software for Kubernetes 8.2.0-13 (August 2026) release notes
+weight: 26
+---
+
+## Highlights
+
+This is a maintenance release to support [Redis Software 8.2.0-46]({{<relref "/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46">}}). For version changes, supported distributions, and known limitations, see the [release notes for 8.2.0-12 (July 2026)]({{<relref "/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026">}}).
+
+## Resolved issues
+
+- Fixed a failure caused by setting AWS load balancer annotations on `ClusterIP` services. These annotations now apply only to pod exposure services, and annotation changes re-create the Cluster Manager UI, API, and Prometheus services consistently <!--RED-209555-->
+
+- Fixed an Active-Active database whose REAADB spec omitted `externalReplicationPort` for a participating cluster. The operator now syncs the port from the existing Active-Active database <!--RED-205147-->
+
+- Fixed an endless "could not set label" loop caused by reserved keys in the persistent volume claim (PVC) extra labels annotation <!--RED-189152-->
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:8.2.0-46.13` (`redislabs/redis:8.2.0-46.13.minimal` for minimal base image)
+- **Operator**: `redislabs/operator:8.2.0-13`
+- **Services Rigger**: `redislabs/k8s-controller:8.2.0-13`
+- **Call Home Client**: `redislabs/re-call-home-client:8.2.0-13`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `8.2.0-13.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.2.0-46.13` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.2.0-46.13.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.2.0-13`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.2.0-13`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.2.0-13`
+
+## Known limitations
+
+See [8.2.0 releases]({{<relref "/operate/kubernetes/release-notes/8-2-0-releases/">}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-13-august2026.md
+++ b/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-13-august2026.md
@@ -13,7 +13,7 @@ weight: 26
 
 ## Highlights
 
-This is a maintenance release to support [Redis Software 8.2.0-46]({{<relref "/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46">}}). For version changes, supported distributions, and known limitations, see the [release notes for 8.2.0-12 (July 2026)]({{<relref "/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026">}}).
+This is a maintenance release to support [Redis Software 8.2.0]({{<relref "/operate/rs/release-notes/rs-8-2-releases/">}}) version 8.2.0-46. For version changes, supported distributions, and known limitations, see the [release notes for 8.2.0-12 (July 2026)]({{<relref "/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026">}}).
 
 ## Resolved issues
 

--- a/content/operate/kubernetes/release-notes/8-2-0-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-2-0-releases/_index.md
@@ -7,11 +7,11 @@ categories:
 description: Releases with support for Redis Enterprise Software 8.2.0
 hideListLinks: true
 linkTitle: 8.2.0 releases
-title: Redis Enterprise for Kubernetes 8.2.0 release notes
+title: Redis Software for Kubernetes 8.2.0 release notes
 weight: 83
 ---
 
-Redis Enterprise for Kubernetes 8.2.0 includes new features, bug fixes, enhancements, and support for Redis Software 8.2.0. The latest release is 8.2.0-12 with support for Redis Software version 8.2.0-25.
+Redis Software for Kubernetes 8.2.0 includes new features, bug fixes, enhancements, and support for Redis Software 8.2.0. The latest release is 8.2.0-13 with support for Redis Software version 8.2.0-46.
 
 ## Detailed release notes
 
@@ -19,7 +19,7 @@ Redis Enterprise for Kubernetes 8.2.0 includes new features, bug fixes, enhancem
 
 ## Supported distributions
 
-Redis Enterprise for Kubernetes is compatible with [CNCF-conformant](https://www.cncf.io/training/certification/software-conformance/) Kubernetes platforms. The operator follows standard Kubernetes APIs and practices and is designed to run consistently across certified Kubernetes environments.
+Redis Software for Kubernetes is compatible with [CNCF-conformant](https://www.cncf.io/training/certification/software-conformance/) Kubernetes platforms. The operator follows standard Kubernetes APIs and practices and is designed to run consistently across certified Kubernetes environments.
 
 The following table shows supported Kubernetes versions at the time of this release. For a list of platforms tested with this release, see [Supported Kubernetes distributions]({{< relref "/operate/kubernetes/reference/supported_k8s_distributions" >}}).
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to release notes and naming; no application code or operational behavior.
> 
> **Overview**
> Adds **Redis Software for Kubernetes 8.2.0-13 (August 2026)** release notes as a maintenance release for Redis Software **8.2.0-46**, with three resolved issues (AWS LB annotations on `ClusterIP` services, REAADB `externalReplicationPort` sync, PVC extra-label loop) plus container image download tags for standard and OpenShift.
> 
> Updates the **8.2.0 releases** index so the latest version is **8.2.0-13** / **8.2.0-46** (was 8.2.0-12 / 8.2.0-25).
> 
> Renames product wording from **Redis Enterprise for Kubernetes** to **Redis Software for Kubernetes** in the 8.2.0-12 page title/body and the 8.2.0 releases index (including supported-distributions copy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f042c610f6f7ef7f3c48180d584b762e300e373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->