### PR TITLE
K8s: Document disconnectClientsOnPasswordRemoval (RED-197499)

### DIFF
--- a/content/operate/kubernetes/re-clusters/_index.md
+++ b/content/operate/kubernetes/re-clusters/_index.md
@@ -23,6 +23,60 @@ Manage your Redis Enterprise cluster lifecycle and configuration:
 - [Multi-namespace deployment]({{< relref "/operate/kubernetes/re-clusters/multi-namespace" >}}) - Deploy clusters across multiple Kubernetes namespaces
 - [Delete custom resources]({{< relref "/operate/kubernetes/re-clusters/delete-custom-resources" >}}) - Safely remove REC and related resources
 
+### Disconnect clients on password removal
+
+Redis Software 8.0.2 and later can actively disconnect client connections
+that authenticated with a removed, revoked, or rotated password. In Redis
+Software you configure this setting through the REST API — see the
+[cluster object]({{< relref "/operate/rs/references/rest-api/objects/cluster/" >}})
+and [bdb object]({{< relref "/operate/rs/references/rest-api/objects/bdb/" >}}).
+Starting with operator version X.Y.Z, the operator configures it through
+the custom resources instead:
+
+<!-- TODO: replace all occurrences of X.Y.Z with the first operator release
+that includes this feature -->
+
+- Cluster-wide policy: `spec.disconnectClientsOnPasswordRemoval` on the REC
+  (`Enabled`, `Disabled`, or `Auto`).
+- Per-database setting: `spec.disconnectClientsOnPasswordRemoval` on the
+  [REDB]({{< relref "/operate/kubernetes/re-databases/db-controller#disconnect-clients-on-password-removal" >}})
+  (boolean; the Redis Software default is `false`). Takes effect only when
+  the cluster-wide policy is `Auto`.
+- Active-Active databases:
+  `spec.globalConfigurations.disconnectClientsOnPasswordRemoval` on the
+  REAADB, propagated to all participating clusters — see
+  [Set global database configurations]({{< relref "/operate/kubernetes/active-active/global-config" >}}).
+  Takes effect when the cluster-wide policy on the participating clusters
+  is `Auto`.
+
+Set the cluster-wide policy in your REC specification:
+
+```yaml
+spec:
+  disconnectClientsOnPasswordRemoval: Enabled
+```
+
+Allowed values are `Enabled`, `Disabled`, and `Auto`. `Auto` (the Redis
+Software default) defers the decision to each database's own setting.
+`Enabled` and `Disabled` force the behavior for all databases in the
+cluster, ignoring the per-database setting.
+
+Whether the operator owns the setting depends on your upgrade path:
+
+- Resources **created by operator version X.Y.Z or later**: the operator
+  owns the setting from creation. Configure it only through the custom
+  resource — changes made through the Redis Software REST API or admin
+  console are reverted the next time the operator reconciles the resource.
+  Removing the field from the spec reverts the setting to its Redis
+  Software default (`Auto` for the cluster, `false` for a database); it
+  does not keep the last value.
+- Resources **that existed before you upgraded to operator version X.Y.Z**:
+  values configured through the Redis Software REST API are preserved. The
+  operator takes ownership only once you set the field in the custom
+  resource. From then on, ownership is permanent — if you later remove the
+  field, the setting reverts to the Redis Software default, not to the
+  previously configured value.
+
 ## Storage and performance
 
 Optimize storage and performance for your Redis Enterprise cluster:

--- a/content/operate/kubernetes/re-databases/db-controller.md
+++ b/content/operate/kubernetes/re-databases/db-controller.md
@@ -100,6 +100,37 @@ To modify the database:
 
 To add tags to a database and expose them as metric labels, see [Enrich database metrics with tags]({{< relref "/operate/kubernetes/re-databases/enrich-metrics-with-tags" >}}).
 
