### PR TITLE
RS: Remove the OpenSSL 3.3 requirement from the 8.2.0 release notes

### DIFF
--- a/content/operate/rs/release-notes/rs-8-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/_index.md
@@ -57,22 +57,6 @@ Redis Software version 8.2.0 introduces the following breaking changes:
 
     - Existing functionality for listing, deleting, and loading modules is unchanged.
 
-### OpenSSL version on RHEL 9
-
-On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
-
-Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
-
-The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
-
-Before you upgrade, check the OpenSSL version on each node:
-
-```sh
-openssl version
-```
-
-If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
-
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -177,22 +177,6 @@ Redis Software version 8.2.0 introduces the following breaking changes:
 
     - Existing functionality for listing, deleting, and loading modules is unchanged.
 
-### OpenSSL version on RHEL 9
-
-On RHEL 9, Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later. Other supported platforms are unaffected.
-
-Redis Software is built against the OpenSSL 3.3 runtime included in recent RHEL 9 minor releases. Nodes on an earlier RHEL 9 minor release don't meet this requirement. For example, RHEL 9.6 ships OpenSSL 3.2.2.
-
-The pre-upgrade checks don't detect an incompatible OpenSSL version, so an upgrade can pass validation and then fail partway through. This can leave the management services on the node in a failed state.
-
-Before you upgrade, check the OpenSSL version on each node:
-
-```sh
-openssl version
-```
-
-If the version is earlier than 3.3.0, upgrade the `openssl` and `openssl-libs` packages before you upgrade Redis Software.
-
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -71,10 +71,6 @@ The following table shows which Redis modules are compatible with each Redis dat
 
 ## Version changes
 
-### OpenSSL version
-
-Redis Software version 8.0.16 and later requires OpenSSL 3.3 or later.
-
 ### Reserved ports
 
 Make sure the following ports are open before upgrading Redis Software.


### PR DESCRIPTION
## What

Removes the OpenSSL 3.3 requirement from the 8.2.0 release notes. **The 8.2.0 line never required it.**

Three files, pure deletions (36 lines, nothing added):

| File | Removed |
|---|---|
| `rs-8-2-0-25.md` | full "OpenSSL version on RHEL 9" section |
| `rs-8-2-0-46.md` | 4-line `### OpenSSL version` block |
| `rs-8-2-releases/_index.md` | full "OpenSSL version on RHEL 9" section |

## Why

The RED-196656 fix — RS built against an earlier OpenSSL, rather than adding a pre-upgrade check — was already in `v8.2.0-25`, the **first 8.2.0 GA build**. So no shipped 8.2.0 version was ever affected.

Confirmed two independent ways:

1. **Mariana Aviv on RED-196656:** _"this fix is part of the 8.2.0-25 build BUT is not yet part of 8.0.20 (this will only come on the next branch maint.)"_
2. **Build tags in `Redis-Enterprise`:** `v8.2.0-25` (2026-07-17) and `v8.2.0-46` (2026-08-03) both contain fix commit `ed048dbc6b` (2026-07-12). `v8.0.20-68` does not; `v8.0.20-96` does.

Customer impact: 8.2.0 users were being told to run `openssl version` and upgrade `openssl`/`openssl-libs` before upgrading — unnecessary work that never applied to their version.

## Relationship to #3762

This **partially reverts #3762 (DOC-6946) for the 8.2.0 line only.** That change correctly scoped the requirement to RHEL 9, but propagated it onto the 8.2.0 pages where it didn't apply.

**The 8.0.x pages deliberately keep the requirement** — it genuinely applies to 8.0.16 through 8.0.20-68. The matching 8.0 correction (scoping it to that range, since -96 lifts it) is in #3787 and is gated on the -96 GA, because it references a build that hasn't shipped yet. This PR has no such gate: the 8.2.0 pages are wrong *now*, so it can merge immediately.

## Notes for reviewers

- Vale error counts are byte-identical to `main` (130/130, 123/123, 62/62) — deletions only, so nothing new introduced and nothing masked.
- Evidence is build configuration at tag time, taking the RED-196656 RCA at its word that the build image determines the linked OpenSSL. Not a runtime test on a RHEL 9.2 host.
- Found while drafting the 8.0.20-96 notes: the inherited "Version changes" section contradicted that release's own resolved-issues list, which includes RED-210040 (the 8.0.20 cherry-pick of the same fix).
- ⚠️ Minor merge-order note: #3779 adds a JWT section immediately after the OpenSSL section in `rs-8-2-0-25.md` and `rs-8-2-0-46.md`. Whichever merges second may need a trivial conflict resolution — keep the JWT section, drop the OpenSSL one. Merging #3779 first is smoother since it's already approved.

No DOC ticket yet — this was found during release-note drafting rather than reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure documentation deletions with no product or runtime behavior changes; only corrects misleading upgrade guidance for 8.2.0 readers.
> 
> **Overview**
> Removes **OpenSSL 3.3 on RHEL 9** upgrade guidance from Redis Software **8.2.x** release documentation, because that requirement never applied to the 8.2.0 line (the RED-196656 build fix was already in the first GA builds).
> 
> The **OpenSSL version on RHEL 9** section is deleted from the 8.2.x index and from `rs-8-2-0-25.md`; the shorter **OpenSSL version** block is removed from `rs-8-2-0-46.md`. **Version changes** now goes straight from breaking changes (where present) to **Reserved ports**.
> 
> 8.0.x release notes are unchanged and still document the OpenSSL requirement where it applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48f8804d16a902a111af1f82121184c8c8140015. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->