### PR TITLE
RS: clarify reserved_ports also applies to internal shard traffic

### DIFF
--- a/content/operate/rs/7.22/networking/port-configurations.md
+++ b/content/operate/rs/7.22/networking/port-configurations.md
@@ -48,7 +48,7 @@ Redis Enterprise Software's port usage falls into three general categories:
 
 ### Reserve ports
 
-Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints, configure `reserved_ports` using one of the following methods:
+Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/7.22/references/cli-utilities/rladmin/cluster/config" >}})
 
@@ -59,7 +59,7 @@ Redis Enterprise Software reserves some ports by default (`system_reserved_ports
     For example:
 
     ```sh
-    rladmin cluster config reserved_ports 11000 13000-13010
+    rladmin cluster config reserved_ports 11000 13000-13010 20048
     ```
 
 - [Update cluster settings]({{< relref "/operate/rs/7.22/references/rest-api/requests/cluster#put-cluster" >}}) REST API request
@@ -73,7 +73,7 @@ Redis Enterprise Software reserves some ports by default (`system_reserved_ports
 
     ```sh
     PUT /v1/cluster
-    { "reserved_ports": ["11000", "13000-13010"] }
+    { "reserved_ports": ["11000", "13000-13010", "20048"] }
     ```
 
 ### Change the Cluster Manager UI port

--- a/content/operate/rs/7.22/networking/port-configurations.md
+++ b/content/operate/rs/7.22/networking/port-configurations.md
@@ -44,11 +44,15 @@ Redis Enterprise Software's port usage falls into three general categories:
 | TCP | 8002, 8004, 8006 | <span title="Configurable">&#x2705; Yes</span> | Internal | Default system health monitoring (envoy admin, envoy management server, gossip envoy admin)|
 | TCP | 8444, 9080 | <span title="Not configurable">&#x274c; No</span> | Internal | Traffic between web proxy and cnm_http/cm |
 
+{{< note >}}
+The cluster uses ports 20000-29999 for internal shard traffic. You can't change the range, but `reserved_ports` excludes specific ports or port ranges from shard assignment.
+{{< /note >}}
+
 ## Change port configuration
 
 ### Reserve ports
 
-Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
+Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/7.22/references/cli-utilities/rladmin/cluster/config" >}})
 

--- a/content/operate/rs/7.22/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/7.22/references/cli-utilities/rladmin/cluster/config.md
@@ -86,7 +86,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `reserved_ports 11000 13000-13010`) |
+| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/7.22/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/7.22/references/cli-utilities/rladmin/cluster/config.md
@@ -86,7 +86,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
+| reserved_ports | list of ports/port ranges | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/7.22/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/7.22/references/rest-api/objects/cluster/_index.md
@@ -61,7 +61,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
+| reserved_ports | array of strings | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | robust_crdt_syncer | boolean (default: false) | If `true`, enables the robust syncer for Active-Active databases |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |
 | s3_url | string | Specifies the URL for S3 export and import |

--- a/content/operate/rs/7.22/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/7.22/references/rest-api/objects/cluster/_index.md
@@ -61,7 +61,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `"reserved_ports": ["11000", "13000-13010"]`) |
+| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | robust_crdt_syncer | boolean (default: false) | If `true`, enables the robust syncer for Active-Active databases |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |
 | s3_url | string | Specifies the URL for S3 export and import |

--- a/content/operate/rs/7.4/networking/port-configurations.md
+++ b/content/operate/rs/7.4/networking/port-configurations.md
@@ -46,7 +46,7 @@ Redis Enterprise Software's port usage falls into three general categories:
 
 ### Reserve ports
 
-Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints, configure `reserved_ports` using one of the following methods:
+Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/7.4/references/cli-utilities/rladmin/cluster/config" >}})
 
