### PR TITLE
DOC-6968 Fix two node-redis step names, and add the missing incr step for nine clients

### DIFF
--- a/.claude/skills/tce-examples/reference/testing.md
+++ b/.claude/skills/tce-examples/reference/testing.md
@@ -10,8 +10,24 @@ Two environments and one Codex gate. Client identity for all of them comes from
 | Dependencies | self-bootstrapped into `work/`, **cached** | tracked manifests in `fidelity/`, reinstalled every run |
 | Client repos | none needed | clones required (`bootstrap.sh`) |
 | C# / PHP | local stubs (`dotnet/stubs.cs`) | the real `Doc.csproj` / real PHPUnit |
-| Clients | 13 (no C) | 13 (no RedisVL) |
+| Clients | 17 of the 18 in `clients.tsv` (no RedisVL) | 17 of the 18 (no RedisVL) |
 | Speed | seconds once warm | minutes — full toolchain install per client |
+
+**C (hiredis) is the one client portable mode cannot bootstrap.** Every other portable
+runner installs its dependency into `work/` (`pip install redis`, `npm i redis`,
+`gem install redis`); hiredis is a system C library, so `run_hiredis` compiles against
+an existing install, searching `/usr/local`, `/opt/homebrew`, then `/usr` for
+`include/hiredis/hiredis.h` and baking the library path in with `-rpath`. Where hiredis
+is absent it reports `SKIP (hiredis headers not found ...)` rather than a compile-error
+FAIL, so a green run on a box without it still says nothing about the C examples —
+check for the SKIP rather than assuming coverage.
+
+**A client whose `portable` column is `-` is filtered out of the run list entirely**
+by `clients_for_mode()` — it gets no row at all, not a `SKIP`. The "no portable runner"
+FAIL branch only fires if you name that client explicitly on the command line. So
+"absent from the results table" and "passed" look identical when scanning output; count
+the rows against `clients.tsv` if coverage matters. (RedisVL is the only such client
+now.)
 
 **Iterate in portable, confirm in fidelity.** Portable is the fast loop because `work/`
 persists between runs. Fidelity is the pre-merge check: it runs the example the way the

