### PR TITLE
Fix five dead links on the Agent Memory landing page

### DIFF
--- a/content/develop/ai/context-engine/agent-memory/_index.md
+++ b/content/develop/ai/context-engine/agent-memory/_index.md
@@ -103,12 +103,12 @@ Get started with Redis Agent Memory on Redis Cloud or join the private preview f
   <div class="p-5 border border-redis-pen-300 rounded-lg">
     <h3 class="text-redis-ink-900 font-semibold mb-3">Redis Cloud</h3>
     <p>Create a managed Redis Agent Memory service and make your first requests.</p>
-    <p><a href="/operate/iris/agent-memory/create-service">Open the Redis Cloud setup guide</a></p>
+    <p><a href="{{< relref "/operate/iris/agent-memory/create-service" >}}">Open the Redis Cloud setup guide</a></p>
   </div>
   <div class="p-5 border border-redis-pen-300 rounded-lg">
     <h3 class="text-redis-ink-900 font-semibold mb-3">Redis Software private preview</h3>
     <p>Deploy Redis Agent Memory on Kubernetes with Redis Software.</p>
-    <p><a href="/operate/iris/agent-memory/self-managed">Open the self-managed deployment guide</a></p>
+    <p><a href="{{< relref "/operate/iris/agent-memory/self-managed" >}}">Open the self-managed deployment guide</a></p>
   </div>
 </div>
 
@@ -120,17 +120,17 @@ After your Redis Agent Memory service is ready, choose a client. Each quickstart
   <div class="p-5 border border-redis-pen-300 rounded-lg">
     <h3 class="text-redis-ink-900 font-semibold mb-3">Python SDK</h3>
     <p>Explore the Redis Agent Memory workflow with the Python SDK.</p>
-    <p><a href="/develop/ai/context-engine/agent-memory/python-sdk-quickstart">Open the Python quickstart</a></p>
+    <p><a href="{{< relref "/develop/ai/context-engine/agent-memory/python-sdk-quickstart" >}}">Open the Python quickstart</a></p>
   </div>
   <div class="p-5 border border-redis-pen-300 rounded-lg">
     <h3 class="text-redis-ink-900 font-semibold mb-3">TypeScript SDK</h3>
     <p>Explore the Redis Agent Memory workflow with the TypeScript SDK.</p>
-    <p><a href="/develop/ai/context-engine/agent-memory/typescript-sdk-quickstart">Open the TypeScript quickstart</a></p>
+    <p><a href="{{< relref "/develop/ai/context-engine/agent-memory/typescript-sdk-quickstart" >}}">Open the TypeScript quickstart</a></p>
   </div>
   <div class="p-5 border border-redis-pen-300 rounded-lg">
     <h3 class="text-redis-ink-900 font-semibold mb-3">REST API</h3>
     <p>Explore the Redis Agent Memory workflow with <code>curl</code>.</p>
-    <p><a href="/develop/ai/context-engine/agent-memory/rest-api-quickstart">Open the REST API quickstart</a></p>
+    <p><a href="{{< relref "/develop/ai/context-engine/agent-memory/rest-api-quickstart" >}}">Open the REST API quickstart</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
## Problem