@@ -57,7 +57,7 @@ Redis Enterprise Software reserves some ports by default (`system_reserved_ports
     For example:
 
     ```sh
-    rladmin cluster config reserved_ports 11000 13000-13010
+    rladmin cluster config reserved_ports 11000 13000-13010 20048
     ```
 
 - [Update cluster settings]({{< relref "/operate/rs/7.4/references/rest-api/requests/cluster#put-cluster" >}}) REST API request
@@ -71,7 +71,7 @@ Redis Enterprise Software reserves some ports by default (`system_reserved_ports
 
     ```sh
     PUT /v1/cluster
-    { "reserved_ports": ["11000", "13000-13010"] }
+    { "reserved_ports": ["11000", "13000-13010", "20048"] }
     ```
 
 ### Change the Cluster Manager UI port

--- a/content/operate/rs/7.4/networking/port-configurations.md
+++ b/content/operate/rs/7.4/networking/port-configurations.md
@@ -42,11 +42,15 @@ Redis Enterprise Software's port usage falls into three general categories:
 | TCP | 8002, 8004, 8006 | <span title="Configurable">&#x2705; Yes</span> | Internal | Default system health monitoring (envoy admin, envoy management server, gossip envoy admin)|
 | TCP | 8444, 9080 | <span title="Not configurable">&#x274c; No</span> | Internal | Traffic between web proxy and cnm_http/cm |
 
+{{< note >}}
+The cluster uses ports 20000-29999 for internal shard traffic. You can't change the range, but `reserved_ports` excludes specific ports or port ranges from shard assignment.
+{{< /note >}}
+
 ## Change port configuration
 
 ### Reserve ports
 
-Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
+Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/7.4/references/cli-utilities/rladmin/cluster/config" >}})
 

--- a/content/operate/rs/7.4/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/7.4/references/cli-utilities/rladmin/cluster/config.md
@@ -84,7 +84,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `reserved_ports 11000 13000-13010`) |
+| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/7.4/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/7.4/references/cli-utilities/rladmin/cluster/config.md
@@ -84,7 +84,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
+| reserved_ports | list of ports/port ranges | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/7.4/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/7.4/references/rest-api/objects/cluster/_index.md
@@ -55,7 +55,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | proxy_max_ccs_disconnection_time | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `"reserved_ports": ["11000", "13000-13010"]`) |
+| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |
 | s3_url | string | Specifies the URL for S3 export and import |
 | sentinel_cipher_suites | array | Specifies the list of enabled ciphers for the sentinel service. The supported ciphers are those implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package. |

--- a/content/operate/rs/7.4/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/7.4/references/rest-api/objects/cluster/_index.md
@@ -55,7 +55,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | proxy_max_ccs_disconnection_time | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
+| reserved_ports | array of strings | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |
 | s3_url | string | Specifies the URL for S3 export and import |
 | sentinel_cipher_suites | array | Specifies the list of enabled ciphers for the sentinel service. The supported ciphers are those implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package. |

--- a/content/operate/rs/7.8/networking/port-configurations.md
+++ b/content/operate/rs/7.8/networking/port-configurations.md
@@ -42,11 +42,15 @@ Redis Enterprise Software's port usage falls into three general categories:
 | TCP | 8002, 8004, 8006 | <span title="Configurable">&#x2705; Yes</span> | Internal | Default system health monitoring (envoy admin, envoy management server, gossip envoy admin)|
 | TCP | 8444, 9080 | <span title="Not configurable">&#x274c; No</span> | Internal | Traffic between web proxy and cnm_http/cm |
 
+{{< note >}}
+The cluster uses ports 20000-29999 for internal shard traffic. You can't change the range, but `reserved_ports` excludes specific ports or port ranges from shard assignment.
+{{< /note >}}
+
 ## Change port configuration
 
 ### Reserve ports
 
-Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
+Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/7.8/references/cli-utilities/rladmin/cluster/config" >}})
 

--- a/content/operate/rs/7.8/networking/port-configurations.md
+++ b/content/operate/rs/7.8/networking/port-configurations.md
@@ -46,7 +46,7 @@ Redis Enterprise Software's port usage falls into three general categories:
 
 ### Reserve ports
 
-Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints, configure `reserved_ports` using one of the following methods:
+Redis Enterprise Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/7.8/references/cli-utilities/rladmin/cluster/config" >}})
 
@@ -57,7 +57,7 @@ Redis Enterprise Software reserves some ports by default (`system_reserved_ports
     For example:
 
     ```sh
-    rladmin cluster config reserved_ports 11000 13000-13010
+    rladmin cluster config reserved_ports 11000 13000-13010 20048
     ```
 
 - [Update cluster settings]({{< relref "/operate/rs/7.8/references/rest-api/requests/cluster#put-cluster" >}}) REST API request
@@ -71,7 +71,7 @@ Redis Enterprise Software reserves some ports by default (`system_reserved_ports
 
     ```sh
     PUT /v1/cluster
-    { "reserved_ports": ["11000", "13000-13010"] }
+    { "reserved_ports": ["11000", "13000-13010", "20048"] }
     ```
 
 ### Change the Cluster Manager UI port

--- a/content/operate/rs/7.8/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/7.8/references/cli-utilities/rladmin/cluster/config.md
@@ -84,7 +84,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `reserved_ports 11000 13000-13010`) |
+| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/7.8/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/7.8/references/cli-utilities/rladmin/cluster/config.md
@@ -84,7 +84,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
+| reserved_ports | list of ports/port ranges | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/7.8/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/7.8/references/rest-api/objects/cluster/_index.md
@@ -59,7 +59,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
+| reserved_ports | array of strings | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |
 | s3_url | string | Specifies the URL for S3 export and import |
 | sentinel_cipher_suites | array | Specifies the list of enabled ciphers for the sentinel service. The supported ciphers are those implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package. |

--- a/content/operate/rs/7.8/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/7.8/references/rest-api/objects/cluster/_index.md
@@ -59,7 +59,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `"reserved_ports": ["11000", "13000-13010"]`) |
+| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |
 | s3_url | string | Specifies the URL for S3 export and import |
 | sentinel_cipher_suites | array | Specifies the list of enabled ciphers for the sentinel service. The supported ciphers are those implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package. |

--- a/content/operate/rs/8.0/networking/port-configurations.md
+++ b/content/operate/rs/8.0/networking/port-configurations.md
@@ -45,11 +45,15 @@ Redis Software's port usage falls into three general categories:
 | TCP | 8002, 8004, 8006 | <span title="Configurable">&#x2705; Yes</span> | Internal | Default system health monitoring (envoy admin, envoy management server, gossip envoy admin)|
 | TCP | 8444, 9080 | <span title="Not configurable">&#x274c; No</span> | Internal | Traffic between web proxy and cnm_http/cm |
 
+{{< note >}}
+The cluster uses ports 20000-29999 for internal shard traffic. You can't change the range, but `reserved_ports` excludes specific ports or port ranges from shard assignment.
+{{< /note >}}
+
 ## Change port configuration
 
 ### Reserve ports
 
-Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
+Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/8.0/references/cli-utilities/rladmin/cluster/config" >}})
 

--- a/content/operate/rs/8.0/networking/port-configurations.md
+++ b/content/operate/rs/8.0/networking/port-configurations.md
@@ -49,7 +49,7 @@ Redis Software's port usage falls into three general categories:
 
 ### Reserve ports
 
-Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints, configure `reserved_ports` using one of the following methods:
+Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/8.0/references/cli-utilities/rladmin/cluster/config" >}})
 
@@ -60,7 +60,7 @@ Redis Software reserves some ports by default (`system_reserved_ports`). To rese
     For example:
 
     ```sh
-    rladmin cluster config reserved_ports 11000 13000-13010
+    rladmin cluster config reserved_ports 11000 13000-13010 20048
     ```
 
 - [Update cluster settings]({{< relref "/operate/rs/8.0/references/rest-api/requests/cluster#put-cluster" >}}) REST API request
@@ -74,7 +74,7 @@ Redis Software reserves some ports by default (`system_reserved_ports`). To rese
 
     ```sh
     PUT /v1/cluster
-    { "reserved_ports": ["11000", "13000-13010"] }
+    { "reserved_ports": ["11000", "13000-13010", "20048"] }
     ```
 
 ### Change the Cluster Manager UI port

