### PR TITLE
Fix incorrect rladmin command in create-certificates.md (fixes #3737)

### DIFF
--- a/content/operate/rs/security/certificates/create-certificates.md
+++ b/content/operate/rs/security/certificates/create-certificates.md
@@ -600,7 +600,7 @@ After creating and validating your certificates, install them on the Redis Softw
 1. Check certificate status:
 
     ```sh
-    rladmin status certificates
+    openssl x509 -in /path/to/redis-cert-chain.pem -noout -dates
     ```
 
 1. View certificate details:

--- a/content/operate/rs/security/certificates/create-certificates.md
+++ b/content/operate/rs/security/certificates/create-certificates.md
@@ -603,11 +603,7 @@ After creating and validating your certificates, install them on the Redis Softw
     openssl x509 -in /etc/opt/redislabs/<cert-name>_cert.pem -noout -subject -issuer -dates
     ```
 
-1. View certificate details:
 
-    ```sh
-    rladmin info cluster
-    ```
 
 ### Troubleshooting
 

--- a/content/operate/rs/security/certificates/create-certificates.md
+++ b/content/operate/rs/security/certificates/create-certificates.md
@@ -597,10 +597,10 @@ After creating and validating your certificates, install them on the Redis Softw
     | `proxy` | Database endpoint proxy certificate |
     | `syncer` | Synchronization process certificate |
 
-1. Check certificate status:
+1. Verify the installed certificate:
 
     ```sh
-    openssl x509 -in /path/to/redis-cert-chain.pem -noout -dates
+    openssl x509 -in /etc/opt/redislabs/<cert-name>_cert.pem -noout -subject -issuer -dates
     ```
 
 1. View certificate details:


### PR DESCRIPTION
Fixes #3737

   ## Problem
   The "Install certificates" section instructed users to check certificate status using:

       rladmin status certificates

   This command doesn't work — `rladmin` has no `certificates` subcommand, resulting in:

       ERROR: invalid token 'certificates'

   ## Fix
   Replaced the incorrect command with an `openssl x509` command to verify the installed certificate's expiration dates, as suggested in the issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to install/verify steps; no product code or security behavior is modified.
> 
> **Overview**
> Fixes incorrect **Install certificates** guidance that told readers to run `rladmin status certificates`, which fails because `rladmin` has no `certificates` subcommand.
> 
> The post-install step is retitled to **Verify the installed certificate** and now uses `openssl x509` against `/etc/opt/redislabs/<cert-name>_cert.pem` to show subject, issuer, and validity dates. The follow-on **`rladmin info cluster`** step for certificate details is removed so verification is a single, working command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 401c8bb7fc1236643bb53462b6c3b12557501ecf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->