### PR TITLE
Acl keyspace command isolation docs

### DIFF
--- a/content/operate/oss_and_stack/management/security/acl.md
+++ b/content/operate/oss_and_stack/management/security/acl.md
@@ -51,7 +51,7 @@ accomplish by implementing this layer of protection. Normally there are
 two main goals that are well served by ACLs:
 
 1. You want to improve security by restricting the access to commands and keys, so that untrusted clients have no access and trusted clients have just the minimum access level to the database in order to perform the work needed. For instance, certain clients may just be able to execute read only commands.
-2. You want to improve operational safety, so that processes or humans accessing Redis are not allowed to damage the data or the configuration due to software errors or manual mistakes. For instance, there is no reason for a worker that fetches delayed jobs from Redis to be able to call the [`FLUSHALL`](/commands/flushall) command.
+2. You want to improve operational safety, so that processes or humans accessing Redis are not allowed to damage the data or the configuration due to software errors or manual mistakes. For instance, there is no reason for a worker that fetches delayed jobs from Redis to be able to call the [`FLUSHALL`](/commands/flushall), [`FLUSHDB`](/commands/flushdb), and [`SWAPDB`](/commands/swapdb) commands.
 
 Another typical usage of ACLs is related to managed Redis instances. Redis is
 often provided as a managed service both by internal company teams that handle
@@ -483,6 +483,14 @@ For example, consider the following two commands:
 * `LPOP key2`: modifies "key2" but also returns data from it, the left most item in the list, so the command requires both read and write permission on "key2" to execute.
 
 If an application needs to make sure no data is accessed from a key, including side channels, it's recommended to not provide any access to the key.
+
+Note: Key patterns only restrict commands that act on **specific keys** named in the command's arguments. Commands that operate on an **entire database or the whole keyspace**, and therefore take no key arguments, are **not** limited by key patterns. Such commands are governed only by command and [category](#command-categories) rules.
+
+This includes commands that can destroy or replace data beyond a user's key patterns, such as [`FLUSHALL`](/commands/flushall), [`FLUSHDB`](/commands/flushdb), and [`SWAPDB`](/commands/swapdb).
+
+For example, a user defined with `~tenant1:* +@all` can still run `FLUSHALL` to delete every key in the database, even though its key pattern only matches `tenant1:*`. To prevent this, remove those commands explicitly:
+
+    > ACL SETUSER tenant1 on >strong-password ~tenant1:* +@all -flushall -flushdb -swapdb
 
 ## How passwords are stored internally
 

--- a/content/operate/oss_and_stack/management/security/acl.md
+++ b/content/operate/oss_and_stack/management/security/acl.md
@@ -51,7 +51,7 @@ accomplish by implementing this layer of protection. Normally there are
 two main goals that are well served by ACLs:
 
 1. You want to improve security by restricting the access to commands and keys, so that untrusted clients have no access and trusted clients have just the minimum access level to the database in order to perform the work needed. For instance, certain clients may just be able to execute read only commands.
-2. You want to improve operational safety, so that processes or humans accessing Redis are not allowed to damage the data or the configuration due to software errors or manual mistakes. For instance, there is no reason for a worker that fetches delayed jobs from Redis to be able to call the [`FLUSHALL`](/commands/flushall), [`FLUSHDB`](/commands/flushdb), and [`SWAPDB`](/commands/swapdb) commands.
+2. You want to improve operational safety, so that processes or humans accessing Redis are not allowed to damage the data or the configuration because of software errors or manual mistakes. For example, a worker that fetches delayed jobs from Redis does not need permission to call [`FLUSHALL`](/commands/flushall), [`FLUSHDB`](/commands/flushdb), or [`SWAPDB`](/commands/swapdb).
 
 Another typical usage of ACLs is related to managed Redis instances. Redis is
 often provided as a managed service both by internal company teams that handle
@@ -484,7 +484,9 @@ For example, consider the following two commands:
 
 If an application needs to make sure no data is accessed from a key, including side channels, it's recommended to not provide any access to the key.
 
