### PR TITLE
DOC-6951 Backfill aliases for 256 pages that moved without one

### DIFF
--- a/content/develop/ai/context-engine/agent-memory/_index.md
+++ b/content/develop/ai/context-engine/agent-memory/_index.md
@@ -11,6 +11,8 @@ hideListLinks: true
 weight: 20
 bannerText: Redis Agent Memory is currently available in preview. Features and behavior are subject to change.
 bannerChildren: true
+aliases:
+- /develop/ai/agent-memory/
 ---
 
 ## What is Redis Agent Memory?

--- a/content/develop/ai/context-engine/agent-memory/api-reference.md
+++ b/content/develop/ai/context-engine/agent-memory/api-reference.md
@@ -7,4 +7,6 @@ weight: 20
 params:
   sourcefile: ./openapi-agent-memory.json
   sortOperationsAlphabetically: false
+aliases:
+- /develop/ai/agent-memory/api-reference/
 ---

--- a/content/develop/ai/redisvl/user_guide/getting_started.md
+++ b/content/develop/ai/redisvl/user_guide/getting_started.md
@@ -3,6 +3,7 @@ linkTitle: Getting started
 title: Getting Started
 aliases:
 - /integrate/redisvl/user_guide/01_getting_started
+- /integrate/redisvl/user_guide/getting_started/
 weight: 2
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/advanced_queries.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/advanced_queries.md
@@ -3,6 +3,7 @@ linkTitle: Use advanced query types
 title: Use Advanced Query Types
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/11_advanced_queries
+- /develop/ai/redisvl/user_guide/advanced_queries/
 weight: 11
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/complex_filtering.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/complex_filtering.md
@@ -3,6 +3,7 @@ linkTitle: Query and filter data
 title: Query and Filter Data
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/02_complex_filtering
+- /develop/ai/redisvl/user_guide/complex_filtering/
 weight: 02
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/embeddings_cache.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/embeddings_cache.md
@@ -3,6 +3,8 @@ linkTitle: Cache embeddings
 title: Cache Embeddings
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/10_embeddings_cache
+- /integrate/redisvl/user_guide/embeddings_cache/
+- /develop/ai/redisvl/user_guide/embeddings_cache/
 weight: 10
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/hash_vs_json.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/hash_vs_json.md
@@ -3,6 +3,8 @@ linkTitle: Choose a storage type
 title: Choose a Storage Type
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/05_hash_vs_json
+- /integrate/redisvl/user_guide/hash_vs_json/
+- /develop/ai/redisvl/user_guide/hash_vs_json/
 weight: 05
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/langcache_semantic_cache.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/langcache_semantic_cache.md
@@ -3,6 +3,7 @@ linkTitle: Use langcache as the llm cache backend
 title: Use LangCache as the LLM Cache Backend
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/13_langcache_semantic_cache
+- /develop/ai/redisvl/user_guide/langcache_semantic_cache/
 weight: 13
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/llmcache.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/llmcache.md
@@ -3,6 +3,8 @@ linkTitle: Cache llm responses
 title: Cache LLM Responses
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/03_llmcache
+- /integrate/redisvl/user_guide/llmcache/
+- /develop/ai/redisvl/user_guide/llmcache/
 weight: 03
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/message_history.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/message_history.md
@@ -3,6 +3,8 @@ linkTitle: Manage llm message history
 title: Manage LLM Message History
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/07_message_history
+- /integrate/redisvl/user_guide/message_history/
+- /develop/ai/redisvl/user_guide/message_history/
 weight: 07
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/rerankers.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/rerankers.md
@@ -3,6 +3,8 @@ linkTitle: Rerank search results
 title: Rerank Search Results
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/06_rerankers
+- /integrate/redisvl/user_guide/rerankers/
+- /develop/ai/redisvl/user_guide/rerankers/
 weight: 06
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/semantic_router.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/semantic_router.md
@@ -3,6 +3,8 @@ linkTitle: Route queries with semanticrouter
 title: Route Queries with SemanticRouter
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/08_semantic_router
+- /integrate/redisvl/user_guide/semantic_router/
+- /develop/ai/redisvl/user_guide/semantic_router/
 weight: 08
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/sql_to_redis_queries.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/sql_to_redis_queries.md
@@ -3,6 +3,7 @@ linkTitle: Write sql queries for redis
 title: Write SQL Queries for Redis
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/12_sql_to_redis_queries
+- /develop/ai/redisvl/user_guide/sql_to_redis_queries/
 weight: 12
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/svs_vamana.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/svs_vamana.md
@@ -3,6 +3,7 @@ linkTitle: Optimize indexes with svs-vamana
 title: Optimize Indexes with SVS-VAMANA
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/09_svs_vamana
+- /develop/ai/redisvl/user_guide/svs_vamana/
 weight: 09
 ---
 

--- a/content/develop/ai/redisvl/user_guide/how_to_guides/vectorizers.md
+++ b/content/develop/ai/redisvl/user_guide/how_to_guides/vectorizers.md
@@ -3,6 +3,8 @@ linkTitle: Create embeddings with vectorizers
 title: Create Embeddings with Vectorizers
 aliases:
 - /integrate/redisvl/user_guide/how_to_guides/04_vectorizers
+- /integrate/redisvl/user_guide/vectorizers/
+- /develop/ai/redisvl/user_guide/vectorizers/
 weight: 04
 ---
 

--- a/content/develop/ai/search-and-query/advanced-concepts/stopwords.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/stopwords.md
@@ -1,6 +1,7 @@
 ---
 aliases:
 - /interact/search-and-query/advanced-concepts/stopwords
+- /develop/interact/search-and-query/advanced-concepts/stopwords/
 
 categories:
 - docs

--- a/content/develop/ai/search-and-query/vectors/_index.md
+++ b/content/develop/ai/search-and-query/vectors/_index.md
@@ -2,6 +2,7 @@
 aliases:
 - /develop/interact/search-and-query/advanced-concepts/vectors
 - /interact/search-and-query/advanced-concepts/vectors/
+- /develop/ai/vector-fields/
 categories:
 - docs
 - develop

--- a/content/develop/clients/dotnet/connect.md
+++ b/content/develop/clients/dotnet/connect.md
@@ -13,6 +13,8 @@ description: Connect your .NET application to a Redis database
 linkTitle: Connect
 title: Connect to the server
 weight: 20
+aliases:
+- /develop/connect/clients/dotnet/connect/
 ---
 
 ## Basic connection

--- a/content/develop/clients/dotnet/nredisstack/queryjson.md
+++ b/content/develop/clients/dotnet/nredisstack/queryjson.md
@@ -1,6 +1,7 @@
 ---
 aliases:
 - /develop/clients/dotnet/queryjson
+- /develop/connect/clients/dotnet/queryjson/
 categories:
 - docs
 - develop

--- a/content/develop/clients/jedis/_index.md
+++ b/content/develop/clients/jedis/_index.md
@@ -5,6 +5,8 @@ aliases:
 - /connect/clients/jedis/
 - /clients/jedis/
 - /develop/clients/java
+- /develop/connect/clients/java/
+- /develop/clients/java/jedis/
 categories:
 - docs
 - develop

--- a/content/develop/clients/lettuce/_index.md
+++ b/content/develop/clients/lettuce/_index.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/connect/clients/java/lettuce
 - /connect/clients/lettuce/
 - /clients/lettuce/
+- /develop/clients/java/lettuce/
 categories:
 - docs
 - develop

--- a/content/develop/clients/om-clients/_index.md
+++ b/content/develop/clients/om-clients/_index.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/connect/om-clients
 - /connect/clients/om-clients/
 - /clients/om-clients/
+- /develop/connect/clients/om-clients/
 categories:
 - docs
 - develop

--- a/content/develop/clients/redis-py/_index.md
+++ b/content/develop/clients/redis-py/_index.md
@@ -6,6 +6,7 @@ aliases:
 - /clients/python/
 - /connect/clients/redis-py/
 - /clients/redis-py/
+- /develop/clients/python/redis-py/
 categories:
 - docs
 - develop

--- a/content/develop/clients/redis-vl.md
+++ b/content/develop/clients/redis-vl.md
@@ -1,5 +1,7 @@
 ---
-aliases: /develop/connect/clients/python/redis-vl
+aliases:
+- /develop/connect/clients/python/redis-vl
+- /develop/clients/python/redis-vl/
 categories:
 - docs
 - develop

--- a/content/develop/clients/sch.md
+++ b/content/develop/clients/sch.md
@@ -22,6 +22,8 @@ topics:
 - smart-client-handoffs
 - resilience
 weight: 50
+aliases:
+- /develop/clients/sce/
 ---
 
 *Smart client handoffs (SCH)* is a feature of Redis Cloud and

--- a/content/develop/get-started/rag.md
+++ b/content/develop/get-started/rag.md
@@ -14,6 +14,8 @@ linkTitle: RAG with Redis
 stack: true
 title: RAG with Redis
 weight: 4
+aliases:
+- /develop/ai/rag/
 ---
 ### What is Retrieval Augmented Generation (RAG)?
 Large Language Models (LLMs) generate human-like text but are limited by the data they were trained on. RAG enhances LLMs by integrating them with external, domain-specific data stored in a Redis [vector database]({{< relref "/develop/get-started/search-tutorial/vector-search" >}}).

--- a/content/develop/get-started/redis-in-ai.md
+++ b/content/develop/get-started/redis-in-ai.md
@@ -7,6 +7,8 @@ categories:
 description: Understand key benefits of using Redis for AI.
 linktitle: GenAI apps
 weight: 20