--- a/content/operate/rs/8.0/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/8.0/references/cli-utilities/rladmin/cluster/config.md
@@ -86,7 +86,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `reserved_ports 11000 13000-13010`) |
+| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/8.0/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/8.0/references/cli-utilities/rladmin/cluster/config.md
@@ -86,7 +86,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
+| reserved_ports | list of ports/port ranges | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/8.0/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/8.0/references/rest-api/objects/cluster/_index.md
@@ -75,7 +75,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
+| reserved_ports | array of strings | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | <span class="break-all">replica_sconns_on_demand</span> | "enabled"<br />"disabled"<br />**"auto"** | Reduces DMC internode connections by at least 50%, conserving sockets, file descriptors, and `KEEPALIVE` traffic |
 | robust_crdt_syncer | boolean (default: false) | If `true`, enables the robust syncer for Active-Active databases |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |

--- a/content/operate/rs/8.0/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/8.0/references/rest-api/objects/cluster/_index.md
@@ -75,7 +75,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `"reserved_ports": ["11000", "13000-13010"]`) |
+| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | <span class="break-all">replica_sconns_on_demand</span> | "enabled"<br />"disabled"<br />**"auto"** | Reduces DMC internode connections by at least 50%, conserving sockets, file descriptors, and `KEEPALIVE` traffic |
 | robust_crdt_syncer | boolean (default: false) | If `true`, enables the robust syncer for Active-Active databases |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |

--- a/content/operate/rs/networking/port-configurations.md
+++ b/content/operate/rs/networking/port-configurations.md
@@ -44,11 +44,15 @@ Redis Software's port usage falls into three general categories:
 | TCP | 8002, 8004, 8006 | <span title="Configurable">&#x2705; Yes</span> | Internal | Default system health monitoring (envoy admin, envoy management server, gossip envoy admin)|
 | TCP | 8444, 9080 | <span title="Not configurable">&#x274c; No</span> | Internal | Traffic between web proxy and cnm_http/cm |
 
+{{< note >}}
+The cluster uses ports 20000-29999 for internal shard traffic. You can't change the range, but `reserved_ports` excludes specific ports or port ranges from shard assignment.
+{{< /note >}}
+
 ## Change port configuration
 
 ### Reserve ports
 
-Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
+Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/references/cli-utilities/rladmin/cluster/config" >}})
 

--- a/content/operate/rs/networking/port-configurations.md
+++ b/content/operate/rs/networking/port-configurations.md
@@ -48,7 +48,7 @@ Redis Software's port usage falls into three general categories:
 
 ### Reserve ports
 
-Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints, configure `reserved_ports` using one of the following methods:
+Redis Software reserves some ports by default (`system_reserved_ports`). To reserve other ports or port ranges and prevent the cluster from assigning them to database endpoints or assigning them for internal shard traffic, configure `reserved_ports` using one of the following methods:
 
 - [rladmin cluster config]({{< relref "/operate/rs/references/cli-utilities/rladmin/cluster/config" >}})
 
@@ -59,7 +59,7 @@ Redis Software reserves some ports by default (`system_reserved_ports`). To rese
     For example:
 
     ```sh
-    rladmin cluster config reserved_ports 11000 13000-13010
+    rladmin cluster config reserved_ports 11000 13000-13010 20048
     ```
 
 - [Update cluster settings]({{< relref "/operate/rs/references/rest-api/requests/cluster#put-cluster" >}}) REST API request
@@ -73,7 +73,7 @@ Redis Software reserves some ports by default (`system_reserved_ports`). To rese
 
     ```sh
     PUT /v1/cluster
-    { "reserved_ports": ["11000", "13000-13010"] }
+    { "reserved_ports": ["11000", "13000-13010", "20048"] }
     ```
 
 ### Change the Cluster Manager UI port

