### PR TITLE
DOC-6955 Repoint the Google ADK links at Agent Memory's new home

### DIFF
--- a/content/integrate/google-adk/_index.md
+++ b/content/integrate/google-adk/_index.md
@@ -25,7 +25,7 @@ weight: 30
 
 adk-redis connects several backend systems to the ADK framework:
 
-- **[Redis Agent Memory]({{< relref "/develop/ai/context-engine/agent-memory" >}})** handles working memory (sessions), long-term memory (extracted facts), auto-summarization, and memory search. Use the default `redis-agent-memory` for new work. It runs either on [Redis Cloud]({{< relref "/operate/rc/context-engine/agent-memory" >}}) or [self-managed]({{< relref "/develop/ai/context-engine/agent-memory/self-managed" >}}) on your own Kubernetes cluster; both share one Data Plane API, so you pick a deployment by pointing `api_base_url` at the right endpoint.
+- **[Redis Agent Memory]({{< relref "/develop/ai/context-engine/agent-memory" >}})** handles working memory (sessions), long-term memory (extracted facts), auto-summarization, and memory search. Use the default `redis-agent-memory` for new work. It runs either on [Redis Cloud]({{< relref "/operate/rc/context-engine/agent-memory" >}}) or [self-managed]({{< relref "/operate/iris/agent-memory/self-managed" >}}) on your own Kubernetes cluster; both share one Data Plane API, so you pick a deployment by pointing `api_base_url` at the right endpoint.
 - **[RedisVL]({{< relref "/develop/ai/redisvl" >}})** (Redis Vector Library) powers the search tools and local semantic cache provider.
 - **[LangCache](https://redis.io/langcache/)** provides managed semantic caching with server-side embeddings.
 
@@ -44,8 +44,8 @@ which also covers migrating to Redis Agent Memory.
 
 Provision a store, then pass its Data Plane endpoint, API key, and store ID to the services.
 
-- On **Redis Cloud**, there is nothing to run. See [Create an Agent Memory service]({{< relref "/operate/rc/context-engine/agent-memory/create-service" >}}).
-- To run it **yourself**, see [Self-managed Agent Memory]({{< relref "/develop/ai/context-engine/agent-memory/self-managed" >}}) for deployment, configuration, and operations on your own Kubernetes cluster.
+- On **Redis Cloud**, there is nothing to run. See [Create an Agent Memory service]({{< relref "/operate/iris/agent-memory/create-service" >}}).
+- To run it **yourself**, see [Self-managed Agent Memory]({{< relref "/operate/iris/agent-memory/self-managed" >}}) for deployment, configuration, and operations on your own Kubernetes cluster.
 
 Both use `backend="redis-agent-memory"`. Only `api_base_url` differs.
 

--- a/content/integrate/google-adk/agent-memory-server.md
+++ b/content/integrate/google-adk/agent-memory-server.md
@@ -30,7 +30,7 @@ New agents should use
 [Redis Agent Memory]({{< relref "/integrate/google-adk/redis-agent-memory" >}})
 with `backend="redis-agent-memory"`, on
 [Redis Cloud]({{< relref "/operate/rc/context-engine/agent-memory" >}}) or
-[self-managed]({{< relref "/develop/ai/context-engine/agent-memory/self-managed" >}})
+[self-managed]({{< relref "/operate/iris/agent-memory/self-managed" >}})
 on your own Kubernetes cluster.
 
 This page exists only to help existing deployments migrate.
@@ -64,8 +64,8 @@ like Redis Cloud. You choose a deployment with `api_base_url`, not with
 ## Migrate to Redis Agent Memory
 
 1. Provision a Redis Agent Memory store, on
-   [Redis Cloud]({{< relref "/operate/rc/context-engine/agent-memory/create-service" >}})
-   or [self-managed]({{< relref "/develop/ai/context-engine/agent-memory/self-managed" >}}).
+   [Redis Cloud]({{< relref "/operate/iris/agent-memory/create-service" >}})
+   or [self-managed]({{< relref "/operate/iris/agent-memory/self-managed" >}}).
    Either gives you a Data Plane endpoint, an API key, and a store ID.
 2. Change `backend` from `opensource-agent-memory` to `redis-agent-memory` on
    every service and tool config, or drop the field, since it is the default.
@@ -120,5 +120,5 @@ switches backends with `REDIS_MEMORY_BACKEND`, so it already runs on
 ## More info
 
 - [Redis Agent Memory]({{< relref "/integrate/google-adk/redis-agent-memory" >}}): the supported backend
-- [Self-managed Agent Memory]({{< relref "/develop/ai/context-engine/agent-memory/self-managed" >}}): run Agent Memory on your own Kubernetes cluster
+- [Self-managed Agent Memory]({{< relref "/operate/iris/agent-memory/self-managed" >}}): run Agent Memory on your own Kubernetes cluster
 - [Agent Memory Server on GitHub](https://github.com/redis/agent-memory-server): the deprecated server's own documentation

--- a/content/integrate/google-adk/redis-agent-memory.md
+++ b/content/integrate/google-adk/redis-agent-memory.md
@@ -31,8 +31,8 @@ not by changing `backend`:
 
 | Deployment | `api_base_url` | Setup |
 |------------|----------------|-------|
-| Redis Cloud | Your Redis Cloud Agent Memory endpoint | [Create an Agent Memory service]({{< relref "/operate/rc/context-engine/agent-memory/create-service" >}}) |
-| Self-managed | Your own Data Plane URL | [Self-managed Agent Memory]({{< relref "/develop/ai/context-engine/agent-memory/self-managed" >}}) |
+| Redis Cloud | Your Redis Cloud Agent Memory endpoint | [Create an Agent Memory service]({{< relref "/operate/iris/agent-memory/create-service" >}}) |
+| Self-managed | Your own Data Plane URL | [Self-managed Agent Memory]({{< relref "/operate/iris/agent-memory/self-managed" >}}) |
 
 {{< note >}}
 Running Agent Memory yourself does not mean using the deprecated
@@ -250,6 +250,6 @@ Redis Cloud or self-managed; use the REST tools above.
 - [Integration patterns]({{< relref "/integrate/google-adk/integration-patterns" >}}): Detailed tradeoff comparison of the approaches
 - [managed_memory_quickstart](https://github.com/redis-developer/adk-redis/tree/main/examples/managed_memory_quickstart): Framework services, no Docker
 - [travel_agent_memory_tools](https://github.com/redis-developer/adk-redis/tree/main/examples/travel_agent_memory_tools): REST tools only
-- [Self-managed Agent Memory]({{< relref "/develop/ai/context-engine/agent-memory/self-managed" >}}): run Agent Memory on your own Kubernetes cluster
+- [Self-managed Agent Memory]({{< relref "/operate/iris/agent-memory/self-managed" >}}): run Agent Memory on your own Kubernetes cluster
 - [Agent Memory Server (deprecated)]({{< relref "/integrate/google-adk/agent-memory-server" >}}): existing deployments and migration
 


### PR DESCRIPTION
Note: the AI description below is longwinded but the basic idea is that these links were pointing to the old locations of the files and so they were only being resolved by aliases. This PR fixes the links so they point directly to the appropriate pages.

Fixes [DOC-6955](https://redislabs.atlassian.net/browse/DOC-6955). Ten `relref` calls across three Google ADK pages named Agent Memory paths that moved to `operate/iris`.

| Was | Now | Count |
|---|---|---|
| `/develop/ai/context-engine/agent-memory/self-managed` | `/operate/iris/agent-memory/self-managed` | 7 |
| `/operate/rc/context-engine/agent-memory/create-service` | `/operate/iris/agent-memory/create-service` | 3 |

Targets confirmed rather than assumed — both pages moved *across product areas*, so the file's new home isn't automatically the link's intended destination.

## The damage was worse than the ticket recorded

Both old URLs return **200**, because the moved pages carry aliases for them. That made this look like a build-only complaint with readers being redirected safely. They weren't.

`relref` resolves **pages, not aliases**, so a relref naming an alias path fails at build time even though the URL itself serves a redirect. With `refLinksErrorLevel = "WARNING"` that failure isn't fatal and Hugo emits an empty string — so the live pages render **`<a href="">`**: anchors that go nowhere. Typing the old URL worked; clicking the link did not.

That severity was only visible in the rendered HTML. Status codes said everything was fine.

## Verified against a build, not the diff

| | Before | After |
|---|---|---|
| empty `href=""` on the ADK index | **3** (live today) | **0** |
| resolved links to the new targets | 0 | **10** (7 + 3) |
| `REF_NOT_FOUND` in the build | 10 | **0** |

The six sibling refs to `/develop/ai/context-engine/agent-memory`, its `api-reference`, and `/operate/rc/context-engine/agent-memory` are **deliberately untouched** — those paths still have real pages, restored as bridges during the restructure, which is why only two of the five referenced targets broke.

## Note for next time

DOC-6951's scanner could not have caught this. It reads git rename records and reasons about URLs; `relref` targets resolve at build time from content paths, so broken inbound references are invisible to it. The only signal today is a build warning nobody reads — worth considering whether `refLinksErrorLevel` should be `ERROR` for new breakage, though that would fail the build on any pre-existing instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6955]: https://redislabs.atlassian.net/browse/DOC-6955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link target updates with no application or infrastructure code changes.
> 
> **Overview**
> Updates **10 Hugo `relref` targets** across the Google ADK integration docs (`_index.md`, `redis-agent-memory.md`, `agent-memory-server.md`) so provisioning and self-managed setup links follow Agent Memory’s new location under **`/operate/iris/agent-memory/`**.
> 
> **Self-managed** links move from `/develop/ai/context-engine/agent-memory/self-managed` to **`/operate/iris/agent-memory/self-managed`** (7 occurrences). **Create service** links move from `/operate/rc/context-engine/agent-memory/create-service` to **`/operate/iris/agent-memory/create-service`** (3 occurrences). Other Agent Memory refs (overview, API reference, RC overview) are unchanged.
> 
> This fixes **broken in-page links**: stale paths may still redirect in the browser, but `relref` resolves content paths only, so the old targets produced empty `href=""` anchors at build time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e542e89ce260863335fc6080c88459f379bb2adf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->