### PR TITLE
RS: Document JWT token invalidation on upgrade to 8.0.22 and later

### DIFF
--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -193,6 +193,10 @@ openssl version
 
 If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
 
+### JWT token invalidation on upgrade
+
+To improve system security, the JWT signing secret has changed in version 8.0.22 and later. As a result, upgrading invalidates all previously issued JWT tokens, which must be regenerated. Tokens used programmatically within the cluster are regenerated automatically. Cluster Manager users must sign out and sign in again, or wait for their session (30 minutes) or token (60 minutes) to expire.
+
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.
@@ -327,6 +331,14 @@ For Active-Active databases running Redis database version 8.4, the `ACKED` opti
 #### Rolling upgrade limitation for clusters with custom or deprecated modules
 
 Due to module handling changes introduced in Redis Software version 8.0, upgrading a cluster that contains custom or deprecated modules, such as RedisGraph and RedisGears v2, can become stuck when adding a new node to the cluster during a rolling upgrade.
+
+#### Cluster Manager sign-outs and false "down" status during an Active-Active upgrade
+
+While an Active-Active database has participating clusters running different Redis Software versions, the Cluster Manager UI on an upgraded cluster can sign users out intermittently and show a participating cluster as down, even though replication is active and the syncers are connected.
+
+This affects the Cluster Manager UI only. It's caused by a JWT signing-key mismatch between nodes running different versions during the upgrade window (see [JWT token invalidation on upgrade](#jwt-token-invalidation-on-upgrade)). The data path and replication are not affected.
+
+To resolve it, upgrade the remaining participating clusters. The issue clears once every participating cluster runs the same version. If you're signed out, sign in again.
 
 #### Module commands limitation during Active-Active database upgrades to Redis 8.0
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -338,7 +338,7 @@ While an Active-Active database has participating clusters running different Red
 
 This affects the Cluster Manager UI only. It's caused by a JWT signing-key mismatch between nodes running different versions during the upgrade window (see [JWT token invalidation on upgrade](#jwt-token-invalidation-on-upgrade)). The data path and replication are not affected.
 
