### PR TITLE
DOC-6968 Omit a clients-example tab when that client lacks the requested step

### DIFF
--- a/layouts/partials/tabbed-clients-example.html
+++ b/layouts/partials/tabbed-clients-example.html
@@ -140,6 +140,35 @@
             {{ end }}
         {{ end }}
 
+        {{/* A step was requested that this client's file does not contain. Three cases hide
+             behind that, and only the middle one is a defect:
+
+               step="" (explicitly empty)  -> the whole file IS the example. Keep it.
+               file has other steps, not this one -> an AUTHORING GAP. Omit the tab: the
+                 legacy path below would otherwise dump the client's entire file — imports,
+                 connection setup and every unrelated example — into a pane the reader
+                 opened for one command. Up to 258 lines where a snippet belongs.
+               file has NO steps at all -> predates STEP markers, so the whole file is
+                 still the closest thing to an example. Keep it, or pages like
+                 commands/set.md and commands/get.md lose every client tab.
+
+             The len > 0 clause is what separates the last two, and it is load-bearing.
+             Note this tests membership in named_steps rather than $sliceable: a step that
+             exists but whose range is malformed or out of bounds should still fall through
+             to the whole-file path, which is the safety net that guard was written for. */}}
+        {{ $omitTab := false }}
+        {{ if and (ne $step "") (isset $example "named_steps") }}
+            {{ $steps := index $example "named_steps" }}
+            {{ if and (gt (len $steps) 0) (not (isset $steps $step)) }}
+                {{ $omitTab = true }}
+                {{ warnf "[tabbed-clients-example] %q: client %q has no step %q in set %q — tab omitted. Add the step to that client's example file, or name the supporting clients in lang_filter." $.Page $client $step $id }}
+            {{ end }}
+        {{ end }}
+        {{/* Skip before any content is built: the legacy path mutates .Page.Store and inlines
+             the whole file once per page, so building it for a tab we then drop would leave
+             orphaned markup behind. */}}
+        {{ if $omitTab }}{{ continue }}{{ end }}
+
         {{ $content := "" }}
         {{ $fullFileKey := "" }}
         {{ $hlRange := "" }}


### PR DESCRIPTION
## DOC-6968 — omit a `clients-example` tab when the client lacks the requested step

29 lines in one partial. It stops **63 panes** site-wide from rendering a client's entire example file where a snippet belongs — the worst being 258 lines of Go (`package`, imports and several unrelated examples) on `commands/scan.md`.

This is the fix the rest of DOC-6968 was clearing the way for. The coverage work that had to land first is already on `main` ([#3809](https://github.com/redis/docs/pull/3809)).

### The condition, and why each clause matters

```
step != ""  AND  step not in named_steps  AND  len(named_steps) > 0
```

The shortcode's `else` branch was conflating three situations. Only the middle one is a defect:

| Case | Panes | Behaviour |
|---|---|---|
| `step=""` — explicitly empty | 12 | **Unchanged.** The whole file *is* the example (`data-store.md`) |
| File has other steps, not this one | **63** | **Omit the tab** — an authoring gap |
| File has **no** steps at all | 25 | **Unchanged.** Predates `STEP` markers; the whole file is still the closest thing to an example |

Dropping the `len > 0` clause would strip **every client tab from `commands/set.md` and `commands/get.md`** — 12 each — because those files have no `STEP` markers. That's a regression, not a fix, so the clause is load-bearing rather than defensive.

It deliberately tests membership in `named_steps` rather than `$sliceable`: a step that *exists* but whose line range is malformed or out of bounds should still fall through to the whole-file path, which is exactly the drift `$sliceable` was written to absorb.

The `continue` fires **before any content is built**, not just before the tab is appended — the legacy path mutates `.Page.Store` and inlines the file once per page, so building it for a tab we then drop would leave orphaned markup and a wasted copy of the file in the output.

### Loud, not silent

Each omission emits a `warnf` naming page, client, step and set, so the gaps become a worklist rather than an invisible absence:

```
WARN  [tabbed-clients-example] ".../content/commands/scan.md": client "Go" has no step
      "scan1" in set "cmds_generic" — tab omitted. Add the step to that client's example
      file, or name the supporting clients in lang_filter.
```

Self-extinguishing — it drops to zero as the examples get written. CI runs plain `hugo -d output` with no `--panicOnWarning`, and **the build still exits 0**, so this surfaces the gaps without failing anything. Deliberately *not* warning on the 25 zero-step files, which would produce permanent warnings nobody can action.

### Verification

Two builds of the identical tree, with and without the change:

| | Before | After |
|---|---|---|
| Tab panes | 2711 | **2648** (−63) |
| Legacy-fallback panes | 100 | **37** (−63) |
| Legacy clone panes | 23 | **0** |
| Omission warnings | — | **63** |

The 63 warnings correspond **one-to-one** with the 63 removed panes, and what remains on the legacy path is exactly the two protected classes (25 cosmetic + 12 by-design).

Structural checks, because a change like this fails quietly:

- **All 594 tab groups survive with ≥1 pane** — nothing renders empty.
- **Selector options still match panes** on the worst-hit group (`scan1`: 6 and 6, identical sets) — no tab button left without a pane.
- `commands/incr.md` **untouched** at 12 clients, thanks to the examples added in #3809.
- `commands/set.md` / `commands/get.md` **untouched**, 12 client tabs each.
- `data-store.md` (`step=""`) **untouched**.
- `hashes.md` `hexpire` keeps all 11 clients including Ruby; `hexpireat` keeps its 10 (Ruby excluded by `lang_filter`, so it never reaches this check).
- `vector3`/`vector4` degrade to a **CLI-only tab** as agreed — a 1-pane shape that already exists elsewhere on the site (`nredisstack/prob`).

### What this does *not* fix

The 63 panes stop rendering wrongly; the missing coverage is still missing. `commands/scan.md` drops from 12 client tabs to 5, the `h*` pages from 14 to 12, and `del`/`expire`/`ttl` from 12 to 7. The four `cmds_generic` `scan` steps are 28 of the 63 and remain the biggest lever — see the DOC-6968 status comment for the full per-page table. The `warnf` output is the worklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs layout-only change with explicit guards for legacy no-step files; build still succeeds and tab groups retain at least one pane per verification notes.
> 
> **Overview**
> **Client example tabs** in `tabbed-clients-example.html` now **skip** a language tab when the shortcode asks for a named `step` that client’s example file does not define, but that file **does** define other steps.
> 
> That stops the legacy whole-file path from dumping full multi-example sources (imports, unrelated snippets) into a pane meant for one command—**63 panes** site-wide, per the PR verification.
> 
> **Unchanged behavior:** empty `step` still uses the whole file; files with **no** `STEP` markers at all still get a tab (so pages like `set`/`get` keep all client tabs). Malformed or out-of-bounds ranges still use the existing whole-file fallback via `$sliceable`, not this omission rule.
> 
> Each omission logs a **`warnf`** with page, client, step, and example set. The loop **`continue`s before** building tab content so legacy `.Page.Store` inlining does not run for tabs that are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94cb5abd77f746354c5c04aec3ffd610876f8217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->