### PR TITLE
RDSC-5884: RDI 1.19.1 release notes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -91,7 +91,7 @@ rdi_redis_gears_version = "1.2.6"
 rdi_debezium_server_version = "2.3.0.Final"
 rdi_db_types = "cassandra|mysql|oracle|postgresql|sqlserver"
 rdi_cli_latest = "latest"
-rdi_current_version = "1.19.0"
+rdi_current_version = "1.19.1"
 
 
 [params.clientsConfig]

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-19-1.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-19-1.md
@@ -6,7 +6,7 @@ categories:
 - operate
 - rs
 description: |
-  Improved API behavior, CLI output, Flink processor recovery, logging, and security.
+  Improved Flink processor recovery, logging, and security.
 linkTitle: 1.19.1 (August 2026)
 toc: 'true'
 weight: 968
@@ -14,26 +14,12 @@ weight: 968
 
 ## What's New in 1.19.1
 
-### Compatibility Notes
-
-- **API v1 pipeline actions apply immediately instead of queuing**:
-  - `POST /pipelines`, `PATCH /pipelines`, `/pipelines/undeploy`, `/pipelines/sources/*`, `/pipelines/targets/*`, `/pipelines/processors/*`, `/pipelines/secret-providers/*`, `/pipelines/start`, `/pipelines/stop`, and `/pipelines/reset` now update the Pipeline resource directly instead of posting to an internal task queue. Kubernetes errors are reported with their original status codes, rather than a generic 500.
-  - A request now applies its changes immediately rather than waiting behind earlier in-flight requests, so the most recent request wins if several are issued in quick succession without waiting for each to complete. Polling `GET /actions/{action_id}` for an action ID that a later request has superseded now returns an unknown action error instead of that action's own status.
-  - `POST /pipelines` and `PATCH /pipelines` now also validate target connectivity similarly to their API v2 counterparts, and surface collector API failures as a `422`, `502`, `503`, or `504` error response. A request that previously succeeded despite an unreachable target now fails with a validation error.
-- **API v1 trace endpoint returns Not Implemented**: `POST /trace/start` now immediately returns `501 Not Implemented` instead of accepting the request and queuing a trace that would never run.
-
-### New Features
-
-- **Database-scoped pipeline secret keys**: Pipeline secrets in API v2 and the `redis-di` CLI now use database-independent keys (`USERNAME`, `PASSWORD`, `CACERT`, `CERT`, `KEY`, `KEY_PASSWORD`) together with a `db` parameter (`--db` in the CLI) that names the database the secret belongs to: a source name, or `target`. The previous scope-prefixed keys (`SOURCE_DB_*`, `TARGET_DB_*`) remain accepted for single-source and target secrets, used without the `db` parameter.
-- **Richer validation errors from API v1 pipeline configuration endpoints**: A `422` response from `/pipelines/undeploy`, `/pipelines/sources/*`, `/pipelines/targets/*`, `/pipelines/processors/*`, and `/pipelines/secret-providers/*` may now include an `errors` array with structured per-field detail, in addition to the existing `detail` message, matching the shape already returned by `POST /pipelines` and `PATCH /pipelines`. Existing clients that only read `detail` are unaffected.
-
 ### Improvements
 
 - **API response body logging**: The RDI API now logs response bodies alongside request payloads. Bodies are logged at DEBUG level, while request and response metadata stays at INFO, and large bodies are truncated to keep logs manageable.
 
 ### Bug Fixes
 
-- **Nested processor properties shown incorrectly in `redis-di describe`**: Nested objects and arrays in a processor's advanced properties are now shown as JSON instead of a raw internal format, so the `redis-di describe` output is valid and easy to read.
 - **Stream could stop being processed after a Flink processor restart**: A narrow timing window around a checkpoint could leave a stream permanently unassigned to any reader after a restart (for example, following a TaskManager failure), silently halting ingestion for that stream until the pipeline was redeployed. The Flink processor now confirms with every reader before treating a stream as no longer needed.
 
 ### Security Updates

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-19-1.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-19-1.md
@@ -20,7 +20,7 @@ weight: 968
 
 ### Bug Fixes
 
-- **Stream could stop being processed after a Flink processor restart**: A narrow timing window around a checkpoint could leave a stream permanently unassigned to any reader after a restart (for example, following a TaskManager failure), silently halting ingestion for that stream until the pipeline was redeployed. The Flink processor now confirms with every reader before treating a stream as no longer needed.
+- **Stream could stop being processed after a Flink processor restart**: A narrow timing window around a checkpoint could leave a stream permanently unassigned to any reader after a restart (for example, following a TaskManager failure). This would silently halt ingestion for that stream until the pipeline was redeployed. The Flink processor now confirms with every reader before treating a stream as no longer needed.
 
 ### Security Updates
 