-Note: Key patterns only restrict commands that act on **specific keys** named in the command's arguments. Commands that operate on an **entire database or the whole keyspace**, and therefore take no key arguments, are **not** limited by key patterns. Such commands are governed only by command and [category](#command-categories) rules.
+{{< note >}}
+Key patterns only restrict commands that operate on specific keys named in the command's arguments. Commands that operate on an entire database or the whole keyspace, and therefore take no key arguments, are not limited by key patterns. Such commands are governed only by command and [category](#command-categories) rules.
+{{< /note >}}
 
 This includes commands that can destroy or replace data beyond a user's key patterns, such as [`FLUSHALL`](/commands/flushall), [`FLUSHDB`](/commands/flushdb), and [`SWAPDB`](/commands/swapdb).
 

--- a/content/operate/oss_and_stack/management/security/acl.md
+++ b/content/operate/oss_and_stack/management/security/acl.md
@@ -488,7 +488,7 @@ If an application needs to make sure no data is accessed from a key, including s
 Key patterns only restrict commands that operate on specific keys named in the command's arguments. Commands that operate on an entire database or the whole keyspace, and therefore take no key arguments, are not limited by key patterns. Such commands are governed only by command and [category](#command-categories) rules.
 {{< /note >}}
 
-This includes commands that can destroy or replace data beyond a user's key patterns, such as [`FLUSHALL`](/commands/flushall), [`FLUSHDB`](/commands/flushdb), and [`SWAPDB`](/commands/swapdb).
+This includes commands that can destroy or replace data beyond a user's key patterns, such as [`FLUSHALL`]({{< relref "/commands/flushall" >}}), [`FLUSHDB`]({{< relref "/commands/flushdb" >}}), and [`SWAPDB`]({{< relref "/commands/swapdb" >}}).
 
 For example, a user defined with `~tenant1:* +@all` can still run `FLUSHALL` to delete every key in the database, even though its key pattern only matches `tenant1:*`. To prevent this, remove those commands explicitly:
 

--- a/content/operate/oss_and_stack/management/security/acl.md
+++ b/content/operate/oss_and_stack/management/security/acl.md
@@ -51,7 +51,7 @@ accomplish by implementing this layer of protection. Normally there are
 two main goals that are well served by ACLs:
 
 1. You want to improve security by restricting the access to commands and keys, so that untrusted clients have no access and trusted clients have just the minimum access level to the database in order to perform the work needed. For instance, certain clients may just be able to execute read only commands.
-2. You want to improve operational safety, so that processes or humans accessing Redis are not allowed to damage the data or the configuration because of software errors or manual mistakes. For example, a worker that fetches delayed jobs from Redis does not need permission to call [`FLUSHALL`](/commands/flushall), [`FLUSHDB`](/commands/flushdb), or [`SWAPDB`](/commands/swapdb).
+2. You want to improve operational safety, so that processes or humans accessing Redis are not allowed to damage the data or the configuration because of software errors or manual mistakes. For example, a worker that fetches delayed jobs from Redis does not need permission to call [`FLUSHALL`]({{< relref "/commands/flushall" >}}), [`FLUSHDB`]({{< relref "/commands/flushdb" >}}), or [`SWAPDB`]({{< relref "/commands/swapdb" >}}).
 
 Another typical usage of ACLs is related to managed Redis instances. Redis is
 often provided as a managed service both by internal company teams that handle


### PR DESCRIPTION
Refines the ACL documentation around operational safety and key pattern restrictions.

Refines the example of restricting potentially destructive commands such as `FLUSHALL`, `FLUSHDB`, and `SWAPDB`, and clarifies that key patterns only apply to commands that operate on specific keys. Commands that operate on an entire database or keyspace are governed by command and category rules instead.

Also converts the key pattern explanation to a note callout and removes unnecessary bold formatting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to ACL guidance; no runtime or security behavior changes.
> 
> **Overview**
> **Operational safety** guidance now points at [`FLUSHALL`]({{< relref "/commands/flushall" >}}), [`FLUSHDB`]({{< relref "/commands/flushdb" >}}), and [`SWAPDB`]({{< relref "/commands/swapdb" >}}) with doc links, and drops bold on command names.
> 
> A new **note** in the key-permissions section states that `~` key patterns apply only to commands that name keys in their arguments; whole-database/keyspace commands (no key args) are limited only by command and category rules—not by patterns.
> 
> The docs add an explicit **`tenant1` example**: `~tenant1:* +@all` still allows `FLUSHALL`, and show denying those commands with `-flushall -flushdb -swapdb` on `ACL SETUSER`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c552d34f297fa7dd822c038ee3f370a43385f086. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->