+## Disconnect clients on password removal
+
+Redis Software can actively disconnect client connections that
+authenticated with a removed, revoked, or rotated password. The
+per-database setting applies only when the
+[cluster-wide policy]({{< relref "/operate/kubernetes/re-clusters/#disconnect-clients-on-password-removal" >}})
+is `Auto`; if the cluster policy is `Enabled` or `Disabled`, that value
+applies to every database in the cluster. This setting requires Redis
+Software 8.0.2 or later; configuring it through the custom resource
+requires operator version X.Y.Z or later.
+
+<!-- TODO: replace X.Y.Z with the first operator release that includes
+this feature -->
+
+Set the per-database value in your REDB specification:
+
+```yaml
+spec:
+  disconnectClientsOnPasswordRemoval: true
+```
+
+The Redis Software default for a database is `false`. See the
+[Redis Software REST API bdb object]({{< relref "/operate/rs/references/rest-api/objects/bdb/" >}})
+for details about the underlying setting.
+
+For when the operator takes ownership of this setting, and how to
+configure it for Active-Active databases, see
+[Disconnect clients on password removal]({{< relref "/operate/kubernetes/re-clusters/#disconnect-clients-on-password-removal" >}}).
+Once the operator owns the setting, configure it only through the REDB
+specification; removing the field reverts the database to `false`.
+
 ## Delete a database
 
 The database exists as long as the custom resource exists.

--- a/content/operate/kubernetes/security/access-control/manage-users.md
+++ b/content/operate/kubernetes/security/access-control/manage-users.md
@@ -111,6 +111,12 @@ In Rotatable mode the operator makes referenced Kubernetes Secrets immutable, so
 
 `status.passwordSecrets` lists each active Secret with its resolved version.
 
+Whether connections that authenticated with the removed password are
+actively disconnected is controlled by the cluster's
+`disconnectClientsOnPasswordRemoval` setting and, when that is `Auto`, by
+the database's own setting — see
+[Disconnect clients on password removal]({{< relref "/operate/kubernetes/re-clusters/#disconnect-clients-on-password-removal" >}}).
+
 ## Update the email address
 
 You can change `spec.email` only while `passwordSecrets` contains exactly one entry. If a Rotatable rotation is in progress, reduce to a single secret first, change the email, then add the second secret back.


### PR DESCRIPTION
## Summary

Documents the operator's new CRD fields exposing the Redis Software
setting `disconnect_clients_on_password_removal` (controls whether client
connections that authenticated with a removed, revoked, or rotated
password are actively disconnected):

- **REC** `spec.disconnectClientsOnPasswordRemoval` — `Enabled` /
  `Disabled` / `Auto`. Cluster-wide policy: `Enabled`/`Disabled` force
  the behavior for all databases; `Auto` (the Redis Software default)
  defers to each database's own setting.
- **REDB** `spec.disconnectClientsOnPasswordRemoval` — boolean (default
  `false`). Takes effect only when the cluster policy is `Auto`.
- **REAADB** `spec.globalConfigurations.disconnectClientsOnPasswordRemoval`
  — boolean, propagated to all participating clusters.

The canonical explanation (setting semantics + operator ownership /
upgrade path) lives on the REC page; the REDB section and a
manage-users rotation cross-link point to it.

## Pages changed

- `content/operate/kubernetes/re-clusters/_index.md` — canonical section
- `content/operate/kubernetes/re-databases/db-controller.md` — REDB
  example + pointer
- `content/operate/kubernetes/security/access-control/manage-users.md` —
  cross-link after the Rotatable password-rotation steps

## Notes for reviewers

- The operator release that includes this feature is **not yet
  released** — the version appears as `X.Y.Z` with `<!-- TODO -->`
  comments marking every occurrence. Replace them when the release
  number is fixed.
- The auto-generated CRD API reference pages under
  `reference/api/` are intentionally untouched; the new field entries
  arrive with the next regeneration.
- Requires Redis Software 8.0.2 or later (field added in RS 8.0.2-17).

Ticket: [RED-197499](https://redislabs.atlassian.net/browse/RED-197499)


[RED-197499]: https://redislabs.atlassian.net/browse/RED-197499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no code, API, or runtime impact. Placeholder operator version `X.Y.Z` still needs replacement before release.
> 
> **Overview**
> Documents how to configure **disconnect clients on password removal** through Kubernetes custom resources (requires Redis Software 8.0.2+ and operator `X.Y.Z`).
> 
> Adds a canonical section on the REC page covering cluster-wide policy (`Enabled`/`Disabled`/`Auto`), per-database and Active-Active settings, YAML examples, and when the operator takes ownership vs. preserving pre-upgrade REST API values.
> 
> Also adds a REDB configuration section with an example, and a cross-link from the Rotatable password-rotation steps in manage-users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb9563e22fe8b1426778d830fce86e13dcc63c59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->