### PR TITLE
DOC-6909 Teach the feed pipeline and version archiver the /content/ link form

### DIFF
--- a/build/test_version_archiver.py
+++ b/build/test_version_archiver.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""
+Test script for version_archiver's link versioning.
+
+When a version is archived, intra-product links must point at the frozen copy,
+not at latest. The archiver originally rewrote only `relref`, so a section
+migrated to plain Markdown links (DOC-6909) was silently left pointing at
+latest -- wrong content in an archived version, with no error or warning.
+
+These tests cover both notations, the guards they share, and the forms that must
+NOT be touched.
+"""
+
+import os
+import sys
+import tempfile
+
+# Add the build directory to the path
+sys.path.insert(0, os.path.dirname(__file__))
+
+from version_archiver import VersionArchiver
+
+
+def archive(product, version, page_relpath, content):
+    """Run the real version_relrefs() over one page in an isolated tree.
+
+    page_relpath is relative to the versioned directory, so nesting can be
+    realistic -- it matters for source-relative links, which resolve against the
+    page's own location.
+    """
+    cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmp:
+        arch_cwd = tmp
+        os.chdir(arch_cwd)
+        try:
+            archiver = VersionArchiver(product, version)
+            page = os.path.join(archiver.new_directory, page_relpath)
+            os.makedirs(os.path.dirname(page), exist_ok=True)
+            with open(page, "w") as f:
+                f.write(content)
+            archiver.version_relrefs()
+            with open(page) as f:
+                return f.read()
+        finally:
+            os.chdir(cwd)
+
+
+DEEP = os.path.join("databases", "configure", "page.md")
+
+
+def test_relref_is_versioned():
+    """The original behaviour: an intra-product relref gains the version."""
+    out = archive("rs", "9.9", DEEP,
+                  '[a]({{< relref "/operate/rs/databases/memory/eviction" >}})')
+    assert "/operate/rs/9.9/databases/memory/eviction" in out, out
+    print("✓ relref link is versioned")
+
+
+def test_plain_content_link_is_versioned():
+    """DOC-6909's repo-root-relative form must be versioned the same way."""
+    out = archive("rs", "9.9", DEEP,
+                  '[b](/content/operate/rs/databases/memory/eviction.md)')
+    assert "](/content/operate/rs/9.9/databases/memory/eviction.md)" in out, out
+    print("✓ plain /content/ link is versioned")
+
+
+def test_plain_content_link_keeps_anchor():
+    """An anchor must survive versioning."""
+    out = archive("rs", "9.9", DEEP,
+                  '[c](/content/operate/rs/databases/memory/eviction.md#policies)')
+    assert "/operate/rs/9.9/databases/memory/eviction.md#policies" in out, out
+    print("✓ anchor preserved when versioning a plain link")
+
+
+def test_source_relative_link_is_left_alone():
+    """Source-relative links need no rewriting and must not be touched.
+
+    The whole subtree is copied, so a link between two pages inside it already
+    resolves within the versioned directory.
+    """
+    link = '[d](../memory/eviction.md)'
+    out = archive("rs", "9.9", DEEP, link)
+    assert out == link, out
+    # and confirm the claim: it resolves inside the frozen tree
+    page_dir = os.path.join("content", "operate", "rs", "9.9",
+                            os.path.dirname(DEEP))
+    resolved = os.path.normpath(os.path.join(page_dir, "../memory/eviction.md"))
+    assert resolved.startswith(os.path.join("content", "operate", "rs", "9.9")), resolved
+    print("✓ source-relative link untouched, and resolves inside the version")
+
+
+def test_release_notes_are_exempt():
+    """Release notes are deliberately not versioned, in either notation."""
+    both = ('[e]({{< relref "/operate/rs/release-notes/rs-7-8" >}})\n'
+            '[f](/content/operate/rs/release-notes/rs-7-8.md)')
+    out = archive("rs", "9.9", DEEP, both)
+    assert out == both, out
+    print("✓ release-notes links exempt in both notations")
+
+
+def test_already_versioned_is_idempotent():
+    """Re-running must not double-version an already-versioned link."""
+    both = ('[g]({{< relref "/operate/rs/9.9/databases/memory/eviction" >}})\n'
+            '[h](/content/operate/rs/9.9/databases/memory/eviction.md)')
+    out = archive("rs", "9.9", DEEP, both)
+    assert out == both, out
+    assert "9.9/9.9" not in out, out
+    print("✓ already-versioned links are left alone (idempotent)")
+
+
+def test_other_product_and_external_urls_untouched():
+    """Only the product being archived is rewritten, and external URLs are safe.
+
+    The GitHub blob URL is the important one: it contains the substring
+    '/content/operate/rs/', so the pattern must anchor on a link destination
+    ('](/content/...') rather than matching anywhere in the line.
+    """
+    content = ('[i](/content/operate/kubernetes/deploy/quickstart.md)\n'
+               '[j](https://github.com/redis/docs/blob/main/content/operate/rs/x.md)\n'
+               '[k]({{< relref "/develop/data-types/hashes" >}})')
+    out = archive("rs", "9.9", DEEP, content)
+    assert out == content, out
+    print("✓ other products, external URLs and other sections untouched")
+
+
+def test_other_products_use_their_own_prefix():
+    """The pattern is parameterised, so non-'operate' products work too."""
+    out = archive("redis-data-integration", "1.20", DEEP,
+                  '[l](/content/integrate/redis-data-integration/reference/config.md)')
+    assert "/integrate/redis-data-integration/1.20/reference/config.md" in out, out
+    print("✓ redis-data-integration (integrate prefix) is versioned")
+
+
+def main():
+    tests = [
+        test_relref_is_versioned,
+        test_plain_content_link_is_versioned,
+        test_plain_content_link_keeps_anchor,
+        test_source_relative_link_is_left_alone,
+        test_release_notes_are_exempt,
+        test_already_versioned_is_idempotent,
+        test_other_product_and_external_urls_untouched,
+        test_other_products_use_their_own_prefix,
+    ]
+    try:
+        for t in tests:
+            t()
+        print("\n✅ All tests passed!")
+        return 0
+    except AssertionError as e:
+        print(f"\n❌ Test failed: {e}")
+        return 1
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/build/version_archiver.py
+++ b/build/version_archiver.py
@@ -49,6 +49,19 @@ class VersionArchiver:
             + re.escape(product)
             + r'/([^"]+)" ?>\}\})'
         )
