### PR TITLE
DOC-6954 Give the Client tools page its categories back

### DIFF
--- a/content/develop/tools/_index.md
+++ b/content/develop/tools/_index.md
@@ -1,6 +1,5 @@
 ---
 categories:
-aliases:
 - docs
 - develop
 - stack


### PR DESCRIPTION
Fixes [DOC-6954](https://redislabs.atlassian.net/browse/DOC-6954). **One deleted line.**

`content/develop/tools/_index.md` had `categories:` with no value and `aliases:` immediately beneath it, so YAML bound the category list to `aliases` and left `categories` null:

```diff
 ---
 categories:
-aliases:
 - docs
 - develop
```

## How it got there

Commit `daf2053e2` (DOC-4543 restructure, 2024-11-11) inserted `aliases: ` on the line *between* `categories:` and its list. Before that the frontmatter was correct.

So this was never a mistyped category list — a new key landed one line too high and took the existing list with it, silently, for twenty-one months. Inserting any key directly above a block list does the same thing, which is worth knowing independently of this file.

## Two verified effects

Both checked against a full build with a production-style baseURL.

**The AI outputs get their `tags` back.** The per-page JSON and the Markdown metadata block both derive `tags` from `categories`, so this page had been publishing an empty array to every feed consumer. It now carries all nine entries.

**Seven bogus redirects stop being published.** Hugo resolves a slash-less alias against the declaring page's parent directory, so the category words had been publishing live stubs:

| Was published | Now |
|---|---|
| `/develop/develop/` → `/develop/tools/` | gone |
| `/develop/docs/` → `/develop/tools/` | gone |
| `/develop/kubernetes/` → `/develop/tools/` | gone |
| `/develop/oss/` → `/develop/tools/` | gone |
| `/develop/rc/` → `/develop/tools/` | gone |
| `/develop/rs/` → `/develop/tools/` | gone |
| `/develop/stack/` → `/develop/tools/` | gone |

Safe to remove: **nothing** in `content/`, `layouts/` or `static/` references any of them, and Hugo's alias stubs carry `robots: noindex` — confirmed in the built output — so they were never indexed either.

## Two things I checked rather than assumed

**The duplicate `oss` is kept.** It looked like a typo worth tidying until I counted: **822 pages** carry this exact nine-entry list, and 857 of 4,696 category lists contain some duplicate. It's the house pattern, and removing it here would make this page the odd one out for no benefit. The list is restored verbatim.

**The ticket's claimed impact was wrong.** It said the page was missing from its category listings. It wasn't — there *are* no category listings. `layouts/_default/term.html` and `taxonomy.html` each contain only `{{/* suppress warnings */}}`, so every category page renders one byte. The real cost was the empty `tags` array and the seven spurious redirects, not navigation. Corrected on the ticket.

Build emits the same 10 pre-existing `REF_NOT_FOUND` warnings already on `main` ([DOC-6955](https://redislabs.atlassian.net/browse/DOC-6955)) and no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6954]: https://redislabs.atlassian.net/browse/DOC-6954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOC-6955]: https://redislabs.atlassian.net/browse/DOC-6955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation frontmatter line removal with no runtime or security impact; only fixes metadata and alias generation for one page.
> 
> **Overview**
> Fixes a **YAML frontmatter mistake** on the Client tools section index (`content/develop/tools/_index.md`) by removing a stray `aliases:` line that sat between `categories:` and its list. That mis-indentation had left `categories` empty and treated the nine standard labels (`docs`, `develop`, `stack`, etc.) as URL aliases.
> 
> **Restores metadata for AI feeds:** layouts map `categories` to JSON `tags` and Markdown metadata, so this page again publishes the full nine-entry tag set instead of an empty array.
> 
> **Stops seven accidental redirects:** those category strings are no longer published as Hugo aliases (e.g. `/develop/docs/` → `/develop/tools/`). No app or layout code changes—only frontmatter structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b760b1e8b4f5c940d6697f9d80b4de44555949e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->