Five links at the bottom of [Agent Memory](https://redis.io/docs/latest/develop/ai/context-engine/agent-memory/) are dead on the live site — the two "Get started" cards (Redis Cloud, Redis Software private preview) and all three "Choose a quickstart" cards (Python SDK, TypeScript SDK, REST API).

They were hand-written HTML using site-absolute paths:

```html
<p><a href="/operate/iris/agent-memory/create-service">…</a></p>
```

The docs site is served under a path prefix — `.github/workflows/main.yml:104` rewrites `baseURL` to `https://redis.io/docs/latest` — so these resolve to `redis.io/operate/…` and `redis.io/develop/…`, which 404. Confirmed against production:

| URL | Status |
|---|---|
| `redis.io/operate/iris/agent-memory/create-service` | 404 |
| `redis.io/operate/iris/agent-memory/self-managed` | 404 |
| `redis.io/develop/ai/context-engine/agent-memory/python-sdk-quickstart` | 404 |
| `redis.io/develop/ai/context-engine/agent-memory/typescript-sdk-quickstart` | 404 |
| `redis.io/develop/ai/context-engine/agent-memory/rest-api-quickstart` | 404 |

The three cards at the *top* of the same page were unaffected, because the `image-card` shortcode already pipes its `url` param through `relref` (`layouts/shortcodes/image-card.html:24`). Only the hand-rolled cards skipped it.

## Fix

Route all five through `relref` so Hugo emits the prefixed URL:

```html
<p><a href="{{< relref "/operate/iris/agent-memory/create-service" >}}">…</a></p>
```

All five targets exist in `content/`, so `relref` resolves:

- `content/operate/iris/agent-memory/create-service.md`
- `content/operate/iris/agent-memory/self-managed/_index.md`
- `content/develop/ai/context-engine/agent-memory/python-sdk-quickstart.md`
- `content/develop/ai/context-engine/agent-memory/typescript-sdk-quickstart.md`
- `content/develop/ai/context-engine/agent-memory/rest-api-quickstart.md`

## Verification

Built locally with Hugo v0.143.0 extended (the version pinned in the README) using the production base URL:

```
hugo --baseURL "https://redis.io/docs/latest/"
```

All five links render with the correct prefix, and every target page is present in the build output:

```
/docs/latest/operate/iris/agent-memory/create-service/                         Open the Redis Cloud setup guide
/docs/latest/operate/iris/agent-memory/self-managed/                           Open the self-managed deployment guide
/docs/latest/develop/ai/context-engine/agent-memory/python-sdk-quickstart/     Open the Python quickstart
/docs/latest/develop/ai/context-engine/agent-memory/typescript-sdk-quickstart/ Open the TypeScript quickstart
/docs/latest/develop/ai/context-engine/agent-memory/rest-api-quickstart/       Open the REST API quickstart
```

Zero empty `href`s on the page, and no `REF_NOT_FOUND` warning for `agent-memory/_index.md`. Text-only change to link targets — no copy or layout changes.

One caveat on the local build: it did not run to completion, failing at the end on issues unrelated to this change — the `jupyter-example` shortcode on four client pages and a missing `fastapi_tutorial` example (both need `make deps components`, which fetches example code from external client repos), plus a PostCSS step blocked by a local npm cache permission problem. Page HTML is written before those steps, so the link rendering above is unaffected. Staging preview confirmation is still welcome as a second check.

## Related, not in this PR

The same Agent Memory reorg into `/operate/iris/` left **10 broken `relref` calls** on the Google ADK integration pages, which render as `href=""` on production today:

- `content/integrate/google-adk/_index.md:28,47,48`
- `content/integrate/google-adk/agent-memory-server.md:33,67,68,123`
- `content/integrate/google-adk/redis-agent-memory.md:34,35,253`

Seven point at `/develop/ai/context-engine/agent-memory/self-managed` (should be `/operate/iris/agent-memory/self-managed`); three at `/operate/rc/context-engine/agent-memory/create-service` (should be `/operate/iris/agent-memory/create-service` — the `rc` path survives only as an alias, and `relref` does not resolve aliases).

Worth noting these fail silently: `refLinksErrorLevel = "WARNING"` in `config.toml:6` means a broken `relref` emits an empty `href` instead of failing the build. Happy to follow up with those fixes and a `build/check_relrefs.py` CI check.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link target changes with no application or security impact; staging verification of the five URLs is the main check.
> 
> **Overview**
> **Fixes five broken links** on the Agent Memory landing page (`agent-memory/_index.md`) in the hand-written “Get started” and “Choose a quickstart” cards.
> 
> Each `href` was changed from a root-absolute path (e.g. `/operate/iris/...`, `/develop/ai/...`) to Hugo’s `{{< relref "..." >}}` so URLs include the docs site’s `/docs/latest` base prefix on production. Copy and layout are unchanged; only link resolution changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87c3f425dd9cb3f9466f0945793a3dd6d441f681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