+aliases:
+- /develop/ai/genai-apps/
 ---
 
 Redis enables high-performance, scalable, and reliable data management, making it a key component for GenAI apps, chatbots, and AI agents. By leveraging Redis for fast data retrieval, caching, and vector search capabilities, you can enhance AI-powered interactions, reduce latency, and improve user experience.

--- a/content/develop/tools/insight/release-notes/v.2.14.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.14.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.14.0 (Nov 2022)
 date: 2022-11-28 00:00:00 +0000
 description: RedisInsight v2.14.0
 weight: 3
+aliases:
+- /develop/connect/insight/release-notes/v.2.14.0/
 ---
 ## 2.14.0 (November 2022)
 This is the General Availability (GA) release of RedisInsight 2.14.

--- a/content/develop/tools/insight/release-notes/v.2.16.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.16.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.16.0 (Dec 2022)
 date: 2022-12-28 00:00:00 +0000
 description: RedisInsight v2.16.0
 weight: 2
+aliases:
+- /develop/connect/insight/release-notes/v.2.16.0/
 ---
 ## 2.16.0 (December 2022)
 This is the General Availability (GA) release of RedisInsight 2.16.

--- a/content/develop/tools/insight/release-notes/v.2.18.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.18.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.18.0 (Jan 2023)
 date: 2023-01-31 00:00:00 +0000
 description: RedisInsight v2.18.0
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.18.0/
 ---
 ## 2.18.0 (January 2023)
 This is the General Availability (GA) release of RedisInsight 2.18.

--- a/content/develop/tools/insight/release-notes/v.2.20.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.20.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.20.0 (Feb 2023)
 date: 2023-02-28 00:00:00 +0000
 description: RedisInsight v2.20.0
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.20.0/
 ---
 ## 2.20.0 (February 2023)
 This is the General Availability (GA) release of RedisInsight 2.20.

--- a/content/develop/tools/insight/release-notes/v.2.22.1.md
+++ b/content/develop/tools/insight/release-notes/v.2.22.1.md
@@ -4,6 +4,8 @@ linkTitle: v2.22.1 (Mar 2023)
 date: 2023-03-30 00:00:00 +0000
 description: RedisInsight v2.22.1
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.22.1/
 ---
 ## 2.22.1 (March 2023)
 This is the General Availability (GA) release of RedisInsight 2.22.

--- a/content/develop/tools/insight/release-notes/v.2.24.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.24.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.24.0 (Apr 2023)
 date: 2023-04-27 00:00:00 +0000
 description: RedisInsight v2.24
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.24.0/
 ---
 ## 2.24 (April 2023)
 This is the General Availability (GA) release of RedisInsight 2.24.

--- a/content/develop/tools/insight/release-notes/v.2.26.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.26.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.26.0 (May 2023)
 date: 2023-05-31 00:00:00 +0000
 description: RedisInsight v2.26
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.26.0/
 ---
 ## 2.26 (May 2023)
 This is the General Availability (GA) release of RedisInsight 2.26.

--- a/content/develop/tools/insight/release-notes/v.2.30.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.30.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.30.0 (July 2023)
 date: 2023-07-27 00:00:00 +0000
 description: RedisInsight v2.30
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.30.0/
 ---
 ## 2.30 (July 2023)
 This is the General Availability (GA) release of RedisInsight 2.30.

--- a/content/develop/tools/insight/release-notes/v.2.32.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.32.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.32.0 (August 2023)
 date: 2023-08-31 00:00:00 +0000
 description: RedisInsight v2.32
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.32.0/
 ---
 ## 2.32 (August 2023)
 This is the General Availability (GA) release of RedisInsight 2.32.

--- a/content/develop/tools/insight/release-notes/v.2.34.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.34.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.34.0 (September 2023)
 date: 2023-09-28 00:00:00 +0000
 description: RedisInsight v2.34
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.34.0/
 ---
 ## 2.34 (September 2023)
 This is the General Availability (GA) release of RedisInsight 2.34.

--- a/content/develop/tools/insight/release-notes/v.2.36.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.36.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.36.0 (October 2023)
 date: 2023-10-26 00:00:00 +0000
 description: RedisInsight v2.36
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.36.0/
 ---
 ## 2.36 (October 2023)
 This is the General Availability (GA) release of RedisInsight 2.36.

--- a/content/develop/tools/insight/release-notes/v.2.38.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.38.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.38.0 (November 2023)
 date: 2023-11-29 00:00:00 +0000
 description: RedisInsight v2.38
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.38.0/
 ---
 ## 2.38 (November 2023)
 This is the General Availability (GA) release of RedisInsight 2.38.

--- a/content/develop/tools/insight/release-notes/v.2.4.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.4.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.4.0 (June 2022)
 date: 2022-06-27 00:00:00 +0000
 description: RedisInsight v2.4.0
 weight: 9
+aliases:
+- /develop/connect/insight/release-notes/v.2.4.0/
 ---
 
 ## 2.4.0 (June 2022)

--- a/content/develop/tools/insight/release-notes/v.2.40.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.40.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.40.0 (December 2023)
 date: 2023-12-27 00:00:00 +0000
 description: RedisInsight v2.40
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.40.0/
 ---
 ## 2.40 (December 2023)
 This is the General Availability (GA) release of RedisInsight 2.40.

--- a/content/develop/tools/insight/release-notes/v.2.42.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.42.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.42.0 (January 2024)
 date: 2024-01-30 00:00:00 +0000
 description: RedisInsight v2.42
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.42.0/
 ---
 ## 2.42 (January 2024)
 This is the General Availability (GA) release of RedisInsight 2.42.

--- a/content/develop/tools/insight/release-notes/v.2.44.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.44.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.44.0 (February 2024)
 date: 2024-02-29 00:00:00 +0000
 description: RedisInsight v2.44
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.44.0/
 ---
 ## 2.44 (February 2024)
 This is the General Availability (GA) release of RedisInsight 2.44.

--- a/content/develop/tools/insight/release-notes/v.2.46.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.46.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.46.0 (March 2024)
 date: 2024-03-28 00:00:00 +0000
 description: RedisInsight v2.46
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v.2.46.0/
 ---
 ## 2.46 (March 2024)
 This is the General Availability (GA) release of RedisInsight 2.46.

--- a/content/develop/tools/insight/release-notes/v.2.48.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.48.0.md
@@ -5,6 +5,8 @@ date: 2024-04-10 00:00:00 +0000
 description: Redis Insight v2.48
 weight: 1
 
+aliases:
+- /develop/connect/insight/release-notes/v.2.48.0/
 ---
 ## 2.48 (April 2024)
 This is the General Availability (GA) release of Redis Insight 2.48.

--- a/content/develop/tools/insight/release-notes/v.2.50.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.50.0.md
@@ -5,6 +5,8 @@ date: 2024-05-30 00:00:00 +0000
 description: Redis Insight v2.50
 weight: 1
 
+aliases:
+- /develop/connect/insight/release-notes/v.2.50.0/
 ---
 ## 2.50 (May 2024)
 This is the General Availability (GA) release of Redis Insight 2.50.

--- a/content/develop/tools/insight/release-notes/v.2.52.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.52.0.md
@@ -5,6 +5,8 @@ date: 2024-06-26 00:00:00 +0000
 description: Redis Insight v2.52
 weight: 1
 
+aliases:
+- /develop/connect/insight/release-notes/v.2.52.0/
 ---
 ## 2.52 (June 2024)
 This is the General Availability (GA) release of Redis Insight 2.52.

--- a/content/develop/tools/insight/release-notes/v.2.54.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.54.0.md
@@ -5,6 +5,8 @@ date: 2024-08-06 00:00:00 +0000
 description: Redis Insight v2.54
 weight: 1
 
+aliases:
+- /develop/connect/insight/release-notes/v.2.54.0/
 ---
 ## 2.54 (August 2024)
 This is the General Availability (GA) release of Redis Insight 2.54.

--- a/content/develop/tools/insight/release-notes/v.2.56.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.56.0.md
@@ -5,6 +5,8 @@ date: 2024-09-09 00:00:00 +0000
 description: Redis Insight v2.56
 weight: 1
 
+aliases:
+- /develop/connect/insight/release-notes/v.2.56.0/
 ---
 ## 2.56 (September 2024)
 This is the General Availability (GA) release of Redis Insight 2.56.

--- a/content/develop/tools/insight/release-notes/v.2.58.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.58.0.md
@@ -5,6 +5,8 @@ date: 2024-10-01 00:00:00 +0000
 description: Redis Insight v2.58
 weight: 1
 
+aliases:
+- /develop/connect/insight/release-notes/v.2.58.0/
 ---
 ## 2.58 (October 2024)
 This is the General Availability (GA) release of Redis Insight 2.58.

--- a/content/develop/tools/insight/release-notes/v.2.6.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.6.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.6.0 (July 2022)
 date: 2022-07-25 00:00:00 +0000
 description: RedisInsight v2.6.0
 weight: 8
+aliases:
+- /develop/connect/insight/release-notes/v.2.6.0/
 ---
 
 ## 2.6.0 (July 2022)

--- a/content/develop/tools/insight/release-notes/v.2.60.0.md
+++ b/content/develop/tools/insight/release-notes/v.2.60.0.md
@@ -5,6 +5,8 @@ date: 2024-10-30 00:00:00 +0000
 description: Redis Insight v2.60
 weight: 1
 
+aliases:
+- /develop/connect/insight/release-notes/v.2.60.0/
 ---
 ## 2.60 (October 2024)
 This is the General Availability (GA) release of Redis Insight 2.60.

