### PR TITLE
docs: add fixed window, sliding window log, sliding window counter, and leaky bucket algorithms to redis-py rate limiter page

### DIFF
--- a/content/develop/use-cases/rate-limiter/redis-py/_index.md
+++ b/content/develop/use-cases/rate-limiter/redis-py/_index.md
@@ -221,32 +221,25 @@ if not allowed:
     response.headers['Retry-After'] = str(int(limiter.refill_interval))
 ```
 
-## Learn more
+## Alternative rate limiting algorithms
 
-* [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts
-* [EVALSHA command]({{< relref "/commands/evalsha" >}}) - Execute cached Lua scripts
-* [Lua scripting]({{< relref "/develop/programmability/eval-intro" >}}) - Introduction to Redis Lua scripting
-* [HMGET command]({{< relref "/commands/hmget" >}}) - Get multiple hash fields
-* [HMSET command]({{< relref "/commands/hmset" >}}) - Set multiple hash fields
-* [Transactions]({{< relref "/develop/using-commands/transactions" >}}) - Alternative to Lua scripts for atomicity
-
-## Additional rate limiting algorithms
-
-The token bucket algorithm above handles most use cases. Redis supports
-four other patterns depending on your requirements. All implementations
-below use `redis.call('TIME')` inside the Lua script to derive the
-current timestamp from the Redis server clock — this eliminates clock
-drift when the limiter runs across multiple application servers.
-
-### Algorithm comparison
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
 
 | Algorithm | Memory | Accuracy | Burst behavior | Best for |
 |---|---|---|---|---|
-| Token bucket | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
-| Fixed window | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
-| Sliding window log | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
-| Sliding window counter | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
-| Leaky bucket (policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+All of them use `redis.call('TIME')` inside the Lua script to derive the
+current timestamp from the Redis server clock. This eliminates clock
+drift when the limiter runs across multiple application servers.
 
 ### Fixed window counter
 
@@ -343,15 +336,21 @@ footprint as a fixed window. The two keys use hash tags so they map
 to the same slot in Redis Cluster.
 
 ```python
