### PR TITLE
RS: add RED-186912 security entry

### DIFF
--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
@@ -220,6 +220,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
 - Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
@@ -248,6 +250,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
 - Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
@@ -275,6 +279,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
@@ -330,6 +336,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
 - Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
@@ -379,6 +387,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
@@ -431,6 +441,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
@@ -527,6 +539,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -242,6 +242,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
 - Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
@@ -270,6 +272,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
 - Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
@@ -297,6 +301,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
@@ -352,6 +358,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
 - Insufficient sanitization of Lua script error messages can allow an authenticated user with `EVAL` permission to inject arbitrary RESP protocol responses, leading to denial of service, data manipulation, and connection pool poisoning.
@@ -401,6 +409,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
@@ -453,6 +463,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 
@@ -549,6 +561,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - (CVE-2026-25588) A vulnerability in the `RESTORE` command, when used with the RedisTimeSeries module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE‑2026‑25589) A vulnerability in the `RESTORE` command, when used with the RedisBloom module, allows an authenticated attacker to trigger invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
+
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
 
 - (CVE-2026-23631) An authenticated user may exploit the synchronization mechanism of the master-replica and trigger a use-after-free vulnerability, potentially leading to remote code execution. The bug affects only replicas that are configured, or may be configured with `replica-read-only` disabled, and exists in all versions of Redis with Lua scripting.
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to release notes; no product code or configuration changes.
> 
> **Overview**
> Adds a **Redis Open Source security fixes** bullet for ticket **RED-186912** in the August 2026 Redis Software release notes for **8.0.20-96** and **8.2.0-46**.
> 
> The new entry (no CVE label in the text) states that **`RESTORE`** and **RDB loading** can allow an authenticated user to trigger a **use-after-free in stream consumer groups** via a crafted serialized payload, with possible **remote code execution**. It is inserted in the same position in each per-version collapsible block (Redis 8.6.x through 6.2.x), immediately after the RedisBloom `RESTORE` CVE bullets and before CVE-2026-23631.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11532449dd2be29c780e7e361f42557ae1eeee42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->