### PR TITLE
K8s: Cancun maint 5 (8.0.20-26) release notes

### DIFF
--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
@@ -32,7 +32,7 @@ This is a maintenance release to support [Redis Software 8.0.20]({{<relref "/ope
 
 ### OpenShift downloads
 
-- **OLM operator bundle**: `8.0.20-26.0`
+- **OLM operator bundle**: `8.0.20-26.2`
 - **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-96.26` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-96.26.minimal` for minimal base image)
 - **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.20-26`
 - **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.20-26`

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
@@ -1,0 +1,43 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: This is a maintenance release to support Redis Software version 8.0.20-96.
+hideListLinks: true
+linkTitle: 8.0.20-26 (August 2026)
+title: Redis Software for Kubernetes 8.0.20-26 (August 2026) release notes
+weight: 27
+---
+
+## Highlights
+
+This is a maintenance release to support [Redis Software 8.0.20]({{<relref "/operate/rs/release-notes/rs-8-0-releases/">}}) version 8.0.20-96. For version changes, supported distributions, and known limitations, see the [release notes for 8.0.18-11 (April 2026)]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/8-0-18-11-april2026">}}).
+
+## Resolved issues
+
+- Fixed client authentication being turned off and client certificates being cleared when you patched a field other than a certificate field, such as `evictionPolicy`, in the `spec.globalConfigurations` of a REAADB. The operator now preserves the mutual TLS (mTLS) settings on the underlying Active-Active database. REDB resources were not affected <!--RED-212113-->
+
+- Fixed an Active-Active database whose REAADB spec omitted `externalReplicationPort` for a participating cluster. The operator now syncs the port from the existing Active-Active database <!--RED-205147-->
+
+- Fixed an endless "could not set label" loop caused by reserved keys in the persistent volume claim (PVC) extra labels annotation <!--RED-189152-->
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:8.0.20-96.26` (`redislabs/redis:8.0.20-96.26.minimal` for minimal base image)
+- **Operator**: `redislabs/operator:8.0.20-26`
+- **Services Rigger**: `redislabs/k8s-controller:8.0.20-26`
+- **Call Home Client**: `redislabs/re-call-home-client:8.0.20-26`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `8.0.20-26.0`
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-96.26` (`registry.connect.redhat.com/redislabs/redis-enterprise:8.0.20-96.26.minimal` for minimal base image)
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:8.0.20-26`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:8.0.20-26`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:8.0.20-26`
+
+## Known limitations
+
+See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/_index.md
@@ -11,7 +11,7 @@ title: Redis Enterprise for Kubernetes 8.0.20 release notes
 weight: 84
 ---
 
-Redis Enterprise for Kubernetes 8.0.20 is a maintenance release of [Redis Enterprise for Kubernetes 8.0.18]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/">}}). The latest release is 8.0.20-25 with support for Redis Enterprise Software version 8.0.20-68.
+Redis Enterprise for Kubernetes 8.0.20 is a maintenance release of [Redis Enterprise for Kubernetes 8.0.18]({{<relref "/operate/kubernetes/release-notes/8-0-18-releases/">}}). The latest release is 8.0.20-26 with support for Redis Software version 8.0.20-96.
 
 ## Detailed release notes
 


### PR DESCRIPTION
Adds release notes for Redis Software for Kubernetes 8.0.20-26 (Cancun maintenance release 5), announced by Yuval in #k8s on 2026-08-11.

- Operator: `8.0.20-26`
- RS: `8.0.20-96` (`8.0.20-96.26`)
- OLM/CSV: `8.0.20-26.0`

## Changes

- New note: `content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md`
- Bumped the latest-release line in `8-0-20-releases/_index.md` to 8.0.20-26 / 8.0.20-96

## Resolved issues

Verified against `git log v8.0.20-25..v8.0.20-26` in the operator repo, not just the announcement:

- **RED-212113** — backport of `RED-192548: preserve mTLS state when patching REAADB globalConfigurations`. Patching a non-cert field such as `evictionPolicy` on a REAADB's `spec.globalConfigurations` reset `enforce_client_authentication` to disabled and cleared `authentication_ssl_client_certs`. REAADB-only; REDBs unaffected. The original fix landed in `v8.2.0-6`, before 8.2.0 GA, so this backport is the only place it is user-facing news.
- **RED-205147** — `externalReplicationPort` sync for participating clusters.
- **RED-189152** — endless "could not set label" loop from reserved keys in the PVC extra-labels annotation.

RED-205147 and RED-189152 reuse the wording already published in the 8.2.0-13 note so the same fix reads identically across trains. The remaining commits in the range (RS version bump, post-release chores, a Marketplace container fix) are internal and not noted.

## Notes for review

- Uses "Redis Software for Kubernetes" naming, matching the 8.2.0 folder. The rest of the 8.0.20 folder still uses the older "Redis Enterprise for Kubernetes", so this page does not match its siblings.
- The RS link points at the generic 8.0 releases index because there is no `rs-8-0-20-96.md` yet. Worth repointing once the RS-side note lands.

Vale passes with 0 errors and 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or configuration impact.
> 
> **Overview**
> Adds documentation for **Redis Software for Kubernetes 8.0.20-26**, a maintenance release aligned with Redis Software **8.0.20-96**, including image tags for operator, RS, Services Rigger, Call Home, and OpenShift/OLM bundles.
> 
> The new page documents three operator fixes: preserving **mTLS** on Active-Active databases when patching non-certificate fields in REAADB `spec.globalConfigurations`, syncing **`externalReplicationPort`** when omitted from a participating cluster’s REAADB spec, and stopping an endless **PVC extra-labels** loop from reserved annotation keys.
> 
> **`8-0-20-releases/_index.md`** now points “latest release” at **8.0.20-26** / **8.0.20-96** (was 8.0.20-25 / 8.0.20-68).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e0d14dfdad972369f633809491f59382ad02068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->