### PR TITLE
docs: add Apache APISIX to the rate limiter ecosystem

### DIFF
--- a/content/develop/use-cases/rate-limiter/_index.md
+++ b/content/develop/use-cases/rate-limiter/_index.md
@@ -66,7 +66,9 @@ The following libraries and frameworks provide Redis-backed rate limiting:
 -   **Python**: [limits](https://limits.readthedocs.io/),
     plus custom implementations on top of [redis-py](https://redis.readthedocs.io/)
 -   **Go**: [go-redis/redis_rate](https://github.com/go-redis/redis_rate)
--   **API gateways**: [Kong](https://docs.konghq.com/hub/kong-inc/rate-limiting/) and
+-   **API gateways**:
+    [Apache APISIX](https://apisix.apache.org/docs/apisix/plugins/limit-count/),
+    [Kong](https://docs.konghq.com/hub/kong-inc/rate-limiting/), and
     [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/rate_limit_filter)
     use Redis for distributed rate limiting
 


### PR DESCRIPTION
### Summary

Add Apache APISIX to the API gateway entries in the Redis rate-limiter ecosystem list.

The linked APISIX `limit-count` documentation describes Redis and Redis Cluster counter policies and includes an example in which multiple APISIX nodes share a rate-limiting quota through Redis.

### Scope

- Update one ecosystem-list entry.
- Link to the official Apache APISIX plugin documentation.
- Do not change Redis behavior, examples, or recommendations.

### Validation

- [x] Confirmed that the target Redis page already lists API gateways that use Redis for distributed rate limiting.
- [x] Confirmed that Apache APISIX 3.17 documents `redis` and `redis-cluster` policies for `limit-count`.
- [x] Confirmed that the APISIX documentation contains a cross-node shared-quota example.
- [x] Applied the patch to Redis `main` at `e8c5782b614482976bd5da66f23b7033c3e67558` and ran `git diff --check`.
- [x] Checked GitHub code, Issue, and PR search for an existing APISIX entry; none was found on 2026-08-11.
- [x] Ran the Redis `make all` build successfully with Hugo v0.143.0 extended.
- [x] Confirmed that the rendered page contains the expected Apache APISIX link and that the link returns HTTP 200.

Author: Yilia Lin, Apache APISIX Committer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only list and link update with no product or code impact.
>
> **Overview**
> Adds **Apache APISIX** to the Redis rate-limiter **Ecosystem** section under **API gateways**, with a link to the official `limit-count` plugin docs (Redis / Redis Cluster shared quotas).
>
> The gateways bullet is lightly reformatted so APISIX is listed first, alongside existing Kong and Envoy entries; no behavior, examples, or recommendations change.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08912ed5296f8ba08201f8e94dc7dbf5857184a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