--- a/content/develop/tools/insight/release-notes/v1.0.0.md
+++ b/content/develop/tools/insight/release-notes/v1.0.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.0 (Nov 2019)
 date: 2019-10-01 03:49:29 +0000
 description: The initial release after Redis acquired RDBTools
 weight: 100
+aliases:
+- /develop/connect/insight/release-notes/v1.0.0/
 ---
 
 ## RedisInsight v1.0.0 release notes (November 2019)

--- a/content/develop/tools/insight/release-notes/v1.1.0.md
+++ b/content/develop/tools/insight/release-notes/v1.1.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.1 (Dec 2019)
 date: 2019-12-27 03:49:29 +0000
 description: Stability improvements and other fixes
 weight: 99
+aliases:
+- /develop/connect/insight/release-notes/v1.1.0/
 ---
 ## RedisInsight v1.1.0 release notes (December 2019)
 

--- a/content/develop/tools/insight/release-notes/v1.10.0.md
+++ b/content/develop/tools/insight/release-notes/v1.10.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.10 (Mar 2021)
 date: 2021-03-08 00:00:00 +0000
 description: RedisInsight v1.10.0
 weight: 90
+aliases:
+- /develop/connect/insight/release-notes/v1.10.0/
 ---
 
 ## 1.10.1 (April 2021)

--- a/content/develop/tools/insight/release-notes/v1.11.0.md
+++ b/content/develop/tools/insight/release-notes/v1.11.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.11 (Oct 2021)
 date: 2021-10-17 00:00:00 +0000
 description: RedisInsight v1.11.0
 weight: 89
+aliases:
+- /develop/connect/insight/release-notes/v1.11.0/
 ---
 
 ## 1.11.1 (January 2022)

--- a/content/develop/tools/insight/release-notes/v1.12.0.md
+++ b/content/develop/tools/insight/release-notes/v1.12.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.12 (May 2022)
 date: 2022-05-24 00:00:00 +0000
 description: RedisInsight v1.12.0
 weight: 11
+aliases:
+- /develop/connect/insight/release-notes/v1.12.0/
 ---
 
 ## 1.12.1 (July 2022)

--- a/content/develop/tools/insight/release-notes/v1.13.0.md
+++ b/content/develop/tools/insight/release-notes/v1.13.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.13 (Aug 2022)
 date: 2022-08-24 00:00:00 +0000
 description: RedisInsight v1.13.0
 weight: 7
+aliases:
+- /develop/connect/insight/release-notes/v1.13.0/
 ---
 
 ## 1.13.1 (November 2022)

--- a/content/develop/tools/insight/release-notes/v1.14.0.md
+++ b/content/develop/tools/insight/release-notes/v1.14.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.14 (May 2023)
 date: 2023-05-02 00:00:00 +0000
 description: RedisInsight v1.14.0
 weight: 5
+aliases:
+- /develop/connect/insight/release-notes/v1.14.0/
 ---
 
 ## 1.14.0 (May 2023)

--- a/content/develop/tools/insight/release-notes/v1.2.0.md
+++ b/content/develop/tools/insight/release-notes/v1.2.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.2 (Jan 2020)
 date: 2020-01-27 00:00:00 +0000
 description: TLS Client side authentication support and stability improvements
 weight: 98
+aliases:
+- /develop/connect/insight/release-notes/v1.2.0/
 ---
 ## RedisInsight v1.2.2 release notes
 

--- a/content/develop/tools/insight/release-notes/v1.3.0.md
+++ b/content/develop/tools/insight/release-notes/v1.3.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.3 (Mar 2020)
 date: 2020-03-30 00:00:00 +0000
 description: Auto-discovery of Redis Cloud databases, visualising paths in RedisGraph
 weight: 97
+aliases:
+- /develop/connect/insight/release-notes/v1.3.0/
 ---
 
 ## RedisInsight v1.3.1 release notes (April 2020)

--- a/content/develop/tools/insight/release-notes/v1.4.0.md
+++ b/content/develop/tools/insight/release-notes/v1.4.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.4 (Apr 2020)
 date: 2020-04-29 00:00:00 +0000
 description: Redis 6 ACLs support, improved CLI and full screen support in Graph, TimeSeries and RedisSearch
 weight: 96
+aliases:
+- /develop/connect/insight/release-notes/v1.4.0/
 ---
 
 This is the General Availability Release of RedisInsight 1.4 (v1.4.0)!

--- a/content/develop/tools/insight/release-notes/v1.5.0.md
+++ b/content/develop/tools/insight/release-notes/v1.5.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.5 (May 2020)
 date: 2020-05-12 00:00:00 +0000
 description: New tool for RedisGears, Multi-line query builder and improved suppport of Redis 6 ACLs
 weight: 95
+aliases:
+- /develop/connect/insight/release-notes/v1.5.0/
 ---
 
 This is the General Availability Release of RedisInsight 1.5 (v1.5.0)!

--- a/content/develop/tools/insight/release-notes/v1.6.0.md
+++ b/content/develop/tools/insight/release-notes/v1.6.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.6 (June 2020)
 date: 2020-06-10 00:00:00 +0000
 description: Rootless Docker container, Copy keys in Browser and Stream UX improvements
 weight: 94
+aliases:
+- /develop/connect/insight/release-notes/v1.6.0/
 ---
 
 ## 1.6.3 (July 2020)

--- a/content/develop/tools/insight/release-notes/v1.7.0.md
+++ b/content/develop/tools/insight/release-notes/v1.7.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.7 (Sep 2020)
 date: 2020-09-10 00:00:00 +0000
 description: RediSearch 2.0 support and stability improvements
 weight: 93
+aliases:
+- /develop/connect/insight/release-notes/v1.7.0/
 ---
 
 ## 1.7.1 (October 2020)

--- a/content/develop/tools/insight/release-notes/v1.8.0.md
+++ b/content/develop/tools/insight/release-notes/v1.8.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.8 (Nov 2020)
 date: 2020-11-11 00:00:00 +0000
 description: RedisInsight v1.8.0
 weight: 92
+aliases:
+- /develop/connect/insight/release-notes/v1.8.0/
 ---
 
 ## 1.8.3 (January 2021)

--- a/content/develop/tools/insight/release-notes/v1.9.0.md
+++ b/content/develop/tools/insight/release-notes/v1.9.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.9 (Jan 2021)
 date: 2020-01-15 00:00:00 +0000
 description: RedisInsight v1.9.0
 weight: 91
+aliases:
+- /develop/connect/insight/release-notes/v1.9.0/
 ---
 
 ## 1.9.0 (January 2021)

--- a/content/develop/tools/insight/release-notes/v2.0.md
+++ b/content/develop/tools/insight/release-notes/v2.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.0 (Nov 2021)
 date: 2021-11-23 00:00:00 +0000
 description: RedisInsight v2.0.2
 weight: 12
+aliases:
+- /develop/connect/insight/release-notes/v2.0/
 ---
 
 ## 2.0.6 (April 2022)

--- a/content/develop/tools/insight/release-notes/v2.10.0.md
+++ b/content/develop/tools/insight/release-notes/v2.10.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.10.0 (Sept 2022)
 date: 2022-09-29 00:00:00 +0000
 description: RedisInsight v2.10.0
 weight: 5
+aliases:
+- /develop/connect/insight/release-notes/v2.10.0/
 ---
 ## 2.10.0 (September 2022)
 This is the General Availability (GA) release of RedisInsight 2.10.

--- a/content/develop/tools/insight/release-notes/v2.12.0.md
+++ b/content/develop/tools/insight/release-notes/v2.12.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.12.0 (Oct 2022)
 date: 2022-09-29 00:00:00 +0000
 description: RedisInsight v2.12.0
 weight: 4
+aliases:
+- /develop/connect/insight/release-notes/v2.12.0/
 ---
 ## 2.12.0 (October 2022)
 This is the General Availability (GA) release of RedisInsight 2.12.

--- a/content/develop/tools/insight/release-notes/v2.2.0.md
+++ b/content/develop/tools/insight/release-notes/v2.2.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.2.0 (May 2022)
 date: 2022-05-26 00:00:00 +0000
 description: RedisInsight v2.2.0
 weight: 10
+aliases:
+- /develop/connect/insight/release-notes/v2.2.0/
 ---
 
 ## 2.2.0 (May 2022)

--- a/content/develop/tools/insight/release-notes/v2.28.0.md
+++ b/content/develop/tools/insight/release-notes/v2.28.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.28.0 (June 2023)
 date: 2023-06-28 00:00:00 +0000
 description: RedisInsight v2.28
 weight: 1
+aliases:
+- /develop/connect/insight/release-notes/v2.28.0/
 ---
 ## 2.28 (June 2023)
 This is the General Availability (GA) release of RedisInsight 2.28.

--- a/content/develop/tools/insight/release-notes/v2.8.0.md
+++ b/content/develop/tools/insight/release-notes/v2.8.0.md
@@ -4,6 +4,8 @@ linkTitle: v2.8.0 (Aug 2022)
 date: 2022-08-23 00:00:00 +0000
 description: RedisInsight v2.8.0
 weight: 6
+aliases:
+- /develop/connect/insight/release-notes/v2.8.0/
 ---
 ## 2.8.0 (August 2022)
 This is the General Availability (GA) release of RedisInsight 2.8.0

--- a/content/develop/tools/redis-for-vscode/release-notes/_index.md
+++ b/content/develop/tools/redis-for-vscode/release-notes/_index.md
@@ -14,6 +14,8 @@ linkTitle: Release notes
 title: Redis for VS Code release notes
 weight: 7
 hideListLinks: true
