### PR TITLE
DOC-6967 Add Ruby (redis-rb) hash field expiration examples

### DIFF
--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -162,7 +162,7 @@ it runs on its own.
 Set a TTL of 60 seconds for two fields of a hash and then retrieve the remaining TTL for
 those fields:
 
-{{< clients-example set="hash_tutorial" step="hexpire" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set a TTL in seconds on individual hash fields using HEXPIRE, then read the remaining TTL with HTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
+{{< clients-example set="hash_tutorial" step="hexpire" description="Field expiration: Set a TTL in seconds on individual hash fields using HEXPIRE, then read the remaining TTL with HTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
 > DEL sensor:sensor1
 (integer) 0
 > HSET sensor:sensor1 air_quality 256 battery_level 89
@@ -177,7 +177,7 @@ those fields:
 
 Set a hash field's TTL in milliseconds and then retrieve the remaining TTL in milliseconds:
 
-{{< clients-example set="hash_tutorial" step="hpexpire" lang_filter="Python, Node.js, Java-Sync, Java-Async, Java-Reactive, Go, C#-Sync (SE.Redis), PHP, Rust-Sync, Rust-Async" description="Field expiration: Set a TTL in milliseconds on a hash field using HPEXPIRE, then read the remaining TTL with HPTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
+{{< clients-example set="hash_tutorial" step="hpexpire" description="Field expiration: Set a TTL in milliseconds on a hash field using HPEXPIRE, then read the remaining TTL with HPTTL" difficulty="intermediate" buildsUpon="set_get_all" >}}
 > DEL sensor:sensor1
 (integer) 1
 > HSET sensor:sensor1 air_quality 256 battery_level 89

--- a/local_examples/ruby/dt_hash.rb
+++ b/local_examples/ruby/dt_hash.rb
@@ -10,7 +10,7 @@ def assert_equal(expected, actual)
   raise "Expected #{expected.inspect}, got #{actual.inspect}" unless actual == expected
 end
 
-r.del('bike:1', 'bike:1:stats')
+r.del('bike:1', 'bike:1:stats', 'sensor:sensor1')
 # REMOVE_END
 
 # STEP_START set_get_all
@@ -116,5 +116,44 @@ assert_equal(1, res11)
 assert_equal(1, res12)
 assert_equal('3', res13)
 assert_equal(['1', '1'], res14)
+# REMOVE_END
+
+# STEP_START hexpire
+r.del('sensor:sensor1')
+r.hset('sensor:sensor1', { 'air_quality' => 256, 'battery_level' => 89 })
+
+# Set a TTL of 60 seconds on two fields of the hash.
+res15 = r.hexpire('sensor:sensor1', 60, 'air_quality', 'battery_level')
+puts res15.inspect # >>> [1, 1]
+
+# Retrieve the remaining TTL for those fields.
+res16 = r.httl('sensor:sensor1', 'air_quality', 'battery_level')
+puts res16.inspect # >>> [60, 60]
+# (your actual values may be slightly lower)
+# STEP_END
+
+# REMOVE_START
+assert_equal([1, 1], res15)
+raise "Unexpected TTLs: #{res16.inspect}" unless res16.all? { |ttl| ttl.positive? && ttl <= 60 }
+# REMOVE_END
+
+# STEP_START hpexpire
+r.del('sensor:sensor1')
+r.hset('sensor:sensor1', { 'air_quality' => 256, 'battery_level' => 89 })
+
+# Set the TTL of the 'air_quality' field in milliseconds.
+res17 = r.hpexpire('sensor:sensor1', 60_000, 'air_quality')
+puts res17.inspect # >>> [1]
+
+# Retrieve the remaining TTL in milliseconds.
+res18 = r.hpttl('sensor:sensor1', 'air_quality')
+puts res18.inspect # >>> [59999]
+# (your actual value may vary)
+# STEP_END
+
+# REMOVE_START
+assert_equal([1], res17)
+raise "Unexpected TTL: #{res18.inspect}" unless res18.all? { |pttl| pttl.positive? && pttl <= 60_000 }
+r.del('bike:1', 'bike:1:stats', 'sensor:sensor1')
 r.close
 # REMOVE_END


### PR DESCRIPTION
## DOC-6967 — Ruby (redis-rb) hash field expiration examples

Adds a **Ruby tab** to two of the three hash field expiration examples on
`content/develop/data-types/hashes.md`:

- `hexpire` — set a TTL in seconds on two fields with `hexpire`, read it back with `httl`
- `hpexpire` — set a TTL in milliseconds with `hpexpire`, read it back with `hpttl`

Both steps go into the existing `local_examples/ruby/dt_hash.rb` (which previously stopped
after `incrby_get_mget`), and each self-resets with `r.del` + `r.hset` so it stands alone.

### Why now — the exclusion was already stale

These three steps carry a `lang_filter` allowlist of ten clients that omits Ruby. That was
correct when authored under DOC-6887: the released gem was **5.4.1**, which had no
hash-field-expiration methods at all, so `hexpire` fell through `method_missing` and omitted
the required `FIELDS` keyword.

But gem **6.0.0** (published 2026-07-31) ships `hexpire`, `httl`,
`hpexpire(key, ttl, *fields, nx:/xx:/gt:/lt:)` and `hpttl` — verified by reading
`lib/redis/commands/hashes.rb` at tag `v6.0.0`, not inferred from release notes. Nothing
re-checked the premise, so the tab stayed suppressed after the reason for it expired. A
`lang_filter` exclusion encodes a *release-time* gap and rots silently, because a missing tab
looks identical whether a client can't do something or merely couldn't yet.

Surfaced by the daily upstream PR scan of Thu 13 Aug 2026 while chasing
[redis-rb#1374](https://github.com/redis/redis-rb/pull/1374).

### Also: two `lang_filter` allowlists removed

With Ruby added, the `hexpire` and `hpexpire` allowlists named **all 11 clients in the set**,
making them no-ops. Both are removed, which is a net simplification of the page source.

Verified rather than assumed — two isolated builds (`hugo -d <dir>`, not touching `public/`)
with the filters present vs removed:

| Output | Difference |
|---|---|
| `index.html` | identical apart from whitespace and one nanotime element id |
| `index.json` | **0** diff lines |
| `index.html.md` | **0** diff lines |

Tab order is unchanged because it comes from `config.toml`, not the filter — `lang_filter` has
exactly one consumer, [`clients-example.html:45`](layouts/shortcodes/clients-example.html#L45),
which sets the tab-selector scratch var and nothing else.

**The `hexpireat` allowlist stays, and is load-bearing.** Ruby is the only client without that
step, and `hexpireat`/`hpexpireat`/`hexpiretime`/`hpexpiretime` are absent from released gem
6.0.0 (they're in the still-open redis-rb#1374). Removing that filter would not hide Ruby's
tab — it would render Ruby's *entire file* into the page via the legacy fallback.

### Verification

| Layer | Status | How |
|---|---|---|
| Method names, arity, keywords | ✅ **run-verified** | `build/example-test-harness/run.sh hash_tutorial ruby` → **PASS**, against **Redis 8.8.0** and the **released** gem 6.0.0 |
| Wire serialization | ✅ **confirmed twice** | A stubbed replay predicted `HEXPIRE … FIELDS 2 air_quality battery_level`; a live server then echoed the identical arg list back |
| Expected-output comments | ✅ **observed** | `[1, 1]`, `[60, 60]`, `[1]`, `[59999]` — all four printed by the real run |
| Signatures vs API mapping | ✅ | `data/command-api-mapping/{HEXPIRE,HTTL,HPEXPIRE,HPTTL}.json`, key `redis_rb`, agree with the gem source |
| Rendered page | ✅ | Built HTML checked: Ruby on 6 of 7 blocks, 11 tabs on both new steps, 10 on `hexpireat`, no `REMOVE`/`HIDE` scaffolding in either pane |
| Independent review | ✅ | Codex review — `verdict: pass`, no findings (after one medium finding was fixed, see below) |

One comment was wrong before the run and would not have been caught by inspection: `hpttl`'s
expected value was **inherited from the Python tab as `59994`**, where Ruby actually returns
`59999`. Copying an expected value from a sibling tab is not verification of this one, even
when the wire format is identical. It now carries an observed value, and keeps its
"may vary" caveat because consecutive runs gave 59999 and 59998.

The Codex review's one finding was that the new output comments omitted the `>>>` marker. I'd
used plain comments to match this file's other four steps, but the check went against me: the
same set's other legacy-layout files (`local_examples/php/DtHashTest.php`,
`local_examples/rust-async/dt-hash.rs`) use `>>>` in **every** step, so the `dt_*.rb` family is
the outlier — and a reader compares tabs within one step block far more readily than steps
within one tab. Fixed; re-review came back clean.

### Out of scope, deliberately

- **The `hexpireat` step.** Blocked on redis-rb#1374, which is open and **not yet on `master`
  either** — `hashes.rb` at `master` is byte-identical to `v6.0.0`. Revisit when it ships in a
  released gem.
- **`data/command-api-mapping/` entries.** Already present for `redis_rb`; nothing to add.
- **Output-comment style in the other four steps.** This file is now internally mixed (two
  steps with `>>>`, four without), as are its six sibling `dt_*.rb` files. Normalizing all
  seven is mechanical but reader-visible, so it belongs in its own change.

### ⚠️ Pre-existing bug found while doing this — not fixed here

**`incrby_get_mget` has no `lang_filter`, and node-redis has no `incrby_get_mget` step.** So
that tab is hitting the whole-file fallback on the published page right now: the Node.js pane
renders the complete `dt-hash.js`, `import` lines and all, instead of the counter example.
Confirmed in the built HTML (`data-legacy-src` on that pane, body starting at `import`).

Two non-equivalent fixes — adding the step to the node-redis example (better; the other ten
clients all have it) or adding a `lang_filter` excluding Node.js (one line, but leaves a
coverage gap). Being tracked separately, along with whether other pages share the shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-harness only; no runtime product or security-sensitive code changes.
> 
> **Overview**
> Adds **Ruby (redis-rb)** runnable steps for hash field expiration on the hashes data-type page: `hexpire`/`httl` (second TTL) and `hpexpire`/`hpttl` (millisecond TTL), with self-contained `sensor:sensor1` setup and harness assertions in `local_examples/ruby/dt_hash.rb`.
> 
> On **`hashes.md`**, removes the `lang_filter` allowlists from the `hexpire` and `hpexpire` `clients-example` blocks so Ruby appears in those tabs now that redis-rb 6.0.0 supports the APIs. The `hexpireat` block keeps its filter (Ruby still lacks those commands).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3be4d3ab8c762cf12c57ee80a76b7d0811e1738. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->