### PR TITLE
DEV: update OSS version mgmt page for 8.10

### DIFF
--- a/content/operate/oss_and_stack/install/version-mgmt.md
+++ b/content/operate/oss_and_stack/install/version-mgmt.md
@@ -36,11 +36,12 @@ Redis uses two release types within a major version:
 
 | Version | Release type | Status | EOL Date |
 |---------|--------------|--------|----------|
-| **Redis 8.8** | Standard | GA | TBD |
-| **Redis 8.6** | Standard | GA | TBD |
-| **Redis 8.4** | Standard | GA | TBD |
-| **Redis 8.2** | Extended | GA | September 1, 2030 |
-| **Redis 8.0** | Standard | GA | December 1, 2026 |
-| **Redis 7.4** | Extended | GA | December 1, 2029 |
-| **Redis 7.2** | Extended | GA | December 1, 2029 |
-| **Redis 6.2** | Extended | GA | April 1, 2027 |
+| **Redis 8.10** | Standard | GA | TBD |
+| **Redis 8.8**  | Standard | GA | TBD |
+| **Redis 8.6**  | Standard | GA | TBD |
+| **Redis 8.4**  | Standard | GA | TBD |
+| **Redis 8.2**  | Extended | GA | September 1, 2030 |
+| **Redis 8.0**  | Standard | GA | December 1, 2026 |
+| **Redis 7.4**  | Extended | GA | December 1, 2029 |
+| **Redis 7.2**  | Extended | GA | December 1, 2029 |
+| **Redis 6.2**  | Extended | GA | April 1, 2027 |


### PR DESCRIPTION
I botched the ticket number; it should be DOC-6963. Darn failing eyes.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to a version support matrix with no runtime or security logic.
> 
> **Overview**
> Updates the **Supported versions** table on the OSS version management page to list **Redis 8.10** as a **Standard** release in **GA** with **EOL TBD**, at the top of the 8.x entries.
> 
> Also adjusts column spacing in the table for alignment; no other policy or lifecycle text changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a843e088a86062ecac055411a6be9e49a9ccaf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->