+aliases:
+- /develop/connect/redis-for-vscode/release-notes/
 ---
 
 Here are the most recent changes for Redis for VS Code:

--- a/content/develop/tools/redis-for-vscode/release-notes/v1.0.0.md
+++ b/content/develop/tools/redis-for-vscode/release-notes/v1.0.0.md
@@ -4,6 +4,8 @@ linkTitle: v1.0.0 (September 2024)
 date: 2024-09-06 00:00:00 +0000
 description: Redis for VS Code v1.0
 weight: 99
+aliases:
+- /develop/connect/redis-for-vscode/release-notes/v1.0.0/
 ---
 
 ## 1.0.0 (September 2024)

--- a/content/develop/using-commands/keyspace.md
+++ b/content/develop/using-commands/keyspace.md
@@ -2,6 +2,7 @@
 aliases:
 - /develop/use/keyspace
 - /manual/keyspace/
+- /develop/keyspace/
 categories:
 - docs
 - develop

--- a/content/develop/using-commands/transactions.md
+++ b/content/develop/using-commands/transactions.md
@@ -3,6 +3,7 @@ aliases:
 - /develop/interact/transactions
 - /manual/transactions/
 - /interact/transactions/
+- /develop/reference/transactions/
 categories:
 - docs
 - develop

--- a/content/integrate/amazon-bedrock/_index.md
+++ b/content/integrate/amazon-bedrock/_index.md
@@ -17,6 +17,8 @@ summary: With Amazon Bedrock, users can access foundational AI models from a var
   artificial intelligence.
 type: integration
 weight: 3