--- a/content/integrate/redis-data-integration/release-notes/rdi-1-19-1.md
+++ b/content/integrate/redis-data-integration/release-notes/rdi-1-19-1.md
@@ -1,0 +1,51 @@
+---
+Title: Redis Data Integration release notes 1.19.1 (August 2026)
+alwaysopen: false
+categories:
+- docs
+- operate
+- rs
+description: |
+  Improved API behavior, CLI output, Flink processor recovery, logging, and security.
+linkTitle: 1.19.1 (August 2026)
+toc: 'true'
+weight: 968
+---
+
+## What's New in 1.19.1
+
+### Compatibility Notes
+
+- **API v1 pipeline actions apply immediately instead of queuing**:
+  - `POST /pipelines`, `PATCH /pipelines`, `/pipelines/undeploy`, `/pipelines/sources/*`, `/pipelines/targets/*`, `/pipelines/processors/*`, `/pipelines/secret-providers/*`, `/pipelines/start`, `/pipelines/stop`, and `/pipelines/reset` now update the Pipeline resource directly instead of posting to an internal task queue. Kubernetes errors are reported with their original status codes, rather than a generic 500.
+  - A request now applies its changes immediately rather than waiting behind earlier in-flight requests, so the most recent request wins if several are issued in quick succession without waiting for each to complete. Polling `GET /actions/{action_id}` for an action ID that a later request has superseded now returns an unknown action error instead of that action's own status.
+  - `POST /pipelines` and `PATCH /pipelines` now also validate target connectivity similarly to their API v2 counterparts, and surface collector API failures as a `422`, `502`, `503`, or `504` error response. A request that previously succeeded despite an unreachable target now fails with a validation error.
+- **API v1 trace endpoint returns Not Implemented**: `POST /trace/start` now immediately returns `501 Not Implemented` instead of accepting the request and queuing a trace that would never run.
+
+### New Features
+
+- **Database-scoped pipeline secret keys**: Pipeline secrets in API v2 and the `redis-di` CLI now use database-independent keys (`USERNAME`, `PASSWORD`, `CACERT`, `CERT`, `KEY`, `KEY_PASSWORD`) together with a `db` parameter (`--db` in the CLI) that names the database the secret belongs to: a source name, or `target`. The previous scope-prefixed keys (`SOURCE_DB_*`, `TARGET_DB_*`) remain accepted for single-source and target secrets, used without the `db` parameter.
+- **Richer validation errors from API v1 pipeline configuration endpoints**: A `422` response from `/pipelines/undeploy`, `/pipelines/sources/*`, `/pipelines/targets/*`, `/pipelines/processors/*`, and `/pipelines/secret-providers/*` may now include an `errors` array with structured per-field detail, in addition to the existing `detail` message, matching the shape already returned by `POST /pipelines` and `PATCH /pipelines`. Existing clients that only read `detail` are unaffected.
+
+### Improvements
+
+- **API response body logging**: The RDI API now logs response bodies alongside request payloads. Bodies are logged at DEBUG level, while request and response metadata stays at INFO, and large bodies are truncated to keep logs manageable.
+
+### Bug Fixes
+
+- **Nested processor properties shown incorrectly in `redis-di describe`**: Nested objects and arrays in a processor's advanced properties are now shown as JSON instead of a raw internal format, so the `redis-di describe` output is valid and easy to read.
+- **Stream could stop being processed after a Flink processor restart**: A narrow timing window around a checkpoint could leave a stream permanently unassigned to any reader after a restart (for example, following a TaskManager failure), silently halting ingestion for that stream until the pipeline was redeployed. The Flink processor now confirms with every reader before treating a stream as no longer needed.
+
+### Security Updates
+
+- **Hardened API log redaction**: Ensured secrets, credentials, tokens, and connection strings are masked in the request and response bodies the RDI API logs, with login and pipeline secret payloads fully redacted.
+- **Flink processor and collector security updates**: Resolved `CVE-2024-57699`, `CVE-2025-12183`, `CVE-2025-27820`, `CVE-2025-55163`, `CVE-2025-66566`, `CVE-2025-68973`, `CVE-2026-35194`, `CVE-2026-42198`, `CVE-2026-42583`, `CVE-2026-44249`, `CVE-2026-45416`, `CVE-2026-45447`, `CVE-2026-50010`, `CVE-2026-54291`, `CVE-2026-54512`, `CVE-2026-54513`, `CVE-2026-59901`, and `GHSA-r7wm-3cxj-wff9`.
+- **Monitor security updates**: Resolved `CVE-2024-6345` and `CVE-2025-47273`.
+- **Collector API security updates**: Resolved `CVE-2025-66566`, `CVE-2026-10050`, `CVE-2026-40973`, `CVE-2026-40983`, `CVE-2026-40984`, `CVE-2026-42198`, `CVE-2026-42579`, `CVE-2026-42583`, `CVE-2026-44249`, `CVE-2026-45416`, `CVE-2026-45674`, `CVE-2026-47691`, `CVE-2026-50010`, `CVE-2026-54291`, `CVE-2026-54512`, `CVE-2026-54513`, `CVE-2026-59901`, and `GHSA-r7wm-3cxj-wff9`.
+- **Shared utilities security updates**: Resolved `CVE-2026-21441` and `CVE-2026-33154`.
+- **Operator security updates**: Resolved `CVE-2026-24051`, `CVE-2026-33186`, `CVE-2026-35469`, `CVE-2026-39821`, `CVE-2026-39829`, `CVE-2026-39830`, `CVE-2026-39831`, `CVE-2026-39832`, `CVE-2026-39833`, `CVE-2026-39834`, `CVE-2026-42508`, `CVE-2026-46595`, `CVE-2026-46597`, `CVE-2026-46680`, `CVE-2026-50151`, `CVE-2026-50163`, `CVE-2026-53488`, and `GHSA-hrxh-6v49-42gf`.
+- **Collector initializer security update**: Upgraded jq to resolve `CVE-2026-32316`, `CVE-2026-33947`, `CVE-2026-33948`, `CVE-2026-39979`, `CVE-2026-40612`, `CVE-2026-41256`, `CVE-2026-41257`, `CVE-2026-43894`, `CVE-2026-43895`, `CVE-2026-43896`, `CVE-2026-44777`, `CVE-2026-47770`, `CVE-2026-49839`, and `CVE-2026-54679`.
+- **Fluentd security updates**: Resolved 20 unique CVEs compared with the previous image, including 1 Critical and 11 High findings: `CVE-2025-46394`, `CVE-2025-60876`, `CVE-2025-6442`, `CVE-2026-7383`, `CVE-2026-9076`, `CVE-2026-22184`, `CVE-2026-28387`, `CVE-2026-28388`, `CVE-2026-28389`, `CVE-2026-28390`, `CVE-2026-31789`, `CVE-2026-31790`, `CVE-2026-34180`, `CVE-2026-34182`, `CVE-2026-42766`, `CVE-2026-42767`, `CVE-2026-42770`, `CVE-2026-45445`, `CVE-2026-45446`, and `CVE-2026-45447`.
+- **Classic processor security updates**: Resolved `CVE-2024-6345`, `CVE-2025-47273`, and `CVE-2025-67221`.
+- **API security updates**: Resolved `CVE-2024-53981`, `CVE-2024-6345`, `CVE-2025-47273`, `CVE-2025-62727`, `CVE-2026-24486`, `CVE-2026-32597`, `CVE-2026-42561`, `CVE-2026-48522`, `CVE-2026-48523`, `CVE-2026-48524`, `CVE-2026-48525`, `CVE-2026-48526`, `CVE-2026-48710`, `CVE-2026-53539`, and `CVE-2026-54283`.
+- **Metrics aggregator security updates**: Resolved `CVE-2024-6345`, `CVE-2025-47273`, `CVE-2025-62727`, `CVE-2025-66418`, `CVE-2025-66471`, `CVE-2026-23490`, `CVE-2026-26007`, `CVE-2026-30922`, `CVE-2026-32597`, `CVE-2026-48710`, and `CVE-2026-54283`.


### PR DESCRIPTION
## Summary

- Add public release notes for RDI 1.19.1.
- Document the Flink processor recovery fix, API response-body logging, hardened log redaction, and component security updates included in the patch release.
- Update the documented current RDI version from 1.19.0 to 1.19.1.
- Remove changes that are present on `main` but were not backported to `release.1.19`.

## Source

The release-note content is aligned with the RDI 1.19.1 changelog in https://github.com/RedisLabs/redis-data-integration/pull/2738.

Jira: https://redislabs.atlassian.net/browse/RDSC-5884

## Validation

- `git diff --check`
- Compared the public release-note entries with the RDI 1.19.1 changelog.
- Compared structure and ordering with the RDI 1.19.0 release-note page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change: new release notes and a version string bump with no runtime or security impact.
> 
> **Overview**
> Adds public release notes for **RDI 1.19.1** and bumps `rdi_current_version` from `1.19.0` to `1.19.1`.
> 
> The notes cover API response-body logging, a Flink processor recovery fix for streams left unassigned after restart, hardened API log redaction, and component security updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf91043a0d12b27703d28ab46f2100fd32b2a531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->