+        # Repo-root-relative Markdown links replace relref in sections migrated
+        # for DOC-6909, and need the same versioning. Without this they keep
+        # resolving to the latest page instead of the copy being frozen, which is
+        # silently wrong content in an archived version (no error, no warning).
+        # Source-relative links need no rewriting: the whole subtree is copied, so
+        # a link between two pages inside it already resolves within the version.
+        plain_pattern = (
+            r'(\]\(/content/'
+            + self.prefix
+            + "/"
+            + re.escape(product)
+            + r'/([^)]+)\))'
+        )
         with open(file_path, "r") as file:
             lines = file.readlines()
 
@@ -74,8 +87,12 @@ class VersionArchiver:
                     return f"{new_link}"
                 return full_match
 
-            # Replace all relref links in the line
+            # Replace all relref links in the line, then the plain Markdown ones.
+            # Both share replace_link: each match contains "/<prefix>/<product>/",
+            # so the same substitution and the same release-notes and
+            # already-versioned guards apply to either notation.
             modified_line = re.sub(pattern, replace_link, lines[i])
+            modified_line = re.sub(plain_pattern, replace_link, modified_line)
 
             # If the line was modified, update the lines list
             if modified_line != lines[i]:

--- a/layouts/partials/process-markdown-content.html
+++ b/layouts/partials/process-markdown-content.html
@@ -60,6 +60,18 @@
 {{- /* Pattern for literal: {{< relref "path" >}} - capture optional leading slash */ -}}
 {{- $content = $content | replaceRE `\{\{<\s*relref\s+"/?([^"]+)"\s*>\}\}` "https://redis.io/docs/latest/$1" -}}
 
