### PR TITLE
K8s: 7.22.2-43

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
@@ -34,6 +34,6 @@ This is a maintenance release of Redis for Kubernetes to support Redis Software 
 
 ### New limitations
 
-- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Upgrade to the next 8.0.20 maintenance release instead.
+- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Remain on 7.22.2-43 until a later 8.0.20 maintenance release is available.
 
 See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on other known limitations.

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
@@ -32,4 +32,8 @@ This is a maintenance release of Redis for Kubernetes to support Redis Software 
 
 ## Known limitations
 
-See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.
+### New limitations
+
+- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Upgrade to the next 8.0.20 maintenance release instead.
+
+See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on other known limitations.

--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
@@ -1,0 +1,35 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: Maintenance release to support Redis Software version 7.22.2-179.
+hideListLinks: true
+linkTitle: 7.22.2-43 (August 2026)
+title: Redis for Kubernetes 7.22.2-43 (August 2026) release notes
+weight: 15
+---
+
+## Highlights
+
+This is a maintenance release of Redis for Kubernetes to support Redis Software version 7.22.2-179. For supported distributions and known limitations, see the [7.22.2 releases]({{< relref "/operate/kubernetes/release-notes/7-22-2-releases/" >}}).
+
+## Downloads
+
+- **Redis Software**: `redislabs/redis:7.22.2-179`
+- **Operator**: `redislabs/operator:7.22.2-43`
+- **Services Rigger**: `redislabs/k8s-controller:7.22.2-43`
+- **Call Home Client**: `redislabs/re-call-home-client:7.22.2-43`
+
+### OpenShift downloads
+
+- **OLM operator bundle**: `v7.22.2-43.0`
+- **Redis Software**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.22.2-179`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.22.2-43`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.22.2-43`
+- **Call Home Client**: `registry.connect.redhat.com/redislabs/call-home-client:7.22.2-43`
+
+## Known limitations
+
+See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on known limitations.

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
@@ -40,4 +40,8 @@ This is a maintenance release to support [Redis Software 8.0.20]({{<relref "/ope
 
 ## Known limitations
 
-See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on known limitations.
+### New limitations
+
+- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Upgrade to the next 8.0.20 maintenance release instead.
+
+See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on other known limitations.

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
@@ -42,6 +42,6 @@ This is a maintenance release to support [Redis Software 8.0.20]({{<relref "/ope
 
 ### New limitations
 
-- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Upgrade to the next 8.0.20 maintenance release instead.
+- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Remain on 7.22.2-43 until a later 8.0.20 maintenance release is available.
 
 See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on other known limitations.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only release notes and upgrade guidance; no product code or configuration changes.
> 
> **Overview**
> Adds release notes for **Redis for Kubernetes 7.22.2-43** (August 2026), documenting it as a maintenance release aligned with **Redis Software 7.22.2-179**, including container image tags for Redis Software, operator, services rigger, and call-home client (Docker Hub and OpenShift/Red Hat registry).
> 
> Documents a **new known limitation** on both the 7.22.2-43 page and **8.0.20-26**: direct upgrade from **7.22.2-43** to **8.0.20-26** is not supported; customers should stay on 7.22.2-43 until a later 8.0.20 maintenance release addresses the upgrade path. The 8.0.20-26 page gains a dedicated **New limitations** subsection for this note instead of only linking to the parent 8.0.20 limitations list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee5542ad2df65eadcdc9d9dfb5e6ff408fb22e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->