### PR TITLE
DOC-6957 Add Ruby (redis-rb) array data type examples [PARKED]

### DIFF
--- a/local_examples/arrays_tutorial/ruby/dt_arrays.rb
+++ b/local_examples/arrays_tutorial/ruby/dt_arrays.rb
@@ -1,0 +1,275 @@
+# EXAMPLE: arrays_tutorial
+# HIDE_START
+require 'redis'
+
+r = Redis.new
+# HIDE_END
+
+# REMOVE_START
+def assert_equal(expected, actual)
+  raise "Expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
+end
+
+r.del('events:1')
+# REMOVE_END
+
+# STEP_START arset_arget
+res1 = r.arset('events:1', 0, 'login', 'click', 'purchase')
+puts res1 # 3
+
+res2 = r.arget('events:1', 0)
+puts res2 # login
+
+res3 = r.arget('events:1', 999)
+puts res3.inspect # nil
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res1)
+assert_equal('login', res2)
+assert_equal(nil, res3)
+r.del('events:1')
+# REMOVE_END
+
+# REMOVE_START
+r.del('metrics')
+# REMOVE_END
+
+# STEP_START armset_armget
+res4 = r.armset('metrics', { 0 => '10', 5 => '20', 100 => '30' })
+puts res4 # 3
+
+res5 = r.armget('metrics', 0, 5, 100, 999)
+puts res5.inspect # ["10", "20", "30", nil]
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res4)
+assert_equal(['10', '20', '30', nil], res5)
+r.del('metrics')
+# REMOVE_END
+
+# REMOVE_START
+r.del('sparse')
+# REMOVE_END
+
+# STEP_START len_count
+res6 = r.arset('sparse', 0, 'a')
+puts res6 # 1
+
+res7 = r.arset('sparse', 1000000, 'b')
+puts res7 # 1
+
+res8 = r.arlen('sparse')
+puts res8 # 1000001
+
+res9 = r.arcount('sparse')
+puts res9 # 2
+# STEP_END
+
+# REMOVE_START
+assert_equal(1, res6)
+assert_equal(1, res7)
+assert_equal(1000001, res8)
+assert_equal(2, res9)
+r.del('sparse')
+# REMOVE_END
+
+# REMOVE_START
+r.del('seq')
+# REMOVE_END
+
+# STEP_START argetrange
+res10 = r.armset('seq', { 0 => 'a', 1 => 'b', 3 => 'd' })
+puts res10 # 3
+
+res11 = r.argetrange('seq', 0, 3)
+puts res11.inspect # ["a", "b", nil, "d"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res10)
+assert_equal(['a', 'b', nil, 'd'], res11)
+r.del('seq')
+# REMOVE_END
+
+# REMOVE_START
+r.del('seq')
+# REMOVE_END
+
+# STEP_START arscan
+res12 = r.armset('seq', { 0 => 'a', 1 => 'b', 3 => 'd' })
+puts res12 # 3
+
+res13 = r.arscan('seq', 0, 3)
+res13.each { |index, value| puts "#{index} -> #{value}" }
+# 0 -> a
+# 1 -> b
+# 3 -> d
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res12)
+assert_equal([[0, 'a'], [1, 'b'], [3, 'd']], res13)
+r.del('seq')
+# REMOVE_END
+
+# REMOVE_START
+r.del('log')
+# REMOVE_END
+
+# STEP_START arinsert
+res14 = r.arinsert('log', 'event1')
+puts res14 # 0
+
+res15 = r.arinsert('log', 'event2')
+puts res15 # 1
+
+res16 = r.arnext('log')
+puts res16 # 2
+
+res17 = r.arseek('log', 10)
+puts res17 # true
+
+res18 = r.arinsert('log', 'event3')
+puts res18 # 10
+# STEP_END
+
+# REMOVE_START
+assert_equal(0, res14)
+assert_equal(1, res15)
+assert_equal(2, res16)
+assert_equal(true, res17)
+assert_equal(10, res18)
+r.del('log')
+# REMOVE_END
+
+# REMOVE_START
+r.del('readings')
+# REMOVE_END
+
+# STEP_START arring
+res19 = r.arring('readings', 3, 'v0')
+puts res19 # 0
+
+res20 = r.arring('readings', 3, 'v1')
+puts res20 # 1
+
+res21 = r.arring('readings', 3, 'v2')
+puts res21 # 2
+
+res22 = r.arring('readings', 3, 'v3')
+puts res22 # 0
+
+res23 = r.arget('readings', 0)
+puts res23 # v3
+# STEP_END
+
+# REMOVE_START
+assert_equal(0, res19)
+assert_equal(1, res20)
+assert_equal(2, res21)
+assert_equal(0, res22)
+assert_equal('v3', res23)
+r.del('readings')
+# REMOVE_END
+
+# REMOVE_START
+r.del('readings')
+# REMOVE_END
+
+# STEP_START arlastitems
+r.arring('readings', 3, 'v0')
+r.arring('readings', 3, 'v1')
+r.arring('readings', 3, 'v2')
+r.arring('readings', 3, 'v3')
+
+res24 = r.arlastitems('readings', 3)
+puts res24.inspect # ["v1", "v2", "v3"]
+
+res25 = r.arlastitems('readings', 3, rev: true)
+puts res25.inspect # ["v3", "v2", "v1"]
+# STEP_END
+
+# REMOVE_START
+assert_equal(%w[v1 v2 v3], res24)
+assert_equal(%w[v3 v2 v1], res25)
+r.del('readings')
+# REMOVE_END
+
+# REMOVE_START
+r.del('scores')
+# REMOVE_END
+
+# STEP_START arop
+res26 = r.armset('scores', { 0 => '10', 1 => '20', 2 => '30' })
+puts res26 # 3
+
+res27 = r.arop('scores', 0, 2, :sum)
+puts res27 # 60.0
+
+res28 = r.arop('scores', 0, 2, :max)
+puts res28 # 30.0
+
+res29 = r.arop('scores', 0, 2, :match, value: '10')
+puts res29 # 1
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res26)
+assert_equal(60.0, res27)
+assert_equal(30.0, res28)
+assert_equal(1, res29)
+r.del('scores')
+# REMOVE_END
+
+# REMOVE_START
+r.del('log')
+# REMOVE_END
+
+# STEP_START argrep
+res30 = r.armset('log', {
+  0 => 'boot: ok',
+  1 => 'warn: disk',
+  2 => 'ERROR: cpu',
+  3 => 'info: ready',
+  4 => 'error: net'
+})
+puts res30 # 5
+
+res31 = r.argrep('log', 0, 4, match: 'error', nocase: true)
+puts res31.inspect # [2, 4]
+
+res32 = r.argrep('log', 0, 4, glob: ['warn:*', 'error:*'], logic: :or, with_values: true)
+puts res32.inspect # [[1, "warn: disk"], [4, "error: net"]]
+# STEP_END
+
+# REMOVE_START
+assert_equal(5, res30)
+assert_equal([2, 4], res31)
+assert_equal([[1, 'warn: disk'], [4, 'error: net']], res32)
+r.del('log')
+# REMOVE_END
+
+# REMOVE_START
+r.del('scores')
+# REMOVE_END
+
+# STEP_START ardel
+res33 = r.armset('scores', { 0 => '10', 1 => '20', 2 => '30' })
+puts res33 # 3
+
+res34 = r.ardel('scores', 1)
+puts res34 # 1
+
+res35 = r.ardelrange('scores', 0, 2)
+puts res35 # 2
+# STEP_END
+
+# REMOVE_START
+assert_equal(3, res33)
+assert_equal(1, res34)
+assert_equal(2, res35)
+r.del('scores')
+r.close
+# REMOVE_END