-To resolve it, upgrade the remaining participating clusters. The issue clears once every participating cluster runs the same version. If you're signed out, sign in again.
+To resolve it, upgrade the remaining participating clusters. The issue clears after every participating cluster runs the same version. If you're signed out, sign in again.
 
 #### Module commands limitation during Active-Active database upgrades to Redis 8.0
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -195,7 +195,7 @@ If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` p
 
 ### JWT token invalidation on upgrade
 
-To improve system security, the JWT signing secret has changed in version 8.0.22 and later. As a result, upgrading invalidates all previously issued JWT tokens, which must be regenerated. Tokens used programmatically within the cluster are regenerated automatically. Cluster Manager users must sign out and sign in again, or wait for their session (30 minutes) or token (60 minutes) to expire.
+To improve system security, the JWT signing secret has changed in version 8.0.22 and later. As a result, upgrading invalidates all previously issued JWT tokens, which must be regenerated. Tokens used programmatically within the cluster are regenerated automatically. Cluster Manager users must sign out and sign in again, or wait for their session or token to expire.
 
 ### Reserved ports
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -75,6 +75,10 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
 
+### JWT token invalidation on upgrade
+
+To improve system security, the JWT signing secret has changed in version 8.0.22 and later. As a result, upgrading invalidates all previously issued JWT tokens, which must be regenerated. Tokens used programmatically within the cluster are regenerated automatically. Cluster Manager users must sign out and sign in again, or wait for their session (30 minutes) or token (60 minutes) to expire.
+
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.
@@ -195,6 +199,14 @@ For Active-Active databases running Redis database version 8.4, the `ACKED` opti
 #### Rolling upgrade limitation for clusters with custom or deprecated modules
 
 Due to module handling changes introduced in Redis Software version 8.0, upgrading a cluster that contains custom or deprecated modules, such as RedisGraph and RedisGears v2, can become stuck when adding a new node to the cluster during a rolling upgrade.
+
+#### Cluster Manager sign-outs and false "down" status during an Active-Active upgrade
+
+While an Active-Active database has participating clusters running different Redis Software versions, the Cluster Manager UI on an upgraded cluster can sign users out intermittently and show a participating cluster as down, even though replication is active and the syncers are connected.
+
+This affects the Cluster Manager UI only. It's caused by a JWT signing-key mismatch between nodes running different versions during the upgrade window (see [JWT token invalidation on upgrade](#jwt-token-invalidation-on-upgrade)). The data path and replication are not affected.
+
+To resolve it, upgrade the remaining participating clusters. The issue clears once every participating cluster runs the same version. If you're signed out, sign in again.
 
 #### Module commands limitation during Active-Active database upgrades to Redis 8.0
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -77,7 +77,7 @@ Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
 
 ### JWT token invalidation on upgrade
 
-To improve system security, the JWT signing secret has changed in version 8.0.22 and later. As a result, upgrading invalidates all previously issued JWT tokens, which must be regenerated. Tokens used programmatically within the cluster are regenerated automatically. Cluster Manager users must sign out and sign in again, or wait for their session (30 minutes) or token (60 minutes) to expire.
+To improve system security, the JWT signing secret has changed in version 8.0.22 and later. As a result, upgrading invalidates all previously issued JWT tokens, which must be regenerated. Tokens used programmatically within the cluster are regenerated automatically. Cluster Manager users must sign out and sign in again, or wait for their session or token to expire.
 
 ### Reserved ports
 
@@ -206,7 +206,7 @@ While an Active-Active database has participating clusters running different Red
 
 This affects the Cluster Manager UI only. It's caused by a JWT signing-key mismatch between nodes running different versions during the upgrade window (see [JWT token invalidation on upgrade](#jwt-token-invalidation-on-upgrade)). The data path and replication are not affected.
 
-To resolve it, upgrade the remaining participating clusters. The issue clears once every participating cluster runs the same version. If you're signed out, sign in again.
+To resolve it, upgrade the remaining participating clusters. The issue clears after every participating cluster runs the same version. If you're signed out, sign in again.
 
 #### Module commands limitation during Active-Active database upgrades to Redis 8.0
 


### PR DESCRIPTION
Closes DOC-6953. Also covers the release-note request on RED-212186.

Two entries on both 8.2 release notes: the behavior change under **Version
changes** (verbatim SME wording from RED-212186, unedited), and the Cluster
Manager sign-out symptom with its workaround under **Known limitations**
(DOC-6953). Cross-linked, since they're one phenomenon in two sections.

**No other release lines change.** Verified at version-matched tags:
`_rotate_weak_jwt_secret_key` (RED-196853) is absent at `v8.0.20-96`,
present from `v8.0.22-40`, and not backported to `v7.22.2-178` or
`v7.8.6-302`. 8.0.22 has no release-note page of its own, so 8.2 is the
first publishable surface — same as the existing Amazon Linux 2 note.

-----------

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to release notes; no product or runtime behavior changes.
> 
> **Overview**
> Documents **JWT signing-secret rotation from Redis Software 8.0.22+** in the 8.2.0-25 and 8.2.0-46 release notes.
> 
> Under **Version changes**, a new **JWT token invalidation on upgrade** section states that upgrades invalidate existing JWTs, in-cluster programmatic tokens are regenerated automatically, and Cluster Manager users must sign in again or wait for session expiry.
> 
> Under **Known limitations**, a cross-linked entry describes **intermittent Cluster Manager sign-outs and false “down” status** for participating clusters during Active-Active upgrades while versions differ (JWT key mismatch; data path unaffected), with workarounds to complete the upgrade and re-authenticate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdaf05b194d763bf153ea17c9dce0906d3418511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->