### PR TITLE
DOC-6951 Publish redirects so a moved page is not read as a deletion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,16 @@ json_transform: hugo
 	@echo "Transforming JSON files for RAG..."
 	@npx tsx build/transform_json_sections.ts
 
+# Tombstones need public/redirects.json, which hugo renders, and must run before
+# ndjson so that generate_ndjson.py can filter them back out of the feed. They are
+# written after json_transform only for tidiness -- the transform skips a record
+# that has a page_type and no content, so either order is safe.
+redirect_tombstones: json_transform
+	@echo "Writing redirect tombstones..."
+	@python3 build/write_redirect_tombstones.py public
+
 # ndjson requires json_transform to have processed the JSON files
-ndjson: json_transform
+ndjson: redirect_tombstones
 	@echo "Generating NDJSON feed..."
 	@python3 build/generate_ndjson.py
 	@echo "Compressing NDJSON feed..."

--- a/build/generate_ndjson.py
+++ b/build/generate_ndjson.py
@@ -32,6 +32,15 @@ def load_and_validate_json_files(public_dir: Path) -> list[tuple[Path, dict]]:
         try:
             with open(json_file, 'r', encoding='utf-8') as f:
                 data = json.load(f)
+                # Redirect tombstones live at a moved page's old URL and share the
+                # index.json name, so rglob picks them up. They are deliberately
+                # kept out of the feed: they would add roughly 1,100 near-empty
+                # records to 2,600 real ones and make every "how many documents"
+                # figure ambiguous. Consumers resolve a moved URL either per-URL at
+                # its own /index.json, or in bulk from /redirects.json. See
+                # DOC-6951.
+                if data.get('page_type') == 'moved':
+                    continue
                 # Check for our expected fields
                 if all(key in data for key in ['id', 'title', 'url']):
                     valid_files.append((json_file, data))

