### PR TITLE
K8s 7.8.6-19 maint RN

### DIFF
--- a/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-19-august2026.md
+++ b/content/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-19-august2026.md
@@ -1,0 +1,36 @@
+---
+alwaysopen: false
+categories:
+- docs
+- operate
+- kubernetes
+description: A maintenance release that includes support for Redis Software 7.8.6-303.
+hideListLinks: true
+linkTitle: 7.8.6-19 (August 2026)
+title: Redis Enterprise for Kubernetes 7.8.6-19 (August 2026) release notes
+weight: 15
+---
+
+Redis Enterprise for Kubernetes 7.8.6-19 (August 2026) is a maintenance release that includes support for [Redis Software 7.8.6-303]({{<relref "/operate/rs/release-notes/rs-7-8-releases/" >}}).
+
+For supported distributions, known limitations, and API changes, see [Redis Enterprise for Kubernetes 7.8.6-1 March 2025 release notes]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases/7-8-6-1-march2025" >}}).
+
+## Downloads
+
+- **Redis Enterprise**: `redislabs/redis:7.8.6-303`
+- **Operator**: `redislabs/operator:7.8.6-19`
+- **Services Rigger**: `redislabs/k8s-controller:7.8.6-19`
+
+### OpenShift images
+
+- **Redis Enterprise**: `registry.connect.redhat.com/redislabs/redis-enterprise:7.8.6-303`
+- **Operator**: `registry.connect.redhat.com/redislabs/redis-enterprise-operator:7.8.6-19`
+- **Services Rigger**: `registry.connect.redhat.com/redislabs/services-manager:7.8.6-19`
+
+### OLM bundle
+
+**Redis Enterprise operator bundle**: `v7.8.6-19.0`
+
+## Known limitations
+
+See [7.8.6 releases]({{<relref "/operate/kubernetes/release-notes/7-8-6-releases" >}}) for information on known limitations.


### PR DESCRIPTION
Maintenance release note for Redis Enterprise for Kubernetes 7.8.6-19 (Wisconsin maint 12, August 2026), which adds support for Redis Software 7.8.6-303.

No itemized content: the operator changelog between the shipped tags v7.8.6-16 and v7.8.6-19 is three commits, and the only substantive one is the RS version bump, so there are no operator-side changes to report.

Versions verified against tag v7.8.6-19 rather than carried forward: RS 7.8.6-303 is pinned in pkg/apis/app/v1alpha1/defaults.go, and the OLM bundle suffix v7.8.6-19.0 came from Yuval's release announcement since it is not present in the operator repo. The Redis Software link points at the 7.8.x line index, matching the rest of this folder and avoiding a relref to rs-7-8-6-303.md while that page is still unmerged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no product or configuration code changes.
> 
> **Overview**
> Adds a new release notes page for **Redis Enterprise for Kubernetes 7.8.6-19** (August 2026), documenting a maintenance release that ships **Redis Software 7.8.6-303**.
> 
> The page lists container image tags (Redis Enterprise, operator, Services Rigger), OpenShift registry images, and OLM bundle **v7.8.6-19.0**. It defers supported distributions, API changes, and known limitations to the March 2025 baseline notes and the 7.8.6 releases index, matching other recent maint notes in this folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 849435d58047eba6ffdafb992ff2933c8735b5e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->