### PR TITLE
Add Redis Repo Memory discovery links to AI/search docs

### DIFF
--- a/content/develop/ai/_index.md
+++ b/content/develop/ai/_index.md
@@ -164,6 +164,7 @@ Need a deeper-dive through different use cases and topics?
 * [ArXiv Chat](https://github.com/redis-developer/ArxivChatGuru) - Streamlit demo of RAG over ArXiv documents with Redis & OpenAI
 
 #### Recommendations and search
+* [Redis Repo Memory](https://github.com/redis-learn/redis-repo-memory) - A GitHub Action that surfaces semantically related PRs, issues, and commits from repository history using Redis vector search ([install from the Marketplace](https://github.com/marketplace/actions/redis-repo-memory))
 * [Recommendation systems w/ NVIDIA Merlin & Redis](https://github.com/redis-developer/redis-nvidia-recsys) - Three examples, each escalating in complexity, showcasing the process of building a realtime recsys with NVIDIA and Redis
 * [Redis product search](https://github.com/redis-developer/redis-product-search) - Build a real-time product search engine using features like full-text search, vector similarity, and real-time data updates
 * [ArXiv Search](https://github.com/redis-developer/redis-arxiv-search) - Full stack implementation of Redis with React FE

--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -51,6 +51,10 @@ Here are the next steps to get you started:
 Experiment with Redis Search interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.
 {{< /alert >}}
 
+{{< tip >}}
+See Redis vector search in a real workflow: [Redis Repo Memory](https://github.com/marketplace/actions/redis-repo-memory) is a GitHub Action that surfaces related past PRs, issues, and commits on every pull request. Add it to any repository in a few minutes.
+{{< /tip >}}
+
 ## Enable Redis Search
 
 Redis Search is available in Redis Open Source, Redis Software, and Redis Cloud.

--- a/content/develop/ai/search-and-query/vectors/_index.md
+++ b/content/develop/ai/search-and-query/vectors/_index.md
@@ -23,6 +23,10 @@ Redis includes a [high-performance vector database](https://redis.io/blog/benchm
 
 To quickly get started, check out the [Redis vector quickstart guide]({{< relref "develop/get-started/vector-database" >}}) and the [Redis AI Resources](https://github.com/redis-developer/redis-ai-resources) Github repo.
 
+{{< alert title="See vector search in action" >}}
+[Redis Repo Memory](https://github.com/marketplace/actions/redis-repo-memory) is a GitHub Action that gives your repository a memory: on every pull request it embeds the change and uses Redis KNN vector search to surface semantically related past PRs, issues, and commits — a concise, real-world example of the concepts on this page. See the [source on GitHub](https://github.com/redis-learn/redis-repo-memory).
+{{< /alert >}}
+
 
 ## Overview
 


### PR DESCRIPTION
Surface the Redis Repo Memory GitHub Action in three high-traffic vector search pages so developers can discover it: a callout on the vector search concepts page, a tip on the Redis Search overview, and a tutorials entry on the Redis for AI hub. Callouts link the Marketplace listing; the tutorials entry links the source repo (redis-learn/redis-repo-memory).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add discovery links; no code, API, or runtime behavior is affected.
> 
> **Overview**
> Surfaces **Redis Repo Memory** — a GitHub Action that uses Redis KNN vector search to find related PRs, issues, and commits — on three high-traffic docs pages.
> 
> Adds an alert callout on the vector search concepts page, a tip on the Redis Search overview, and a tutorials entry under Recommendations and search on the Redis for AI hub. Callouts link the Marketplace listing; the tutorials entry links the source repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 566e26e671c164904d5f8a592e26059a3e3c3bbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->