### PR TITLE
RS: security updates

### DIFF
--- a/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-154.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/rs-7-2-4-154.md
@@ -98,6 +98,10 @@ Redis Enterprise 7.2.4-154 supports open source Redis 7.2, 6.2, and 6.0. Below i
 
 {{< collapsible "Redis 7.2.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -193,6 +197,10 @@ Redis Enterprise 7.2.4-154 supports open source Redis 7.2, 6.2, and 6.0. Below i
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-133.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-133.md
@@ -145,6 +145,10 @@ Redis Software 7.22.2-133 supports open source Redis 7.4, 7.2, and 6.2. Below is
 
 Redis 7.4.x:
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -194,6 +198,10 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -286,6 +294,10 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-170.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-170.md
@@ -159,6 +159,10 @@ Redis Software 7.22.2-170 supports open source Redis 7.4, 7.2, and 6.2. Below is
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -210,6 +214,10 @@ Redis Software 7.22.2-170 supports open source Redis 7.4, 7.2, and 6.2. Below is
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -306,6 +314,10 @@ Redis Software 7.22.2-170 supports open source Redis 7.4, 7.2, and 6.2. Below is
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-280.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/rs-7-4-6-280.md
@@ -220,6 +220,10 @@ Redis Software 7.4.6-280 supports open source Redis 7.2, 6.2, and 6.0. Below is 
 
 {{< collapsible "Redis 7.2.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -315,6 +319,10 @@ Redis Software 7.4.6-280 supports open source Redis 7.2, 6.2, and 6.0. Below is 
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-263.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-263.md
@@ -133,6 +133,10 @@ Redis Software 7.8.6-263 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 
 Redis 7.4.x:
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -182,6 +186,10 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -274,6 +282,10 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-286.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-286.md
@@ -139,6 +139,10 @@ Redis Software 7.8.6-286 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -190,6 +194,10 @@ Redis Software 7.8.6-286 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -286,6 +294,10 @@ Redis Software 7.8.6-286 supports open source Redis 7.4, 7.2, and 6.2. Below is 
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -248,6 +248,10 @@ Redis Software 8.0.20-19 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 Redis 8.6.x:
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -274,6 +278,10 @@ Redis 8.6.x:
 
 Redis 8.4.x:
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -299,6 +307,10 @@ Redis 8.4.x:
 - Added validation of limits during RDB load and data creation to avoid resource exhaustion and Denial-of-Service (DoS) vulnerabilities.
 
 Redis 8.2.x:
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -352,6 +364,10 @@ Redis 8.2.x:
 
 Redis 8.0.x:
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -402,6 +418,10 @@ Redis 8.0.x:
 
 Redis 7.4.x:
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -451,6 +471,10 @@ Redis 7.4.x:
 - (CVE-2025-21605) An unauthenticated client can cause unlimited growth of output buffers until the server runs out of memory or is terminated, which can lead to denial-of-service.
 
 Redis 7.2.x:
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -543,6 +567,10 @@ Redis 7.0.x:
 - (CVE-2022-24735) By exploiting weaknesses in the Lua script execution environment, an attacker with access to Redis can inject Lua code that will execute with the (potentially higher) privileges of another Redis user. (Redis 7.0.0)
 
 Redis 6.2.x:
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
@@ -232,6 +232,10 @@ Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.6.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -260,6 +264,10 @@ Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -287,6 +295,10 @@ Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -342,6 +354,10 @@ Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.0.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -394,6 +410,10 @@ Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -445,6 +465,10 @@ Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -541,6 +565,10 @@ Redis Software 8.0.20-44 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-68.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-68.md
@@ -218,6 +218,10 @@ Redis Software 8.0.20-68 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.6.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -246,6 +250,10 @@ Redis Software 8.0.20-68 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -273,6 +281,10 @@ Redis Software 8.0.20-68 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -328,6 +340,10 @@ Redis Software 8.0.20-68 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.0.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -380,6 +396,10 @@ Redis Software 8.0.20-68 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -431,6 +451,10 @@ Redis Software 8.0.20-68 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -527,6 +551,10 @@ Redis Software 8.0.20-68 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
@@ -214,6 +214,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -260,6 +262,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -267,6 +271,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -304,6 +310,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -311,6 +319,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -374,6 +384,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -381,6 +393,8 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -442,9 +456,17 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -506,9 +528,17 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -614,9 +644,17 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
@@ -272,8 +272,6 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
 
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
@@ -319,8 +317,6 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -390,12 +386,6 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
 
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
@@ -462,12 +452,6 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
 
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
@@ -533,12 +517,6 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -649,12 +627,6 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-96.md
@@ -210,6 +210,24 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.6.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -238,6 +256,22 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.4.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -265,6 +299,22 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -320,6 +370,22 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 8.0.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -372,6 +438,18 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -423,6 +501,18 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -519,6 +609,18 @@ Redis Software 8.0.20-96 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -352,6 +352,10 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.6.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -380,6 +384,10 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -407,6 +415,10 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -462,6 +474,10 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.0.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -514,6 +530,10 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -565,6 +585,10 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -661,6 +685,10 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-25.md
@@ -352,10 +352,6 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.6.x" >}}
 
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -384,10 +380,6 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.4.x" >}}
 
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -415,10 +407,6 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -474,10 +462,6 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.0.x" >}}
 
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -530,10 +514,6 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 7.4.x" >}}
 
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -585,10 +565,6 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -685,10 +661,6 @@ Redis Software 8.2.0-25 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -250,20 +250,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -308,18 +294,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -363,18 +337,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -446,18 +408,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -522,14 +472,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -593,14 +535,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -709,14 +643,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -246,6 +246,24 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -286,6 +304,22 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -313,6 +347,22 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
 
@@ -392,6 +442,22 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -452,6 +518,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
 
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -503,6 +581,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
 
@@ -607,6 +697,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -232,24 +232,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.6.x" >}}
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -278,22 +260,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.4.x" >}}
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -321,22 +287,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
-
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -392,22 +342,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.0.x" >}}
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -460,18 +394,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 7.4.x" >}}
 
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
-
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -523,18 +445,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
-
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -631,18 +541,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
-
-- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
-
-- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
-
-- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
-
-- An out-of-bounds read during command key extraction may cause the server to crash.
-
-- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
-
-- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -232,6 +232,20 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.6.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -260,6 +274,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.4.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -287,6 +313,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -342,6 +380,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.0.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -394,6 +444,14 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -445,6 +503,14 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -541,6 +607,14 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -232,6 +232,24 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.6.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -260,6 +278,22 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.4.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -287,6 +321,22 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 8.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
@@ -342,6 +392,22 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 8.0.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - VSET: Large `VADD REDUCE` values can lead to out-of-memory crashes or buffer overflow.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
@@ -394,6 +460,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 {{< collapsible "Redis 7.4.x" >}}
 
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
+
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
 - (CVE‑2026‑25243) A vulnerability in the Redis `RESTORE` command allows an authenticated user to trigger an invalid memory access via a specially crafted serialized payload, potentially resulting in remote code execution.
@@ -445,6 +523,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 7.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 
@@ -541,6 +631,18 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 {{< /collapsible >}}
 
 {{< collapsible "Redis 6.2.x" >}}
+
+- Memory corruption in `SLOT_INFO` handling may allow an unauthenticated user to potentially run their own code.
+
+- A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
+
+- An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
+
+- An out-of-bounds read during command key extraction may cause the server to crash.
+
+- (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
+
+- RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
 
 - (CVE-2026-23479) When a blocked client is evicted while re-executing a blocked command, an authenticated user may trigger a use-after-free and potentially lead to remote code execution.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -294,8 +294,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
 
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
@@ -341,8 +339,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -412,12 +408,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
 
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
@@ -484,12 +474,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
 
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
-
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
 - RedisBloom: Out-of-bounds access in the `TopK` heap cleanup path.
@@ -555,12 +539,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -671,12 +649,6 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
-
-- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
-
-- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
-
-- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 

--- a/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/rs-8-2-0-46.md
@@ -236,6 +236,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -282,6 +284,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -289,6 +293,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -326,6 +332,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -333,6 +341,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -396,6 +406,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
@@ -403,6 +415,8 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 - VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
 
 - VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -464,9 +478,17 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -528,9 +550,17 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 
@@ -636,9 +666,17 @@ Redis Software 8.2.0-46 supports Redis Open Source 8.6, 8.4, 8.2, 8.0, 7.4, 7.2,
 
 - A use-after-free in TLS pending-data processing may allow an authenticated user to cause a denial-of-service.
 
+- A vulnerability in the `RESTORE` command and in RDB loading allows an authenticated user to trigger a use-after-free in stream consumer groups via a specially crafted serialized payload, potentially resulting in remote code execution.
+
 - An ACL key-pattern bypass in `GEORADIUS` and `GEORADIUSBYMEMBER` may allow an authenticated user to write to keys outside their permitted key patterns.
 
 - An out-of-bounds read during command key extraction may cause the server to crash.
+
+- VSET: Missing `level` cap when loading a serialized HNSW graph may lead to resource exhaustion.
+
+- VSET: Missing validation of the parameter count when loading a serialized vector set may lead to oversized allocation and resource exhaustion.
+
+- Certificate common-name handling can allow an authentication bypass when `tls-auth-clients-user` is set to `CN`.
 
 - (CVE-2026-62356) An authenticated user may trigger a heap out-of-bounds write in RedisBloom by loading a specially crafted Count-Min Sketch (`CMSketch`) object, for example via the `RESTORE` command or a crafted RDB file.
 


### PR DESCRIPTION
Adds the Melissa and Nexus security entries to the RS release notes (DOC-6970).

Sources: [GHSA-q5p6-hwxh-c23h](https://github.com/RedisBloom/RedisBloom/security/advisories/GHSA-q5p6-hwxh-c23h)
for CVE-2026-62356; cherry-pick tickets RED-210241/210242/210243 for the build mapping.
Vector set entries are scoped to Redis 8.2+ and the TLS CN entry to 8.6+, per Yaacov.

Supersedes #3801.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to release-note markdown; accuracy of version-to-fix mapping should be confirmed in review, especially Nexus entries under older Redis line sections.
> 
> **Overview**
> Updates **Redis Software release notes** so the **Open source Redis security fixes compatibility** lists reflect recent Melissa and Nexus backports (DOC-6970).
> 
> **RedisBloom (all touched builds):** Prepends **CVE-2026-62356** (crafted `CMSketch` via `RESTORE`/RDB) and a **TopK** heap-cleanup out-of-bounds item at the top of each applicable Redis OSS version subsection (7.2.x, 6.2.x, and 7.4.x/8.x where those lines ship), following the existing “propagate to every release at or after the fix” pattern across RS **7.2.4**, **7.4.6**, **7.8.6**, **7.22.2**, **8.0.20**, and **8.2.0** note pages.
> 
> **Nexus batch (newer cherry-pick builds only):** **`rs-8-0-20-96.md`** and **`rs-8-2-0-46.md`** also gain a block of additional fixes at the head of each Redis version section—e.g. **`SLOT_INFO`** memory corruption, TLS pending-data UAF, stream consumer-group **`RESTORE`/RDB** UAF, **`GEORADIUS`** ACL bypass, command key-extraction OOB read, **VSET** RDB validation gaps, and (on 8.6.x) **`tls-auth-clients-user` CN** auth bypass—plus the same RedisBloom lines. Other pages in the diff only receive the two RedisBloom bullets.
> 
> No product code changes; reviewers should sanity-check **which OSS version sections** include VSET/TLS entries versus 8.x-only, as flagged in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d5191656f3ab56938b577e3a085aba8f8ffc05f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