+{{- /* Fix repo-root-relative Markdown links (`](/content/...)`), which replace relref
+       in sections migrated for DOC-6909. Without this they reach the AI-facing
+       Markdown/JSON output as raw source paths, which resolve nowhere on the
+       published site. Rewritten to the same absolute form as relref above.
+       Section/leaf-bundle forms go first so the index segment is dropped rather
+       than left in the URL; `/index.md` mirrors the render-link hook, which
+       strips it, even though no content currently uses that form. A trailing
+       `#anchor` is outside each match and so survives untouched. */ -}}
+{{- $content = $content | replaceRE `\]\(/content/([^)#]*?)/_index\.md` "](https://redis.io/docs/latest/$1" -}}
+{{- $content = $content | replaceRE `\]\(/content/([^)#]*?)/index\.md` "](https://redis.io/docs/latest/$1" -}}
+{{- $content = $content | replaceRE `\]\(/content/([^)#]*?)\.md` "](https://redis.io/docs/latest/$1" -}}
+
 {{- /* Fix images - handle both HTML-escaped entities and literal characters */ -}}
 {{- /* Pattern for HTML-escaped: {{&lt; image filename=&#34;path&#34; [alt=&#34;...&#34;] &gt;}} */ -}}
 {{- $content = $content | replaceRE "\\{\\{&lt;\\s*image\\s+filename=&#34;/?([^&]+)&#34;[^}]*&gt;\\}\\}" "![$1](https://redis.io/docs/latest/$1)" -}}


### PR DESCRIPTION
Part 2 of 4. **Stack:** #3795 → **#3796 (this)** → #3797 → #3798

## What this is

Updates the two tools that read `relref` **as a literal string**, ahead of any content moving off it. This is @paoloredis's review point from #3732, and it turns out not to be a "before we remove relref" concern — it bites **per section, at migration time**.

Both changes are inert until content actually uses repo-root-relative links, so this is safe to land on its own.

| Tool | Blind spot | Consequence |
|---|---|---|
| `process-markdown-content.html` | rewrote only `relref` to absolute URLs | a migrated page ships raw source paths into the AI Markdown/JSON feed, resolving nowhere |
| `version_archiver.py` | pattern matched only `relref` | links in an **archived** version keep resolving to *latest* instead of the frozen copy — silently, no error |

The archiver one was found by probe rather than by reasoning, and it's the more expensive: wrong content in a frozen version, discovered late.

## Notes for review

- Both patterns anchor on a Markdown **link destination** (`](/content/…`), not the bare `/content/` prefix — otherwise they rewrite the `github.com` blob URLs that legitimately embed the same path segment. There's a test pinning this.
- The archiver shares one `replace_link` closure across both notations, so the release-notes exemption and the already-versioned guard can't drift apart.
- **Source-relative links need no archiver rewriting** — the whole subtree is copied, so a link between two pages inside it already resolves within the version. `test_source_relative_link_is_left_alone` asserts the resolution, not just that the text is unchanged.
- `build/test_version_archiver.py` (8 tests) was confirmed to **fail** with only the new substitution disabled, so it isn't passing vacuously. Like its `build/test_*.py` siblings it isn't wired into CI.

## Not covered

394 `.html.md` files still leak pre-existing `../` relative links into the feed, plus 21 with rooted non-`/content/` links. That defect predates this work entirely and is out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/feed tooling only; behavior is inert until content uses `/content/` links, with targeted tests on the archiver path.
> 
> **Overview**
> Extends **DOC-6909** link handling so repo-root-relative Markdown destinations (`](/content/...`) are treated like `relref` in the two pipelines that still match links as literal text.
> 
> **`version_archiver.py`** now rewrites those plain links into the frozen version path using the same `replace_link` logic as `relref` (release-notes skip, idempotency, product prefix). **`process-markdown-content.html`** maps the same link form to `https://redis.io/docs/latest/...`, with `_index.md` / `index.md` / `.md` ordering so bundle URLs match site behavior and anchors stay intact.
> 
> Adds **`build/test_version_archiver.py`** (eight isolated tests) for both notations, exemptions, idempotency, other products, and the GitHub-URL false-positive guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af36636946a7e08e96d47be88142f091ba89629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->