### PR DESCRIPTION
## DOC-6957 — Ruby (redis-rb) array data type examples

Adds `local_examples/arrays_tutorial/ruby/dt_arrays.rb`, giving the array data type page a **Ruby tab** across all eleven of its steps: `arset_arget`, `armset_armget`, `len_count`, `argetrange`, `arscan`, `arinsert`, `arring`, `arlastitems`, `arop`, `argrep`, `ardel`.

`content/develop/data-types/arrays.md` embeds `clients-example` with **no `lang_filter`**, so the Ruby tab appears automatically once the example pipeline regenerates `examples.json` — **no page edit is needed, and none is in this PR.** Existing tabs (6): Go, Java-Async, Java-Reactive, Node.js, PHP, Python.

Follow-up to DOC-6755, which created the `arrays_tutorial` set.

> ## ⛔ Do not merge yet
>
> These examples are written against **redis-rb `master`**, where array support is merged but
> **not released**. [redis-rb#1371](https://github.com/redis/redis-rb/pull/1371) merged
> 2026-08-10; the latest gem, **`v6.0.0` (2026-07-31), does not contain
> `lib/redis/commands/arrays.rb`** — verified, not assumed.
>
> Merging to `main` auto-publishes. A reader on the released gem would get `NoMethodError` on
> every line. Hold until a released gem ships the array commands.

### How much of this is actually verified

Worth reading before trusting the expected-output comments, because the three sources are not equally strong:

| Layer | Status | How |
|---|---|---|
| Method existence, arity, keyword names | ✅ **verified by execution** | Replayed all 26 calls against real redis-rb `master` (`8a06ce6`) with `send_command` stubbed, in a throwaway git worktree — no server needed. Every call accepted; every wire command matched expectation. |
| Ruby-side type conversions | ✅ **verified by execution** | `arseek`/`arop` are the only places Ruby diverges from the Python tab (`arrays.rb` passes `&Boolify` / `&Floatify`). Fed the raw replies through the real lambdas: `Boolify.call(1) => true`, `Floatify.call("60") => 60.0`, `Floatify.call("30") => 30.0`. |
| Server reply **values** | ⚠️ **inherited, not observed** | Taken from the `redis-py` and `predis` examples in this same set, which agree with each other on every value. Two independent clients agreeing is decent evidence about the wire — it is not an observation of Ruby against a server. |

**Nothing ran end-to-end.** No Redis 8.8 with the array commands was reachable: the local server is 7.2.7 and the Docker daemon was down. That is the gap the checklist below exists to close.

<!-- park-manifest -->
## Park manifest

Ticket: DOC-6957
Parked at: 2026-08-11
Trigger to pick up: a **released** `redis` gem (tag newer than `v6.0.0`) that contains `lib/redis/commands/arrays.rb` — testably, `gh api "repos/redis/redis-rb/contents/lib/redis/commands?ref=<tag>" --jq '.[].name' | grep arrays` returns a match at that tag.
Labels: parked, do not merge yet

### Pinned sources (state observed at park time)

| Source | State @ park (2026-08-11) | Re-fetch |
|---|---|---|
| [redis-rb#1371](https://github.com/redis/redis-rb/pull/1371) — "Added support for Array commands + Updated agent specs" | **merged** 2026-08-10T10:54:11Z; head `e184fe7d`; base `master`; milestone **none**; 9 files | `gh api repos/redis/redis-rb/pulls/1371 --jq '{state,merged,merged_at,head_sha:.head.sha,milestone:.milestone.title}'` |
| redis-rb `master` — the tree the examples were verified against | `8a06ce6b0c2781ee57bee96c3da723911fded24e` (2026-08-11T08:50:02Z, "Added support for Redis 8.8 new commands (#1372)") | `gh api repos/redis/redis-rb/commits/master --jq '{sha,date:.commit.author.date}'` |
| `lib/redis/commands/arrays.rb` @ `master` — the file every signature came from | blob `d32ec7031cc77c9142b607dd515daa889ea0d147`, 14712 bytes | `gh api "repos/redis/redis-rb/contents/lib/redis/commands/arrays.rb?ref=master" --jq '{sha,size}'` |
| Released gem — **the actual blocker** | latest release `v6.0.0`, published 2026-07-31; confirmed to have **no** `lib/redis/commands/arrays.rb` | `gh api repos/redis/redis-rb/releases --jq '.[0].tag_name'` then check the path at that tag |
| Redis server — array commands are a **preview** feature | `arrays.md` already carries `bannerText: "Array is a new data type that is currently in preview and may be subject to change."` No page edit needed or made. | n/a |

The blob SHA is the cheap drift tripwire: if `d32ec703` still matches at unpark, no signature in this PR can have moved.

### Observed shape the page assumes

Confidence is **split**, deliberately — this is not uniformly LOW:

- **HIGH — method names, arity, keywords, wire serialization.** Read from `arrays.rb` at a known blob SHA *and* executed against that library. `arset(key, index, *values)`, `armset(key, Hash)`, `armget(key, *indices)`, `argetrange(key, start, stop)`, `arlen`, `arcount`, `arscan(key, start, stop, limit:)`, `arinsert(key, *values)`, `arnext`, `arseek(key, index)`, `arlastitems(key, count, rev:)`, `arring(key, size, *values)`, `arop(key, start, stop, operation, value:)`, `argrep(key, start, stop, exact:/match:/glob:/re:, logic:, limit:, with_values:, nocase:)`, `ardel(key, *indices)`, `ardelrange(key, *ranges)`.
- **MEDIUM — Ruby return types.** `arseek → true` and `arop :sum/:max → Float` follow from `&Boolify` / `&Floatify` in the source, and the lambdas were run against the inherited raw replies. Medium rather than high only because the *input* to those lambdas is inherited.
- **LOW — every printed value.** Inherited from the redis-py and predis examples. Not one line was observed from Ruby against a server.

### Re-check checklist (work these on unpark)

- [ ] **(highest risk)** `arop` SUM/MAX: `# 60.0` / `# 30.0` assume a **bulk-string** reply, because `Floatify.call(60)` returns Integer `60` while `Floatify.call("60")` returns `60.0`. Both redis-py (`"60"`) and predis (`'60'`) assert a string, so the inference is sound — but if the server sends a RESP integer the docs show the wrong type and **nothing will fail loudly**. Check this first.
- [ ] **Run the file end-to-end** against a released gem + a Redis with the array commands, and regenerate every expected value from the real output rather than trusting the inherited ones. The `REMOVE`-block asserts become genuine oracles at that point.
- [ ] `arseek → true`: confirm the released gem still routes it through `Boolify` (a raw `1` would make the comment wrong).
- [ ] Re-diff `arrays.rb` against blob `d32ec703`. Array support is a **preview** server feature, so signatures may still move before the gem ships.
- [ ] Confirm the Ruby tab actually renders on `arrays.md` for all 11 steps after `examples.json` regenerates — the no-`lang_filter` assumption is the reason this PR touches no page, so it is worth confirming rather than assuming.
- [ ] Confirm the directory name `arrays_tutorial/ruby/` yields the `Ruby` tab label (nine existing set dirs use `ruby`, but this set had no Ruby tab before).
- [ ] Add `ruby` entries to the 18 `data/command-api-mapping/AR*.json` files (in DOC-6957's scope, deliberately **not** in this PR — mapping entries have been aspirational before, so they should land only once the gem is released).
- [ ] Consider covering `arinfo`, plus the methods no tab exercises. Not required for parity: the other six clients skip it too.

### On unpark, then

When the trigger fires, run `/unpark <this PR>`: it re-fetches each pinned source, diffs it against the snapshots above, reports what changed versus what was predicted, then reconciles the docs and resumes the normal pipeline toward merge. `/finalize` is **deliberately deferred** until then, so these re-check notes survive. The `do not merge yet` guard holds until `/finalize` completes.
<!-- /park-manifest -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only new example file with no production code or auth/data-path changes; main risk is publishing examples before the gem release ships array support.
> 
> **Overview**
> Adds **`local_examples/arrays_tutorial/ruby/dt_arrays.rb`**, a new **Ruby (redis-rb)** client example for the existing `arrays_tutorial` set so the arrays data type docs can show a Ruby tab alongside Go, Java, Node, PHP, and Python.
> 
> The file is structured like the other tutorial examples: **`STEP_START` / `STEP_END`** blocks for eleven steps (`arset_arget`, `armset_armget`, `len_count`, `argetrange`, `arscan`, `arinsert`, `arring`, `arlastitems`, `arop`, `argrep`, `ardel`), with **`HIDE_START`** boilerplate (`require 'redis'`, `Redis.new`) and **`REMOVE_START`** cleanup plus `assert_equal` checks. It exercises redis-rb array APIs (`arset`, `arget`, `armset`, `armget`, `arlen`, `arcount`, `argetrange`, `arscan`, `arinsert`, `arnext`, `arseek`, `arring`, `arlastitems`, `arop`, `argrep`, `ardel`, `ardelrange`) with printed expected outputs aligned to the other clients.
> 
> **No markdown or page edits** are in this diff; the Ruby tab is intended to appear after the examples pipeline regenerates `examples.json` from this file. The PR description notes it is **parked** until a released `redis` gem includes array commands (current examples target unreleased redis-rb `master`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea879bcc32f03b4bed13a4763c02a3e7b8f6306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->