--- a/build/example-test-harness/clients.tsv
+++ b/build/example-test-harness/clients.tsv
@@ -52,7 +52,7 @@ lettuce-sync	Lettuce-Sync	lettuce_sync	lettuce_sync	lettuce-sync	lettuce-sync	{S
 lettuce-async	Java-Async	lettuce_async	lettuce_async	lettuce-async	lettuce-async	{Set}Example.java	src/test/java/io/redis/examples/async	lettuce-async	src/test/java/io/redis/examples/async	lettuce-async
 lettuce-reactive	Java-Reactive	lettuce_reactive	lettuce_reactive	lettuce-reactive	lettuce-reactive	{Set}Example.java	src/test/java/io/redis/examples/reactive	lettuce-reactive	src/test/java/io/redis/examples/reactive	lettuce-reactive
 go-redis	Go	go_redis	go-redis	go-redis|go	go-redis	{set}_test.go	doctests	go-redis	.	go
-hiredis	C	hi_redis	-	hiredis|c	hiredis	{set}.c	examples	hiredis	.	-
+hiredis	C	hi_redis	-	hiredis|c	hiredis	{set}.c	examples	hiredis	.	hiredis
 nredisstack	C#-Sync (NRedisStack)	nredisstack_sync	nredisstack_sync	NRedisStack|nredisstack|dotnet-sync	nredisstack	{Set}Example.cs	tests/Doc	NRedisStack	tests/Doc	dotnet
 nredisstack-async	C#-Async (NRedisStack)	nredisstack_async	nredisstack_async	dotnet-async	nredisstack	{Set}Example.cs	tests/Doc/Async	NRedisStack	tests/Doc/Async	dotnet
 seredis	C#-Sync (SE.Redis)	seredis_sync	nredisstack_sync	seredis	seredis	{Set}Example.cs	tests/Doc	NRedisStack	tests/Doc	dotnet

--- a/build/example-test-harness/run.sh
+++ b/build/example-test-harness/run.sh
@@ -64,6 +64,16 @@ clients_for_mode() {
     awk -F'\t' '!/^#/ && NF>1 && $11!="-" {print $1}' "$TSV"
   fi
 }
+# The inverse: clients this mode cannot test at all. They never enter the drive loop, so
+# without an explicit row they produce NO output — indistinguishable from a pass when
+# scanning the summary. That is exactly how the C examples went untested unnoticed.
+clients_excluded_for_mode() {
+  if [ "$MODE" = fidelity ]; then
+    awk -F'\t' '!/^#/ && NF>1 && $9=="-" {print $1}' "$TSV"
+  else
+    awk -F'\t' '!/^#/ && NF>1 && $11=="-" {print $1}' "$TSV"
+  fi
+}
 
 CLIENTS_ALL=()
 while IFS= read -r c; do [ -n "$c" ] && CLIENTS_ALL+=("$c"); done < <(clients_for_mode)
@@ -338,10 +348,14 @@ hiredis_prefix() { # prints the first prefix containing hiredis/hiredis.h; non-z
 run_hiredis() {
   local d="$WORK/hiredis" p; mkdir -p "$d"
   p="$(hiredis_prefix)"
+  # Source FIRST, then -lhiredis: GNU ld resolves left to right, and Debian/Ubuntu default
+  # to --as-needed, which drops a library listed before any undefined symbol references it.
+  # macOS/ld64 tolerates either order, so getting this wrong fails only on Linux. Matches
+  # the order bootstrap.sh already uses for the fidelity C build.
   # -rpath bakes the library path into the binary, so it runs without callers having to
   # set DYLD_LIBRARY_PATH (macOS) or LD_LIBRARY_PATH (Linux). On compile failure the
   # compiler diagnostics stay in $LOG; on success the program's own output replaces them.
-  cc -I"$p/include" -L"$p/lib" -Wl,-rpath,"$p/lib" -lhiredis "$1" -o "$d/example" >"$LOG" 2>&1 \
+  cc "$1" -I"$p/include" -L"$p/lib" -Wl,-rpath,"$p/lib" -lhiredis -o "$d/example" >"$LOG" 2>&1 \
     && "$d/example" >"$LOG" 2>&1
   rc=$?
 }
@@ -615,6 +629,20 @@ for c in "${CLIENTS[@]}"; do
   if [ "${rc:-1}" -eq 0 ]; then SUMMARY+=("$c	PASS"); log ">> $c: PASS"
   else SUMMARY+=("$c	FAIL (results/${SET}_${c}.log)"); log ">> $c: FAIL"; fi
 done
+
+# Report the clients this mode cannot test, so "absent from the table" never masquerades as
+# "passed". Only on a full sweep — when clients were named explicitly, the existing "no
+# portable runner" FAIL already covers it.
+if [ $# -eq 0 ]; then
+  while IFS= read -r c; do
+    [ -n "$c" ] || continue
+    if [ "$MODE" = fidelity ]; then
+      SUMMARY+=("$c	SKIP (no fidelity dir in clients.tsv; portable only)")
+    else
+      SUMMARY+=("$c	SKIP (no portable runner in clients.tsv; try --fidelity)")
+    fi
+  done < <(clients_excluded_for_mode)
+fi
 
 log ""; log "=== RESULTS: $SET ==="
 for e in "${SUMMARY[@]}"; do printf '  %-18s %s\n' "${e%%	*}" "${e#*	}"; done

--- a/build/example-test-harness/run.sh
+++ b/build/example-test-harness/run.sh
@@ -140,6 +140,17 @@ toolchain_skip_reason() { # $1 = set, $2 = canonical client key, $3 = repo-relat
         return
       fi
       ;;
+    hiredis)
+      # Unlike every other portable client, hiredis cannot be bootstrapped into work/:
+      # it is a system C library (headers + shared object), not a pip/npm/gem package.
+      # Skip loudly where it is absent rather than FAILing with a compile error that
+      # says nothing about the example.
+      if ! hiredis_prefix >/dev/null; then
+        printf 'hiredis headers not found (looked in %s) — install hiredis to test the C examples' \
+          "$(printf '%s, ' "${HIREDIS_PREFIXES[@]}" | sed 's/, $//')"
+        return
+      fi
+      ;;
     ruby)
       # redis-rb gained native hexpire/httl in 6.0.0, and 6.x requires Ruby >= 3.2. On an
       # older Ruby (macOS still ships 2.6) the Gemfile resolves 5.4.1, where hexpire falls
@@ -313,6 +324,26 @@ run_python() {
 run_ruby() {
   gem list -i redis >/dev/null 2>&1 || gem install --silent redis >/dev/null 2>&1
   ruby "$1" >"$LOG" 2>&1; rc=$?
+}
+# Prefixes searched for a hiredis install, in order. Homebrew uses /usr/local on Intel
+# macOS and /opt/homebrew on Apple silicon; Linux distro packages land in /usr.
+HIREDIS_PREFIXES=(/usr/local /opt/homebrew /usr)
+hiredis_prefix() { # prints the first prefix containing hiredis/hiredis.h; non-zero if none
+  local p
+  for p in "${HIREDIS_PREFIXES[@]}"; do
+    [ -f "$p/include/hiredis/hiredis.h" ] && { printf '%s' "$p"; return 0; }
+  done
+  return 1
+}
+run_hiredis() {
+  local d="$WORK/hiredis" p; mkdir -p "$d"
+  p="$(hiredis_prefix)"
+  # -rpath bakes the library path into the binary, so it runs without callers having to
+  # set DYLD_LIBRARY_PATH (macOS) or LD_LIBRARY_PATH (Linux). On compile failure the
+  # compiler diagnostics stay in $LOG; on success the program's own output replaces them.
+  cc -I"$p/include" -L"$p/lib" -Wl,-rpath,"$p/lib" -lhiredis "$1" -o "$d/example" >"$LOG" 2>&1 \
+    && "$d/example" >"$LOG" 2>&1
+  rc=$?
 }
 run_node() {
   local d="$WORK/node"; mkdir -p "$d"

--- a/local_examples/cmds_string/hiredis/cmds_string.c
+++ b/local_examples/cmds_string/hiredis/cmds_string.c
@@ -23,7 +23,7 @@ int main(int argc, char **argv) {
     // STEP_END
 
     // REMOVE_START
-    redisReply *cleanup = redisCommand(c, "DEL key1 key2 nonexisting");
+    redisReply *cleanup = redisCommand(c, "DEL key1 key2 mykey nonexisting");
     freeReplyObject(cleanup);
     // REMOVE_END
 
@@ -67,7 +67,35 @@ int main(int argc, char **argv) {
     // REMOVE_END
 
     freeReplyObject(reply);
-    redisReply *cleanup2 = redisCommand(c, "DEL key1 key2 nonexisting");
+
+    // STEP_START incr
+    reply = redisCommand(c, "SET mykey 10");
+    printf("%s\n", reply->str);
+    // >>> OK
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "INCR mykey");
+    printf("%lld\n", reply->integer);
+    // >>> 11
+    // REMOVE_START
+    if (reply->integer != 11) {
+        printf("ASSERTION FAILED: Expected 11, got %lld\n", reply->integer);
+    }
+    // REMOVE_END
+    freeReplyObject(reply);
+
+    reply = redisCommand(c, "GET mykey");
+    printf("%s\n", reply->str);
+    // >>> 11
+    // REMOVE_START
+    if (strcmp(reply->str, "11") != 0) {
+        printf("ASSERTION FAILED: Expected '11', got '%s'\n", reply->str);
+    }
+    // REMOVE_END
+    freeReplyObject(reply);
+    // STEP_END
+
+    redisReply *cleanup2 = redisCommand(c, "DEL key1 key2 mykey nonexisting");
     freeReplyObject(cleanup2);
 
     // STEP_START disconnect

--- a/local_examples/cmds_string/ioredis/cmds-string.js
+++ b/local_examples/cmds_string/ioredis/cmds-string.js
@@ -8,7 +8,7 @@ const redis = new Redis();
 // HIDE_END
 
 // REMOVE_START
-await redis.del('key1', 'key2', 'nonexisting');
+await redis.del('key1', 'key2', 'mykey', 'nonexisting');
 // REMOVE_END
 
 // STEP_START mget
@@ -22,6 +22,24 @@ console.log(mgetResult); // >>> ['Hello', 'World', null]
 // REMOVE_START
 assert.deepEqual(mgetResult, ['Hello', 'World', null]);
 await redis.del('key1', 'key2', 'nonexisting');
+// REMOVE_END
+
+// STEP_START incr
+const incrResult1 = await redis.set('mykey', '10');
+console.log(incrResult1); // >>> OK
+
+const incrResult2 = await redis.incr('mykey');
+console.log(incrResult2); // >>> 11
+
+const incrResult3 = await redis.get('mykey');
+console.log(incrResult3); // >>> 11
+// STEP_END
+
+// REMOVE_START
+assert.equal(incrResult1, 'OK');
+assert.equal(incrResult2, 11);
+assert.equal(incrResult3, '11');
+await redis.del('mykey');
 // REMOVE_END
 
 // HIDE_START

--- a/local_examples/cmds_string/lettuce-async/CmdsStringExample.java
+++ b/local_examples/cmds_string/lettuce-async/CmdsStringExample.java
@@ -25,7 +25,7 @@ public class CmdsStringExample {
             RedisAsyncCommands<String, String> asyncCommands = connection.async();
 
             // REMOVE_START
-            asyncCommands.del("key1", "key2", "nonexisting").toCompletableFuture().join();
+            asyncCommands.del("key1", "key2", "mykey", "nonexisting").toCompletableFuture().join();
             // REMOVE_END
 
             // STEP_START mget
@@ -44,8 +44,35 @@ public class CmdsStringExample {
             // STEP_END
 
             mgetExample.join();
+
+            // STEP_START incr
+            CompletableFuture<Void> incrExample = asyncCommands.set("mykey", "10")
+                    .thenCompose(incrResult1 -> {
+                        System.out.println(incrResult1);    // >>> OK
+                        // REMOVE_START
+                        assertThat(incrResult1).isEqualTo("OK");
+                        // REMOVE_END
+                        return asyncCommands.incr("mykey");
+                    })
+                    .thenCompose(incrResult2 -> {
+                        System.out.println(incrResult2);    // >>> 11
+                        // REMOVE_START
+                        assertThat(incrResult2).isEqualTo(11L);
+                        // REMOVE_END
+                        return asyncCommands.get("mykey");
+                    })
+                    .thenAccept(incrResult3 -> {
+                        System.out.println(incrResult3);    // >>> 11
+                        // REMOVE_START
+                        assertThat(incrResult3).isEqualTo("11");
+                        // REMOVE_END
+                    })
+                    .toCompletableFuture();
+            // STEP_END
+
+            incrExample.join();
             // REMOVE_START
-            asyncCommands.del("key1", "key2", "nonexisting").toCompletableFuture().join();
+            asyncCommands.del("key1", "key2", "mykey", "nonexisting").toCompletableFuture().join();
             // REMOVE_END
         } finally {
             redisClient.shutdown();

--- a/local_examples/cmds_string/lettuce-reactive/CmdsStringExample.java
+++ b/local_examples/cmds_string/lettuce-reactive/CmdsStringExample.java
@@ -24,7 +24,7 @@ public class CmdsStringExample {
             RedisReactiveCommands<String, String> reactiveCommands = connection.reactive();
 
             // REMOVE_START
-            reactiveCommands.del("key1", "key2", "nonexisting").block();
+            reactiveCommands.del("key1", "key2", "mykey", "nonexisting").block();
             // REMOVE_END
 
             // STEP_START mget
@@ -43,8 +43,35 @@ public class CmdsStringExample {
             // STEP_END
 
             mgetExample.block();
+
+            // STEP_START incr
+            Mono<Void> incrExample = reactiveCommands.set("mykey", "10")
+                    .flatMap(incrResult1 -> {
+                        System.out.println(incrResult1);    // >>> OK
+                        // REMOVE_START
+                        assertThat(incrResult1).isEqualTo("OK");
+                        // REMOVE_END
+                        return reactiveCommands.incr("mykey");
+                    })
+                    .flatMap(incrResult2 -> {
+                        System.out.println(incrResult2);    // >>> 11
+                        // REMOVE_START
+                        assertThat(incrResult2).isEqualTo(11L);
+                        // REMOVE_END
+                        return reactiveCommands.get("mykey");
+                    })
+                    .doOnNext(incrResult3 -> {
+                        System.out.println(incrResult3);    // >>> 11
+                        // REMOVE_START
+                        assertThat(incrResult3).isEqualTo("11");
+                        // REMOVE_END
+                    })
+                    .then();
+            // STEP_END
+
+            incrExample.block();
             // REMOVE_START
-            reactiveCommands.del("key1", "key2", "nonexisting").block();
+            reactiveCommands.del("key1", "key2", "mykey", "nonexisting").block();
             // REMOVE_END
         } finally {
             redisClient.shutdown();

--- a/local_examples/cmds_string/node-redis/cmds-string.js
+++ b/local_examples/cmds_string/node-redis/cmds-string.js
@@ -8,7 +8,7 @@ await client.connect().catch(console.error);
 // HIDE_END
 
 // REMOVE_START
-await client.del(['key1', 'key2', 'nonexisting']);
+await client.del(['key1', 'key2', 'mykey', 'nonexisting']);
 // REMOVE_END
 
 // STEP_START mget
@@ -22,6 +22,24 @@ console.log(mgetResult); // >>> [ 'Hello', 'World', null ]
 // REMOVE_START
 assert.deepEqual(mgetResult, ['Hello', 'World', null]);
 await client.del(['key1', 'key2', 'nonexisting']);
+// REMOVE_END
+
+// STEP_START incr
+const incrResult1 = await client.set('mykey', '10');
+console.log(incrResult1); // >>> OK
+
+const incrResult2 = await client.incr('mykey');
+console.log(incrResult2); // >>> 11
+
+const incrResult3 = await client.get('mykey');
+console.log(incrResult3); // >>> 11
+// STEP_END
+
+// REMOVE_START
+assert.equal(incrResult1, 'OK');
+assert.equal(incrResult2, 11);
+assert.equal(incrResult3, '11');
+await client.del('mykey');
 // REMOVE_END
 
 // HIDE_START

--- a/local_examples/cmds_string/predis/CmdsStringTest.php
+++ b/local_examples/cmds_string/predis/CmdsStringTest.php
@@ -18,7 +18,7 @@ extends TestCase
         ]);
 
         // REMOVE_START
-        $r->del('key1', 'key2', 'nonexisting');
+        $r->del('key1', 'key2', 'mykey', 'nonexisting');
         // REMOVE_END
 
         // STEP_START mget
@@ -32,6 +32,24 @@ extends TestCase
         // REMOVE_START
         $this->assertEquals(['Hello', 'World', null], $mgetResult);
         $r->del('key1', 'key2', 'nonexisting');
+        // REMOVE_END
+
+        // STEP_START incr
+        $incrResult1 = $r->set('mykey', '10');
+        echo $incrResult1 . PHP_EOL;        // >>> OK
+
+        $incrResult2 = $r->incr('mykey');
+        echo $incrResult2 . PHP_EOL;        // >>> 11
+
+        $incrResult3 = $r->get('mykey');
+        echo $incrResult3 . PHP_EOL;        // >>> 11
+        // STEP_END
+
+        // REMOVE_START
+        $this->assertEquals('OK', (string) $incrResult1);
+        $this->assertEquals(11, $incrResult2);
+        $this->assertEquals('11', $incrResult3);
+        $r->del('mykey');
         // REMOVE_END
     }
 }

--- a/local_examples/cmds_string/redis-py/cmds_string.py
+++ b/local_examples/cmds_string/redis-py/cmds_string.py
@@ -6,7 +6,7 @@ r = redis.Redis(decode_responses=True)
 # HIDE_END
 
 # REMOVE_START
-r.delete("key1", "key2", "nonexisting")
+r.delete("key1", "key2", "mykey", "nonexisting")
 # REMOVE_END
 
 # STEP_START mget
@@ -21,4 +21,25 @@ print(mget_result)
 # REMOVE_START
 assert mget_result == ["Hello", "World", None]
 r.delete("key1", "key2", "nonexisting")
+# REMOVE_END
+
+# STEP_START incr
+incr_result1 = r.set("mykey", "10")
+print(incr_result1)
+# >>> True
+
+incr_result2 = r.incr("mykey")
+print(incr_result2)
+# >>> 11
+
+incr_result3 = r.get("mykey")
+print(incr_result3)
+# >>> 11
+# STEP_END
+
+# REMOVE_START
+assert incr_result1 is True
+assert incr_result2 == 11
+assert incr_result3 == "11"
+r.delete("mykey")
 # REMOVE_END

--- a/local_examples/cmds_string/rust-async/cmds_string.rs
+++ b/local_examples/cmds_string/rust-async/cmds_string.rs
@@ -20,7 +20,7 @@ mod cmds_string_tests {
         };
 
         // REMOVE_START
-        let _: Result<i32, _> = r.del(&["key1", "key2", "nonexisting"]).await;
+        let _: Result<i32, _> = r.del(&["key1", "key2", "mykey", "nonexisting"]).await;
         // REMOVE_END
 
         // STEP_START mget
@@ -49,8 +49,44 @@ mod cmds_string_tests {
         }
         // STEP_END
 
+        // STEP_START incr
+        if let Ok(res) = r.set("mykey", "10").await {
+            let res: String = res;
+            println!("{res}");    // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        }
+
+        match r.incr("mykey", 1).await {
+            Ok(incr_result) => {
+                let incr_result: i64 = incr_result;
+                println!("{incr_result}");    // >>> 11
+                // REMOVE_START
+                assert_eq!(incr_result, 11);
+                // REMOVE_END
+            }
+            Err(e) => {
+                println!("Error incrementing value: {e}");
+            }
+        }
+
+        match r.get("mykey").await {
+            Ok(get_result) => {
+                let get_result: String = get_result;
+                println!("{get_result}");    // >>> 11
+                // REMOVE_START
+                assert_eq!(get_result, "11");
+                // REMOVE_END
+            }
+            Err(e) => {
+                println!("Error getting value: {e}");
+            }
+        }
+        // STEP_END
+
         // REMOVE_START
-        let _: Result<i32, _> = r.del(&["key1", "key2", "nonexisting"]).await;
+        let _: Result<i32, _> = r.del(&["key1", "key2", "mykey", "nonexisting"]).await;
         // REMOVE_END
     }
 }

--- a/local_examples/cmds_string/rust-sync/cmds_string.rs
+++ b/local_examples/cmds_string/rust-sync/cmds_string.rs
@@ -20,7 +20,7 @@ mod cmds_string_tests {
         };
 
         // REMOVE_START
-        let _: Result<i32, _> = r.del(&["key1", "key2", "nonexisting"]);
+        let _: Result<i32, _> = r.del(&["key1", "key2", "mykey", "nonexisting"]);
         // REMOVE_END
 
         // STEP_START mget
@@ -49,8 +49,44 @@ mod cmds_string_tests {
         }
         // STEP_END
 
+        // STEP_START incr
+        if let Ok(res) = r.set("mykey", "10") {
+            let res: String = res;
+            println!("{res}");    // >>> OK
+            // REMOVE_START
+            assert_eq!(res, "OK");
+            // REMOVE_END
+        }
+
+        match r.incr("mykey", 1) {
+            Ok(incr_result) => {
+                let incr_result: i64 = incr_result;
+                println!("{incr_result}");    // >>> 11
+                // REMOVE_START
+                assert_eq!(incr_result, 11);
+                // REMOVE_END
+            }
+            Err(e) => {
+                println!("Error incrementing value: {e}");
+            }
+        }
+
+        match r.get("mykey") {
+            Ok(get_result) => {
+                let get_result: String = get_result;
+                println!("{get_result}");    // >>> 11
+                // REMOVE_START
+                assert_eq!(get_result, "11");
+                // REMOVE_END
+            }
+            Err(e) => {
+                println!("Error getting value: {e}");
+            }
+        }
+        // STEP_END
+
         // REMOVE_START
-        let _: Result<i32, _> = r.del(&["key1", "key2", "nonexisting"]);
+        let _: Result<i32, _> = r.del(&["key1", "key2", "mykey", "nonexisting"]);
         // REMOVE_END
     }
 }

--- a/local_examples/tmp/datatypes/hashes/dt-hash.js
+++ b/local_examples/tmp/datatypes/hashes/dt-hash.js
@@ -94,7 +94,7 @@ assert.equal(res6, 5072)
 assert.equal(res7, 4972)
 // REMOVE_END
 
-// STEP_START hIncrBy_hGet_hMget
+// STEP_START incrby_get_mget
 const res11 = await client.hIncrBy('bike:1:stats', 'rides', 1)
 console.log(res11)  // 1
 const res12 = await client.hIncrBy('bike:1:stats', 'rides', 1)

--- a/local_examples/tmp/datatypes/sets/dt-set.js
+++ b/local_examples/tmp/datatypes/sets/dt-set.js
@@ -53,7 +53,7 @@ assert.equal(res5, 1)
 assert.equal(res6, 0)
 // REMOVE_END
 
-// STEP_START sinster
+// STEP_START sinter
 // HIDE_START
 await client.del('bikes:racing:france')
 await client.del('bikes:racing:usa')
@@ -61,7 +61,7 @@ await client.sAdd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
 await client.sAdd('bikes:racing:usa', ['bike:1', 'bike:4'])
 // HIDE_END
 const res7 = await client.sInter(['bikes:racing:france', 'bikes:racing:usa'])
-console.log(res7)  // >>> {'bike:1'}
+console.log(res7)  // >>> ['bike:1']
 // STEP_END
 
 // REMOVE_START


### PR DESCRIPTION
## DOC-6968 — two node-redis step names that never matched their sets

Three lines changed across two files. The effect is larger than the diff: two docs pages stop dumping an entire example file where a short snippet belongs.

| File | Was | Now |
|---|---|---|
| `local_examples/tmp/datatypes/hashes/dt-hash.js` | `STEP_START hIncrBy_hGet_hMget` | `STEP_START incrby_get_mget` |
| `local_examples/tmp/datatypes/sets/dt-set.js` | `STEP_START sinster` | `STEP_START sinter` |
| `local_examples/tmp/datatypes/sets/dt-set.js` | `// >>> {'bike:1'}` | `// >>> ['bike:1']` |

### What was actually broken

Both files always contained correct, working code for these steps. Only the **name** was wrong, so `clients-example` could not find the step and fell back to embedding the whole file:

- `develop/data-types/hashes` — the Node.js tab for `incrby_get_mget` rendered **120 lines** instead of 14.
- `develop/data-types/sets` — the Node.js tab for `sinter` rendered **114 lines** instead of 6.

Imports, connection setup and every unrelated example in the file, in a tab a reader opened to see one counter pattern. Nothing failed and no test broke — the tab was present and populated the entire time, which is exactly why this survived.

`build/components/example.py:146` lowercases step names, so the other camelCase markers in these files (`hmGet`, `hExpire`, `hpExpire`) land on the canonical names by accident. These two didn't: one has the wrong name *structure* rather than the wrong case, and the other is a plain typo — `sinster` is not a command, a method, or a word.

### The comment the rename exposed

Making the `sinter` pane visible surfaced a second defect in the six lines it revealed. The expected-output comment read `{'bike:1'}` — a **Python set literal** — in a JavaScript example whose own assertion two lines below reads `assert.deepEqual(res7, [ 'bike:1' ])`. Observed output is `[ 'bike:1' ]`. It had evidently been copied from the redis-py tab, and the whole-file fallback had buried it in 114 lines where nobody would read it against the assertion.

Worth noting as a pattern: this is the **second** time in this run of work that an expected value inherited from a sibling client's tab proved wrong for the client it was published under (the first was `hpttl` in [#3808](https://github.com/redis/docs/pull/3808), inherited as `59994` where Ruby returns `59999`).

### Verification

| Check | Result |
|---|---|
| Step names now match the reference client | ✅ node-redis `named_steps` identical to Python's for both sets |
| Examples still run | ✅ `run.sh hash_tutorial node-redis` and `run.sh sets_tutorial node-redis` both **PASS** against Redis 8.8.0 |
| Output comments match reality | ✅ hash step's `1, 2, 3, 1, 1, 3, ['1','1']` confirmed against the run; `sinter` corrected to the observed `['bike:1']` |
| Panes now slice | ✅ 14 lines and 6 lines respectively, checked in built HTML |
| Nothing else changed | ✅ site-wide legacy-fallback panes **111 → 109**, the two removed being exactly these, **none added** |

Only comments and a marker name changed, so no runtime behaviour is affected — but both examples were run anyway rather than assumed.

### Context

This is the "cause A" item from [DOC-6968](https://redislabs.atlassian.net/browse/DOC-6968), which catalogues **74** panes site-wide rendering whole files this way. These two were the only ones fixable by a rename — the other ~64 are files that genuinely lack the example code and need examples written. The shortcode fix that makes the whole class impossible is tracked in the same ticket and has no prerequisites.

Doing these two *before* that fix is deliberate: afterwards the symptom becomes a quietly-omitted tab rather than an obvious whole-file dump, so a typo like `sinster` would get harder to spot, not easier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[DOC-6968]: https://redislabs.atlassian.net/browse/DOC-6968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local example sources, doc step markers, and the example test harness; no production services, auth, or data paths are affected.
> 
> **Overview**
> Fixes **DOC-6968** doc slicing and expands example coverage for `incr` and C (hiredis).
> 
> **Node.js datatype tutorials:** Renames mismatched `STEP_START` markers in `dt-hash.js` (`incrby_get_mget`) and `dt-set.js` (`sinter`), and corrects the `sinter` expected-output comment from a Python-style set to `['bike:1']`, so those tabs render short snippets instead of whole files.
> 
> **`cmds_string` / INCR:** Adds a shared `incr` step (`SET` → `INCR` → `GET`) to nine clients (Python, Node, ioredis, Predis, Rust sync/async, Lettuce async/reactive, hiredis), with client-accurate `>>>` comments (e.g. redis-py `True` vs `OK`) and cleanup keys updated for `mykey`.
> 
> **Example test harness:** Registers **hiredis** as a portable runner (`run_hiredis`, system-library discovery, Linux-safe link order), sets `portable` to `hiredis` in `clients.tsv`, and on full sweeps emits explicit **SKIP** rows for clients excluded from the current mode so missing coverage is visible. `testing.md` documents hiredis limits and the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc44a07709c192d431269bca71159d43da2a7733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

## Second commit — the missing `incr` step for nine clients

Adds an `incr` step (`SET mykey 10` → `INCR` → `GET`) to the **redis-py, node-redis, ioredis, predis, rust-sync, rust-async, lettuce-async, lettuce-reactive and hiredis** files in `cmds_string`. Nine of the twelve clients on `content/commands/incr.md` had no such step, so each of those tabs rendered its client's whole file — 12 to 51 lines — instead of three commands.

**`commands/incr.md` now renders all 12 client tabs correctly sliced** (verified in built HTML: 13 panes including redis-cli, none on the legacy path).

### Why this is in the same PR, and why it comes first

The shortcode fix tracked in [DOC-6968](https://redislabs.atlassian.net/browse/DOC-6968) omits a tab when the client lacks the requested step. On this page that would have cut **12 client tabs to 3, losing Python and Node.js** — the two clients most readers arrive with — from a core string command page. Wrong-but-present beats absent for a reader, so the coverage lands before the fix rather than after it. With this in, the fix takes nothing from `incr.md`.

### `set()` does not return `OK` everywhere

redis-py's `set()` returns a **bool**, so the Python tab's comment reads `# >>> True` where the Go and Jedis reference implementations read `OK`. Copying the reference value into the Python tab would have been wrong — the same failure mode as the two other defects on this branch, both from an expected value inherited off a sibling client's tab.

### Verification

| Client | Result |
|---|---|
| redis-py | ✅ ran — `True`, `11`, `11` |
| node-redis | ✅ ran — `OK`, `11`, `11` |
| ioredis | ✅ ran — `OK`, `11`, `11` |
| predis | ✅ ran — `OK`, `11`, `11` |
| rust-sync / rust-async | ✅ ran, 1 test passed each; values confirmed by the in-step `assert_eq!` calls (cargo captures stdout) |
| lettuce-async / lettuce-reactive | ✅ ran; values confirmed by the in-chain `assertThat` calls |
| **hiredis (C)** | ✅ ran — `OK`, `11`, `11` (compiled and executed after hiredis was installed locally; see the update below) |

`build/example-test-harness/run.sh cmds_string` reports **PASS for all nine**, with the pre-existing jedis, go-redis and nredisstack implementations untouched and still passing. The remaining `SKIP (no source)` entries are clients with no file in this set at all.

**The C gap is now closed.** It was initially unverifiable here — `clients.tsv` gives hiredis no portable runner, and no hiredis headers were installed. With the headers now in place it compiles clean (`gcc -Wall -Wextra`; the only two warnings are pre-existing complaints about `main`'s unused `argc`/`argv`) and runs against Redis 8.8.0, printing `OK`, `11`, `11` — matching all three comments exactly, exiting 0, with no assertion-failure output and no keys left behind.

Note for anyone re-running this: hiredis remains untestable through `run.sh`, so this was a manual `gcc` + execute. The `Gaps:` trailer on commit 282798c25 still says the C implementation is unverified; that was true when written and is now stale — see the reflect-note comment on this PR.

### Whole-site effect of both commits

Legacy-fallback panes across the entire built site: **111 → 100**. The eleven removed are exactly the two renames plus these nine `incr` panes; **none added**.

Rendered panes were also checked by eye for Python, C and Java-Async: assertions and cleanup stripped, no `REMOVE`/`HIDE`/`STEP_` scaffolding reaching the page, and the Lettuce chain still valid Java once its inner `REMOVE` blocks are removed.

