### PR TITLE
docs: add a third-party tools section with LibreDB Studio

### DIFF
--- a/content/develop/tools/_index.md
+++ b/content/develop/tools/_index.md
@@ -23,6 +23,7 @@ manage it and interact with the data:
 * [Redis Insight](#redis-insight) (a graphical user interface tool)
 * The Redis [VSCode extension](#redis-vscode-extension)
 * [`redisctl`](#redisctl) (a unified CLI for managing Redis Cloud and Redis Software)
+* [Third-party tools](#third-party-tools) maintained by the community
 
 ## Redis command line interface (CLI)
 
@@ -47,3 +48,17 @@ is an extension that allows you to connect to your Redis databases from within M
 [`redisctl`](https://github.com/redis/redisctl) is a unified command-line tool for managing Redis Cloud and Redis Software from your terminal. It provides complete API coverage for both platforms — including subscriptions, databases, VPC peering, ACLs, clusters, and users — without needing custom scripts. It also includes an MCP server component that exposes management operations to AI assistants.
 
 Install via Homebrew, Cargo, or download a binary release from the [GitHub repository](https://github.com/redis/redisctl).
+
+## Third-party tools
+
+The tools above are maintained by Redis. The tools below are maintained by their authors, who are responsible for supporting them.
+
+### LibreDB Studio
+
+[LibreDB Studio](https://github.com/libredb/libredb-studio) is an MIT-licensed, self-hosted database GUI that runs in the browser and is deployed next to the databases it connects to, as a container, a Helm chart, or an npm package. It presents Redis in the same interface as the other engines a team runs, so a cache and the application database behind it can be inspected in one place. The Redis support is built on [`ioredis`](https://github.com/redis/ioredis) and provides:
+
+* A command console that sends any command through a generic dispatch path, including module commands such as `JSON.GET`.
+* A key browser that groups keys by prefix using `SCAN` over a bounded sample of the keyspace, rather than `KEYS`.
+* Server, client, and slow command views built from `INFO`, `CLIENT LIST`, and `SLOWLOG GET`.
+
+It connects to a single standalone node over an unencrypted connection: Cluster, Sentinel, and TLS are not supported. Commands carry the privileges of the user you connect as, so read-only access has to come from a Redis ACL rather than from the tool.


### PR DESCRIPTION
### Summary

The Client tools page documents the four tools Redis maintains. This adds a "Third-party tools" section for community-maintained tools that connect to Redis, with one entry: LibreDB Studio, an MIT-licensed self-hosted database GUI.

The archived `redis/redis-doc` repository carried a curated third-party tool list under `tools/gui` (redis-commander, AnotherRedisDesktopManager, medis, p3x-redis-ui and others). That list did not carry over to this repository, so there is currently no page in the docs where a community tool can be documented. If leaving that surface closed is a deliberate decision, say so and I will close this.

### Scope

- One file changed: `content/develop/tools/_index.md`.
- Adds a section, one entry, and one line to the intro list. The four Redis-maintained tools are untouched, and the new section is explicit about who supports what is listed under it.
- The entry states what the tool does not support (Cluster, Sentinel, TLS), so a reader is not sent to it with a managed, TLS-only endpoint.

### Validation

- Every claim in the entry comes from the project's own Redis provider reference: https://github.com/libredb/libredb-studio/blob/main/docs/providers/redis.md
- Repository: https://github.com/libredb/libredb-studio, MIT licence, built on `ioredis`.
- Affiliation: I maintain LibreDB Studio.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a single markdown page; no product code, auth, or runtime behavior.
> 
> **Overview**
> The **Client tools** page (`content/develop/tools/_index.md`) gains a **Third-party tools** section for community-maintained clients, separate from Redis-owned tools.
> 
> The intro bullet list now links to that section. The new content states that listed third-party tools are author-supported, and documents **LibreDB Studio** (self-hosted multi-engine GUI with Redis via `ioredis`), including capabilities (console, SCAN-based key browser, INFO/CLIENT LIST/SLOWLOG views) and explicit limits: standalone only, no Cluster/Sentinel/TLS, ACL-based read-only access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2b75b09c0a2465b7679d3c9db60ca7486466895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->