### PR TITLE
DEV/OP: raise visibility of new redis-cli installation method

### DIFF
--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -31,7 +31,9 @@ This topic covers the different aspects of `redis-cli`, starting from the simple
 
 ## Install `redis-cli`
 
-You have several options for installing or using `redis-cli`.
+You have several options for installing or using `redis-cli`. The easiest method is to install the standalone `redis-cli` binary for Linux or macOS. See the [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) page for more information.
+
+Other methods include:
 
 - [Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}). The `redis-cli` utility is installed as part of each installation method.
 - [Build Redis from source]({{< relref "/operate/oss_and_stack/install/build-stack" >}}). Instead of building everything, you can just run the following command:
@@ -39,7 +41,6 @@ You have several options for installing or using `redis-cli`.
     `$ make redis-cli`.
     
     The `redis-cli` utility will be built in the `/path/to/redis-source/src` directory as `/path/to/redis-source/src/redis-cli`.
-- [Install the standalone `redis-cli` binary]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) for Linux or macOS.
 
 If you prefer not to install Redis, you can also run `redis-cli` in Docker. See the [Run `redis-cli` using Docker]({{< relref "/operate/oss_and_stack/install/install-stack/docker/#connect-with-redis-cli" >}}) page for instructions.
 

--- a/content/operate/rc/databases/connect/_index.md
+++ b/content/operate/rc/databases/connect/_index.md
@@ -139,6 +139,8 @@ The [`redis-cli`]({{< relref "/develop/tools/cli" >}}) utility is installed when
 
 To run `redis-cli`, [install Redis]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) on your machine. After it's installed, copy the `redis-cli` command under **Redis CLI** in the connection wizard and enter it into your terminal. If the username and password are not already filled in, replace `<username>` and `<password>` with your username and password.
 
+If you only need the Redis CLI (`redis-cli`) and not the full Redis Open Source distribution, you can [install the standalone `redis-cli` binary]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) on Linux or macOS.
+
 See [Redis CLI]({{< relref "/develop/tools/cli" >}}) to learn how to use `redis-cli`.
 
 ## More info

--- a/content/operate/rc/rc-quickstart.md
+++ b/content/operate/rc/rc-quickstart.md
@@ -170,6 +170,8 @@ The [`redis-cli`]({{< relref "/develop/tools/cli" >}}) utility is installed when
 
 To run `redis-cli`, [install Redis]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}) on your machine.
 
+If you only need the Redis CLI (`redis-cli`) and not the full Redis Open Source distribution, you can [install the standalone `redis-cli` binary]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) on Linux or macOS.
+
 See [Redis CLI]({{< relref "/develop/tools/cli" >}}) to learn how to use `redis-cli`.
 
 ## More info

--- a/content/operate/rs/databases/connect/test-client-connectivity.md
+++ b/content/operate/rs/databases/connect/test-client-connectivity.md
@@ -56,6 +56,8 @@ OK
 "123"
 ```
 
+To connect from your own machine rather than from a cluster node, you can [install the standalone `redis-cli` binary]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) on Linux or macOS.
+
 For more `redis-cli` connection examples, see the [`redis-cli` reference]({{< relref "/operate/rs/references/cli-utilities/redis-cli" >}}).
 
 ### Connect with Redis Insight

--- a/content/operate/rs/references/cli-utilities/redis-cli/_index.md
+++ b/content/operate/rs/references/cli-utilities/redis-cli/_index.md
@@ -29,6 +29,8 @@ To learn how to install Redis and `redis-cli`, see the following installation gu
 
 - [Redis Software with Docker]({{< relref "/operate/rs/installing-upgrading/quickstarts/docker-quickstart" >}})
 
+If you only need `redis-cli` on your local machine to connect to a remote database, you can [install the standalone `redis-cli` binary]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) on Linux or macOS, without installing the full Redis Open Source distribution.
+
 ## Connect to a database
 
 To run Redis commands with `redis-cli`, you need to connect to your Redis database.


### PR DESCRIPTION
... on RC and RS pages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording and internal links; no product, auth, or runtime behavior changes.
> 
> **Overview**
> Documentation updates **raise visibility** of the standalone **`redis-cli`** install path (`install-redis-cli`) on Redis Cloud, Redis Software, and developer CLI topics.
> 
> On **`cli.md`**, the **Install `redis-cli`** section now calls the standalone Linux/macOS binary the **easiest** option up front (with a link to the install page) and groups full Redis install, source build, and Docker under **Other methods**, removing the duplicate standalone bullet from that list.
> 
> **Redis Cloud** (`connect/_index.md`, `rc-quickstart.md`) and **Redis Software** (`test-client-connectivity.md`, `redis-cli/_index.md`) each add a short note that readers can install the **standalone binary** when they only need the CLI to connect remotely, without installing the full Redis Open Source distribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c889de9a2188f6e7333d8787a3beee95b95a8990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->