--- a/build/transform_json_sections.ts
+++ b/build/transform_json_sections.ts
@@ -49,21 +49,27 @@ interface CodeExample {
 interface PageJsonInput {
   // Emitted by the Hugo templates and carried through untouched. Declared so the
   // spread below preserves them explicitly rather than by accident: schema_version is
-  // what consumers gate re-parsing on, and since is the only version information the
-  // feed carries.
+  // what consumers gate re-parsing on, since is the only version information the
+  // feed carries, and aliases is how a consumer holding a record resolves a stale
+  // URL without fetching the redirect map.
   schema_version?: number;
   id: string;
   title: string;
   url: string;
   summary: string;
   since?: string;
+  aliases?: string[];
   content?: string;
   tags: string[];
   last_updated: string;
   children?: unknown[];
 }
 
-type PageType = 'content' | 'index';
+// 'moved' is written by the tombstone pass at a moved page's old URL, and carries
+// only url and moved_to -- no sections, examples or content_hash. A consumer must
+// switch on page_type before assuming the documented content shape. Added in
+// schema_version 2 (DOC-6951).
+type PageType = 'content' | 'index' | 'moved';
 
 interface PageJsonOutput {
   schema_version?: number;
@@ -72,6 +78,7 @@ interface PageJsonOutput {
   url: string;
   summary: string;
   since?: string;
+  aliases?: string[];
   page_type: PageType;
   content_hash?: string;
   tags: string[];

--- a/build/write_redirect_tombstones.py
+++ b/build/write_redirect_tombstones.py
@@ -29,9 +29,11 @@ cannot disagree with the map or with the site.
 
 Two things it will not do, both load-bearing:
 
-- **Never overwrite an existing ``index.json``.** An alias whose path a real page
-  occupies gets no tombstone; Hugo does not emit a stub there either, and
-  clobbering a real record would be far worse than a 404.
+- **Never overwrite a real page's ``index.json``.** An alias whose path a real page
+  occupies gets no tombstone; Hugo does not emit a stub there either, and clobbering
+  a real record would be far worse than a 404. A file that is recognisably one of
+  our own tombstones *is* rewritten, so an incremental build cannot keep serving a
+  ``moved_to`` that has since changed, and one the map no longer names is removed.
 - **Only write where a stub exists.** An alias declared on a draft, or one Hugo
   dropped because the URL was taken, produces no stub and so gets no tombstone.
 
@@ -73,7 +75,16 @@ def main() -> int:
     base_url = (redirect_map.get("base_url") or "").rstrip("/")
     entries = redirect_map.get("redirects") or []
 
-    written = no_stub = occupied = 0
+    def is_tombstone(path: str) -> bool:
+        """True if this index.json is one of ours rather than a real page record."""
+        try:
+            with open(path, encoding="utf-8") as existing:
+                return json.load(existing).get("page_type") == "moved"
+        except (OSError, json.JSONDecodeError):
+            return False
+
+    written = refreshed = no_stub = occupied = 0
+    expected: set[str] = set()
     for entry in entries:
         source = (entry.get("from") or "").strip()
         target = (entry.get("to") or "").strip()
@@ -81,7 +92,8 @@ def main() -> int:
             continue
 
         rel = source.lstrip("/")
-        directory = os.path.join(args.public_dir, *rel.split("/")) if rel else args.public_dir
+        directory = (os.path.join(args.public_dir, *rel.split("/")) if rel
+                     else args.public_dir)
 
         # Only where Hugo actually emitted a stub. A missing directory or missing
         # index.html means the alias was dropped -- the URL was already taken, or
@@ -92,10 +104,12 @@ def main() -> int:
             continue
 
         tombstone_path = os.path.join(directory, "index.json")
-        if os.path.exists(tombstone_path):
+        already = os.path.exists(tombstone_path)
+        if already and not is_tombstone(tombstone_path):
             # A real page lives here. Never clobber a real record.
             occupied += 1
             continue
+        expected.add(os.path.realpath(tombstone_path))
 
         record = {
             "schema_version": schema_version,
@@ -109,10 +123,41 @@ def main() -> int:
             with open(tombstone_path, "w", encoding="utf-8") as handle:
                 json.dump(record, handle, indent=2)
                 handle.write("\n")
-        written += 1
+        if already:
+            # One of ours from a previous run. Rewritten rather than left alone, or
+            # an incremental build would keep serving a moved_to that has since
+            # changed. CI always builds into a fresh tree, so this only shows up
+            # locally -- but "correct because CI starts clean" is not correct.
+            refreshed += 1
+        else:
+            written += 1
 
+    # Sweep tombstones that no longer belong: the alias was removed, or it became
+    # ambiguous and is now published as a candidate list instead. Only files that
+    # are recognisably ours are ever removed, and only when the map no longer names
+    # them, so a real page record can never be caught by this.
+    removed = 0
+    for root, _dirs, files in os.walk(args.public_dir):
+        if "index.json" not in files:
+            continue
+        path = os.path.join(root, "index.json")
+        if os.path.realpath(path) in expected:
+            continue
+        if not is_tombstone(path):
+            continue
+        if not args.dry_run:
+            os.remove(path)
+        removed += 1
+
+    verb = "would be written" if args.dry_run else "written"
     logger.info("write_redirect_tombstones: %d tombstone(s) %s from %d map entries.",
-                written, "would be written" if args.dry_run else "written", len(entries))
+                written, verb, len(entries))
+    if refreshed:
+        logger.info("  %d existing tombstone(s) %s.", refreshed,
+                    "would be refreshed" if args.dry_run else "refreshed")
+    if removed:
+        logger.info("  %d obsolete tombstone(s) %s -- no longer in the map.", removed,
+                    "would be removed" if args.dry_run else "removed")
     if no_stub:
         logger.info("  %d alias(es) had no stub, so were skipped -- the URL is taken "
                     "by a real page, or the alias is on a draft.", no_stub)

--- a/build/write_redirect_tombstones.py
+++ b/build/write_redirect_tombstones.py
@@ -1,0 +1,125 @@
+"""Write a JSON tombstone beside every alias stub Hugo emitted.
+
+Hugo generates alias stubs for the **HTML output format only**. So a moved page's
+old URL serves a 200 meta-refresh page, while its ``/index.json`` and
+``/index.html.md`` both 404 -- verified on three independent correctly-aliased
+moves and reproduced against Hugo 0.143.1.
+
+That matters because ``content/ai-agent-resources.md`` tells consumers to find a
+page's JSON by appending ``/index.json`` to its URL. Following that instruction on
+a page that moved returns 404, so the move is indistinguishable from a deletion --
+and this happens for *every* move, including the ones we alias correctly. Fixing
+alias coverage does not fix it; this does.
+
+At each of those URLs we now publish a minimal record:
+
+    {"schema_version": 2, "page_type": "moved",
+     "id": "develop/ai/agent-memory",
+     "url": "https://redis.io/docs/latest/develop/ai/agent-memory/",
+     "moved_to": "https://redis.io/docs/latest/develop/ai/context-engine/agent-memory/"}
+
+``page_type: "moved"`` is a new value in that vocabulary and ``moved_to`` a new
+field, so this is a record-shape change and bumps ``aiSchemaVersion`` to 2. A
+consumer must switch on ``page_type`` before assuming the documented content shape:
+a tombstone deliberately has no ``sections``, ``examples`` or ``content_hash``.
+
+Reads ``public/redirects.json`` -- the map Hugo renders from the same ``.Aliases``
+data it uses for the stubs -- rather than parsing stub HTML, so the tombstones
+cannot disagree with the map or with the site.
+
+Two things it will not do, both load-bearing:
+
+- **Never overwrite an existing ``index.json``.** An alias whose path a real page
+  occupies gets no tombstone; Hugo does not emit a stub there either, and
+  clobbering a real record would be far worse than a 404.
+- **Only write where a stub exists.** An alias declared on a draft, or one Hugo
+  dropped because the URL was taken, produces no stub and so gets no tombstone.
+
+See DOC-6951.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+logger = logging.getLogger("write_redirect_tombstones")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("public_dir", nargs="?", default="public",
+                        help="path to the rendered site (default: public)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="report what would be written without writing it")
+    return parser.parse_args()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    args = parse_args()
+
+    map_path = os.path.join(args.public_dir, "redirects.json")
+    if not os.path.isfile(map_path):
+        logger.error("write_redirect_tombstones: %s not found. Run hugo first; the "
+                     "map is rendered by layouts/index.redirects.json.", map_path)
+        return 1
+
+    with open(map_path, encoding="utf-8") as handle:
+        redirect_map = json.load(handle)
+
+    schema_version = redirect_map.get("schema_version")
+    base_url = (redirect_map.get("base_url") or "").rstrip("/")
+    entries = redirect_map.get("redirects") or []
+
+    written = no_stub = occupied = 0
+    for entry in entries:
+        source = (entry.get("from") or "").strip()
+        target = (entry.get("to") or "").strip()
+        if not source or not target:
+            continue
+
+        rel = source.lstrip("/")
+        directory = os.path.join(args.public_dir, *rel.split("/")) if rel else args.public_dir
+
+        # Only where Hugo actually emitted a stub. A missing directory or missing
+        # index.html means the alias was dropped -- the URL was already taken, or
+        # it was declared on a draft -- and inventing a record there would publish
+        # a JSON document at a URL that serves no page.
+        if not os.path.isfile(os.path.join(directory, "index.html")):
+            no_stub += 1
+            continue
+
+        tombstone_path = os.path.join(directory, "index.json")
+        if os.path.exists(tombstone_path):
+            # A real page lives here. Never clobber a real record.
+            occupied += 1
+            continue
+
+        record = {
+            "schema_version": schema_version,
+            "id": rel.rstrip("/"),
+            "title": "Moved",
+            "url": f"{base_url}/{rel}/" if rel else f"{base_url}/",
+            "page_type": "moved",
+            "moved_to": target,
+        }
+        if not args.dry_run:
+            with open(tombstone_path, "w", encoding="utf-8") as handle:
+                json.dump(record, handle, indent=2)
+                handle.write("\n")
+        written += 1
+
+    logger.info("write_redirect_tombstones: %d tombstone(s) %s from %d map entries.",
+                written, "would be written" if args.dry_run else "written", len(entries))
+    if no_stub:
+        logger.info("  %d alias(es) had no stub, so were skipped -- the URL is taken "
+                    "by a real page, or the alias is on a draft.", no_stub)
+    if occupied:
+        logger.info("  %d had an index.json already and were left alone.", occupied)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/config.toml
+++ b/config.toml
@@ -71,7 +71,14 @@ gitHubRepo = "https://github.com/redis/docs"
 # content is a second content hash, which they will learn to ignore.
 #
 # Changing what a field *contains* is not a shape change and does not bump this.
-aiSchemaVersion = 1
+#
+# History:
+#   1 -- initial: sections, examples, content_hash, page_type, id, since (DOC-6939)
+#   2 -- adds `aliases` to page records, and a new `page_type` value, "moved", for
+#        the redirect tombstones published at a moved page's old URL. A parser
+#        switching on page_type now meets a value it has not seen, and those
+#        records carry a `moved_to` field, so this is a shape change (DOC-6951).
+aiSchemaVersion = 2
 
 # Display and sort order for client examples
 clientsExamples = ["Python", "Node.js", "ioredis", "Java-Sync", "Lettuce-Sync", "Java-Async", "Java-Reactive", "Go", "C", "C#-Sync (NRedisStack)", "C#-Async (NRedisStack)", "C#-Sync (SE.Redis)", "C#-Async (SE.Redis)", "RedisVL", "PHP", "Ruby", "Rust-Sync", "Rust-Async"]
@@ -149,7 +156,22 @@ rdi_current_version = "1.19.0"
     mediaType = "application/json"
     isPlainText = true
 
+  # A site-wide map of every alias to the page it resolves to, published once on
+  # the home page as /redirects.json. Rendered from `.Aliases` -- the same data
+  # Hugo uses to emit its own redirect stubs -- so the map and the site's actual
+  # behavior cannot drift, and there is no generated file to keep in step.
+  [outputFormats.redirects]
+    name = "redirects"
+    baseName = "redirects"
+    mediaType = "application/json"
+    isPlainText = true
+
 # Comment out if you don't want the "print entire section" link enabled.
 [outputs]
 section = ["HTML", "RSS", "Markdown", "JSON"]
 page = ["HTML", "Markdown", "JSON"]
+# The home page had no entry, so it was on Hugo's default of HTML and RSS. That
+# default is reproduced here deliberately: adding Markdown or JSON would publish a
+# new record for the site root, which is one of the pages the feed excludes today.
+# Only the redirects map is new.
+home = ["HTML", "RSS", "redirects"]

--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -68,13 +68,85 @@ Two consequences worth knowing if you diff the feed against the sitemap:
 ### Schema version
 
 Every record carries a `schema_version` integer, and the same value appears in the
-`json metadata` block of the Markdown output. It is currently **1**.
+`json metadata` block of the Markdown output. It is currently **2**.
 
 It increments only when the **shape** of a record changes: a field added, removed or
 renamed, or a new value entering the [role vocabulary](#section-roles). It does **not**
 change when page content changes, and it does not change when the value inside a field
 changes without the field itself changing. Use `content_hash` to detect content changes;
 use `schema_version` to detect when your parser might need attention.
+
+Version 2 added the `aliases` field to page records, and a new `page_type` value,
+`moved`, for the [redirect records](#pages-that-have-moved) served at a moved page's
+old URL. Version 1 was the initial shape: `sections`, `examples`, `content_hash`,
+`page_type`, `id` and `since`.
+
+## Pages that have moved
+
+When a page moves, its old URL keeps working — but until now it served only an HTML
+redirect, so appending `/index.json` to it returned 404 and a move was
+indistinguishable from a deletion. Two things now fix that.
+
+### A redirect record at the old URL
+
+Appending `/index.json` to a moved page's URL returns a record with
+`page_type` set to `moved`:
+
+```json
+{
+  "schema_version": 2,
+  "id": "develop/ai/agent-memory",
+  "title": "Moved",
+  "url": "https://redis.io/docs/latest/develop/ai/agent-memory/",
+  "page_type": "moved",
+  "moved_to": "https://redis.io/docs/latest/develop/ai/context-engine/agent-memory/"
+}
+```
+
+**Check `page_type` before assuming the shape of a record.** A `moved` record
+deliberately carries no `sections`, `examples` or `content_hash` — there is no content
+at that URL, only a pointer. Fetch `moved_to` to get the page itself.
+
+These records are **not** included in `docs.ndjson`. The feed is one record per
+documentation page, and adding roughly a thousand pointer records would make any count
+of the corpus ambiguous. Use the map below if you need them in bulk.
+
+### A map of every redirect
+
+`https://redis.io/docs/latest/redirects.json` lists every alias the site publishes and
+the page it resolves to:
+
+```json
+{
+  "schema_version": 2,
+  "base_url": "https://redis.io/docs/latest/",
+  "generated": "2026-08-07T15:00:00Z",
+  "count": 771,
+  "ambiguous_count": 12,
+  "redirects": [
+    {"from": "/develop/ai/langcache", "to": "https://redis.io/docs/latest/develop/ai/context-engine/langcache/"}
+  ],
+  "ambiguous": [
+    {"from": "/develop/use/pipelining", "candidates": ["https://redis.io/docs/latest/develop/using-commands/", "https://redis.io/docs/latest/develop/using-commands/pipelining/"]}
+  ]
+}
+```
+
+Three things worth knowing before you rely on it:
+
+- `from` is normalized to a leading slash and no trailing slash. `to` is absolute,
+  matching the `url` field on page records.
+- **It is an alias map, not a move log.** Many entries are vanity or legacy paths that
+  were never a page's location, and there is no date, because the source data does not
+  record when a page moved.
+- `ambiguous` holds the keys that more than one page claims, with every candidate
+  listed. We publish them separately rather than picking one, because the site itself
+  resolves those arbitrarily — so any single answer we gave you would sometimes
+  disagree with what you would actually be served. Treat an `ambiguous` key as
+  unresolved.
+
+The map covers the current version of the documentation. Version-specific
+documentation is outside both machine-readable feeds.
 
 ### JSON schema
 

--- a/content/ai-agent-resources.md
+++ b/content/ai-agent-resources.md
@@ -121,21 +121,27 @@ the page it resolves to:
   "schema_version": 2,
   "base_url": "https://redis.io/docs/latest/",
   "generated": "2026-08-07T15:00:00Z",
-  "count": 771,
-  "ambiguous_count": 12,
+  "count": 1061,
+  "ambiguous_count": 27,
+  "shadowed_count": 10,
   "redirects": [
     {"from": "/develop/ai/langcache", "to": "https://redis.io/docs/latest/develop/ai/context-engine/langcache/"}
   ],
   "ambiguous": [
     {"from": "/develop/use/pipelining", "candidates": ["https://redis.io/docs/latest/develop/using-commands/", "https://redis.io/docs/latest/develop/using-commands/pipelining/"]}
+  ],
+  "shadowed": [
+    {"from": "/glossary", "declared": ["https://redis.io/docs/latest/glossary/"]}
   ]
 }
 ```
 
-Three things worth knowing before you rely on it:
+Four things worth knowing before you rely on it:
 
 - `from` is normalized to a leading slash and no trailing slash. `to` is absolute,
-  matching the `url` field on page records.
+  matching the `url` field on page records. Every key in `redirects` has a redirect
+  record of its own at `<from>/index.json`, so you can resolve one URL without
+  fetching the whole map.
 - **It is an alias map, not a move log.** Many entries are vanity or legacy paths that
   were never a page's location, and there is no date, because the source data does not
   record when a page moved.
@@ -144,6 +150,10 @@ Three things worth knowing before you rely on it:
   resolves those arbitrarily — so any single answer we gave you would sometimes
   disagree with what you would actually be served. Treat an `ambiguous` key as
   unresolved.
+- `shadowed` holds aliases a page declares that the site does not act on, because a
+  real page already occupies that URL — so the URL serves its own content rather than
+  redirecting. They are listed for completeness and **must not** be followed as
+  redirects; doing so would take a reader away from a live page.
 
 The map covers the current version of the documentation. Version-specific
 documentation is outside both machine-readable feeds.

--- a/layouts/_default/section.json
+++ b/layouts/_default/section.json
@@ -27,7 +27,8 @@
   "title": {{ .Title | jsonify }},
   "url": {{ .Permalink | jsonify }},
   "summary": {{ $summary | jsonify }},{{ with .Params.since }}
-  "since": {{ . | jsonify }},{{ end }}
+  "since": {{ . | jsonify }},{{ end }}{{ with .Aliases }}
+  "aliases": {{ . | jsonify }},{{ end }}
   "content": {{ $content | jsonify }},
   "tags": {{ $tags | jsonify }},
   "last_updated": {{ $lastUpdated | jsonify }},

--- a/layouts/_default/single.json
+++ b/layouts/_default/single.json
@@ -16,7 +16,8 @@
   "title": {{ .Title | jsonify }},
   "url": {{ .Permalink | jsonify }},
   "summary": {{ $summary | jsonify }},{{ with .Params.since }}
-  "since": {{ . | jsonify }},{{ end }}
+  "since": {{ . | jsonify }},{{ end }}{{ with .Aliases }}
+  "aliases": {{ . | jsonify }},{{ end }}
   "content": {{ $content | jsonify }},
   "tags": {{ $tags | jsonify }},
   "last_updated": {{ $lastUpdated | jsonify }}

--- a/layouts/index.redirects.json
+++ b/layouts/index.redirects.json
@@ -1,0 +1,60 @@
+{{- /* Site-wide redirect map, published as /redirects.json.
+
+  Every alias any published page declares, mapped to the page it resolves to.
+  Rendered from `.Aliases`, which is the same data Hugo uses to emit its own
+  redirect stubs, so the map and the site's real behavior cannot drift and there
+  is no generated file to keep in step.
+
+  Ambiguity is separated out rather than resolved. Two pages can declare the same
+  alias -- 40 do in a production build, 12 of them pointing somewhere different --
+  and Hugo settles that by emitting one stub and picking a winner arbitrarily.
+  Publishing one of those targets as though it were the answer would hand
+  consumers data the site does not honour, so those keys go in `ambiguous` with
+  every candidate listed, and `redirects` contains only keys with exactly one
+  target. An alias declared twice with the same target is simply deduplicated.
+
+  Two caveats a consumer needs, both documented on ai-agent-resources:
+
+  - `from` is normalized to a leading slash and no trailing slash. Authors write
+    both forms -- 918 of 929 entries carry a leading slash, and the trailing slash
+    is an even split -- so normalizing here saves every consumer doing it. `to` is
+    absolute, matching the `url` field every per-page record already publishes.
+  - This is an *alias* map, not a move log. Many entries are vanity or legacy paths
+    that were never a page's location, and it carries no date, because frontmatter
+    does not record when a page moved.
+
+  Only pages Hugo publishes appear, so drafts contribute nothing -- which matches
+  the site, since Hugo emits no stub for a draft's aliases either.
+
+  See DOC-6951.
+*/ -}}
+{{- $seen := newScratch -}}
+{{- range .Site.Pages -}}
+  {{- $to := .Permalink -}}
+  {{- range .Aliases -}}
+    {{- $from := . | strings.TrimSuffix "/" -}}
+    {{- if not (hasPrefix $from "/") -}}
+      {{- $from = printf "/%s" $from -}}
+    {{- end -}}
+    {{- $targets := index ($seen.Get "map" | default dict) $from | default slice -}}
+    {{- $seen.SetInMap "map" $from ($targets | append $to | uniq) -}}
+  {{- end -}}
+{{- end -}}
+{{- $redirects := slice -}}
+{{- $ambiguous := slice -}}
+{{- range $from, $targets := ($seen.Get "map" | default dict) -}}
+  {{- if eq (len $targets) 1 -}}
+    {{- $redirects = $redirects | append (dict "from" $from "to" (index $targets 0)) -}}
+  {{- else -}}
+    {{- $ambiguous = $ambiguous | append (dict "from" $from "candidates" (sort $targets)) -}}
+  {{- end -}}
+{{- end -}}
+{{ dict
+     "schema_version" site.Params.aiSchemaVersion
+     "base_url" site.BaseURL
+     "generated" (now.Format "2006-01-02T15:04:05Z07:00")
+     "count" (len $redirects)
+     "ambiguous_count" (len $ambiguous)
+     "redirects" (sort $redirects "from")
+     "ambiguous" (sort $ambiguous "from")
+   | jsonify (dict "indent" "  ") }}

--- a/layouts/index.redirects.json
+++ b/layouts/index.redirects.json
@@ -39,9 +39,19 @@
        keeps serving its own page. Publishing it as a redirect would send a consumer
        away from a live page, which is worse than omitting it, so those go in
        `shadowed` instead. 10 in a full build. */ -}}
+{{- /* RelPermalink carries the baseURL's path, which is empty in a local build and
+       /docs/latest in production -- while Hugo writes alias stubs relative to the
+       publish directory, with no such prefix. Comparing or publishing RelPermalink
+       directly therefore works locally and silently breaks in production: keys stop
+       matching, so nothing is ever detected as shadowed, and a slash-less alias is
+       published at /docs/latest/... where no stub exists. Reproduced against Hugo
+       0.143.1 with a prefixed baseURL. Everything below works in publish-relative
+       paths. */ -}}
+{{- $basePath := (urls.Parse site.BaseURL).Path | strings.TrimSuffix "/" -}}
 {{- $occupied := newScratch -}}
 {{- range .Site.Pages -}}
-  {{- $occupied.SetInMap "url" (.RelPermalink | strings.TrimSuffix "/") true -}}
+  {{- $occupied.SetInMap "url"
+        (strings.TrimPrefix $basePath (.RelPermalink | strings.TrimSuffix "/")) true -}}
 {{- end -}}
 {{- $seen := newScratch -}}
 {{- range .Site.Pages -}}
@@ -56,7 +66,8 @@
              Hugo 0.143.1. Prepending a slash instead would name a location the
              redirect is not at, which is worse than omitting it -- and 11 entries in
              this corpus are written that way. */ -}}
-      {{- $parent := path.Dir (strings.TrimSuffix "/" $page.RelPermalink) -}}
+      {{- $rel := strings.TrimPrefix $basePath (strings.TrimSuffix "/" $page.RelPermalink) -}}
+      {{- $parent := path.Dir $rel -}}
       {{- $from = path.Join (cond (eq $parent ".") "/" $parent) $from -}}
     {{- end -}}
     {{- $targets := index ($seen.Get "map" | default dict) $from | default slice -}}

--- a/layouts/index.redirects.json
+++ b/layouts/index.redirects.json
@@ -5,11 +5,17 @@
   redirect stubs, so the map and the site's real behavior cannot drift and there
   is no generated file to keep in step.
 
+  Entries the site does not honor are separated out too. An alias whose path a real
+  page occupies is never written as a stub, because Hugo will not overwrite a page:
+  that URL keeps serving its own content. Listing it as a redirect would send a
+  consumer away from a live page, so those go in `shadowed` -- 10 of them -- which
+  also means every key in `redirects` has a stub and a tombstone behind it.
+
   Ambiguity is separated out rather than resolved. Two pages can declare the same
-  alias -- 40 do in a production build, 12 of them pointing somewhere different --
+  alias -- 27 keys in a full build, each naming two or more targets --
   and Hugo settles that by emitting one stub and picking a winner arbitrarily.
   Publishing one of those targets as though it were the answer would hand
-  consumers data the site does not honour, so those keys go in `ambiguous` with
+  consumers data the site does not honor, so those keys go in `ambiguous` with
   every candidate listed, and `redirects` contains only keys with exactly one
   target. An alias declared twice with the same target is simply deduplicated.
 
@@ -28,13 +34,30 @@
 
   See DOC-6951.
 */ -}}
+{{- /* Every URL a real page occupies. Hugo refuses to write an alias stub over a
+       page, so an alias naming one of these is declared but never honored: the URL
+       keeps serving its own page. Publishing it as a redirect would send a consumer
+       away from a live page, which is worse than omitting it, so those go in
+       `shadowed` instead. 10 in a full build. */ -}}
+{{- $occupied := newScratch -}}
+{{- range .Site.Pages -}}
+  {{- $occupied.SetInMap "url" (.RelPermalink | strings.TrimSuffix "/") true -}}
+{{- end -}}
 {{- $seen := newScratch -}}
 {{- range .Site.Pages -}}
+  {{- $page := . -}}
   {{- $to := .Permalink -}}
   {{- range .Aliases -}}
     {{- $from := . | strings.TrimSuffix "/" -}}
     {{- if not (hasPrefix $from "/") -}}
-      {{- $from = printf "/%s" $from -}}
+      {{- /* Hugo resolves a slash-less alias relative to the declaring page's
+             parent directory, not to the site root: `docs` on a page at
+             /develop/tools/ publishes its stub at /develop/docs/. Verified against
+             Hugo 0.143.1. Prepending a slash instead would name a location the
+             redirect is not at, which is worse than omitting it -- and 11 entries in
+             this corpus are written that way. */ -}}
+      {{- $parent := path.Dir (strings.TrimSuffix "/" $page.RelPermalink) -}}
+      {{- $from = path.Join (cond (eq $parent ".") "/" $parent) $from -}}
     {{- end -}}
     {{- $targets := index ($seen.Get "map" | default dict) $from | default slice -}}
     {{- $seen.SetInMap "map" $from ($targets | append $to | uniq) -}}
@@ -42,8 +65,11 @@
 {{- end -}}
 {{- $redirects := slice -}}
 {{- $ambiguous := slice -}}
+{{- $shadowed := slice -}}
 {{- range $from, $targets := ($seen.Get "map" | default dict) -}}
-  {{- if eq (len $targets) 1 -}}
+  {{- if index ($occupied.Get "url" | default dict) $from -}}
+    {{- $shadowed = $shadowed | append (dict "from" $from "declared" (sort $targets)) -}}
+  {{- else if eq (len $targets) 1 -}}
     {{- $redirects = $redirects | append (dict "from" $from "to" (index $targets 0)) -}}
   {{- else -}}
     {{- $ambiguous = $ambiguous | append (dict "from" $from "candidates" (sort $targets)) -}}
@@ -55,6 +81,8 @@
      "generated" (now.Format "2006-01-02T15:04:05Z07:00")
      "count" (len $redirects)
      "ambiguous_count" (len $ambiguous)
+     "shadowed_count" (len $shadowed)
      "redirects" (sort $redirects "from")
      "ambiguous" (sort $ambiguous "from")
+     "shadowed" (sort $shadowed "from")
    | jsonify (dict "indent" "  ") }}


### PR DESCRIPTION
Makes a moved page resolvable instead of looking deleted — item **D** of [DOC-6951](https://redislabs.atlassian.net/browse/DOC-6951). Based on `main`, independent of #3767/#3769/#3770.

## The problem

Hugo emits alias stubs for the **HTML output format only**. So a moved page's old URL serves a 200 meta-refresh page, while its `/index.json` and `/index.html.md` both **404**.

Our own `ai-agent-resources` page tells consumers to find a page's JSON by appending `/index.json` to its URL. Following that instruction on a page that moved returns 404 — so **a move is indistinguishable from a deletion**, for *every* move, including the ~90% we now alias correctly. #3769 fixed alias coverage; it could not fix this.

## Two mechanisms

**A record at the old URL.** `page_type: "moved"`, carrying `url` and `moved_to` and nothing else:

```json
{"schema_version": 2, "page_type": "moved",
 "id": "data-types/bitmaps",
 "url": "https://redis.io/docs/latest/data-types/bitmaps/",
 "moved_to": "https://redis.io/docs/latest/develop/data-types/strings/bitmaps/"}
```

(That's a real one from the build — and one of the two moves the applied AI team's assessment originally cited.)

**A map of all of them** at `/redirects.json`, rendered from `.Aliases` — the same data Hugo uses for its own stubs, so map and site cannot drift and there's no generated file to keep in step.

## The map's design changed once I counted the keys

The obvious version — one entry per declaration — published **duplicate keys, 29 of them naming different targets**, because two pages can declare the same alias. Hugo settles that by writing one stub and picking a winner arbitrarily, so publishing either target would hand consumers an answer the site doesn't honour.

So `redirects` holds only keys with exactly one target (**791**), and contested keys go in `ambiguous` with every candidate listed (**29**). Tombstones are written only for unambiguous keys, for the same reason. That's the same report-don't-guess principle as the scanner's collision bucket in #3767 — this is the fourth place the duplicate-alias problem has surfaced.

## Tombstones stay out of `docs.ndjson`

They share the `index.json` name, so the feed's `rglob` would have swept in ~1,000 pointer records against 2,600 real ones, making any count of the corpus ambiguous — precisely the confusion DOC-6939 spent its time reconciling. `generate_ndjson.py` filters on `page_type` instead.

## `schema_version` → 2

`page_type: "moved"` is a new value and `moved_to` a new field, so this is a shape change by the definition the AI team proposed and we adopted. Refusing to bump on the first real change would teach them the field is inert.

Page records also gain **`aliases`**, declared on both transform interfaces rather than riding on a spread, per the constraint from the `schema_version` work. It doesn't disturb `content_hash`, which covers `summary`, `sections` and `examples` only.

## Verification — full build, real pipeline order

| | Result |
|---|---|
| tombstones written | **774** from 791 map entries (8 no stub, 9 already held a real record) |
| duplicate keys in `redirects` | **0** |
| distinct keys accounted for | 791 + 29 = **820**, matching an independent count |
| feed records before / after tombstones | **5,733 / 5,733** |
| `moved` records leaking into the feed | **0** |
| transform re-run over the result | 6,507 files, **0** transformed, all skipped |

The no-overwrite guard did real work: 9 live pages left alone.

## Review round (`32d3f1a5b`)

Two Bugbot findings, both correct, and both cases where the pass worked only because CI builds into a fresh tree:

| Finding | Fix |
|---|---|
| Skips updating existing tombstones | the no-overwrite guard was too broad — it now reads `page_type` and refuses only for a **real page's** record, rewriting its own tombstones every run |
| Obsolete tombstones never removed | the pass records the set it expects and sweeps any recognisable tombstone the map no longer names |

Both are invisible in production, which is precisely why they were worth fixing: the script was correct by accident of its environment rather than by construction, and anyone running it locally twice would have got a wrong answer with no signal.

Verified against a real built tree: a re-run refreshes all 774 rather than skipping, a deliberately poisoned `moved_to` is corrected, a planted orphan is removed, a real page record is **byte-identical** afterwards, and the feed still holds 5,733 records with nothing leaking in.

## Known gap

The published `base_url` depends on CI rewriting `baseURL` in `config.toml` with `sed`. That sed still matches after my edits — checked — but I haven't observed it against a deployed build.

## Not included

**D3** — `data/page-moves.json` for move *dates* and *deleted* pages, the two things Hugo cannot know. Deferred; say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6951]: https://redislabs.atlassian.net/browse/DOC-6951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public AI JSON contract (schema v2, new page_type) and build order; tombstone logic must not overwrite real page index.json files.
> 
> **Overview**
> Moved doc URLs no longer look like deletions to AI/RAG consumers: **`/index.json` at an old alias** now returns a minimal **`page_type: "moved"`** record with **`moved_to`**, and **`/redirects.json`** lists unambiguous aliases (with **`ambiguous`** and **`shadowed`** buckets for contested or blocked paths).
> 
> **`aiSchemaVersion` bumps to 2**; page JSON gains optional **`aliases`**, and the transform pipeline recognizes **`moved`** as a distinct shape. A new **`write_redirect_tombstones.py`** step runs after Hugo/`json_transform` and before NDJSON; **`generate_ndjson.py`** excludes tombstones so **`docs.ndjson`** stays one record per real page. **`ai-agent-resources.md`** documents the new behavior for agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4af980d86474c792f90cbb171cafe87a8bb8ee24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->