-import time
 import redis
 
 SCRIPT = """
-local curr_key = KEYS[1]
-local prev_key = KEYS[2]
-local limit    = tonumber(ARGV[1])
-local window   = tonumber(ARGV[2])
-local elapsed  = tonumber(ARGV[3])
+local base   = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local window_num = math.floor(now / window)
+local elapsed     = (now % window) / window
+
+local curr_key = base .. ':' .. window_num
+local prev_key = base .. ':' .. (window_num - 1)
 
 local prev = tonumber(redis.call('GET', prev_key) or 0)
 local curr = tonumber(redis.call('GET', curr_key) or 0)
@@ -372,15 +371,10 @@ return {1, 0}
 
 
 def is_allowed(client: redis.Redis, key: str, limit: int, window_seconds: int) -> dict:
-    now = time.time()
-    window_num = int(now // window_seconds)
-    elapsed = (now % window_seconds) / window_seconds
-    curr_key = "{" + key + "}:" + str(window_num)
-    prev_key = "{" + key + "}:" + str(window_num - 1)
     script = client.register_script(SCRIPT)
     allowed, _ = script(
-        keys=[curr_key, prev_key],
-        args=[limit, window_seconds, elapsed],
+        keys=["{" + key + "}"],
+        args=[limit, window_seconds],
         client=client,
     )
     return {"allowed": bool(allowed)}
@@ -389,7 +383,7 @@ def is_allowed(client: redis.Redis, key: str, limit: int, window_seconds: int) -
 **Trade-off**: The weighted estimate may let slightly more or fewer
 requests through than the exact limit. Negligible for most apps.
 
-### Leaky bucket (policing mode)
+### Leaky bucket (policing)
 
 A virtual bucket fills with incoming requests and drains at a fixed rate.
 If the bucket is full, requests are rejected immediately. This is the
@@ -448,15 +442,12 @@ def is_allowed(client: redis.Redis, key: str, capacity: int, leak_rate: float) -
 **Trade-off**: Overflow traffic is rejected immediately. Clients must
 handle `429 Too Many Requests` and retry with backoff.
 
-### Choosing an algorithm
+## Learn more
 
-- **Most APIs**: sliding window counter — near-exact accuracy, low memory, no boundary bursts
-- **Need exact timestamps or audit trail**: sliding window log
-- **Allow short bursts**: token bucket (see the main implementation above)
-- **Strict no-burst, immediate deny**: leaky bucket (policing)
-- **Simplest possible**: fixed window
-
-A complete runnable implementation of all five algorithms with a demo
-script is available at
-[redis-rate-limiting-python](https://github.com/YashwinReddy29/redis-rate-limiting-python)
-on GitHub.
+* [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts
+* [EVALSHA command]({{< relref "/commands/evalsha" >}}) - Execute cached Lua scripts
+* [Lua scripting]({{< relref "/develop/programmability/eval-intro" >}}) - Introduction to Redis Lua scripting
+* [HMGET command]({{< relref "/commands/hmget" >}}) - Get multiple hash fields
+* [HMSET command]({{< relref "/commands/hmset" >}}) - Set multiple hash fields
+* [Transactions]({{< relref "/develop/using-commands/transactions" >}}) - Alternative to Lua scripts for atomicity
+* [redis-rate-limiting-python](https://github.com/YashwinReddy29/redis-rate-limiting-python) - community-maintained GitHub repo (contributed by Yashwin Reddy) with examples of the alternative rate limiting algorithms.

--- a/content/develop/use-cases/rate-limiter/redis-py/_index.md
+++ b/content/develop/use-cases/rate-limiter/redis-py/_index.md
@@ -230,3 +230,233 @@ if not allowed:
 * [HMSET command]({{< relref "/commands/hmset" >}}) - Set multiple hash fields
 * [Transactions]({{< relref "/develop/using-commands/transactions" >}}) - Alternative to Lua scripts for atomicity
 
+## Additional rate limiting algorithms
+
+The token bucket algorithm above handles most use cases. Redis supports
+four other patterns depending on your requirements. All implementations
+below use `redis.call('TIME')` inside the Lua script to derive the
+current timestamp from the Redis server clock — this eliminates clock
+drift when the limiter runs across multiple application servers.
+
+### Algorithm comparison
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| Token bucket | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| Fixed window | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| Sliding window log | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| Sliding window counter | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| Leaky bucket (policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```python
+import redis
+
+SCRIPT = """
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('EXPIRE', key, window)
+end
+
+local ttl = redis.call('PTTL', key)
+
+if count > limit then
+    return {0, ttl}
+end
+return {1, ttl}
+"""
+
+
+def is_allowed(client: redis.Redis, key: str, limit: int, window_seconds: int) -> dict:
+    script = client.register_script(SCRIPT)
+    allowed, ttl = script(keys=[key], args=[limit, window_seconds], client=client)
+    return {"allowed": bool(allowed), "retry_after_ms": ttl if not allowed else 0}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```python
+import uuid
+import redis
+
+SCRIPT = """
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local member = ARGV[3]
+
+local t      = redis.call('TIME')
+local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+local cutoff = now - window
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+    redis.call('ZADD', key, now, member)
+    redis.call('EXPIRE', key, window * 2)
+    return {1, 0}
+end
+
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local retry_after_ms = 0
+if oldest[2] then
+    retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+end
+
+return {0, retry_after_ms}
+"""
+
+
+def is_allowed(client: redis.Redis, key: str, limit: int, window_seconds: int) -> dict:
+    script = client.register_script(SCRIPT)
+    member = str(uuid.uuid4())
+    allowed, retry_after_ms = script(
+        keys=[key], args=[limit, window_seconds, member], client=client
+    )
+    return {"allowed": bool(allowed), "retry_after_ms": int(retry_after_ms)}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```python
+import time
+import redis
+
+SCRIPT = """
+local curr_key = KEYS[1]
+local prev_key = KEYS[2]
+local limit    = tonumber(ARGV[1])
+local window   = tonumber(ARGV[2])
+local elapsed  = tonumber(ARGV[3])
+
+local prev = tonumber(redis.call('GET', prev_key) or 0)
+local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+local estimate = prev * (1 - elapsed) + curr
+
+if estimate >= limit then
+    return {0, 0}
+end
+
+local new_count = redis.call('INCR', curr_key)
+if new_count == 1 then
+    redis.call('EXPIRE', curr_key, window * 2)
+end
+
+return {1, 0}
+"""
+
+
+def is_allowed(client: redis.Redis, key: str, limit: int, window_seconds: int) -> dict:
+    now = time.time()
+    window_num = int(now // window_seconds)
+    elapsed = (now % window_seconds) / window_seconds
+    curr_key = "{" + key + "}:" + str(window_num)
+    prev_key = "{" + key + "}:" + str(window_num - 1)
+    script = client.register_script(SCRIPT)
+    allowed, _ = script(
+        keys=[curr_key, prev_key],
+        args=[limit, window_seconds, elapsed],
+        client=client,
+    )
+    return {"allowed": bool(allowed)}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing mode)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```python
+import redis
+
+SCRIPT = """
+local key       = KEYS[1]
+local capacity  = tonumber(ARGV[1])
+local leak_rate = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local data      = redis.call('HGETALL', key)
+local level     = 0
+local last_leak = now
+
+if #data > 0 then
+    for i = 1, #data, 2 do
+        if data[i] == 'level' then
+            level = tonumber(data[i+1])
+        elseif data[i] == 'last_leak' then
+            last_leak = tonumber(data[i+1])
+        end
+    end
+end
+
+local elapsed = now - last_leak
+level = math.max(0, level - elapsed * leak_rate)
+
+if level + 1 > capacity then
+    return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+end
+
+level = level + 1
+local ttl = math.ceil(capacity / leak_rate) + 1
+
+redis.call('HSET', key, 'level', level, 'last_leak', now)
+redis.call('EXPIRE', key, ttl)
+
+return {1, 0}
+"""
+
+
+def is_allowed(client: redis.Redis, key: str, capacity: int, leak_rate: float) -> dict:
+    script = client.register_script(SCRIPT)
+    allowed, retry_after_ms = script(
+        keys=[key], args=[capacity, leak_rate], client=client
+    )
+    return {"allowed": bool(allowed), "retry_after_ms": int(retry_after_ms)}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
+### Choosing an algorithm
+
+- **Most APIs**: sliding window counter — near-exact accuracy, low memory, no boundary bursts
+- **Need exact timestamps or audit trail**: sliding window log
+- **Allow short bursts**: token bucket (see the main implementation above)
+- **Strict no-burst, immediate deny**: leaky bucket (policing)
+- **Simplest possible**: fixed window
+
+A complete runnable implementation of all five algorithms with a demo
+script is available at
+[redis-rate-limiting-python](https://github.com/YashwinReddy29/redis-rate-limiting-python)
+on GitHub.


### PR DESCRIPTION
## What this adds

Four additional rate limiting algorithm implementations in Python to
the existing redis-py rate limiter page, which currently covers only
the token bucket algorithm.

The other language pages (nodejs, go, java, rust, dotnet, php) also
only cover token bucket. This PR fills that gap for Python.

## What's included

- Algorithm comparison table (token bucket, fixed window, sliding
  window log, sliding window counter, leaky bucket)
- Fixed window counter — STRING + Lua, one EVAL round trip
- Sliding window log — SORTED SET + Lua, exact rolling window
- Sliding window counter — STRING x2 + Lua, near-exact with hash
  tags for Redis Cluster compatibility
- Leaky bucket (policing mode) — HASH + Lua, strict no-burst

## Clock drift fix

All new scripts derive `now` from `redis.call('TIME')` inside the
Lua script rather than time.time() in the caller. This eliminates
clock drift when the limiter runs across multiple application servers.

## Full implementation

A complete runnable implementation with demo script is at:
https://github.com/YashwinReddy29/redis-rate-limiting-python

## Context

This contribution was suggested by @petyaslavova during review of
redis-py PRs #4248 and #4257, where she pointed to redis/docs as
the right home for application-level rate limiting patterns in Python.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with illustrative Lua/Python snippets; no runtime, auth, or infrastructure behavior is modified.
> 
> **Overview**
> Expands the **redis-py rate limiter** doc beyond token bucket with an **algorithm comparison table** and four new **Lua + Python** patterns: fixed window counter, sliding window log, sliding window counter (with **hash tags** for Cluster), and leaky bucket (policing).
> 
> All new examples use **`redis.call('TIME')`** in Lua instead of caller-side clocks, and each section notes **trade-offs** (boundary bursts, memory, estimate accuracy, immediate rejects). **Learn more** adds a link to the community **redis-rate-limiting-python** repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7e0d2bb8e5e8dac168d5460498053916046c46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->