+aliases:
+- /integrate/aws-bedrock/
 ---
 
 [Amazon Bedrock](https://aws.amazon.com/bedrock/) streamlines GenAI deployment by offering foundational models (FMs) as a unified API, eliminating complex infrastructure management. It lets you create AI-powered [Agents](https://aws.amazon.com/bedrock/agents/) that execute complex tasks. Through [Knowledge Bases](https://aws.amazon.com/bedrock/knowledge-bases/) within Amazon Bedrock, you can seamlessly tether FMs to your proprietary data sources using retrieval-augmented generation (RAG). This direct integration amplifies the FM's intelligence based on your organization's resources.

--- a/content/integrate/amazon-bedrock/create-agent.md
+++ b/content/integrate/amazon-bedrock/create-agent.md
@@ -15,6 +15,8 @@ summary: With Amazon Bedrock, users can access foundational AI models from a var
   artificial intelligence.
 type: integration
 weight: 3
+aliases:
+- /integrate/aws-bedrock/create-agent/
 ---
 
 After you have [created a knowledge base]({{< relref "/integrate/amazon-bedrock/create-knowledge-base" >}}), you can use it to create an agent on Amazon Bedrock.

--- a/content/integrate/amazon-bedrock/create-knowledge-base.md
+++ b/content/integrate/amazon-bedrock/create-knowledge-base.md
@@ -15,6 +15,8 @@ summary: With Amazon Bedrock, users can access foundational AI models from a var
   artificial intelligence.
 type: integration
 weight: 2
+aliases:
+- /integrate/aws-bedrock/create-knowledge-base/
 ---
 
 After you have set up a vector database with Redis Cloud, you can use it to create a knowledge base for your models.

--- a/content/integrate/amazon-bedrock/set-up-redis.md
+++ b/content/integrate/amazon-bedrock/set-up-redis.md
@@ -15,6 +15,8 @@ summary: With Amazon Bedrock, users can access foundational AI models from a var
   artificial intelligence.
 type: integration
 weight: 1
+aliases:
+- /integrate/aws-bedrock/set-up-redis/
 ---
 
 You need to set up your Redis Cloud database before you can set it as the vector database in Amazon Bedrock. To do this, you need to:

--- a/content/integrate/redis-data-integration/data-pipelines/data-denormalization.md
+++ b/content/integrate/redis-data-integration/data-pipelines/data-denormalization.md
@@ -1,6 +1,8 @@
 ---
 Title: Data denormalization
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/data-denormalization/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/data-denormalization/
+- /integrate/redis-data-integration/data-transformation/data-denormalization/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
+++ b/content/integrate/redis-data-integration/data-pipelines/pipeline-config.md
@@ -13,6 +13,8 @@ summary: Redis Data Integration keeps Redis in sync with the primary database in
   real time.
 type: integration
 weight: 3
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/data-pipelines/
 ---
 
 The main configuration details for an RDI pipeline are in the `config.yaml` file.

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/my-sql-mariadb.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/my-sql-mariadb.md
@@ -1,6 +1,9 @@
 ---
 Title: Prepare MySQL/MariaDB for RDI
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/my-sql-mariadb/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/my-sql-mariadb/
+- /integrate/redis-data-integration/ingest/data-transformation/prepare-dbs/my-sql-mariadb/
+- /integrate/redis-data-integration/ingest/installation/prepare-dbs/my-sql-mariadb/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/oracle.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/oracle.md
@@ -1,6 +1,9 @@
 ---
 Title: Prepare Oracle and Oracle RAC for RDI
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/oracle/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/oracle/
+- /integrate/redis-data-integration/ingest/data-transformation/prepare-dbs/oracle/
+- /integrate/redis-data-integration/ingest/installation/prepare-dbs/oracle/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
@@ -1,6 +1,9 @@
 ---
 Title: Prepare PostgreSQL for RDI
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/postgresql/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/postgresql/
+- /integrate/redis-data-integration/ingest/data-transformation/prepare-dbs/postgresql/
+- /integrate/redis-data-integration/ingest/installation/prepare-dbs/postgresql/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/sql-server.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/sql-server.md
@@ -1,6 +1,9 @@
 ---
 Title: Prepare SQL Server for RDI
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/sql-server/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/prepare-dbs/sql-server/
+- /integrate/redis-data-integration/ingest/data-transformation/prepare-dbs/sql-server/
+- /integrate/redis-data-integration/ingest/installation/prepare-dbs/sql-server/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/_index.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/_index.md
@@ -1,6 +1,8 @@
 ---
 Title: Job files
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/
+- /integrate/redis-data-integration/ingest/data-transformation/transform-examples/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-hash-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-hash-example.md
@@ -1,6 +1,9 @@
 ---
 Title: Write to a Redis hash
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-hash-example/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-hash-example/
+- /integrate/redis-data-integration/data-transformation/examples/redis-hash-example/
+- /integrate/redis-data-integration/ingest/data-transformation/examples/redis-hash-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-json-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-json-example.md
@@ -1,6 +1,9 @@
 ---
 Title: Write to a Redis JSON document
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-json-example/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-json-example/
+- /integrate/redis-data-integration/data-transformation/examples/redis-json-example/
+- /integrate/redis-data-integration/ingest/data-transformation/examples/redis-json-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-set-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-set-example.md
@@ -1,6 +1,9 @@
 ---
 Title: Write to a Redis set
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-set-example/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-set-example/
+- /integrate/redis-data-integration/data-transformation/examples/redis-set-example/
+- /integrate/redis-data-integration/ingest/data-transformation/examples/redis-set-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-sorted-set-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-sorted-set-example.md
@@ -1,6 +1,9 @@
 ---
 Title: Write to a Redis sorted set
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-sorted-set-example/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-sorted-set-example/
+- /integrate/redis-data-integration/data-transformation/examples/redis-sorted-set-example/
+- /integrate/redis-data-integration/ingest/data-transformation/examples/redis-sorted-set-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-stream-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-stream-example.md
@@ -1,6 +1,9 @@
 ---
 Title: Write to a Redis stream
-aliases: /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-stream-example/
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-stream-example/
+- /integrate/redis-data-integration/data-transformation/examples/redis-stream-example/
+- /integrate/redis-data-integration/ingest/data-transformation/examples/redis-stream-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-string-example.md
+++ b/content/integrate/redis-data-integration/data-pipelines/transform-examples/redis-string-example.md
@@ -1,6 +1,7 @@
 ---
 Title: Write to a Redis string
-aliases: null
+aliases:
+- /integrate/redis-data-integration/ingest/data-pipelines/transform-examples/redis-string-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/observability.md
+++ b/content/integrate/redis-data-integration/observability.md
@@ -1,6 +1,8 @@
 ---
 Title: Observability
-aliases: /integrate/redis-data-integration/ingest/observability/
+aliases:
+- /integrate/redis-data-integration/ingest/observability/
+- /integrate/redis-data-integration/ingest/data-transformation/observability/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/redis-data-integration/reference/api-reference.md
+++ b/content/integrate/redis-data-integration/reference/api-reference.md
@@ -3,6 +3,8 @@ linkTitle: RDI API Reference
 Title: Redis Data Integration API
 layout: apireference
 type: page
+aliases:
+- /integrate/redis-data-integration/reference/api/api-reference/
 ---
 
 <!--

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-delete-context.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-delete-context.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-delete-context/
 ---
 
 Deletes a context from the `~/.redis-di` context file. Because this is destructive, the command asks

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-delete.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-delete.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-delete/
 ---
 
 Deletes a pipeline. Because this is destructive, the command asks for confirmation unless you pass

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-deploy.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-deploy.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-deploy/
 ---
 
 Deploys a pipeline, creating it or updating it from the configuration in the `--dir` directory. The

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-describe-job.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-describe-job.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-describe-job/
 ---
 
 Describes a single job of a pipeline, printing its source properties followed by tables that

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-dump-support-package.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-dump-support-package.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-dump-support-package/
 ---
 
 Dumps a comprehensive set of RDI forensics data that you can send to Redis support (see

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-list-contexts.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-list-contexts.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-list-contexts/
 ---
 
 Lists all contexts from the `~/.redis-di` context file and indicates which one is active. See the

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-list-jobs.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-list-jobs.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-list-jobs/
 ---
 
 Lists the jobs of a pipeline, one row per job with its source, its transformation and output counts,

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-reset.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-reset.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-reset/
 ---
 
 Resets a pipeline into initial full-sync mode, so it reloads a snapshot of the source data before

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-scaffold.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-scaffold.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-scaffold/
 ---
 
 Generates a starter pipeline configuration for the given source database type. With `--dir`, the

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-set-context.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-set-context.md
@@ -8,6 +8,7 @@ categories: ["redis-di"]
 aliases:
   - /integrate/redis-data-integration/reference/cli/redis-di-add-context/
   - /integrate/redis-data-integration/reference/cli/redis-di-delete-all-contexts/
+  - /integrate/redis-data-integration/ingest/reference/cli/redis-di-set-context/
 ---
 
 Creates or updates a context in the `~/.redis-di` context file. A context stores an API connection

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-set-secret.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-set-secret.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-set-secret/
 ---
 
 Creates or updates a secret of a pipeline. Secrets hold the credentials and certificates that the

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-start.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-start.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-start/
 ---
 
 Starts a pipeline. By default, the command waits for the pipeline to reach the `started` state before

--- a/content/integrate/redis-data-integration/reference/cli/redis-di-stop.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di-stop.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di-stop/
 ---
 
 Stops a pipeline. By default, the command waits for the pipeline to reach the `stopped` state before

--- a/content/integrate/redis-data-integration/reference/cli/redis-di.md
+++ b/content/integrate/redis-data-integration/reference/cli/redis-di.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/cli/redis-di/
 ---
 
 `redis-di` is the command line tool that manages Redis Data Integration (RDI). It is a thin client

--- a/content/integrate/redis-data-integration/reference/config-yaml-reference.md
+++ b/content/integrate/redis-data-integration/reference/config-yaml-reference.md
@@ -6,6 +6,7 @@ weight: 10
 alwaysopen: false
 categories: ["redis-di"]
 aliases:
+- /integrate/redis-data-integration/ingest/reference/config-yaml-reference/
 ---
 
 Configuration file for Redis Data Integration (RDI) source collectors and target connections.

--- a/content/integrate/redis-mcp/client-conf.md
+++ b/content/integrate/redis-mcp/client-conf.md
@@ -11,6 +11,8 @@ linkTitle: Configure client apps
 description: Configure client apps to use the Redis MCP server.
 type: integration
 weight: 20
+aliases:
+- /integrate/redis-mcp/ciient-conf/
 ---
 
 When you have [installed]({{< relref "/integrate/redis-mcp/install" >}})

--- a/content/integrate/redisom-for-java/_index.md
+++ b/content/integrate/redisom-for-java/_index.md
@@ -16,6 +16,7 @@ title: Redis OM Spring
 type: integration
 aliases:
 - /connect/clients/om-clients/stack-spring/
+- /develop/connect/clients/om-clients/stack-spring/
 weight: 9
 ---
 

--- a/content/integrate/redisom-for-net/_index.md
+++ b/content/integrate/redisom-for-net/_index.md
@@ -15,6 +15,7 @@ title: Redis OM .NET
 type: integration
 aliases:
 - /connect/clients/om-clients/stack-dotnet/
+- /develop/connect/clients/om-clients/stack-dotnet/
 weight: 9
 ---
 

--- a/content/integrate/redisom-for-node-js/_index.md
+++ b/content/integrate/redisom-for-node-js/_index.md
@@ -14,6 +14,8 @@ summary: Redis OM for Node.js is an object-mapping library for Redis.
 title: Redis OM Node.js
 type: integration
 weight: 9
+aliases:
+- /develop/connect/clients/om-clients/stack-node/
 ---
 
 This tutorial will show you how to build a simple, RESTful API that reads, writes, and finds data on persons (including first name, last name, and  age) using Node.js and Redis Stack. You'll also add a simple location tracking feature for a bit of extra interest. You'll be using [Express](https://expressjs.com/) and [Redis OM](https://github.com/redis/redis-om-node) to do this.

--- a/content/integrate/redisom-for-python/_index.md
+++ b/content/integrate/redisom-for-python/_index.md
@@ -15,6 +15,7 @@ title: Redis OM Python
 type: integration
 aliases:
 - /connect/clients/om-clients/stack-python/
+- /develop/connect/clients/om-clients/stack-python/
 weight: 9
 ---
 

--- a/content/integrate/write-behind/architecture.md
+++ b/content/integrate/write-behind/architecture.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind architecture
-aliases: /integrate/redis-data-integration/write-behind/architecture/
+aliases:
+- /integrate/redis-data-integration/write-behind/architecture/
+- /integrate/redis-data-integration/write behind/architecture/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/configuration-guide.md
+++ b/content/integrate/write-behind/configuration-guide.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind configuration guide
-aliases: /integrate/redis-data-integration/write-behind/configuration-guide/
+aliases:
+- /integrate/redis-data-integration/write-behind/configuration-guide/
+- /integrate/redis-data-integration/write behind/configuration-guide/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/data-transformation/_index.md
+++ b/content/integrate/write-behind/data-transformation/_index.md
@@ -1,6 +1,8 @@
 ---
 Title: Data transformation
-aliases: null
+aliases:
+- /integrate/redis-data-integration/data-transformation/
+- /integrate/redis-data-integration/write-behind/data-transformation/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/data-transformation/data-transformation-pipeline.md
+++ b/content/integrate/write-behind/data-transformation/data-transformation-pipeline.md
@@ -1,6 +1,9 @@
 ---
 Title: Data transformation pipeline
-aliases: null
+aliases:
+- /integrate/redis-data-integration/data-transformation/data-transformation-pipeline/
+- /integrate/redis-data-integration/ingest/data-pipelines/data-transformation-pipeline/
+- /integrate/redis-data-integration/write-behind/data-transformation/data-transformation-pipeline/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/data-transformation/transformation-examples/_index.md
+++ b/content/integrate/write-behind/data-transformation/transformation-examples/_index.md
@@ -1,6 +1,7 @@
 ---
 Title: Write-behind transformation examples
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/data-transformation/transformation-examples/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/data-transformation/transformation-examples/foreach-example.md
+++ b/content/integrate/write-behind/data-transformation/transformation-examples/foreach-example.md
@@ -1,6 +1,11 @@
 ---
 Title: Write-behind foreach example
-aliases: null
+aliases:
+- /integrate/redis-data-integration/data-transformation/examples/foreach-example/
+- /integrate/redis-data-integration/ingest/data-transformation/examples/foreach-example/
+- /integrate/redis-data-integration/write behind/foreach-example/
+- /integrate/redis-data-integration/write-behind/foreach-example/
+- /integrate/redis-data-integration/write-behind/data-transformation/transformation-examples/foreach-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/data-transformation/transformation-examples/write-behind-to-redis-example.md
+++ b/content/integrate/write-behind/data-transformation/transformation-examples/write-behind-to-redis-example.md
@@ -1,6 +1,11 @@
 ---
 Title: Write-behind to Redis Enterprise target example
-aliases: null
+aliases:
+- /integrate/redis-data-integration/data-transformation/examples/write-behind-to-redis-example/
+- /integrate/redis-data-integration/ingest/data-transformation/examples/write-behind-to-redis-example/
+- /integrate/redis-data-integration/write behind/write-behind-to-redis-example/
+- /integrate/redis-data-integration/write-behind/write-behind-to-redis-example/
+- /integrate/redis-data-integration/write-behind/data-transformation/transformation-examples/write-behind-to-redis-example/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/installation/_index.md
+++ b/content/integrate/write-behind/installation/_index.md
@@ -1,6 +1,7 @@
 ---
 Title: Installation
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/installation/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/installation/install-rdi-cli.md
+++ b/content/integrate/write-behind/installation/install-rdi-cli.md
@@ -1,6 +1,9 @@
 ---
 Title: Install Write-behind CLI
-aliases: null
+aliases:
+- /integrate/redis-data-integration/installation/install-rdi-cli/
+- /integrate/redis-data-integration/write behind/installation/install-rdi-cli/
+- /integrate/redis-data-integration/write-behind/installation/install-rdi-cli/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/installation/install-redis-gears.md
+++ b/content/integrate/write-behind/installation/install-redis-gears.md
@@ -1,6 +1,9 @@
 ---
 Title: Install RedisGears for Redis Data Integration
-aliases: null
+aliases:
+- /integrate/redis-data-integration/installation/install-redis-gears/
+- /integrate/redis-data-integration/write behind/installation/install-redis-gears/
+- /integrate/redis-data-integration/write-behind/installation/install-redis-gears/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/monitoring-guide.md
+++ b/content/integrate/write-behind/monitoring-guide.md
@@ -1,6 +1,9 @@
 ---
 Title: Monitoring guide
-aliases: /integrate/redis-data-integration/write-behind/monitoring-guide/
+aliases:
+- /integrate/redis-data-integration/write-behind/monitoring-guide/
+- /integrate/redis-data-integration/monitoring-guide/
+- /integrate/redis-data-integration/write behind/monitoring-guide/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/quickstart/write-behind-guide.md
+++ b/content/integrate/write-behind/quickstart/write-behind-guide.md
@@ -1,6 +1,9 @@
 ---
 Title: Quickstart
-aliases: null
+aliases:
+- /integrate/redis-data-integration/quickstart/write-behind-guide/
+- /integrate/redis-data-integration/write behind/quickstart/write-behind-guide/
+- /integrate/redis-data-integration/write-behind/quickstart/write-behind-guide/
 alwaysopen: false
 categories:
 - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-add-context.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-add-context.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di add-context
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-add-context/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-configure.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-configure.md
@@ -1,6 +1,8 @@
 ---
 Title: redis-di configure
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/cli/redis-di-configure/
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-configure/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-create.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-create.md
@@ -1,6 +1,8 @@
 ---
 Title: redis-di create
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/cli/redis-di-create/
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-create/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-delete-all-contexts.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-delete-all-contexts.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di delete-all-contexts
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-delete-all-contexts/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-delete-context.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-delete-context.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di delete-context
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-delete-context/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-delete.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-delete.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di delete
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-delete/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-deploy.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-deploy.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di deploy
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-deploy/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-describe-job.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-describe-job.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di describe-job
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-describe-job/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-dump-support-package.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-dump-support-package.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di dump-support-package
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-dump-support-package/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-get-rejected.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-get-rejected.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di get-rejected
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-get-rejected/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-list-contexts.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-list-contexts.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di list-contexts
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-list-contexts/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-list-jobs.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-list-jobs.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di list-jobs
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-list-jobs/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-monitor.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-monitor.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di monitor
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-monitor/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-reset.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-reset.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di reset
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-reset/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-scaffold.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-scaffold.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di scaffold
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-scaffold/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-set-context.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-set-context.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di set-context
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-set-context/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-set-secret.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-set-secret.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di set-secret
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-set-secret/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-start.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-start.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di start
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-start/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-status.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-status.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di status
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-status/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-stop.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-stop.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di stop
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-stop/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-trace.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-trace.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di trace
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-trace/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di-upgrade.md
+++ b/content/integrate/write-behind/reference/cli/redis-di-upgrade.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di upgrade
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di-upgrade/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/cli/redis-di.md
+++ b/content/integrate/write-behind/reference/cli/redis-di.md
@@ -1,6 +1,7 @@
 ---
 Title: redis-di
-aliases: null
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/cli/redis-di/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/_index.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/_index.md
@@ -1,6 +1,8 @@
 ---
 Title: Data transformation block types
-aliases: /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/
+- /integrate/redis-data-integration/reference/data-transformation-block-types/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/add_field.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/add_field.md
@@ -1,6 +1,8 @@
 ---
 Title: add_field
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/add_field/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/add_field/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/cassandra_write.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/cassandra_write.md
@@ -1,6 +1,8 @@
 ---
 Title: cassandra.write
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/cassandra_write/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/cassandra_write/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/filter.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/filter.md
@@ -1,6 +1,8 @@
 ---
 Title: filter
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/filter/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/filter/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/key.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/key.md
@@ -1,6 +1,8 @@
 ---
 Title: key
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/key/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/key/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/map.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/map.md
@@ -1,6 +1,8 @@
 ---
 Title: map
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/map/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/map/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/redis_write.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/redis_write.md
@@ -1,6 +1,8 @@
 ---
 Title: redis.write
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/redis_write/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/redis_write/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/relational_write.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/relational_write.md
@@ -1,6 +1,8 @@
 ---
 Title: relational.write
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/relational_write/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/relational_write/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/remove_field.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/remove_field.md
@@ -1,6 +1,8 @@
 ---
 Title: remove_field
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/remove_field/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/remove_field/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-transformation-block-types/rename_field.md
+++ b/content/integrate/write-behind/reference/data-transformation-block-types/rename_field.md
@@ -1,6 +1,8 @@
 ---
 Title: rename_field
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/data-transformation-block-types/rename_field/
+- /integrate/redis-data-integration/write-behind/reference/data-transformation-block-types/rename_field/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/data-types-conversion.md
+++ b/content/integrate/write-behind/reference/data-types-conversion.md
@@ -1,6 +1,8 @@
 ---
 Title: Data type conversion
-aliases: /integrate/redis-data-integration/write-behind/reference/data-types-conversion/
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/data-types-conversion/
+- /integrate/redis-data-integration/reference/data-types-conversion/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/debezium/_index.md
+++ b/content/integrate/write-behind/reference/debezium/_index.md
@@ -1,6 +1,8 @@
 ---
 Title: Debezium Server configuration file
-aliases: /integrate/redis-data-integration/write-behind/reference/debezium/
+aliases:
+- /integrate/redis-data-integration/write-behind/reference/debezium/
+- /integrate/redis-data-integration/reference/debezium/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/debezium/cassandra.md
+++ b/content/integrate/write-behind/reference/debezium/cassandra.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind configuration for cassandra
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/debezium/cassandra/
+- /integrate/redis-data-integration/write-behind/reference/debezium/cassandra/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/debezium/mongodb.md
+++ b/content/integrate/write-behind/reference/debezium/mongodb.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind configuration for mongodb
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/debezium/mongodb/
+- /integrate/redis-data-integration/write-behind/reference/debezium/mongodb/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/debezium/mysql.md
+++ b/content/integrate/write-behind/reference/debezium/mysql.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind configuration for mysql
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/debezium/mysql/
+- /integrate/redis-data-integration/write-behind/reference/debezium/mysql/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/debezium/oracle.md
+++ b/content/integrate/write-behind/reference/debezium/oracle.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind configuration for oracle
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/debezium/oracle/
+- /integrate/redis-data-integration/write-behind/reference/debezium/oracle/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/debezium/postgresql.md
+++ b/content/integrate/write-behind/reference/debezium/postgresql.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind configuration for postgresql
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/debezium/postgresql/
+- /integrate/redis-data-integration/write-behind/reference/debezium/postgresql/
 alwaysopen: false
 categories:
   - docs

--- a/content/integrate/write-behind/reference/debezium/sqlserver.md
+++ b/content/integrate/write-behind/reference/debezium/sqlserver.md
@@ -1,6 +1,8 @@
 ---
 Title: Write-behind configuration for sqlserver
-aliases: null
+aliases:
+- /integrate/redis-data-integration/reference/debezium/sqlserver/
+- /integrate/redis-data-integration/write-behind/reference/debezium/sqlserver/
 alwaysopen: false
 categories:
   - docs

--- a/content/operate/iris/agent-memory/create-service.md
+++ b/content/operate/iris/agent-memory/create-service.md
@@ -12,6 +12,7 @@ weight: 5
 bannerText: Redis Agent Memory on Redis Cloud is currently available as a public preview. Features and behavior are subject to change.
 aliases:
 - /operate/rc/context-engine/agent-memory/create-service/
+- /operate/rc/agent-memory/create-service/
 ---
 
 Redis Agent Memory provides a persistent, structured memory layer that AI agents can use to store, retrieve, and manage contextual data across interactions. This guide walks you through creating and configuring an Agent Memory service in Redis Cloud.

--- a/content/operate/iris/agent-memory/view-service.md
+++ b/content/operate/iris/agent-memory/view-service.md
@@ -12,6 +12,7 @@ weight: 15
 bannerText: Redis Agent Memory on Redis Cloud is currently available as a public preview. Features and behavior are subject to change.
 aliases:
 - /operate/rc/context-engine/agent-memory/view-service/
+- /operate/rc/agent-memory/view-service/
 ---
 
 After you have [created your first Agent Memory service]({{< relref "/operate/iris/agent-memory/create-service" >}}), selecting **Agent Memory** from the Redis Cloud Console menu will take you to the **Agent Memory Services** page.

--- a/content/operate/kubernetes/release-notes/7-4-2-releases/7-4-2-12.md
+++ b/content/operate/kubernetes/release-notes/7-4-2-releases/7-4-2-12.md
@@ -8,6 +8,8 @@ description: This is a feature release with a new version of Redis Enterprise So
 linkTitle: 7.4.2-12 (May 2024)
 title: Redis Enterprise for Kubernetes 7.4.2-12 (May 2024) release notes
 weight: 6
+aliases:
+- /operate/kubernetes/release-notes/7-4-2-12/
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2.md
+++ b/content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2.md
@@ -9,7 +9,9 @@ description: This is a feature release with a new version of Redis Enterprise So
 linkTitle: 7.4.6-2 (July 2024)
 title: Redis Enterprise for Kubernetes 7.4.6-2 (July 2024) release notes
 weight: 29
-aliases: /operate/kubernetes/release-notes/7-4-6-2, 
+aliases:
+- /operate/kubernetes/release-notes/7-4-6-2,
+- /operate/kubernetes/release-notes/7-4-6-2/
 ---
 
 ## Highlights

--- a/content/operate/kubernetes/release-notes/7-8-4-releases/7-8-4-9-mar25.md
+++ b/content/operate/kubernetes/release-notes/7-8-4-releases/7-8-4-9-mar25.md
@@ -9,6 +9,8 @@ hideListLinks: true
 linkTitle: 7.8.4-9 (March 2025)
 title: Redis Enterprise for Kubernetes 7.8.4-9 (March 2025) release notes
 weight: 1
+aliases:
+- /operate/kubernetes/release-notes/7-8-4-releases/7-8-4-8-mar25/
 ---
 
 This is a maintenance release to support [Redis Enterprise Software version 7.8.4-95]({{<relref "/operate/rs/release-notes/rs-7-8-releases/rs-7-8-4-95/">}}) and OpenShift 4.17 and 4.18.

--- a/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-21-feb2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-10-releases/8-0-10-21-feb2026.md
@@ -9,6 +9,8 @@ hideListLinks: true
 linkTitle: 8.0.10-21 (February 2026)
 title: Redis Enterprise for Kubernetes 8.0.10-21 (February 2026) release notes
 weight: 31
+aliases:
+- /operate/kubernetes/release-notes/8-0-10-releases/8-0-10-19-february2026/
 ---
 
 Redis Enterprise for Kubernetes 8.0.10-21 is a feature release that supports [Redis Software 8.0.10-64

--- a/content/operate/kubernetes/release-notes/previous-releases/k8s-6-2-10-4-2022-03.md
+++ b/content/operate/kubernetes/release-notes/previous-releases/k8s-6-2-10-4-2022-03.md
@@ -12,6 +12,7 @@ aliases: [
   /operate/kubernetes/release-notes/k8s-6-2-10-4-2022-03-copy/,
   /operate/kubernetes/release-notes/k8s-6-2-10-4-2022-03/,
   /operate/kubernetes/release-notes/6-2-releases/k8s-6-2-10-4-2022-03/,
+  /operate/kubernetes/release-notes/k8s-6-2-10-4-2022-03 copy/,
 ]
 ---
 ## Overview

--- a/content/operate/kubernetes/release-notes/previous-releases/k8s-6-2-18-3.md
+++ b/content/operate/kubernetes/release-notes/previous-releases/k8s-6-2-18-3.md
@@ -11,6 +11,7 @@ weight: 60
 aliases: [
   /operate/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-41/,
   /operate/kubernetes/release-notes/6-2-releases/k8s-6-2-18-3/,
+  /operate/kubernetes/release-notes/6-2-18-releases/k8s-6-2-18-3/,
 ]
 ---
 ## Overview

--- a/content/operate/kubernetes/release-notes/previous-releases/k8s-6-2-8-15-2022-01.md
+++ b/content/operate/kubernetes/release-notes/previous-releases/k8s-6-2-8-15-2022-01.md
@@ -11,6 +11,7 @@ weight: 64
 aliases: [
   /operate/kubernetes/release-notes/k8s-6-2-8-15-2022-01.md,
   /operate/kubernetes/release-notes/6-2-releases/k8s-6-2-8-15-2022-01/,
+  /operate/kubernetes/release-notes/k8s-6-2-8-15-2022-01/,
 ]
 ---
 ## Overview

--- a/content/operate/oss_and_stack/install/archive/install-stack/mac-os.md
+++ b/content/operate/oss_and_stack/install/archive/install-stack/mac-os.md
@@ -8,6 +8,8 @@ description: How to install Redis Stack on macOS
 linkTitle: MacOS
 title: Install Redis Stack on macOS
 weight: 2
+aliases:
+- /operate/oss_and_stack/install/install-stack/mac-os/
 ---
 
 To install Redis Stack on macOS, use [Homebrew](https://brew.sh/). Make sure that you have [Homebrew installed](https://docs.brew.sh/Installation) before starting on the installation instructions below.

--- a/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0-release-notes.md
@@ -10,6 +10,8 @@ linkTitle: v8.0.0 (May 2025)
 min-version-db: blah
 min-version-rs: blah
 weight: 80
+aliases:
+- /operate/oss_and_stack/stack-with-enterprise/release-notes/redisce/redisos-8.0.0-release-notes/
 ---
 
 ## Redis Open Source 8.0.6 (February 2026)

--- a/content/operate/rc/changelog/2023/november-2023.md
+++ b/content/operate/rc/changelog/2023/november-2023.md
@@ -12,6 +12,8 @@ linktitle: November 2023
 tags:
 - changelog
 weight: 74
+aliases:
+- /operate/rc/changelog/november-2023/
 ---
 
 ## New features

--- a/content/operate/rc/changelog/october-2025.md
+++ b/content/operate/rc/changelog/october-2025.md
@@ -12,6 +12,8 @@ linktitle: October 2025
 weight: 65
 tags:
 - changelog
+aliases:
+- /operate/rc/changelog/september-2025/
 ---
 
 ## New features

--- a/content/operate/rc/context-engine/agent-memory/_index.md
+++ b/content/operate/rc/context-engine/agent-memory/_index.md
@@ -10,6 +10,8 @@ linktitle: Redis Agent Memory
 title: Redis Agent Memory on Redis Cloud
 weight: 10
 bannerText: Redis Agent Memory on Redis Cloud is currently available as a public preview. Features and behavior are subject to change.
+aliases:
+- /operate/rc/agent-memory/
 ---
 
 Redis Agent Memory is available as a managed service on Redis Cloud.

--- a/content/operate/rc/databases/version-management/_index.md
+++ b/content/operate/rc/databases/version-management/_index.md
@@ -10,6 +10,8 @@ linkTitle: Version management
 weight: 36
 hideListLinks: true
 tocEmbedHeaders: true
+aliases:
+- /operate/rc/databases/version-management/version-management/
 ---
 
 Redis Cloud provides comprehensive database version management that prioritizes customer control over major changes. 

--- a/content/operate/rc/databases/version-management/upgrade-version.md
+++ b/content/operate/rc/databases/version-management/upgrade-version.md
@@ -10,6 +10,7 @@ linkTitle: Upgrade database version
 weight: 1
 aliases:
   - /rc/databases/upgrade-version
+  - /operate/rc/databases/upgrade-version/
 ---
 
 You can upgrade databases that are not on the latest available version of Redis to a later database version at any time.

--- a/content/operate/rc/subscriptions/bring-your-own-cloud/cloud-account-settings.md
+++ b/content/operate/rc/subscriptions/bring-your-own-cloud/cloud-account-settings.md
@@ -12,6 +12,7 @@ aliases:
   - /operate/rc/how-to/view-edit-cloud-account/cloud-account-settings
   - /operate/rc/cloud-accounts/cloud-account-settings
   - /operate/rc/cloud-integrations/aws-cloud-accounts/cloud-account-settings
+  - /operate/rc/subscriptions/aws-cloud-accounts/cloud-account-settings/
 ---
 
 Redis Cloud Bring your own Cloud (BYOC) lets you use your own cloud infrastructure to deploy Redis Cloud.

--- a/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/_index.md
+++ b/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/_index.md
@@ -12,6 +12,7 @@ aliases:
   - /operate/rc/how-to/view-edit-cloud-account/iam-resources
   - /operate/rc/cloud-accounts/iam-resources
   - /operate/rc/cloud-integrations/aws-cloud-accounts/iam-resources
+  - /operate/rc/subscriptions/aws-cloud-accounts/iam-resources/
 ---
 For Redis Cloud Bring your Own Cloud (BYOC) on Amazon Web Services (AWS), we manage the supporting infrastructure for you in dedicated AWS accounts.
 

--- a/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/aws-console.md
+++ b/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/aws-console.md
@@ -11,6 +11,7 @@ aliases:
   - /operate/rc/how-to/view-edit-cloud-account/iam-resources/aws-console
   - /operate/rc/cloud-accounts/iam-resources/aws-console
   - /operate/rc/cloud-integrations/aws-cloud-accounts/iam-resources/aws-console
+  - /operate/rc/subscriptions/aws-cloud-accounts/iam-resources/aws-console/
 ---
 Follow these steps to manually create IAM resources using the [AWS console](https://console.aws.amazon.com/).
 

--- a/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/cloudformation.md
+++ b/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/cloudformation.md
@@ -11,6 +11,7 @@ aliases:
   - /operate/rc/how-to/view-edit-cloud-account/iam-resources/cloudformation
   - /operate/rc/cloud-accounts/iam-resources/cloudformation
   - /operate/rc/cloud-integrations/aws-cloud-accounts/iam-resources/cloudformation
+  - /operate/rc/subscriptions/aws-cloud-accounts/iam-resources/cloudformation/
 ---
 You can use [AWS CloudFormation](https://aws.amazon.com/cloudformation/) to create the IAM resources for Redis Cloud Bring your Own Cloud (BYOC).
 

--- a/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/terraform.md
+++ b/content/operate/rc/subscriptions/bring-your-own-cloud/iam-resources/terraform.md
@@ -11,6 +11,7 @@ aliases:
   - /operate/rc/how-to/view-edit-cloud-account/iam-resources/terraform
   - /operate/rc/cloud-accounts/iam-resources/terraform
   - /operate/rc/cloud-integrations/aws-cloud-accounts/iam-resources/terraform
+  - /operate/rc/subscriptions/aws-cloud-accounts/iam-resources/terraform/
 ---
 You can use [HashiCorp Terraform](https://www.terraform.io/intro/index.html) to create identity and access management (IAM) resources to support AWS cloud account access to Redis Cloud subscriptions.
 

--- a/content/operate/rc/subscriptions/bring-your-own-cloud/subscription-whitelist.md
+++ b/content/operate/rc/subscriptions/bring-your-own-cloud/subscription-whitelist.md
@@ -13,6 +13,7 @@ aliases:
   - /operate/rc/how-to/view-edit-cloud-account/subscription-whitelist
   - /operate/rc/cloud-accounts/subscription-whitelist
   - /operate/rc/cloud-integrations/aws-cloud-accounts/subscription-whitelist
+  - /operate/rc/subscriptions/aws-cloud-accounts/subscription-whitelist/
 ---
 
 The [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) [allow list](https://en.wikipedia.org/wiki/Whitelist) lets you restrict traffic to your Redis Cloud database. When you configure an allow list, only the [IP addresses](https://en.wikipedia.org/wiki/IP_address) defined in the list can connect to the database. Traffic from all other IP addresses is blocked.

--- a/content/operate/rc/subscriptions/view-essentials-subscription/_index.md
+++ b/content/operate/rc/subscriptions/view-essentials-subscription/_index.md
@@ -9,6 +9,8 @@ categories:
 description: null
 hideListLinks: true
 weight: 30
+aliases:
+- /operate/rc/subscriptions/view-fixed-subscription/
 ---
 To view the details of a Redis Cloud Essentials subscription:
 

--- a/content/operate/rc/subscriptions/view-pro-subscription.md
+++ b/content/operate/rc/subscriptions/view-pro-subscription.md
@@ -8,6 +8,8 @@ categories:
 description: null
 linktitle: View and edit Pro plan
 weight: 40
+aliases:
+- /operate/rc/subscriptions/view-flexible-subscription/
 ---
 To view the details of a Redis Cloud Pro subscription:
 

--- a/content/operate/redisinsight/configuration.md
+++ b/content/operate/redisinsight/configuration.md
@@ -6,6 +6,9 @@ categories:
 linkTitle: Configuration settings
 title: Redis Insight configuration settings
 weight: 5
+aliases:
+- /operate/redisinsight/install/env-variables/
+- /operate/oss_and_stack/install/install-redis-insight/env-variables/
 ---
 ## Configuration environment variables
 

--- a/content/operate/redisinsight/install/_index.md
+++ b/content/operate/redisinsight/install/_index.md
@@ -8,6 +8,8 @@ linkTitle: Install Redis Insight
 title: Install Redis Insight
 weight: 3
 hideListLinks: true
+aliases:
+- /operate/oss_and_stack/install/install-redis-insight/
 ---
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-6 my-8 max-w-2xl">

--- a/content/operate/redisinsight/install/install-on-aws.md
+++ b/content/operate/redisinsight/install/install-on-aws.md
@@ -9,6 +9,8 @@ description: 'How to install Redis Insight on AWS EC2
 linkTitle: Install on AWS EC2
 title: Install on AWS EC2
 weight: 4
+aliases:
+- /operate/oss_and_stack/install/install-redis-insight/install-on-aws/
 ---
 This tutorial shows you how to install Redis Insight on an AWS EC2 instance and manage ElastiCache Redis instances using Redis Insight. To complete this tutorial you must have access to the AWS Console and permissions to launch EC2 instances.
 

--- a/content/operate/redisinsight/install/install-on-docker.md
+++ b/content/operate/redisinsight/install/install-on-docker.md
@@ -7,6 +7,8 @@ description: How to install Redis Insight on Docker
 linkTitle: Install on Docker
 title: Install on Docker
 weight: 2
+aliases:
+- /operate/oss_and_stack/install/install-redis-insight/install-on-docker/
 ---
 This tutorial shows how to install Redis Insight on [Docker](https://www.docker.com/) so you can use Redis Insight in development.
 See a separate guide for installing [Redis Insight on AWS]({{< relref "/operate/redisinsight/install/install-on-aws" >}}).

--- a/content/operate/redisinsight/install/install-on-k8s.md
+++ b/content/operate/redisinsight/install/install-on-k8s.md
@@ -7,6 +7,8 @@ description: How to install Redis Insight on Kubernetes
 linkTitle: Install on Kubernetes
 title: Install on Kubernetes
 weight: 3
+aliases:
+- /operate/oss_and_stack/install/install-redis-insight/install-on-k8s/
 ---
 This tutorial shows how to install Redis Insight on [Kubernetes](https://kubernetes.io/) (K8s).
 This is an easy way to use Redis Insight with a [Redis Enterprise K8s deployment]({{< relref "operate/kubernetes/" >}}).

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-126.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-126.md
@@ -9,6 +9,9 @@ compatibleOSSVersion: Redis 7.2.3, 6.2.13, 6.0.20
 description: Redis database version selection during database creation in the Cluster Manager UI. New Redis logo.
 linkTitle: 7.4.2-126 (April 2024)
 weight: 70
+aliases:
+- /operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-119/
+- /operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-2-tba/
 ---
 
 This is a maintenance release for ​[​Redis Enterprise Software version 7.4.2](https://redis.io/downloads/#software).

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-41.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-41.md
@@ -9,6 +9,8 @@ compatibleOSSVersion: Redis 8.2.1, 8.0.2, 7.4.3, 7.2.7, 6.2.13
 description: Bug fixes for cluster_wd configuration after restarts, internode encryption certificate storage and retrieval, database creation, Lua script migration issues, and database endpoint assignment after node removal.
 linkTitle: 8.0.2-41 (November 2025)
 weight: 89
+aliases:
+- /operate/rs/release-notes/rs-8-0-releases/rs-8-0-2-tba/
 ---
 
 This is a maintenance release for ​[​Redis Software version 8.0.2](https://redis.io/downloads/#Redis_Software).


### PR DESCRIPTION
Restores **256 dead URLs** — item **B1** of [DOC-6951](https://redislabs.atlassian.net/browse/DOC-6951).

> **Stacked on #3767.** Based on `DOC-6951-redirect-map` so this diff is content-only. Merge #3767 first; GitHub will retarget this to `main` automatically.

Every URL here belonged to a page that was renamed at some point in this repo's history without an alias being added for its old path, so it has been returning 404 ever since. **253** were generated with `make check_aliases_fix`; the remaining **3** are hand-written and are the interesting part (see below). **No prose was touched and no page moved** — the only changes are `aliases:` entries in frontmatter.

Coverage of URL-changing moves goes from **291 of 598 to 544**. The gaps run back to 2024, concentrated in the Redis Data Integration and RedisInsight restructures, with the rest scattered across individual moves.

## Deliberately not fixed

Reported by the tool rather than acted on, because none has a safe automatic answer:

| | Count | Why |
|---|---|---|
| old URL is a live page today | 22 | redirecting it would break a working page |
| collision | 25 | another page already claims the URL; Hugo picks a winner arbitrarily and only warns |
| page split into a section | 6 | lineage ends at one child; only a person can choose the landing page |
| target is a draft | 1 | a draft publishes nothing, its aliases included |

## The three hand-written aliases

Review caught a class of redirect the generator gets subtly wrong, and it's worth understanding because it isn't a coding bug — it's **lineage not being the same as equivalence**.

Both the Jedis and redis-py sections began as a single page that was later split up: `develop/clients/jedis.md` became `develop/clients/jedis/connect.md` with a new `_index.md` beside it. The *file's* lineage therefore runs from the old landing page to one child of the new section — so following it faithfully would point a bookmark for the generic Java client page at a Jedis **connection guide**, four renames later. The right target is the hub.

Six URLs are affected. **Three needed nothing**: they were already declared on the hub pages, and had been surfacing in the collision bucket — which turned out to be the tool saying *the right page already owns this*. The other three are added here, by hand, to `develop/clients/jedis/_index.md` and `develop/clients/redis-py/_index.md`.

Reviewers spotted two instances on the Java side; the same mistake is mirrored exactly in the Python docs. Chains crossing a split are now never auto-fixed (#3767).

## Verification — two full builds, diffed

The generator was wrong three times in ways that were invisible in every cheaper artifact, so this was checked by building the corpus with and without the change and diffing the page sets:

| | Result |
|---|---|
| new paths | **256** — every one an alias stub |
| pages lost | **0** |
| real pages replaced by a stub | **0** |
| hand-written hub aliases resolving to the hub, not the leaf | **3 / 3** |
| Hugo's alias count | 929 → **1,185** |
| build warnings | none, either build |

## What each cheaper check missed

Worth recording, because it's the argument for the build step existing:

- **unit tests, dry run, duplicate-claim analysis, Bugbot** — missed both the draft trap and a silently changed live URL
- **a clean build log** — Hugo says nothing when it skips a draft's aliases
- **a correct alias count** — the count was right while a URL was being lost
- **a stub-by-stub check** — every expected stub was present; the loss was in a stub nobody expected to *disappear*
- **all of the above, four rounds of it** — missed that three redirects pointed at defensible-but-wrong pages. A human reading the content caught that.

The page-set diff caught it as `index.html` coming out one short of the 256 added.

## One case not to re-tidy

The alias on `content/operate/kubernetes/release-notes/7-4-6-releases/7-4-6-2.md` ends in a **comma**, because an author wrote a list without brackets. That comma is part of the published URL and `.../7-4-6-2,/` returns **200** today, while the comma-free spelling returns 404. It's preserved exactly, with a comma-free alias added beside it. An earlier revision of the generator "tidied" it and silently retired a live URL.

## Re-running this

Use `make check_aliases_fix` rather than hand-editing, and diff two builds afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6951]: https://redislabs.atlassian.net/browse/DOC-6951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Hugo alias additions with no application or auth logic; main risk is an incorrect redirect target for a bookmarked URL, mitigated by build diffing and manual hub-alias review.
> 
> **Overview**
> Adds **`aliases:`** frontmatter entries across **256** docs pages so Hugo serves redirects for URLs that broke when pages were renamed or restructured without aliases (Redis Data Integration, RedisInsight release notes, RedisVL guides, client docs, Agent Memory paths, Amazon Bedrock `/integrate/aws-bedrock/`, and related operate/integrate moves).
> 
> **No body content or URL paths change**—only redirect metadata. Most entries were produced by `make check_aliases_fix`; **three** hub aliases were added manually on `develop/clients/jedis/_index.md` and `develop/clients/redis-py/_index.md` so old generic Java/Python client URLs land on section indexes instead of a child connect page after a page split.
> 
> Also covers edge cases such as **`/develop/clients/sce/`** → SCH doc, comma-bearing K8s release-note URLs, and duplicate alias list normalization (e.g. `redis-vl.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa4cb13fd5304263efe5d7666718d8e9c1e65417. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->