--- a/content/operate/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -85,7 +85,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `reserved_ports 11000 13000-13010`) |
+| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/references/cli-utilities/rladmin/cluster/config.md
+++ b/content/operate/rs/references/cli-utilities/rladmin/cluster/config.md
@@ -85,7 +85,7 @@ Updates the cluster configuration.
 | min_data_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the data path |
 | min_sentinel_TLS_version | `1.2`<br />`1.3` | The minimum TLS protocol version that is supported for the discovery service |
 | options_method_forbidden | `enabled`<br />`disabled` | Enable or turn off forbidding `OPTIONS` method for CNM HTTPS port |
-| reserved_ports | list of ports/port ranges | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
+| reserved_ports | list of ports/port ranges | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `reserved_ports 11000 13000-13010 20048`) |
 | s3_url | string | The URL of S3 export and import |
 | s3_ca_cert | string | The CA certificate filepath for S3 export and import |
 | sentinel_cipher_suites | list of ciphers | Cipher suites used by the discovery service (supported ciphers are implemented by the [cipher_suites.go](<https://golang.org/src/crypto/tls/cipher_suites.go>) package) |

--- a/content/operate/rs/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/references/rest-api/objects/cluster/_index.md
@@ -76,7 +76,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints (for example `"reserved_ports": ["11000", "13000-13010"]`) |
+| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | <span class="break-all">replica_sconns_on_demand</span> | "enabled"<br />"disabled"<br />**"auto"** | Reduces DMC internode connections by at least 50%, conserving sockets, file descriptors, and `KEEPALIVE` traffic |
 | robust_crdt_syncer | boolean (default: false) | If `true`, enables the robust syncer for Active-Active databases |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |

--- a/content/operate/rs/references/rest-api/objects/cluster/_index.md
+++ b/content/operate/rs/references/rest-api/objects/cluster/_index.md
@@ -76,7 +76,7 @@ An API object that represents the cluster.
 | proxy_certificate | string | Cluster's proxy certificate |
 | <span class="break-all">proxy_max_ccs_disconnection_time</span> | integer | Cluster-wide proxy timeout policy between proxy and CCS |
 | rack_aware | boolean | Cluster operates in a rack-aware mode (read-only) |
-| reserved_ports | array of strings | List of reserved ports and/or port ranges to avoid using for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
+| reserved_ports | array of strings | Ports and port ranges that the cluster does not use for database endpoints or internal shard traffic (for example `"reserved_ports": ["11000", "13000-13010", "20048"]`) |
 | <span class="break-all">replica_sconns_on_demand</span> | "enabled"<br />"disabled"<br />**"auto"** | Reduces DMC internode connections by at least 50%, conserving sockets, file descriptors, and `KEEPALIVE` traffic |
 | robust_crdt_syncer | boolean (default: false) | If `true`, enables the robust syncer for Active-Active databases |
 | s3_ca_cert | string | Filepath to the PEM-encoded CA certificate to use for validating TLS connections to the S3 server |


### PR DESCRIPTION
Update the reserved_ports documentation to make clear that the setting prevents the cluster from assigning ports to internal shard traffic in addition to database endpoints. Adds `20048` to the examples in the rladmin cluster config command and the rladmin/REST API reference tables. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only reference updates with no product or runtime changes.
> 
> **Overview**
> **Documentation-only** updates across RS networking and reference pages (versions 7.4, 7.8, 7.22, 8.0, and the main `operate/rs` tree).
> 
> Clarifies that **`reserved_ports`** blocks the cluster from using listed ports/ranges for **database endpoints and internal shard traffic**, not just endpoints. A new note after the port table states that **20000–29999** is fixed for shard traffic and that **`reserved_ports`** can still exclude specific ports or ranges inside that band from assignment.
> 
> **Reserve ports** prose, **`rladmin cluster config`** parameter text, and the REST **cluster** object field description are aligned with that behavior. Examples now include **`20048`** alongside existing samples to show reserving a port in the shard range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d7f7166282d0555db084b63bbfaa1eedd5d5a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->