### PR TITLE
DOC-6909 Migrate develop/clients/redis-py to portable Markdown links and callouts

### DIFF
--- a/content/develop/clients/redis-py/_index.md
+++ b/content/develop/clients/redis-py/_index.md
@@ -27,10 +27,10 @@ weight: 1
 The sections below explain how to install `redis-py` and connect your application
 to a Redis database.
 
-`redis-py` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`redis-py` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 You can also access Redis with an object-mapping client interface. See
-[RedisOM for Python]({{< relref "/integrate/redisom-for-python" >}})
+[RedisOM for Python](/content/integrate/redisom-for-python/_index.md)
 for more information.
 
 ## Install

--- a/content/develop/clients/redis-py/amr.md
+++ b/content/develop/clients/redis-py/amr.md
@@ -26,7 +26,7 @@ letting `redis-entra-id` fetch and renew the authentication tokens for you autom
 
 ## Install
 
-Install [`redis-py`]({{< relref "/develop/clients/redis-py#install" >}}) first,
+Install [`redis-py`](/content/develop/clients/redis-py/_index.md#install) first,
 if you have not already done so. Then, install `redis-entra-id` with the
 following command:
 
@@ -134,11 +134,11 @@ When you have created your `CredentialProvider` instance, you are ready to
 connect to AMR.
 The example below shows how to pass the instance as a parameter to the standard
 `RedisCluster()` connection method.
-{{< note >}} Azure requires you to use
-[Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security)
-when you connect (see
-[Connect with TLS]({{< relref "/develop/clients/redis-py/connect#connect-to-your-production-redis-with-tls" >}}) for more information).
-{{< /note >}}
+> [!NOTE]
+> Azure requires you to use
+> [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security)
+> when you connect (see
+> [Connect with TLS](/content/develop/clients/redis-py/connect.md#connect-to-your-production-redis-with-tls) for more information).
 
 ```python
 from redis import RedisCluster

--- a/content/develop/clients/redis-py/async.md
+++ b/content/develop/clients/redis-py/async.md
@@ -21,7 +21,7 @@ namespace. It mirrors the synchronous client API, so most code patterns
 translate directly — you `await` commands instead of calling them.
 
 Use the async client for I/O-bound workloads, for integration with async web
-frameworks (such as [FastAPI]({{< relref "/integrate/fastapi" >}}), [Starlette](https://www.starlette.io/), [aiohttp](https://docs.aiohttp.org/en/stable/), or [Sanic](https://sanic.dev/en/), or when you need
+frameworks (such as [FastAPI](/content/integrate/fastapi/_index.md), [Starlette](https://www.starlette.io/), [aiohttp](https://docs.aiohttp.org/en/stable/), or [Sanic](https://sanic.dev/en/), or when you need
 to run many concurrent Redis operations from a single process. For simple
 scripts, CPU-bound work, or codebases without an existing event loop, the
 synchronous client is usually a better choice.
@@ -50,7 +50,7 @@ which ensures `aclose()` runs even if an exception is raised:
 
 For production usage, you should manage connections with a connection pool
 rather than opening and closing them individually.
-See [Connection pools and multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}})
+See [Connection pools and multiplexing](/content/develop/clients/pools-and-muxing.md)
 for more information about how this works.
 
 A `Redis` client instance already creates and manages its own connection
@@ -93,7 +93,7 @@ through a single connection instead.)
 ## Pipelines and transactions
 
 Pipelines and transactions work the same way as in the synchronous client
-(see [Pipelines and transactions]({{< relref "/develop/clients/redis-py/transpipe" >}})
+(see [Pipelines and transactions](/content/develop/clients/redis-py/transpipe.md)
 for the conceptual background). The only difference is that you create the
 pipeline inside an `async with` block and `await pipe.execute()`.
 
@@ -125,7 +125,7 @@ consuming task its own subscription.
 
 To connect to a Redis cluster asynchronously, import `RedisCluster` from
 `redis.asyncio.cluster`. The API matches the synchronous cluster client
-(see [Connect to a Redis cluster]({{< relref "/develop/clients/redis-py/connect#connect-to-a-redis-cluster" >}})),
+(see [Connect to a Redis cluster](/content/develop/clients/redis-py/connect.md#connect-to-a-redis-cluster)),
 with `await` in front of each command.
 
 {{< clients-example set="async_intro" step="cluster" lang_filter="Python" description="Foundational: Connect to a Redis cluster with the async client" difficulty="beginner" >}}
@@ -139,7 +139,7 @@ Always close clients and pools when you're done:
   single scope.
 - For longer-lived clients, call `await r.aclose()` explicitly. (The older
   `close()` method is deprecated.)
-- For frameworks with startup/shutdown hooks — for example [FastAPI]({{< relref "/integrate/fastapi" >}})'s
+- For frameworks with startup/shutdown hooks — for example [FastAPI](/content/integrate/fastapi/_index.md)'s
   `lifespan` — create the client or pool at startup and close it at
   shutdown so connections aren't leaked between process restarts.
 
@@ -178,6 +178,6 @@ client, apply these rules:
 
 - The [`redis-py` asyncio examples](https://redis.readthedocs.io/en/stable/examples/asyncio_examples.html)
   on Read the Docs cover further patterns.
-- See [Error handling]({{< relref "/develop/clients/redis-py/error-handling" >}}) and
-  [Client-side geographic failover]({{< relref "/develop/clients/redis-py/failover" >}}) for
+- See [Error handling](/content/develop/clients/redis-py/error-handling.md) and
+  [Client-side geographic failover](/content/develop/clients/redis-py/failover.md) for
   resiliency patterns that apply to both sync and async clients.

--- a/content/develop/clients/redis-py/connect.md
+++ b/content/develop/clients/redis-py/connect.md
@@ -69,7 +69,7 @@ For more information, see [redis-py Clustering](https://redis.readthedocs.io/en/
 
 ## Connect to your production Redis with TLS
 
-When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
+When you deploy your application, use TLS and follow the [Redis security](/content/operate/oss_and_stack/management/security/_index.md) guidelines.
 
 ```python
 import redis
@@ -95,14 +95,14 @@ For more information, see [redis-py TLS examples](https://redis.readthedocs.io/e
 
 Client-side caching is a technique to reduce network traffic between
 the client and server, resulting in better performance. See
-[Client-side caching introduction]({{< relref "/develop/clients/client-side-caching" >}})
+[Client-side caching introduction](/content/develop/clients/client-side-caching.md)
 for more information about how client-side caching works and how to use it effectively.
 
 To enable client-side caching, add some extra parameters when you connect
 to the server:
 
 -   `protocol`: (Required) You must pass a value of `3` here because
-    client-side caching requires the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
+    client-side caching requires the [RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
     protocol.
 -   `cache_config`: (Required) Pass `cache_config=CacheConfig()` here to enable client-side caching.
 
@@ -111,15 +111,15 @@ The example below shows the simplest client-side caching connection to the defau
 All of the connection variants described above accept these parameters, so you can
 use client-side caching with a connection pool or a cluster connection in exactly the same way.
 
-{{< note >}}Client-side caching requires redis-py v5.1.0 or later.
-To maximize compatibility with all Redis products, client-side caching
-is supported by Redis v7.4 or later.
-
-The [Redis server products]({{< relref "/operate" >}}) support
-[opt-in/opt-out]({{< relref "/develop/reference/client-side-caching#opt-in-and-opt-out-caching" >}}) mode
-and [broadcasting mode]({{< relref "/develop/reference/client-side-caching#broadcasting-mode" >}})
-for CSC, but these modes are not currently implemented by `redis-py`.
-{{< /note >}}
+> [!NOTE]
+> Client-side caching requires redis-py v5.1.0 or later.
+> To maximize compatibility with all Redis products, client-side caching
+> is supported by Redis v7.4 or later.
+>
+> The [Redis server products](/content/operate/_index.md) support
+> [opt-in/opt-out](/content/develop/reference/client-side-caching.md#opt-in-and-opt-out-caching) mode
+> and [broadcasting mode](/content/develop/reference/client-side-caching.md#broadcasting-mode)
+> for CSC, but these modes are not currently implemented by `redis-py`.
 
 ```python
 import redis
@@ -137,8 +137,8 @@ cityNameAttempt2 = r.get("city")    # Retrieved from cache
 ```
 
 You can see the cache working if you connect to the same Redis database
-with [`redis-cli`]({{< relref "/develop/tools/cli" >}}) and run the
-[`MONITOR`]({{< relref "/commands/monitor" >}}) command. If you run the
+with [`redis-cli`](/content/develop/tools/cli.md) and run the
+[`MONITOR`](/content/commands/monitor.md) command. If you run the
 code above with the `cache_config` line commented out, you should see
 the following in the CLI among the output from `MONITOR`:
 
@@ -164,8 +164,8 @@ call was satisfied by the cache.
 You can remove individual keys from the cache with the
 `delete_by_redis_keys()` method. This removes all cached items associated
 with the keys, so all results from multi-key commands (such as
-[`MGET`]({{< relref "/commands/mget" >}})) and composite data structures
-(such as [hashes]({{< relref "/develop/data-types/hashes" >}})) will be
+[`MGET`](/content/commands/mget.md)) and composite data structures
+(such as [hashes](/content/develop/data-types/hashes.md)) will be
 cleared at once. The example below shows the effect of removing a single
 key from the cache:
 
@@ -219,7 +219,7 @@ one of its open connections. When you subsequently close the same connection,
 it is not actually closed but simply returned to the pool for reuse.
 This avoids the overhead of repeated connecting and disconnecting.
 See
-[Connection pools and multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}})
+[Connection pools and multiplexing](/content/develop/clients/pools-and-muxing.md)
 for more information.
 
 Use the following code to connect with a connection pool:
@@ -250,7 +250,7 @@ network outage or a server that is temporarily unavailable. In these cases,
 retrying the connection after a short delay will usually succeed. `redis-py` uses
 a simple retry strategy by default, but there are various ways you can customize
 this behavior to suit your use case. See
-[Retries]({{< relref "/develop/clients/redis-py/produsage#retries" >}})
+[Retries](/content/develop/clients/redis-py/produsage.md#retries)
 for more information about custom retry strategies, with example code.
 
 ## Connect using Smart client handoffs (SCH)
@@ -259,13 +259,13 @@ for more information about custom retry strategies, with example code.
 Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH.
 
-{{< note >}}Using SCH with redis-py requires v7.0.0 or later for
-basic connections, and v7.2.0 or later for
-[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
-{{< /note >}}
+> [!NOTE]
+> Using SCH with redis-py requires v7.0.0 or later for
+> basic connections, and v7.2.0 or later for
+> [OSS Cluster API](/content/operate/rs/databases/configure/oss-cluster-api.md) connections.
 
 By default, `redis-py` always attempts to connect via SCH but falls back to
 a non-SCH connection if the server doesn't support it. However, you can configure SCH
@@ -299,9 +299,9 @@ r = redis.Redis(
 )
 ```
 
-{{< note >}}SCH requires the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
-protocol, so you must set `protocol=3` explicitly when you connect.
-{{< /note >}}
+> [!NOTE]
+> SCH requires the [RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
+> protocol, so you must set `protocol=3` explicitly when you connect.
 
 The `MaintNotificationsConfig` constructor accepts the following parameters:
 
@@ -312,10 +312,10 @@ The `MaintNotificationsConfig` constructor accepts the following parameters:
 | `endpoint_type` | `EndpointType` | Auto-detect | The type of endpoint to use for the connection. The options are `EndpointType.EXTERNAL_IP`, `EndpointType.INTERNAL_IP`, `EndpointType.EXTERNAL_FQDN`, `EndpointType.INTERNAL_FQDN`, and `EndpointType.NONE`. |
 | `relaxed_timeout` | `int` | `20` | The timeout (in seconds) to use while the server is performing maintenance. A value of `-1` disables the relax timeout and just uses the normal timeout during maintenance. |
 
-{{< note >}} Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
-either [AWS PrivateLink]({{< relref "/operate/rc/security/aws-privatelink" >}}) or
-[Google Cloud Private Service Connect]({{< relref "/operate/rc/security/private-service-connect" >}})
-(see [Smart client handoffs]({{< relref "/develop/clients/sch#redis-cloud" >}}) for more information).
-To use relaxed timeouts with these services, you should set `endpoint_type=EndpointType.NONE`
-when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.
-{{< /note >}}
+> [!NOTE]
+> Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
+> either [AWS PrivateLink](/content/operate/rc/security/aws-privatelink.md) or
+> [Google Cloud Private Service Connect](/content/operate/rc/security/private-service-connect.md)
+> (see [Smart client handoffs](/content/develop/clients/sch.md#redis-cloud) for more information).
+> To use relaxed timeouts with these services, you should set `endpoint_type=EndpointType.NONE`
+> when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.

--- a/content/develop/clients/redis-py/error-handling.md
+++ b/content/develop/clients/redis-py/error-handling.md
@@ -17,8 +17,8 @@ shows the "happy path" in code examples and omits error handling for brevity.
 This page explains how
 redis-py's error handling works and how to apply common error handling patterns.
 For an overview of error types and handling strategies, see
-[Error handling]({{< relref "/develop/clients/error-handling" >}}).
-See also [Production usage]({{< relref "/develop/clients/redis-py/produsage" >}})
+[Error handling](/content/develop/clients/error-handling.md).
+See also [Production usage](/content/develop/clients/redis-py/produsage.md)
 for more information on connection management, timeouts, and other aspects of
 app reliability.
 
@@ -47,7 +47,7 @@ redis-py organizes exceptions in a hierarchy. The base exception is `redis.Redis
 
 The following exceptions are the most commonly encountered in redis-py applications.
 See
-[Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+[Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 | Exception | When it occurs | Recoverable | Recommended action |
@@ -59,14 +59,14 @@ for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 redis-py:
 
 ### Pattern 1: Fail fast
 
 Catch specific exceptions that represent unrecoverable errors and re-raise them (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```python
@@ -84,7 +84,7 @@ except redis.ResponseError:
 ### Pattern 2: Graceful degradation
 
 Catch connection errors and fall back to an alternative (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```python
@@ -102,18 +102,18 @@ return database.get(key)
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors like timeouts (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description). redis-py has built-in retry logic
 which is highly configurable. You can customize the retry strategy
 (or supply your own custom strategy) and you can also specify which errors
 should be retried. See
-[Production usage]({{< relref "/develop/clients/redis-py/produsage#retries" >}})
+[Production usage](/content/develop/clients/redis-py/produsage.md#retries)
 for more information.
 
 ### Pattern 4: Log and continue
 
 Log non-critical errors and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```python
@@ -145,5 +145,5 @@ async def get_with_fallback(key):
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Production usage]({{< relref "/develop/clients/redis-py/produsage" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Production usage](/content/develop/clients/redis-py/produsage.md)

--- a/content/develop/clients/redis-py/failover.md
+++ b/content/develop/clients/redis-py/failover.md
@@ -28,7 +28,7 @@ bannerText: This feature is currently in preview and may be subject to change.
 redis-py supports [Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. This page explains
 how to configure redis-py for failover. For an overview of the concepts,
-see the main [Client-side geographic failover]({{< relref "/develop/clients/failover" >}}) page.
+see the main [Client-side geographic failover](/content/develop/clients/failover.md) page.
 
 ## Failover configuration
 
@@ -38,7 +38,7 @@ target. If `redis-east` fails, redis-py should fail over to
 `redis-west`.
 
 Supply the weighted endpoints using a list of `DatabaseConfig` objects
-(see [Selecting a failover target]({{< relref "/develop/clients/failover#selecting-a-failover-target" >}}) for a full description of how
+(see [Selecting a failover target](/content/develop/clients/failover.md#selecting-a-failover-target) for a full description of how
 the weighted list is used).
 Use the `weight` option to order the endpoints, with the highest
 weight being tried first. Then, use the list to create a `MultiDbConfig` object,
@@ -74,9 +74,9 @@ constructor in the `databases_config` parameter.
 
 | Option | Description |
 | --- | --- |
-| `client_kwargs` | Keyword parameters to pass to the internal client constructor for this endpoint. Use it to specify the host, port, username, password, and other connection parameters (see [Connect to the server]({{< relref "/develop/clients/redis-py/connect" >}}) for more information). This is especially useful if you are using a custom client class (see [Client configuration](#client-configuration) below for more information). |
+| `client_kwargs` | Keyword parameters to pass to the internal client constructor for this endpoint. Use it to specify the host, port, username, password, and other connection parameters (see [Connect to the server](/content/develop/clients/redis-py/connect.md) for more information). This is especially useful if you are using a custom client class (see [Client configuration](#client-configuration) below for more information). |
 | `from_url` | Redis URL to connect to this endpoint, as an alternative to passing the host and port in `client_kwargs`. |
-| `from_pool` | A `ConnectionPool` to supply the endpoint connection (see [Connect with a connection pool]({{< relref "/develop/clients/redis-py/connect#connect-with-a-connection-pool" >}}) for more information) |
+| `from_pool` | A `ConnectionPool` to supply the endpoint connection (see [Connect with a connection pool](/content/develop/clients/redis-py/connect.md#connect-with-a-connection-pool) for more information) |
 | `weight` | Priority of the endpoint, with higher values being tried first. Default is `1.0`. |
 | `grace_period` | Duration in seconds to keep an unhealthy endpoint disabled before attempting a failback. Default is `60` seconds. |
 | `health_check_url` | URL for health checks that use the database's REST API (see [`LagAwareHealthCheck`](#lag-aware-health-check) for more information). |
@@ -97,7 +97,7 @@ cfg = MultiDbConfig(
 ### Circuit breaker configuration
 
 `MultiDbConfig` gives you several options to configure the circuit breaker
-(see [Detecting connection problems]({{< relref "/develop/clients/failover#detecting-connection-problems" >}}) for more information on how the
+(see [Detecting connection problems](/content/develop/clients/failover.md#detecting-connection-problems) for more information on how the
 circuit breaker works):
 
 | Option | Description |
@@ -109,7 +109,7 @@ circuit breaker works):
 ### Retry configuration
 
 `MultiDbConfig` provides the `command_retry` option to configure retries for failed commands. This follows the usual approach to configuring retries used with a standard
-`RedisClient` connection (see [Retries]({{< relref "/develop/clients/redis-py/produsage#retries" >}}) for more information).
+`RedisClient` connection (see [Retries](/content/develop/clients/redis-py/produsage.md#retries) for more information).
 
 ```py
 cfg = MultiDbConfig(
@@ -194,7 +194,7 @@ client = MultiDBClient(config)
 ## Health check configuration
 
 Each health check consists of one or more separate "probes", each of which is a simple
-test (such as a [`PING`]({{< relref "/commands/ping" >}}) command) to determine if the
+test (such as a [`PING`](/content/commands/ping.md) command) to determine if the
 database is available. The results of the separate probes are combined
 using a configurable policy to determine if the database is healthy.
 
@@ -223,7 +223,7 @@ in more detail.
 ### `PingHealthCheck` (default)
 
 The default strategy, `PingHealthCheck`, periodically sends a Redis
-[`PING`]({{< relref "/commands/ping" >}}) command
+[`PING`](/content/commands/ping.md) command
 and checks that it gives the expected response. Any unexpected response
 or exception indicates an unhealthy server. Although `PingHealthCheck` is
 very simple, it is a good basic approach for most Redis deployments.
@@ -231,9 +231,9 @@ very simple, it is a good basic approach for most Redis deployments.
 ### `LagAwareHealthCheck` (Redis Software only) {#lag-aware-health-check}
 
 `LagAwareHealthCheck` is designed specifically for
-Redis Software [Active-Active]({{< relref "/operate/rs/databases/active-active" >}})
+Redis Software [Active-Active](/content/operate/rs/databases/active-active/_index.md)
 deployments. It determines the health of the server by using the
-[REST API]({{< relref "/operate/rs/references/rest-api" >}}) to check the
+[REST API](/content/operate/rs/references/rest-api/_index.md) to check the
 synchronization lag between a specific database and the others in the Active-Active
 setup. If the lag is within a specified tolerance, the server is considered healthy.
 
@@ -305,7 +305,7 @@ Note that health checks are executed in an asyncio event loop, so you
 must implement the `check_health()` method as an async method.
 
 The example below
-shows a simple custom strategy that sends a Redis [`ECHO`]({{< relref "/commands/echo" >}})
+shows a simple custom strategy that sends a Redis [`ECHO`](/content/commands/echo.md)
 command and checks for the expected response.
 
 ```py
@@ -391,7 +391,7 @@ If you decide to implement manual failback, you will need a way for external sys
 
 ## Pub/Sub and re-subscription
 
-`MultiDBClient` supports [Pub/Sub]({{< relref "/develop/pubsub" >}})
+`MultiDBClient` supports [Pub/Sub](/content/develop/pubsub/_index.md)
 messaging with automatic re-subscription to channels during failover.
 This means you don't have to detect failovers and re-subscribe manually:
 
@@ -420,11 +420,11 @@ if msg:
 Re-subscription happens transparently and is independent of any custom
 event listeners you register (see [Failover callbacks](#failover-callbacks)).
 
-{{< note >}}Message loss can still occur if the failover events happen in
-the reverse order, with the publisher failing over to the new database
-before the subscriber. Messages published during this window may not reach
-a subscriber that is still connected to the previous database.
-{{< /note >}}
+> [!NOTE]
+> Message loss can still occur if the failover events happen in
+> the reverse order, with the publisher failing over to the new database
+> before the subscriber. Messages published during this window may not reach
+> a subscriber that is still connected to the previous database.
 
 ## Behavior when all endpoints are unhealthy
 
@@ -436,7 +436,7 @@ gives a period of 120 seconds to find a healthy endpoint.
 
 You can still keep retrying commands after a `TemporaryUnavailableException` is thrown (for example,
 you could add this exception to the `supported_errors` list in your `Retry` configuration, as described
-in [Retries]({{< relref "/develop/clients/redis-py/produsage#retries" >}})). However, if the client exhausts
+in [Retries](/content/develop/clients/redis-py/produsage.md#retries)). However, if the client exhausts
 all the available failover attempts before any endpoint becomes healthy again, commands will throw a `NoValidDatabaseException`. The client won't recover automatically from this situation, so you
 should handle it by reconnecting with the `MultiDBClient` constructor after a suitable delay (see
 [Failover configuration](#failover-configuration) for a connection example).
@@ -454,7 +454,7 @@ network connectivity problems.
 If you are using [`PingHealthCheck`](#pinghealthcheck-default) or a
 [custom health check strategy](#custom-health-check-strategy),
 check that the `socket_timeout` is not too low for your network conditions
-(see [Timeouts]({{< relref "/develop/clients/redis-py/produsage#timeouts" >}}) for more information).
+(see [Timeouts](/content/develop/clients/redis-py/produsage.md#timeouts) for more information).
 
 For
 [`LagAwareHealthCheck`](#lag-aware-health-check), check that the `health_check_url`

--- a/content/develop/clients/redis-py/observability.md
+++ b/content/develop/clients/redis-py/observability.md
@@ -19,7 +19,7 @@ weight: 75
 instrumentation to collect metrics. This can be very helpful for
 diagnosing problems and improving the performance and connection resiliency of
 your application. See the
-[Observability overview]({{< relref "/develop/clients/observability" >}})
+[Observability overview](/content/develop/clients/observability.md)
 for an introduction to Redis client observability and a reference guide for the
 available metrics.
 
@@ -69,15 +69,15 @@ The available options for `OTelConfig` are described in the table below:
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `metric_groups` | `List[MetricGroup]` | List of metric groups to enable. By default, only `CONNECTION_BASIC` and `RESILIENCY` are enabled. See [Redis metric groups]({{< relref "/develop/clients/observability#redis-metric-groups" >}}) for a list of available groups. |
+| `metric_groups` | `List[MetricGroup]` | List of metric groups to enable. By default, only `CONNECTION_BASIC` and `RESILIENCY` are enabled. See [Redis metric groups](/content/develop/clients/observability.md#redis-metric-groups) for a list of available groups. |
 | `include_commands` | `List[str]` | List of Redis commands to track. If set, only these commands will be tracked. Note that you should use the Redis command name rather than the Python method name where the two differ. |
 | `exclude_commands` | `List[str]` | List of Redis commands to exclude from tracking. If set, all commands except these will be tracked. Note that you should use the Redis command name rather than the Python method name where the two differ. |
 | `hide_pubsub_channel_names` | `bool` | If true, channel names in pub/sub metrics will be hidden. |
 | `hide_stream_names` | `bool` | If true, stream names in streaming metrics will be hidden. |
-| `buckets_operation_duration` | `List[float]` | List of bucket boundaries for the [`operation.duration`]({{< relref "/develop/clients/observability/#metric-db.client.operation.duration" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
-| `buckets_stream_processing_duration` | `List[float]` | List of bucket boundaries for the [`stream.lag`]({{< relref "/develop/clients/observability/#metric-redis.client.stream.lag" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
-| `buckets_connection_create_time` | `List[float]` | List of bucket boundaries for the [`connection.create.time`]({{< relref "/develop/clients/observability/#metric-db.client.connection.create_time" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
-| `buckets_connection_wait_time` | `List[float]` | List of bucket boundaries for the [`connection.wait.time`]({{< relref "/develop/clients/observability/#metric-db.client.connection.wait_time" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `buckets_operation_duration` | `List[float]` | List of bucket boundaries for the [`operation.duration`](/content/develop/clients/observability.md#metric-db.client.operation.duration) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `buckets_stream_processing_duration` | `List[float]` | List of bucket boundaries for the [`stream.lag`](/content/develop/clients/observability.md#metric-redis.client.stream.lag) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `buckets_connection_create_time` | `List[float]` | List of bucket boundaries for the [`connection.create.time`](/content/develop/clients/observability.md#metric-db.client.connection.create_time) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `buckets_connection_wait_time` | `List[float]` | List of bucket boundaries for the [`connection.wait.time`](/content/develop/clients/observability.md#metric-db.client.connection.wait_time) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
 
 ### Custom histogram buckets
 

--- a/content/develop/clients/redis-py/prob.md
+++ b/content/develop/clients/redis-py/prob.md
@@ -16,7 +16,7 @@ weight: 45
 ---
 
 Redis supports several
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md)
 that let you calculate values approximately rather than exactly.
 The types fall into two basic categories:
 
@@ -32,7 +32,7 @@ counting the number of distinct IP addresses that access a website in one day.
 
 Assuming that you already have code that supplies you with each IP
 address as a string, you could record the addresses in Redis using
-a [set]({{< relref "/develop/data-types/sets" >}}):
+a [set](/content/develop/data-types/sets.md):
 
 ```py
 r.sadd("ip_tracker", new_ip_address)
@@ -68,11 +68,11 @@ time than the equivalent precise calculations.
 Redis supports the following approximate set operations:
 
 -   [Membership](#set-membership): The
-    [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-    [Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+    [Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+    [Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
     data types let you track whether or not a given item is a member of a set.
 -   [Cardinality](#set-cardinality): The
-    [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+    [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
     data type gives you an approximate value for the number of items in a set, also
     known as the *cardinality* of the set.
 
@@ -80,8 +80,8 @@ The sections below describe these operations in more detail.
 
 ### Set membership
 
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 objects provide a set membership operation that lets you track whether or not a
 particular item has been added to a set. These two types provide different
 trade-offs for memory usage and speed, so you can select the best one for your
@@ -90,7 +90,7 @@ absence of items in the set. If an item is reported as absent, then it is defini
 absent, but if it is reported as present, then there is a small chance it may really be
 absent.
 
-Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+Instead of storing strings directly, like a [set](/content/develop/data-types/sets.md),
 a Bloom filter records the presence or absence of the
 [hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
 This gives a very compact representation of the
@@ -114,13 +114,13 @@ Which of these two data types you choose depends on your use case.
 Bloom filters are generally faster than Cuckoo filters when adding new items,
 and also have better memory usage. Cuckoo filters are generally faster
 at checking membership and also support the delete operation. See the
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 reference pages for more information and comparison between the two types.
 
 ### Set cardinality
 
-A [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+A [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 object calculates the cardinality of a set. As you add
 items, the HyperLogLog tracks the number of distinct set members but
 doesn't let you retrieve them or query which items have been added.
@@ -144,20 +144,20 @@ Redis supports several approximate statistical calculations
 on numeric data sets:
 
 -   [Frequency](#frequency): The
-    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
     data type lets you find the approximate frequency of a labeled item in a data stream.
 -   [Quantiles](#quantiles): The
-    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
     data type estimates the quantile of a query value in a data stream.
 -   [Ranking](#ranking): The
-    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    [Top-K](/content/develop/data-types/probabilistic/top-k.md) data type
     estimates the ranking of labeled items by frequency in a data stream.
 
 The sections below describe these operations in more detail.
 
 ### Frequency
 
-A [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+A [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
 (CMS) object keeps count of a set of related items represented by
 string labels. The count is approximate, but you can specify
 how close you want to keep the count to the true value (as a fraction)
@@ -173,7 +173,7 @@ sketch commands.
 {{< /clients-example >}}
 
 The advantage of using a CMS over keeping an exact count with a
-[sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
+[sorted set](/content/develop/data-types/sorted-sets.md)
 is that that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
@@ -188,7 +188,7 @@ the value of height below which 75% of all people's heights lie.
 [Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
 to quantiles, except that the fraction is expressed as a percentage.
 
-A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+A [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 object can estimate quantiles from a set of values added to it
 without having to store each value in the set explicitly. This can
 save a lot of memory when you have a large number of samples.
@@ -207,12 +207,12 @@ t-digest commands.
 
 A t-digest object also supports several other related commands, such
 as querying by rank. See the
-[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+[t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 reference for more information.
 
 ### Ranking
 
-A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+A [Top-K](/content/develop/data-types/probabilistic/top-k.md)
 object estimates the rankings of different labeled items in a data
 stream according to frequency. For example, you could use this to
 track the top ten most frequently-accessed pages on a website, or the

--- a/content/develop/clients/redis-py/produsage.md
+++ b/content/develop/clients/redis-py/produsage.md
@@ -41,12 +41,12 @@ of them may not apply to your particular use case.
 
 ### Client-side caching
 
-[Client-side caching]({{< relref "/develop/clients/client-side-caching" >}})
+[Client-side caching](/content/develop/clients/client-side-caching.md)
 involves storing the results from read-only commands in a local cache. If the
 same command is executed again later, the results can be obtained from the cache,
 without contacting the server. This improves command execution time on the client,
 while also reducing network traffic and server load. See
-[Connect using client-side caching]({{< relref "/develop/clients/redis-py/connect#connect-using-client-side-caching" >}})
+[Connect using client-side caching](/content/develop/clients/redis-py/connect.md#connect-using-client-side-caching)
 for more information and example code.
 
 ### Retries
@@ -128,7 +128,7 @@ Set the `health_check_interval` parameter during
 a connection (with either `Redis` or `ConnectionPool`) to specify
 an integer number of seconds. If the connection remains idle for
 longer than this interval, it will automatically issue a
-[`PING`]({{< relref "/commands/ping" >}}) command and check the
+[`PING`](/content/commands/ping.md) command and check the
 response before continuing with any client commands.
 
 ```py
@@ -163,15 +163,15 @@ module. The list below describes some of the most common exceptions.
 - `ResponseError`: Thrown when you attempt an operation that has no valid
   response. Examples include executing a command on the wrong type of key
   (as when you try an
-  ['LPUSH']({{< relref "/develop/data-types/lists#automatic-creation-and-removal-of-keys" >}})
+  ['LPUSH'](/content/develop/data-types/lists.md#automatic-creation-and-removal-of-keys)
   command on a string key), creating an
-  [index]({{< relref "/develop/ai/search-and-query/indexing" >}})
+  [index](/content/develop/ai/search-and-query/indexing/_index.md)
   with a name that already exists, and using an invalid ID for a
-  [stream entry]({{< relref "/develop/data-types/streams/#entry-ids" >}}).
+  [stream entry](/content/develop/data-types/streams/_index.md#entry-ids).
 - `TimeoutError`: Thrown when a timeout persistently happens for a command,
   despite any [retries](#retries).
 - `WatchError`: Thrown when a
-  [watched key]({{< relref "/develop/clients/redis-py/transpipe#watch-keys-for-changes" >}}) is
+  [watched key](/content/develop/clients/redis-py/transpipe.md#watch-keys-for-changes) is
   modified during a transaction.
 
 ### Timeouts
@@ -207,9 +207,9 @@ Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
 
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH and
-[Connect using Smart client handoffs]({{< relref "/develop/clients/redis-py/connect#connect-using-smart-client-handoffs-sch" >}})
+[Connect using Smart client handoffs](/content/develop/clients/redis-py/connect.md#connect-using-smart-client-handoffs-sch)
 for example code.
 
 ### Monitor performance and errors
@@ -217,5 +217,5 @@ for example code.
 `redis-py` supports [OpenTelemetry](https://opentelemetry.io/). This lets
 you trace command execution and monitor your server's performance.
 You can use this information to detect problems before they are reported
-by users. See [Observability]({{< relref "/develop/clients/redis-py/observability" >}})
+by users. See [Observability](/content/develop/clients/redis-py/observability.md)
 for more information.

--- a/content/develop/clients/redis-py/queryjson.md
+++ b/content/develop/clients/redis-py/queryjson.md
@@ -24,31 +24,31 @@ weight: 30
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
-{{< note >}}From [v6.0.0](https://github.com/redis/redis-py/releases/tag/v6.0.0) onwards,
-`redis-py` uses query dialect 2 by default.
-Redis Search methods such as [`ft().search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v6.0.0](https://github.com/redis/redis-py/releases/tag/v6.0.0) onwards,
+> `redis-py` uses query dialect 2 by default.
+> Redis Search methods such as [`ft().search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[`redis-py`]({{< relref "/develop/clients/redis-py" >}}) client library if you
+[`redis-py`](/content/develop/clients/redis-py/_index.md) client library if you
 haven't already done so.
 
 Add the following dependencies. All of them are applicable to both JSON and hash,
 except for the `Path` class, which is specific to JSON (see
-[Path]({{< relref "/develop/data-types/json/path" >}}) for a description of the
+[Path](/content/develop/data-types/json/path.md) for a description of the
 JSON path syntax).
 
 {{< jupyter-example set="py_home_json" lang_filter="Python" step="import" description="Foundational: Import required libraries for Redis Search, JSON operations, and search functionality" difficulty="beginner" />}}
@@ -64,7 +64,7 @@ below is compatible with both JSON and hash objects.
 
 Connect to your Redis database. The code below shows the most
 basic connection but see
-[Connect to the server]({{< relref "/develop/clients/redis-py/connect" >}})
+[Connect to the server](/content/develop/clients/redis-py/connect.md)
 to learn more about the available connection options.
 
 {{< jupyter-example set="py_home_json" lang_filter="Python" step="connect" depends="import" description="Foundational: Establish a connection to a Redis server for query operations" difficulty="beginner" />}}
@@ -78,14 +78,14 @@ conflict with the example:
 
 Create an index for the JSON data. The code below specifies that only JSON documents with
 the key prefix `user:` are indexed. For more information, see
-[Query syntax]({{< relref "/develop/ai/search-and-query/query/" >}}).
+[Query syntax](/content/develop/ai/search-and-query/query/_index.md).
 
 {{< jupyter-example set="py_home_json" lang_filter="Python" step="make_index" depends="import" description="Foundational: Create a search index for JSON documents with field definitions and key prefix filtering" difficulty="intermediate" />}}
 
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them:
 
@@ -94,7 +94,7 @@ objects automatically as you add them:
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -107,7 +107,7 @@ Specify query options to return only the `city` field:
 
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< jupyter-example set="py_home_json" lang_filter="Python" step="query3" depends="import" description="Aggregation queries: Use GROUP BY and COUNT operations to summarize and analyze indexed data" difficulty="advanced" />}}
@@ -134,8 +134,8 @@ the `idx:users` index used for JSON documents in the previous examples:
 {{< jupyter-example set="py_home_json" lang_filter="Python" step="make_hash_index" depends="import" description="Foundational: Create a search index for hash documents with HASH index type and field definitions" difficulty="intermediate" />}}
 
 
-You use [`hset()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`json().set()`]({{< relref "/commands/json.set" >}}),
+You use [`hset()`](/content/commands/hset.md) to add the hash
+documents instead of [`json().set()`](/content/commands/json.set.md),
 but the same flat `userX` dictionaries work equally well with either
 hash or JSON:
 
@@ -150,5 +150,5 @@ result `Document` object instead of in an enclosing `json` dictionary:
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/redis-py/scaniter.md
+++ b/content/develop/clients/redis-py/scaniter.md
@@ -18,15 +18,15 @@ weight: 60
 Redis has a small family of related commands that retrieve
 keys and, in some cases, their associated values:
 
--   [`SCAN`]({{< relref "/commands/scan" >}}) retrieves keys
+-   [`SCAN`](/content/commands/scan.md) retrieves keys
     from the main Redis keyspace.
--   [`HSCAN`]({{< relref "/commands/hscan" >}}) retrieves keys and optionally,
+-   [`HSCAN`](/content/commands/hscan.md) retrieves keys and optionally,
     their values from a
-    [hash]({{< relref "/develop/data-types/hashes" >}}) object.
--   [`SSCAN`]({{< relref "/commands/sscan" >}}) retrieves keys from a
-    [set]({{< relref "/develop/data-types/sets" >}}) object.
--   [`ZSCAN`]({{< relref "/commands/zscan" >}}) retrieves keys and their score values from a
-    [sorted set]({{< relref "/develop/data-types/sorted-sets" >}}) object.
+    [hash](/content/develop/data-types/hashes.md) object.
+-   [`SSCAN`](/content/commands/sscan.md) retrieves keys from a
+    [set](/content/develop/data-types/sets.md) object.
+-   [`ZSCAN`](/content/commands/zscan.md) retrieves keys and their score values from a
+    [sorted set](/content/develop/data-types/sorted-sets.md) object.
 
 These commands can potentially return large numbers of results, so Redis
 provides a paging mechanism to access the results in small, separate batches.
@@ -43,7 +43,7 @@ Each of the commands has its own equivalent iterator. The following example show
 how to use a `SCAN` iterator on the Redis keyspace. Note that, as with the `SCAN`
 command, the results are not sorted into any particular order, . Also, you
 can pass `match`, `count`, and `_type` parameters to `scan_iter()` to constrain
-the set of keys it returns (see the [`SCAN`]({{< relref "/commands/scan" >}})
+the set of keys it returns (see the [`SCAN`](/content/commands/scan.md)
 command page for examples). 
 
 ```py

--- a/content/develop/clients/redis-py/transpipe.md
+++ b/content/develop/clients/redis-py/transpipe.md
@@ -21,11 +21,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -62,7 +62,7 @@ to different keys. The basic idea is to watch for changes to any
 keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The example below shows how to repeatedly attempt a transaction with a watched

--- a/content/develop/clients/redis-py/vecsearch.md
+++ b/content/develop/clients/redis-py/vecsearch.md
@@ -25,14 +25,14 @@ topics:
 weight: 40
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}}) 
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md) 
 reference page for more information).
 Among other things, vector fields can store *text embeddings*, which are AI-generated vector
 representations of the semantic information in pieces of text. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings indicates how similar they are semantically. By comparing the
 similarity of an embedding generated from some query text with embeddings stored in hash
 or JSON fields, Redis can retrieve documents that closely match the query in terms
@@ -45,18 +45,18 @@ Redis Search. The code is first demonstrated for hash documents with a
 separate section to explain the
 [differences with JSON documents](#differences-with-json-documents).
 
-{{< note >}}From [v6.0.0](https://github.com/redis/redis-py/releases/tag/v6.0.0) onwards,
-`redis-py` uses query dialect 2 by default.
-Redis Search methods such as [`ft().search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v6.0.0](https://github.com/redis/redis-py/releases/tag/v6.0.0) onwards,
+> `redis-py` uses query dialect 2 by default.
+> Redis Search methods such as [`ft().search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Install [`redis-py`]({{< relref "/develop/clients/redis-py" >}}) if you
+Install [`redis-py`](/content/develop/clients/redis-py/_index.md) if you
 have not already done so. Also, install `sentence-transformers` with the
 following command:
 
@@ -96,12 +96,12 @@ the index doesn't already exist, which is why you need the
 Next, create the index.
 The schema in the example below specifies hash objects for storage and includes
 three fields: the text content to index, a
-[tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+[tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
 field to represent the "genre" of the text, and the embedding vector generated from
 the original text content. The `embedding` field specifies
-[HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}})
+[HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index)
 indexing, the
-[L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
@@ -111,7 +111,7 @@ and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 ## Add data
 
 You can now supply the data objects, which will be indexed automatically
-when you add them with [`hset()`]({{< relref "/commands/hset" >}}), as long as
+when you add them with [`hset()`](/content/commands/hset.md), as long as
 you use the `doc:` prefix specified in the index definition.
 
 Use the `model.encode()` method of `SentenceTransformer`
@@ -137,7 +137,7 @@ results in order of this numeric similarity value.
 The code below creates the query embedding using `model.encode()`, as with
 the indexing, and passes it as a parameter when the query executes
 (see
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about using query parameters with embeddings).
 
 {{< clients-example set="home_query_vec" step="query" lang_filter="Python" description="Vector similarity search: Find semantically similar documents by comparing query embeddings with indexed vectors using L2 distance" difficulty="intermediate" >}}
@@ -185,7 +185,7 @@ is the result that is most similar in meaning to the query text
 
 Indexing JSON documents is similar to hash indexing, but there are some
 important differences. JSON allows much richer data modelling with nested fields, so
-you must supply a [path]({{< relref "/develop/data-types/json/path" >}}) in the schema
+you must supply a [path](/content/develop/data-types/json/path.md) in the schema
 to identify each field you want to index. However, you can declare a short alias for each
 of these paths (using the `as_name` keyword argument) to avoid typing it in full for
 every query. Also, you must specify `IndexType.JSON` when you create the index.
@@ -196,8 +196,8 @@ the one created previously for hashes:
 {{< clients-example set="home_query_vec" step="json_index" lang_filter="Python" description="Foundational: Create a vector search index for JSON documents with JSON paths and field aliases" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-Use [`json().set()`]({{< relref "/commands/json.set" >}}) to add the data
-instead of [`hset()`]({{< relref "/commands/hset" >}}). The dictionaries
+Use [`json().set()`](/content/commands/json.set.md) to add the data
+instead of [`hset()`](/content/commands/hset.md). The dictionaries
 that specify the fields have the same structure as the ones used for `hset()`
 but `json().set()` receives them in a positional argument instead of
 the `mapping` keyword argument.
@@ -241,6 +241,6 @@ Result{
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about the indexing options, distance metrics, and query format
 for vectors.

--- a/content/develop/clients/redis-py/vecsets.md
+++ b/content/develop/clients/redis-py/vecsets.md
@@ -21,14 +21,14 @@ topics:
 - vectors
 ---
 
-A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+A Redis [vector set](/content/develop/data-types/vector-sets/_index.md) lets
 you store a set of unique keys, each with its own associated vector.
 You can then retrieve keys from the set according to the similarity between
 their stored vectors and a query vector that you specify.
 
 You can use vector sets to store any type of numeric vector but they are
 particularly optimized to work with text embedding vectors (see
-[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+[Redis for AI](/content/develop/ai/_index.md) to learn more about text
 embeddings). The example below shows how to use the
 [`sentence-transformers`](https://pypi.org/project/sentence-transformers/)
 library to generate vector embeddings and then
@@ -90,18 +90,18 @@ Use the
 method of `SentenceTransformer` to generate the
 embedding as an array of `float32` values. The `tobytes()` method converts
 the array to a byte string that you can pass to the
-[`vadd()`]({{< relref "/commands/vadd" >}}) command to set the embedding.
+[`vadd()`](/content/commands/vadd.md) command to set the embedding.
 Note that `vadd()` can also accept a list of `float` values to set the
 vector, but the byte string format is more compact and saves a little
 transmission time. If you later use
-[`vemb()`]({{< relref "/commands/vemb" >}}) to retrieve the embedding,
+[`vemb()`](/content/commands/vemb.md) to retrieve the embedding,
 it will return the vector as an array rather than the original byte
 string (note that this is different from the behavior of byte strings in
-[hash vector indexing]({{< relref "/develop/ai/search-and-query/vectors" >}})).
+[hash vector indexing](/content/develop/ai/search-and-query/vectors/_index.md)).
 
 The call to `vadd()` also adds the `born` and `died` values from the
 original dictionary as attribute data. You can access this during a query
-or by using the [`vgetattr()`]({{< relref "/commands/vgetattr" >}}) method.
+or by using the [`vgetattr()`](/content/commands/vgetattr.md) method.
 
 {{< clients-example set="home_vecsets" step="add_data" lang_filter="Python" description="Foundational: Add vector embeddings and attributes to a vector set using VADD command" difficulty="beginner" >}}
 {{< /clients-example >}}
@@ -111,7 +111,7 @@ or by using the [`vgetattr()`]({{< relref "/commands/vgetattr" >}}) method.
 You can now query the data in the set. The basic approach is to use the
 `encode()` method to generate another embedding vector for the query text.
 (This is the same method used to add the elements to the set.) Then, pass
-the query vector to [`vsim()`]({{< relref "/commands/vsim" >}}) to return elements
+the query vector to [`vsim()`](/content/commands/vsim.md) to return elements
 of the set, ranked in order of similarity to the query.
 
 Start with a simple query for "actors":
@@ -161,7 +161,7 @@ mathematicians. This seems reasonable given the connection between mathematics
 and science.
 
 You can also use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 with `vsim()` to restrict the search further. For example,
 repeat the "science" query, but this time limit the results to people
 who died before the year 2000:
@@ -178,16 +178,16 @@ elements that have already been filtered out of the search.
 
 ## More information
 
-See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+See the [vector sets](/content/develop/data-types/vector-sets/_index.md)
 docs for more information and code examples. See the
-[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+[Redis for AI](/content/develop/ai/_index.md) section for more details
 about text embeddings and other AI techniques you can use with Redis.
 
 You may also be interested in
-[vector search]({{< relref "/develop/clients/redis-py/vecsearch" >}}).
+[vector search](/content/develop/clients/redis-py/vecsearch.md).
 This is a feature of
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 that lets you retrieve
-[JSON]({{< relref "/develop/data-types/json" >}}) and
-[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+[JSON](/content/develop/data-types/json/_index.md) and
+[hash](/content/develop/data-types/hashes.md) documents based on
 vector data stored in their fields.


### PR DESCRIPTION
Part 4 of 4. **Stack:** #3795 → #3796 → #3797 → **#3798 (this)**

## What this is

One section migrated end to end, as the investigation's proof: **147 links** to repo-root-relative `/content/` paths and **8 note shortcodes** to native blockquote alerts. The source becomes standard Markdown that resolves in VS Code and GitHub as well as in Hugo, with unchanged published output.

## Why `/content/` rather than `../../../`

@dwdougherty objected on #3732 that source-relative links produced long parent-traversal chains — fair: 3 levels on 34 of the 147 links, 2 or more on 100. Both GitHub's rendered view and VS Code resolve a **leading slash against the repository root**, so the `/content/` prefix is what makes one link work in all three places.

It also behaves better on the doubly-mounted Active-Active tree, where the same source is served under two URLs:

| Notation | under `/operate/rs` | under `/operate/rc` |
|---|---|---|
| `relref` | `/operate/rs/…` | `/operate/**rs**/…` |
| `/content/…md` | `/operate/rs/…` | `/operate/**rs**/…` |
| `../…md` | `/operate/rs/…` | `/operate/**rc**/…` |

Repo-root-relative tracks `relref` exactly; source-relative is the one that diverges. So this notation is the faithful `relref` replacement, and the form it replaces was quietly changing behaviour on that tree.

## Verified

No href differences across the migrated pages or either Active-Active mount, no new warnings, no errors, build time unchanged.

**Caveat worth stating plainly:** HTML parity is *not* feed parity. The `.md`/`.json` outputs were broken for these pages both before and after the notation change, which is why the pipeline fix in #3796 is a **prerequisite** in this stack rather than a follow-up.

## Open question for reviewers

`relref` is unaffected and still works — 30,218 calls across 4,027 files build warning-free alongside these plain links. But Hugo resolves `/develop/x`, `/develop/x.md` and bare `develop/x` to the same correct URL with **no warning**, so it cannot distinguish "portable" from "merely working". A non-`/content/` link builds a clean site and is silently broken in GitHub and VS Code. If we standardise on this, it wants a lint — `.claude/hooks/check_shortcode_paths.py` validates `relref`/`image`/`embed-*` today and gives plain Markdown links no validation at all.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout formatting; no runtime, auth, or application code changes.
> 
> **Overview**
> **Migrates the entire `develop/clients/redis-py` doc section** from Hugo `{{< relref >}}` internal links to repo-root-relative `/content/...` Markdown paths (about **147 links** across 15 pages), so the same sources resolve in Hugo, GitHub, and VS Code without long `../` chains.
> 
> **Replaces eight `{{< note >}}` shortcodes** with native `> [!NOTE]` blockquote alerts on pages such as `amr.md`, `connect.md`, `failover.md`, `queryjson.md`, and `vecsearch.md`. Hugo `{{% alert %}}` and example shortcodes (`clients-example`, `jupyter-example`) are unchanged.
> 
> This is a **notation-only** change: no redis-py API or behavior updates—only cross-references and callout markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ccb29171eed6362188c8ba1779452849d0c272e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->