### PR TITLE
RS: Document that role-based LDAP authorizes CBA-authenticated users too

### DIFF
--- a/content/operate/rs/security/access-control/ldap/enable-role-based-ldap.md
+++ b/content/operate/rs/security/access-control/ldap/enable-role-based-ldap.md
@@ -13,7 +13,7 @@ weight: 25
 
 Redis Software uses a role-based mechanism to authenticate and authorize users with LDAP. You map LDAP groups to [access control roles]({{< relref "/operate/rs/security/access-control/ldap/map-ldap-groups-to-roles" >}}), and each user receives the access level of the role mapped to their group.
 
-Role-based LDAP authorizes both cluster management users (previously known as _external users_) and database users.
+Role-based LDAP authorizes both cluster management users (previously known as _external users_) and database users. Redis Software uses a role-based mechanism to authorize users authenticated with LDAP authentication or with certificate-based authentication (CBA). To authenticate users with client certificates instead of passwords, see [certificate-based authentication for LDAP]({{< relref "/operate/rs/security/access-control/ldap/certificate-based-authentication" >}}).
 
 ## How role-based LDAP works
 

--- a/content/operate/rs/security/access-control/ldap/enable-role-based-ldap.md
+++ b/content/operate/rs/security/access-control/ldap/enable-role-based-ldap.md
@@ -11,9 +11,9 @@ description: Describes how role-based LDAP authentication and authorization work
 weight: 25
 ---
 
-Redis Software uses a role-based mechanism to authenticate and authorize users with LDAP. You map LDAP groups to [access control roles]({{< relref "/operate/rs/security/access-control/ldap/map-ldap-groups-to-roles" >}}), and each user receives the access level of the role mapped to their group.
+Redis Software uses a role-based mechanism to authorize users authenticated with LDAP authentication or with certificate-based authentication (CBA). You map LDAP groups to [access control roles]({{< relref "/operate/rs/security/access-control/ldap/map-ldap-groups-to-roles" >}}), and each user receives the access level of the role mapped to their group.
 
-Role-based LDAP authorizes both cluster management users (previously known as _external users_) and database users. Redis Software uses a role-based mechanism to authorize users authenticated with LDAP authentication or with certificate-based authentication (CBA). To authenticate users with client certificates instead of passwords, see [certificate-based authentication for LDAP]({{< relref "/operate/rs/security/access-control/ldap/certificate-based-authentication" >}}).
+Role-based LDAP authorizes both cluster management users (previously known as _external users_) and database users. To authenticate users with client certificates instead of passwords, see [certificate-based authentication for LDAP]({{< relref "/operate/rs/security/access-control/ldap/certificate-based-authentication" >}}).
 
 ## How role-based LDAP works
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording and cross-link; no product behavior or security configuration changes.
> 
> **Overview**
> **Clarifies that role-based LDAP is an authorization path**, not only for password-based LDAP sign-in. The intro now states Redis Software uses LDAP group-to-role mapping to authorize users authenticated via **LDAP** or **certificate-based authentication (CBA)**.
> 
> A second sentence links readers to [certificate-based authentication for LDAP]({{< relref "/operate/rs/security/access-control/ldap/certificate-based-authentication" >}}) when they want client-certificate auth instead of passwords. No procedural or configuration steps on the page were changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcc7aa3a27bd19141d967479bb78ae5737db90f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->