### PR TITLE
Fix incorrect rladmin command in create-certificates.md (Fixes #3737)

### DIFF
--- a/content/operate/rs/security/certificates/create-certificates.md
+++ b/content/operate/rs/security/certificates/create-certificates.md
@@ -600,7 +600,7 @@ After creating and validating your certificates, install them on the Redis Softw
 1. Check certificate status:
 
     ```sh
-    rladmin status certificates
+    openssl x509 -in /path/to/redis-cert-chain.pem -noout -dates
     ```
 
 1. View certificate details:


### PR DESCRIPTION
Fixes #3737

## Problem
The "Install certificates" section instructed users to check certificate status using:

    rladmin status certificates

This command doesn't work — `rladmin` has no `certificates` subcommand, resulting in:

    ERROR: invalid token 'certificates'

## Fix
Replaced the incorrect command with an `openssl x509` command to verify the installed certificate's expiration dates, as suggested in the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction; no product code or operational behavior changes.
> 
> **Overview**
> Fixes **#3737** in the **Install certificates** section of `create-certificates.md`.
> 
> The post-install step **Check certificate status** no longer tells users to run `rladmin status certificates` (invalid `rladmin` subcommand). It now uses **`openssl x509 -in /path/to/redis-cert-chain.pem -noout -dates`**, aligned with the validation section elsewhere in the same doc. The following **View certificate details** step (`rladmin info cluster`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a313deeb1d3c22330dde3cc59553f38b946ebd6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->