### PR TITLE
Link search and RAG pages to the AI agent builder

### DIFF
--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -46,7 +46,7 @@ Here are the next steps to get you started:
 1. Learn how to [create an index]({{< relref "/develop/ai/search-and-query/indexing/" >}}).
 1. Learn how to [query your data]({{< relref "/develop/ai/search-and-query/query/" >}}).
 1. [Install Redis Insight]({{< relref "/operate/redisinsight" >}}), connect it to your Redis database, and then use [Redis Copilot]({{< relref "/develop/tools/insight" >}}#redis-copilot) to help you learn how to execute complex queries against your own data using simple, plain language prompts.
-1. Want working code to start from? Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template to generate a complete RAG agent built on Redis vector search.
+1. Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template to generate a working RAG agent built on Redis vector search.
 
 {{< alert title="Try it out" >}}
 Experiment with Redis Search interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.

--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -46,6 +46,7 @@ Here are the next steps to get you started:
 1. Learn how to [create an index]({{< relref "/develop/ai/search-and-query/indexing/" >}}).
 1. Learn how to [query your data]({{< relref "/develop/ai/search-and-query/query/" >}}).
 1. [Install Redis Insight]({{< relref "/operate/redisinsight" >}}), connect it to your Redis database, and then use [Redis Copilot]({{< relref "/develop/tools/insight" >}}#redis-copilot) to help you learn how to execute complex queries against your own data using simple, plain language prompts.
+1. Want working code to start from? Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template to generate a complete RAG agent built on Redis vector search.
 
 {{< alert title="Try it out" >}}
 Experiment with Redis Search interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.

--- a/content/develop/ai/search-and-query/_index.md
+++ b/content/develop/ai/search-and-query/_index.md
@@ -48,10 +48,6 @@ Here are the next steps to get you started:
 1. [Install Redis Insight]({{< relref "/operate/redisinsight" >}}), connect it to your Redis database, and then use [Redis Copilot]({{< relref "/develop/tools/insight" >}}#redis-copilot) to help you learn how to execute complex queries against your own data using simple, plain language prompts.
 1. Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template to generate a working RAG agent built on Redis vector search.
 
-{{< alert title="Try it out" >}}
-Experiment with Redis Search interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.
-{{< /alert >}}
-
 {{< tip >}}
 See Redis vector search in a real workflow: [Redis Repo Memory](https://github.com/marketplace/actions/redis-repo-memory) is a GitHub Action that surfaces related past PRs, issues, and commits on every pull request. Add it to any repository in a few minutes.
 {{< /tip >}}
@@ -63,6 +59,10 @@ See
 [Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
 [Install Redis Software]({{< relref "/operate/rs/installing-upgrading/install" >}})
 for full installation instructions.
+
+{{< alert title="Try it out" >}}
+Experiment with Redis Search interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.
+{{< /alert >}}
 
 ## License and source code
 

--- a/content/develop/ai/search-and-query/query/vector-search.md
+++ b/content/develop/ai/search-and-query/query/vector-search.md
@@ -22,7 +22,7 @@ This article gives you a good overview of how to perform vector search queries w
 A vector search query on a vector field allows you to find all vectors in a vector space that are close to a given vector. You can query for the k-nearest neighbors or vectors within a given radius.
 
 {{< tip >}}
-Want a working example instead of building from scratch? Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template to generate a complete RAG agent that uses the vector search queries described here.
+To generate a complete RAG agent that uses the vector search queries described here, open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template.
 {{< /tip >}}
 
 The examples in this article use a schema with the following fields:

--- a/content/develop/ai/search-and-query/query/vector-search.md
+++ b/content/develop/ai/search-and-query/query/vector-search.md
@@ -21,6 +21,10 @@ This article gives you a good overview of how to perform vector search queries w
 
 A vector search query on a vector field allows you to find all vectors in a vector space that are close to a given vector. You can query for the k-nearest neighbors or vectors within a given radius.
 
+{{< tip >}}
+Want a working example instead of building from scratch? Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template to generate a complete RAG agent that uses the vector search queries described here.
+{{< /tip >}}
+
 The examples in this article use a schema with the following fields:
 
 | JSON field               | Field alias | Field type  | Description |

--- a/content/develop/ai/search-and-query/vectors/_index.md
+++ b/content/develop/ai/search-and-query/vectors/_index.md
@@ -22,7 +22,7 @@ weight: 8
 
 Redis includes a [high-performance vector database](https://redis.io/blog/benchmarking-results-for-vector-databases/) that lets you perform semantic searches over vector embeddings. You can augment these searches with filtering over text, numerical, geospatial, and tag metadata.
 
-To quickly get started, check out the [Redis vector quickstart guide]({{< relref "develop/get-started/search-tutorial/vector-search" >}}) and the [Redis AI Resources](https://github.com/redis-developer/redis-ai-resources) Github repo. For a ready-to-run example, open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template.
+To quickly get started, check out the [Redis vector quickstart guide]({{< relref "develop/get-started/search-tutorial/vector-search" >}}) and the [Redis AI Resources](https://github.com/redis-developer/redis-ai-resources) Github repo. To generate a working example, open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template.
 
 {{< alert title="See vector search in action" >}}
 [Redis Repo Memory](https://github.com/marketplace/actions/redis-repo-memory) is a GitHub Action that gives your repository a memory: on every pull request it embeds the change and uses Redis KNN vector search to surface semantically related past PRs, issues, and commits — a concise, real-world example of the concepts on this page. See the [source on GitHub](https://github.com/redis-learn/redis-repo-memory).

--- a/content/develop/ai/search-and-query/vectors/_index.md
+++ b/content/develop/ai/search-and-query/vectors/_index.md
@@ -22,7 +22,7 @@ weight: 8
 
 Redis includes a [high-performance vector database](https://redis.io/blog/benchmarking-results-for-vector-databases/) that lets you perform semantic searches over vector embeddings. You can augment these searches with filtering over text, numerical, geospatial, and tag metadata.
 
-To quickly get started, check out the [Redis vector quickstart guide]({{< relref "develop/get-started/search-tutorial/vector-search" >}}) and the [Redis AI Resources](https://github.com/redis-developer/redis-ai-resources) Github repo.
+To quickly get started, check out the [Redis vector quickstart guide]({{< relref "develop/get-started/search-tutorial/vector-search" >}}) and the [Redis AI Resources](https://github.com/redis-developer/redis-ai-resources) Github repo. For a ready-to-run example, open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template.
 
 {{< alert title="See vector search in action" >}}
 [Redis Repo Memory](https://github.com/marketplace/actions/redis-repo-memory) is a GitHub Action that gives your repository a memory: on every pull request it embeds the change and uses Redis KNN vector search to surface semantically related past PRs, issues, and commits — a concise, real-world example of the concepts on this page. See the [source on GitHub](https://github.com/redis-learn/redis-repo-memory).

--- a/content/develop/get-started/rag.md
+++ b/content/develop/get-started/rag.md
@@ -29,6 +29,10 @@ RAG involves three main steps:
 RAG enables LLMs to use real-time information, improving the accuracy and relevance of generated content.
 Redis is ideal for RAG due to its speed, versatility, and familiarity.
 
+{{< tip >}}
+Prefer to start from working code? Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template — it generates a complete RAG agent with document ingestion, hybrid retrieval, and citations.
+{{< /tip >}}
+
 ### The role of Redis in RAG
 
 Redis provides a robust platform for managing real-time data. It supports the storage and retrieval of vectors, essential for handling large-scale, unstructured data and performing similarity searches. Key features and components of Redis that make it suitable for RAG include:

--- a/content/develop/get-started/rag.md
+++ b/content/develop/get-started/rag.md
@@ -30,7 +30,7 @@ RAG enables LLMs to use real-time information, improving the accuracy and releva
 Redis is ideal for RAG due to its speed, versatility, and familiarity.
 
 {{< tip >}}
-Prefer to start from working code? Open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template — it generates a complete RAG agent with document ingestion, hybrid retrieval, and citations.
+To generate a complete RAG agent with document ingestion, hybrid retrieval, and citations, open the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) and choose the **Knowledge Assistant** template.
 {{< /tip >}}
 
 ### The role of Redis in RAG


### PR DESCRIPTION
Add pointers from the high-traffic search and RAG pages to the AI agent builder, telling readers to choose the Knowledge Assistant template to generate a working RAG agent built on Redis vector search:

- Redis Search overview: a next-step list item (the page already has other callouts, so this avoids stacking a third box)
- Vector search concepts: appended to the intro
- Vector search how-to and the RAG quick start: a tip callout each

The Redis Agent Memory pages are deferred: they should point at the Redis Iris Conversational Assistant template, which ships with a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only cross-links and callout placement; no product code, APIs, or runtime behavior changes.
> 
> **Overview**
> Routes readers from high-traffic **Redis Search**, **vector search**, and **RAG** docs to the [AI agent builder]({{< relref "/develop/ai/agent-builder" >}}) with the **Knowledge Assistant** template, so they can scaffold a working RAG agent on Redis vector search instead of only following tutorials.
> 
> On the **Redis Search** overview, a new “next steps” list item replaces an earlier playground alert in that spot; the **Try it out** playground callout moves to the **Enable Redis Search** section so the intro does not stack extra boxes. **Vector search concepts** adds a short inline pointer in the intro; the **vector search how-to** and **RAG with Redis** pages each get a `tip` callout (ingestion, hybrid retrieval, citations on the RAG page).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea504b2ff26fb235b03a738084a692121c4a4570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->