### PR TITLE
Infra: Agents.md for contributors using AI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# Redis docs — conventions for AI-assisted editing
+
+Conventions for drafting and editing pages in this repository. Everything here is a
+property of the site or of the house style, so it holds everywhere.
+
+**This file stays small on purpose.** It carries only what is true across every product.
+As soon as a rule needs a product-specific caveat, it belongs in that product's
+`AGENTS.md` instead — where it can be stated with its exception, and loaded only by
+sessions editing those pages.
+
+Product directories under `content/operate/` and `content/develop/` add their own
+`AGENTS.md` covering terminology and disclosure. Read it before editing prose in one of
+those directories. Where it conflicts with this file, the product file wins.
+
+**Disclosure rules are not uniform across this repo.** Open source documentation under
+`content/develop/` and `content/commands/` legitimately links to source code and
+documents implementation internals, because the implementation is public and is part of
+the product. Commercial product directories do not. Never carry a disclosure rule from
+one product's pages into another's — check that product's `AGENTS.md`.
+
+## Before applying any rule here
+
+If a term, structure, or frontmatter shape is already used consistently across this
+section's pages, that usage wins until it is deliberately changed everywhere at once. A
+single page that disagrees with its neighbors is a page to fix; twenty that agree are a
+convention.
+
+Do not normalize an inconsistency you noticed while doing unrelated work — note it and
+move on. Where a rule below says otherwise for a specific term, that rule wins.
+
+## Style
+
+- Google developer documentation style.
+- Lead with the takeaway. The most useful sentence goes first.
+- Present tense, active voice, second person. "The operator detects the change", not
+  "changes are detected".
+- Short sentences. Split anything with three clauses.
+- Plain verbs: `use`, not `utilize`. Contractions are fine.
+- Sentence-case headings. Procedure titles start with a verb: "Create a role".
+- Numbered steps, one action per step. Call them **steps**, never "flows".
+- Expand every acronym on first use in a page, including familiar ones: RBAC, CRD, TLS.
+- No marketing register: not "seamless", "powerful", "simply", "easily", "just".
+- No directional language ("above", "below", "on the left"). Link to the thing.
+- Prefer `replica`, `allowlist`, `denylist`.
+
+## Prose form and code form are different
+
+Use the readable form in prose and the literal identifier only where the reader types
+it, or once in parentheses on first mention.
+
+Configuration keys, API fields, custom resource kinds, command names, and endpoint paths
+are never reworded, re-cased, or pluralized to fit a sentence. If a sentence reads badly
+around a literal, rewrite the sentence.
+
+## Site mechanics
+
+- **Cross-references use the relref shortcode**, not markdown paths:
+  `{{< relref "/operate/rs/clusters/new-cluster-setup" >}}`. A broken relref fails the
+  build. Link text is descriptive — never "click here" or a bare URL.
+- **Preserve shortcodes, frontmatter, and code fences verbatim.** Do not reformat them.
+- **Frontmatter**: copy the shape from a sibling page in the same directory rather than
+  composing one. `title` and `linkTitle` are effectively universal; `description`,
+  `weight`, and `categories` are common but not required — a page without one is not a
+  defect to fix. Key casing is inconsistent across the corpus (`title` and `Title`,
+  `linktitle` and `linkTitle`) — match the directory you are in and do not normalize.
+- **Inline HTML comments are for open items only** — a TODO or an unresolved question
+  someone still has to act on. Never narrate a resolved decision or record where content
+  came from. Delete a comment when its item is resolved rather than rewriting it as a
+  note. Ticket references such as `<!--RED-12345-->` stay.
+- **Examples must be runnable by the reader.** Use angle-bracket placeholders such as
+  `<your-cluster-name>`, and never real credentials, addresses, or customer data.
+- **New pages**: check whether the topic already exists and prefer extending or
+  cross-linking an existing page. Prefer consolidated pages with H2 sections over many
+  small files. Never leave a new page unlinked from its section index.
+
+## Editing scope
+
+Edit only what was asked. If a neighboring page or section also needs work, name it in
+one sentence and stop.
+
+An editorial pass should leave a page shorter, not longer. Do not add summary sections,
+boilerplate introductions, or transitions the original did not have. If a section needs
+new material to be usable, say so instead of writing it.
+
+## Flag rather than decide
+
+- **A technical fact looks wrong.** Never silently correct a command, value, field name,
+  port, or version-specific fact. Say what looks wrong and leave it.
+- **The change would remove or soften a documented limitation.** Weakening a published
+  "no" is a product claim, not an edit.
+- **A term appears that this file does not cover.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/config.toml
+++ b/config.toml
@@ -27,6 +27,12 @@ ignoreFiles = [
   "/__pycache__/",       # Python bytecode cache
   "/models/",            # Hugot model cache
   "/\\.transformers-cache/",  # TransformersPHP cache
+  # AI-audience convention files. These live beside the pages they describe so
+  # coding agents load them by directory, but they are not documentation and must
+  # never render: Hugo turns any .md under content/ into a published page.
+  "AGENTS\\.md$",
+  "CLAUDE\\.md$",
+  "CLAUDE\\.local\\.md$",
 ]
 
 [related]

--- a/content/develop/ai/featureform/AGENTS.md
+++ b/content/develop/ai/featureform/AGENTS.md
@@ -48,9 +48,10 @@ for the product in prose.
 
 ## Resource vocabulary
 
-`concepts.md` defines the resource types and is the canonical source for them. Do not
-restate those definitions on another page — link to it. The distinctions below are the
-ones most often gotten wrong.
+The concepts page at `content/develop/ai/featureform/concepts.md` defines the resource
+types and is the canonical source for them. Do not restate those definitions on another
+page — link to it with `{{< relref "/develop/ai/featureform/concepts" >}}`. The
+distinctions below are the ones most often gotten wrong.
 
 - **Features and labels have the same shape and different jobs.** A feature is model
   input read at inference time. A label is the target value a model is trained to
@@ -131,4 +132,4 @@ Drafting ahead is normal. Draft, verify, open the pull request, and hold it.
   work as written.
 - **Internal material contradicts a published page.** The internal version does not
   automatically win — it may describe unreleased behavior or an internal rename.
-- **A term appears that this file and `concepts.md` do not cover.**
+- **A term appears that neither this file nor the concepts page covers.**

--- a/content/develop/ai/featureform/AGENTS.md
+++ b/content/develop/ai/featureform/AGENTS.md
@@ -1,0 +1,134 @@
+# Redis Feature Form docs — conventions for AI-assisted editing
+
+These pages document **Redis Feature Form**, a feature platform. The documentation is
+split across two directories by audience:
+
+- `content/develop/ai/featureform/` — authoring and serving features: concepts,
+  quickstart, definitions files, providers, workspaces, querying, serving.
+- `content/operate/featureform/` — deploying the product and configuring
+  authentication.
+
+This file is duplicated in both directories so that either one loads it on its own.
+**Keep the two copies identical** — a change to one is a change to both.
+
+Read the repository-root `AGENTS.md` first for style and site mechanics. This file adds
+terminology and disclosure rules for these directories, and wins where the two conflict.
+
+## The source is private — the open source carve-out does not apply here
+
+The root file notes that documentation under `content/develop/` legitimately links to
+source code and documents implementation internals, because the products documented
+there are open source. **Feature Form is not.** Its source repository is private, so a
+file path, repository URL, or "see the implementation" pointer is a dead end for every
+reader of these pages.
+
+These pages currently contain no source links. Do not add one.
+
+Where a statement was only defensible because it cited code, it either stands on its own
+as documented behavior or it comes out. "Check the source for the supported providers",
+in any phrasing, means the page has a real gap. Flag it rather than shipping it.
+
+Published pages carry no audit trail. Strip verification notes, "verified against"
+lines, source lists, and freshness dates.
+
+## Product names
+
+| Use | Not | Note |
+| --- | --- | --- |
+| Redis Feature Form | Featureform, Feature form | First mention on a page. |
+| Feature Form | Featureform, FF | Every later mention on that page. |
+| feature platform | feature store | What the product is. The pages use "feature platform"; "feature store" appears nowhere in them. |
+
+**"Featureform" as one word is a code identifier, never prose.** It is correct in the
+Python package (`import featureform as ff`), in a module path, and in a type name such as
+`ff.FeatureformError`. It is wrong in a sentence.
+
+The command-line tool is `ff`. Use the literal in commands, and never as an abbreviation
+for the product in prose.
+
+## Resource vocabulary
+
+`concepts.md` defines the resource types and is the canonical source for them. Do not
+restate those definitions on another page — link to it. The distinctions below are the
+ones most often gotten wrong.
+
+- **Features and labels have the same shape and different jobs.** A feature is model
+  input read at inference time. A label is the target value a model is trained to
+  predict, and feeds offline training rather than online serving. They are not
+  interchangeable.
+- **A dataset registers data that already exists** in an offline store. A
+  **transformation** produces a new dataset from existing ones. Neither is a "source" —
+  that word is not a resource type here.
+- **A feature view is the only graph resource downstream applications read from.**
+  Applications do not query features directly.
+- **A workspace is the isolation boundary.** Nothing is shared between workspaces. Never
+  describe a resource as shared, global, or deployment-wide unless the page says so.
+
+Provider **roles** are literal values — `offline-store`, `online-store`, `compute`,
+`streaming` — and are not reworded or capitalized to fit a sentence. A provider fills one
+or more roles; it is not "an offline store" in prose where the role name is meant.
+
+## Materialization is described abstractly — never expose the storage layout
+
+Feature Form materializes feature values into an online store, typically Redis. Describe
+what materialization achieves — that values are populated and available to serve — and
+stop there.
+
+**Never document how those values are laid out in Redis.** No key formats, no key naming
+schemes, no hash field names, no reserved metadata fields, no internal encodings. This is
+a deliberate decision, not an omission to helpfully fill in: the layout is internal, it
+changes without notice, and a reader who builds against it builds on sand.
+
+The same holds for the planner and the task DAG. What a change causes is documentable;
+how the work is scheduled and executed internally is not.
+
+## Do not weaken the credential claim
+
+These pages state that Feature Form never stores credentials in any form — not
+plaintext, not hashed, not encrypted — and that a provider configuration carries only a
+reference to a separately registered secret backend.
+
+That is a security claim about the product. Do not soften it, qualify it, or restate it
+in looser words while editing nearby prose. If something appears to contradict it, flag
+it; do not resolve it in the text.
+
+Examples never contain a real credential, host, or account identifier. A secret reference
+in an example is a reference, such as `env:PG_PASSWORD` — not a value.
+
+## Document current behavior only
+
+Do not foreshadow planned support, future feature expansions, or roadmap items — even
+when a specification, an internal document, or a subject-matter expert mentions them.
+Planned work slips, changes shape, or gets cut, and removing a promise from a published
+page is visible to customers.
+
+- Wrong: "Support for additional providers is planned."
+- Wrong: "This provider is expected to gain streaming support."
+- Right: state which providers and roles are documented today, and stop.
+
+**Carve-out — deprecation and removal notices are correct and expected.** The rule bans
+promising something the reader will *gain*, not telling them what is going away.
+Customers need lead time to migrate, and a warning is sometimes published ahead of the
+removal itself to give them that time.
+
+The test: does the sentence tell the reader they will gain something, or lose something?
+Gains are out. Losses are in.
+
+## Do not publish ahead of customer availability
+
+Content describing a feature does not go live until customers can use it. The gate is
+availability to customers — not that the code merged, and not that the capability exists
+in an internal build. A feature that is cut or deferred takes its documentation with it:
+remove the content rather than softening it into a promise.
+
+Drafting ahead is normal. Draft, verify, open the pull request, and hold it.
+
+## Flag rather than decide
+
+- **A provider, role, or resource field cannot be confirmed** against the documented
+  behavior. Never infer a supported provider or an accepted argument.
+- **An example would need a credential, a real endpoint, or infrastructure detail** to
+  work as written.
+- **Internal material contradicts a published page.** The internal version does not
+  automatically win — it may describe unreleased behavior or an internal rename.
+- **A term appears that this file and `concepts.md` do not cover.**

--- a/content/develop/ai/featureform/CLAUDE.md
+++ b/content/develop/ai/featureform/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/content/operate/featureform/AGENTS.md
+++ b/content/operate/featureform/AGENTS.md
@@ -48,9 +48,10 @@ for the product in prose.
 
 ## Resource vocabulary
 
-`concepts.md` defines the resource types and is the canonical source for them. Do not
-restate those definitions on another page — link to it. The distinctions below are the
-ones most often gotten wrong.
+The concepts page at `content/develop/ai/featureform/concepts.md` defines the resource
+types and is the canonical source for them. Do not restate those definitions on another
+page — link to it with `{{< relref "/develop/ai/featureform/concepts" >}}`. The
+distinctions below are the ones most often gotten wrong.
 
 - **Features and labels have the same shape and different jobs.** A feature is model
   input read at inference time. A label is the target value a model is trained to
@@ -131,4 +132,4 @@ Drafting ahead is normal. Draft, verify, open the pull request, and hold it.
   work as written.
 - **Internal material contradicts a published page.** The internal version does not
   automatically win — it may describe unreleased behavior or an internal rename.
-- **A term appears that this file and `concepts.md` do not cover.**
+- **A term appears that neither this file nor the concepts page covers.**

--- a/content/operate/featureform/AGENTS.md
+++ b/content/operate/featureform/AGENTS.md
@@ -1,0 +1,134 @@
+# Redis Feature Form docs — conventions for AI-assisted editing
+
+These pages document **Redis Feature Form**, a feature platform. The documentation is
+split across two directories by audience:
+
+- `content/develop/ai/featureform/` — authoring and serving features: concepts,
+  quickstart, definitions files, providers, workspaces, querying, serving.
+- `content/operate/featureform/` — deploying the product and configuring
+  authentication.
+
+This file is duplicated in both directories so that either one loads it on its own.
+**Keep the two copies identical** — a change to one is a change to both.
+
+Read the repository-root `AGENTS.md` first for style and site mechanics. This file adds
+terminology and disclosure rules for these directories, and wins where the two conflict.
+
+## The source is private — the open source carve-out does not apply here
+
+The root file notes that documentation under `content/develop/` legitimately links to
+source code and documents implementation internals, because the products documented
+there are open source. **Feature Form is not.** Its source repository is private, so a
+file path, repository URL, or "see the implementation" pointer is a dead end for every
+reader of these pages.
+
+These pages currently contain no source links. Do not add one.
+
+Where a statement was only defensible because it cited code, it either stands on its own
+as documented behavior or it comes out. "Check the source for the supported providers",
+in any phrasing, means the page has a real gap. Flag it rather than shipping it.
+
+Published pages carry no audit trail. Strip verification notes, "verified against"
+lines, source lists, and freshness dates.
+
+## Product names
+
+| Use | Not | Note |
+| --- | --- | --- |
+| Redis Feature Form | Featureform, Feature form | First mention on a page. |
+| Feature Form | Featureform, FF | Every later mention on that page. |
+| feature platform | feature store | What the product is. The pages use "feature platform"; "feature store" appears nowhere in them. |
+
+**"Featureform" as one word is a code identifier, never prose.** It is correct in the
+Python package (`import featureform as ff`), in a module path, and in a type name such as
+`ff.FeatureformError`. It is wrong in a sentence.
+
+The command-line tool is `ff`. Use the literal in commands, and never as an abbreviation
+for the product in prose.
+
+## Resource vocabulary
+
+`concepts.md` defines the resource types and is the canonical source for them. Do not
+restate those definitions on another page — link to it. The distinctions below are the
+ones most often gotten wrong.
+
+- **Features and labels have the same shape and different jobs.** A feature is model
+  input read at inference time. A label is the target value a model is trained to
+  predict, and feeds offline training rather than online serving. They are not
+  interchangeable.
+- **A dataset registers data that already exists** in an offline store. A
+  **transformation** produces a new dataset from existing ones. Neither is a "source" —
+  that word is not a resource type here.
+- **A feature view is the only graph resource downstream applications read from.**
+  Applications do not query features directly.
+- **A workspace is the isolation boundary.** Nothing is shared between workspaces. Never
+  describe a resource as shared, global, or deployment-wide unless the page says so.
+
+Provider **roles** are literal values — `offline-store`, `online-store`, `compute`,
+`streaming` — and are not reworded or capitalized to fit a sentence. A provider fills one
+or more roles; it is not "an offline store" in prose where the role name is meant.
+
+## Materialization is described abstractly — never expose the storage layout
+
+Feature Form materializes feature values into an online store, typically Redis. Describe
+what materialization achieves — that values are populated and available to serve — and
+stop there.
+
+**Never document how those values are laid out in Redis.** No key formats, no key naming
+schemes, no hash field names, no reserved metadata fields, no internal encodings. This is
+a deliberate decision, not an omission to helpfully fill in: the layout is internal, it
+changes without notice, and a reader who builds against it builds on sand.
+
+The same holds for the planner and the task DAG. What a change causes is documentable;
+how the work is scheduled and executed internally is not.
+
+## Do not weaken the credential claim
+
+These pages state that Feature Form never stores credentials in any form — not
+plaintext, not hashed, not encrypted — and that a provider configuration carries only a
+reference to a separately registered secret backend.
+
+That is a security claim about the product. Do not soften it, qualify it, or restate it
+in looser words while editing nearby prose. If something appears to contradict it, flag
+it; do not resolve it in the text.
+
+Examples never contain a real credential, host, or account identifier. A secret reference
+in an example is a reference, such as `env:PG_PASSWORD` — not a value.
+
+## Document current behavior only
+
+Do not foreshadow planned support, future feature expansions, or roadmap items — even
+when a specification, an internal document, or a subject-matter expert mentions them.
+Planned work slips, changes shape, or gets cut, and removing a promise from a published
+page is visible to customers.
+
+- Wrong: "Support for additional providers is planned."
+- Wrong: "This provider is expected to gain streaming support."
+- Right: state which providers and roles are documented today, and stop.
+
+**Carve-out — deprecation and removal notices are correct and expected.** The rule bans
+promising something the reader will *gain*, not telling them what is going away.
+Customers need lead time to migrate, and a warning is sometimes published ahead of the
+removal itself to give them that time.
+
+The test: does the sentence tell the reader they will gain something, or lose something?
+Gains are out. Losses are in.
+
+## Do not publish ahead of customer availability
+
+Content describing a feature does not go live until customers can use it. The gate is
+availability to customers — not that the code merged, and not that the capability exists
+in an internal build. A feature that is cut or deferred takes its documentation with it:
+remove the content rather than softening it into a promise.
+
+Drafting ahead is normal. Draft, verify, open the pull request, and hold it.
+
+## Flag rather than decide
+
+- **A provider, role, or resource field cannot be confirmed** against the documented
+  behavior. Never infer a supported provider or an accepted argument.
+- **An example would need a credential, a real endpoint, or infrastructure detail** to
+  work as written.
+- **Internal material contradicts a published page.** The internal version does not
+  automatically win — it may describe unreleased behavior or an internal rename.
+- **A term appears that this file and `concepts.md` do not cover.**

--- a/content/operate/featureform/CLAUDE.md
+++ b/content/operate/featureform/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/content/operate/kubernetes/AGENTS.md
+++ b/content/operate/kubernetes/AGENTS.md
@@ -1,0 +1,151 @@
+# Redis Software for Kubernetes docs — conventions for AI-assisted editing
+
+These pages document the operator-based deployment of Redis Software on Kubernetes and
+OpenShift. The self-managed product is documented under `content/operate/rs/` and the
+managed service under `content/operate/rc/`; both have their own conventions.
+
+Read the repository-root `AGENTS.md` first for style and site mechanics. This file adds
+terminology and disclosure rules for this directory, and wins where the two conflict.
+
+## Product name — a deliberate transition, not an inconsistency to resolve
+
+The current product name is **Redis Software for Kubernetes**. The legacy name is
+"Redis Enterprise for Kubernetes".
+
+These pages are mid-rebrand: most current pages still carry the legacy name. **That is
+expected.**
+
+- **New and rewritten content uses "Redis Software for Kubernetes".**
+- **Do not rename the legacy occurrences.** Rebranding is a deliberate pass across the
+  whole section, not something to do while editing a page for another reason.
+
+**This overrides the root file's "match the corpus" rule for this term.** The legacy name
+is more common here, so following the majority is wrong. Treat the name as settled and
+the pages as lagging.
+
+_This section is transitional. Once the rebrand pass is complete and the legacy name no
+longer appears in this directory, delete it and keep only the name itself._
+
+When linking to a page whose `title` still carries the legacy name, use the current
+name in your link text — `relref` resolves by path, not by title.
+
+## Identifiers that never change
+
+Custom resource kinds are used exactly as they appear in the API, legacy name and all:
+
+`RedisEnterpriseCluster`, `RedisEnterpriseDatabase`, `RedisEnterpriseUser`,
+`RedisEnterpriseACL`, `RedisEnterpriseRole`, `RedisEnterpriseRoleBinding`,
+`RedisEnterpriseClusterRole`, `RedisEnterpriseClusterRoleBinding`,
+`RedisEnterpriseActiveActiveDatabase`, `RedisEnterpriseRemoteCluster`.
+
+The same holds for abbreviations — **REC**, **REDB**, **REAADB**, **RERC** — and for
+field paths such as
+`RedisEnterpriseCluster.spec.accessControl.policy.allowREDBRolesPermissions`.
+
+Never "modernize" an identifier to match the product name. The API is the API.
+
+## Say "databases", not "BDB"
+
+Do not write "BDB" or "BDBs" in prose. Write "databases", or "databases created
+directly through the REST API" where that distinction matters.
+
+- **REDB** is fine — it is the custom resource name.
+- A literal `bdb` in an API path, request body, or placeholder such as `<BDB UID>`
+  stays as-is. It is what the reader types.
+
+## Roles
+
+Use the readable form in prose — "cluster admin" is the established usage — and the
+role ID only where the reader types it, or once in parentheses on first mention.
+
+Role names as *defined* appear in title case in reference tables and examples ("Cluster
+Member", "DB Viewer"). Match the surrounding page: title case where a specific named
+role is being identified, lowercase prose where you are describing who does something.
+
+## Container image paths differ by registry
+
+Release notes and deployment pages reference images from two registries that name the
+same components differently. Match the path style to the registry being documented.
+
+| Component | Red Hat Connect | Docker Hub |
+| --- | --- | --- |
+| Redis Software node | `redis-enterprise` | `redis` |
+| Operator | `redis-enterprise-operator` | `operator` |
+| Services Rigger | `services-manager` | `k8s-controller` |
+| Call-home client | `call-home-client` | `re-call-home-client` |
+
+Getting this wrong produces a path that looks plausible and does not resolve. Check the
+registry before writing or editing an image reference.
+
+## Release codenames are internal
+
+Operator releases carry internal codenames. **None of them appear anywhere in published
+content, and none should.** Refer to releases by version number.
+
+## Versioned content
+
+Version-specific pages live in sibling folders such as `7.22/`, `7.8.6/`, and `8.0/`.
+The unversioned root is the current content.
+
+Default every edit to the current content. When updating shared behavior, check whether
+the change applies across versions or only to the current one, and never propagate a
+current-version change backward into a snapshot.
+
+## Document current behavior only
+
+Do not foreshadow planned support, future feature expansions, or roadmap items — even
+when a specification, an internal document, or a subject-matter expert mentions them.
+Planned work slips, changes shape, or gets cut, and removing a promise from a published
+page is visible to customers.
+
+- Wrong: "Support for multi-namespace deployments is planned for a future release."
+- Wrong: "This limitation is expected to be lifted in a later operator version."
+- Right: state the current limitation flatly, with no forecast — for example, "custom
+  resources of this kind are reconciled only in the operator namespace."
+
+**Carve-out — deprecation and removal notices are correct and expected.** The rule bans
+promising something the reader will *gain*, not telling them what is going away.
+Customers need lead time to migrate or upgrade, and a warning is sometimes published
+ahead of the deprecation itself to give them that time.
+
+- Right: "Support for this platform will be removed in a future release."
+- Right: "This field is deprecated and will be removed in a future release. Use
+  `<replacement>` instead."
+
+The test: does the sentence tell the reader they will gain something, or lose something?
+Gains are out. Losses are in.
+
+## Do not publish ahead of customer availability
+
+Content describing a feature does not go live until customers can use it. The gate is
+availability to customers — not that the code merged, and not that the field exists in
+an internal build. A feature that is cut or deferred takes its documentation with it:
+remove the content rather than softening it into a promise.
+
+Drafting ahead is normal. Draft, verify, open the pull request, and hold it.
+
+## The operator source is private
+
+The operator source repository is not public, so a file path or repository URL is a dead
+end for every reader of these pages. Where a statement was only defensible because it
+cited code, it either stands on its own as documented behavior or it comes out.
+
+"Check the controller for the valid values", in any phrasing, means the page has a real
+gap. Flag it rather than shipping it.
+
+Do not document internal implementation detail — reconcile-loop internals, internal
+service names, or controller-private fields — beyond what a user sets in a custom
+resource or observes in its status.
+
+Published pages carry no audit trail. Strip verification notes, "verified against"
+lines, source lists, and freshness dates.
+
+## Flag rather than decide
+
+- A custom resource field, default, or image tag cannot be confirmed. Operator fields
+  and defaults shift between releases; never infer one.
+- Internal material contradicts a published page. The internal version does not
+  automatically win — it may describe unreleased behavior or a different operator
+  version than the page documents.
+- A version or release boundary is unclear. These pages describe shipped behavior.
+- A term appears that this file does not cover.

--- a/content/operate/kubernetes/CLAUDE.md
+++ b/content/operate/kubernetes/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/content/operate/rs/AGENTS.md
+++ b/content/operate/rs/AGENTS.md
@@ -1,0 +1,150 @@
+# Redis Software docs — conventions for AI-assisted editing
+
+These pages document **Redis Software** — the self-managed product installed on VMs,
+bare metal, or containers. The Kubernetes operator is documented under
+`content/operate/kubernetes/` and the managed service under `content/operate/rc/`;
+both have their own conventions.
+
+Read the repository-root `AGENTS.md` first for style and site mechanics. This file
+adds terminology and disclosure rules for this directory, and wins where the two
+conflict.
+
+## Product names
+
+| Use | Not | Note |
+| --- | --- | --- |
+| Redis Software | Redis Enterprise Software, Redis Enterprise | Current name. Use it in all current prose. |
+| Redis Software | RS | `RS` is internal shorthand and the URL slug (`/operate/rs/`). Never use it in customer-facing prose. |
+
+**Versioned folders predate the rebrand.** Pages under `7.4/`, `7.8/`, and `7.22/`
+still say "Redis Enterprise Software" and "Redis Enterprise". Leave that wording
+alone. Renaming is a deliberate repo-wide pass, not something to do while editing a
+page for another reason.
+
+When linking to a page whose `title` still carries the old name, use the current name
+in your link text — `relref` resolves by path, not by title.
+
+## Active-Active databases
+
+Active-Active databases were formerly called CRDBs, and both forms are correct in
+different places. This is the most commonly mis-corrected convention in this
+directory, so check which surface you are editing.
+
+- **Prose** — "Active-Active database". Where a gloss helps, write "(formerly known as
+  CRDB)". CRDB is a former name, not a current synonym.
+- **REST API reference titles** — **keep CRDB.** The API surface is named `crdb`, and
+  the object pages are titled "CRDB object", "CRDB database config object", and so on.
+  Retitling one makes it the outlier among its siblings.
+- **Code, identifiers, endpoints** — always literal: `crdb-cli`, `/crdbs`, JSON field
+  names.
+
+**Never write bare "Active-Active" with no noun.** Qualify it with whichever is
+accurate:
+
+- The whole replicated object is the **Active-Active database**.
+- Per-cluster settings are configured **per participating cluster** — for example the
+  REST `instances[].cluster.certificate_auth` field, or `crdb-cli --instance`. Write
+  "each participating cluster in the Active-Active database", not "each Active-Active
+  instance".
+
+## Roles
+
+Use the readable form in prose — "cluster admin" is the established usage — and the
+role ID only where the reader types it, or once in parentheses on first mention.
+
+Role names as *defined* appear in title case in the reference tables ("Cluster Member",
+"Cluster Viewer", "DB Member", "DB Viewer"). Match the surrounding page: title case
+where a specific named role is being identified, lowercase prose where you are
+describing who does something.
+
+## Versioned content
+
+The unversioned root of this directory (`clusters/`, `databases/`, `references/`) is
+the current content. `7.4/`, `7.8/`, and `7.22/` are frozen snapshots carrying a
+`bannerText` that names the version.
+
+Default every edit to the current content. Touch a snapshot only when the change is
+specific to that version, and never propagate a current-version change backward into
+one.
+
+## Generated pages — do not hand-edit
+
+The Cluster REST API reference under `references/rest-api/api-reference/` is generated
+from an engineering-owned OpenAPI specification. Edits to those pages are overwritten
+on the next regeneration.
+
+If something there is wrong — a missing property description, an inconsistency between
+request and response fields, an outdated product name — report it so it can be fixed in
+the specification. Do not patch the generated output.
+
+## Release notes
+
+Release notes live under `release-notes/`, grouped by minor line (`rs-8-0-releases/`,
+`rs-7-22-releases/`).
+
+- Build numbers are `<version>-<build>`, for example `8.0.20-19`.
+- Titles read `Redis Software release notes 8.0.20-19 (May 2026)`.
+- Frontmatter includes `compatibleOSSVersion` and a `weight`.
+- Structure: **Highlights**, then **New in this release** (New features, then
+  Enhancements), then resolved issues, then known limitations. Follow the most recent
+  notes in the newest release folder; older notes predate the current template.
+- A new release also updates `references/supported-platforms.md` and
+  `references/upgrade-paths.md`.
+
+## Document current behavior only
+
+Do not foreshadow planned support, future feature expansions, or roadmap items — even
+when a specification, an internal document, or a subject-matter expert mentions them.
+Planned work slips, changes shape, or gets cut, and removing a promise from a published
+page is visible to customers.
+
+- Wrong: "Support for this is planned for a future release."
+- Wrong: "This limitation is expected to be lifted in 8.4."
+- Right: state the current limitation flatly, with no forecast.
+
+**Carve-out — deprecation and removal notices are correct and expected.** The rule bans
+promising something the reader will *gain*, not telling them what is going away.
+Customers need lead time to migrate or upgrade, and a warning is sometimes published
+ahead of the deprecation itself to give them that time. These pages carry many such
+notices deliberately.
+
+- Right: "Support for TLS 1.1 and earlier will be removed in a future release."
+- Right: "This endpoint is deprecated as of Redis Software version 7.2.4 and will be
+  removed in a future release. Use `<replacement>` instead."
+
+The test: does the sentence tell the reader they will gain something, or lose
+something? Gains are out. Losses are in.
+
+## Do not publish ahead of customer availability
+
+Content describing a feature does not go live until customers can use it. The gate is
+availability to customers — not that the code merged, and not that it exists in an
+internal build. A feature that is cut or deferred takes its documentation with it:
+remove the content rather than softening it into a promise.
+
+Drafting ahead is normal. Draft, verify, open the pull request, and hold it.
+
+## The product source is private
+
+The Redis Software source repository is not public, so a file path or repository URL is
+a dead end for every reader of these pages. Where a statement was only defensible
+because it cited code, it either stands on its own as documented behavior or it comes
+out.
+
+"Check the implementation for the valid values", in any phrasing, means the page has a
+real gap. Flag it rather than shipping it.
+
+Do not document internal implementation detail — process names, internal service names,
+on-disk layouts, or internal field encodings — beyond what a customer configures or
+observes.
+
+Published pages carry no audit trail. Strip verification notes, "verified against"
+lines, source lists, and freshness dates.
+
+## Flag rather than decide
+
+- Internal material contradicts a published page. The internal version does not
+  automatically win — it may describe unreleased behavior, an internal rename, or a
+  different version than the page documents.
+- A version or release boundary is unclear. These pages describe shipped behavior.
+- A term appears that this file does not cover.

--- a/content/operate/rs/CLAUDE.md
+++ b/content/operate/rs/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
one `AGENTS.md` per product directory, recording the conventions each
product's pages already follow — so that when a contributor drafts with an agent, the
agent already knows them.


## What a contributor gets

Someone drafting a page with Claude Code, Codex, or Cursor gets a first draft that
already uses our terminology, our style, and the disclosure rules for the product they're
writing about. The conventions an agent would otherwise guess at are simply there.

That means:

- **A better starting point.** The draft arrives closer to publish-ready instead of
  needing the same handful of corrections every time.
- **Less repeat review.** The corrections a reviewer would make are the ones the file
  already answers.
- **Confidence about the boundaries.** Each product has its own rules about what can and
  can't be published, and the agent now has them in front of it rather than inferring
  from a neighboring product's pages.

Quality goes up at the point where the content is created, which is the cheapest place
for it to go up.

## Why several small files rather than one

Two reasons, and they point the same way.

**Agents do better with smaller files.** A context file is loaded into the model's
working memory at the start of a session, sharing room with the task itself. Claude
Code's own guidance is explicit:

> **Size**: target under 200 lines per CLAUDE.md file. Longer files consume more context
> and **reduce adherence**.

Every file here is inside that. For an AI reader, **relevance density beats
completeness** — the reverse of what makes a human guide good, where answering everything
in one place is the point.

Per-directory files get this for free. A subdirectory's file loads when the agent reads
files in that directory, so a session in the Redis Software pages gets Redis Software
conventions and nothing else.

**Each product is genuinely different.** Not stylistically — substantively. The rules
that matter most are the ones that only make sense inside one directory:

- **Terminology that inverts by surface.** In Redis Software, "Active-Active database" is
  correct in prose and `CRDB` is correct in the REST API reference titles, because the API
  surface is named `crdb`. Both are right. Nothing in the pages tells an agent where the
  line falls.
- **Disclosure rules that don't transfer.** Open source documentation under
  `content/develop/` legitimately links to source code, because the implementation is
  public and part of the product. Feature Form lives in that same directory and its
  source is private, so the general rule is backwards for those pages.
- **Names mid-transition.** Most Kubernetes pages still carry the legacy product name, so
  an agent that follows the majority usage gets it wrong.

A single repo-wide file would have to pick one rule per topic and be wrong for somebody.
Per-product files let each rule be stated correctly, with its exception, where it applies.

## Zero extra effort

Nobody has to do anything differently. No install, no new step, no checklist.

The three tools contributors already use read these files automatically — this is the
documented pattern in each, not a workaround we'd be inventing. Codex walks from the git
root down and concatenates every `AGENTS.md` it finds. Cursor supports nested files
combined with their parents. Claude Code has the same hierarchical model under the
filename `CLAUDE.md`, which is why each directory also gets a one-line `CLAUDE.md`
importing the `AGENTS.md` beside it — also documented, down to the syntax:

> Claude Code reads `CLAUDE.md`, not `AGENTS.md`. If your repository already uses
> `AGENTS.md` for other coding agents, create a `CLAUDE.md` that imports it so both tools
> read the same instructions without duplicating them.

**Done right, contributors never need to know they're there.** They draft the way they
already draft, and what comes back needs less correction. That's the measure of success —
not adoption, and not anyone reading anything. There's nothing to launch and nothing to
learn.

Writing for AI readers is already practice here, too: `redis/docs` commits 29
agent-facing files today, including `AGENT.md`, `AI_AGENT_DEVELOPER_GUIDE.md`, eight under
`.agents/`, and nineteen under `for-ais-only/`.

## What's there

Two tiers, both small.

- **A short root `AGENTS.md`** — universal guidance only: Google style, `relref`
  cross-references, frontmatter shape, editing scope. **Nothing product-specific**, so it
  makes no claim about any product's terminology or what it may publish.
- **One `AGENTS.md` per product directory** — terminology and disclosure, loaded only by
  sessions editing those pages.

That division is also the rule for where a new convention goes: as soon as it needs a
product-specific caveat, it belongs in the product file. Which is what keeps root small.

| Path | State |
| --- | --- |
| repo root | written — style and mechanics only |
| `content/operate/kubernetes/` | written |
| `content/operate/rs/` | written |
| `content/develop/ai/featureform/` | written |
| `content/operate/featureform/` | written — identical copy of the above |

## Every rule states its exception

The rules in these files carry their carve-outs inline. That's the most important
convention in them, and it's the one that decides whether they help or hurt.

**A rule without its exception doesn't make an agent cautious. It makes it thorough.** A
person reading a style guide hedges — they hit a surface where the rule looks wrong and
they ask, or they leave it. An agent doesn't hedge. It applies the rule everywhere it
pattern-matches, uniformly, in one pass, and every edit looks deliberate in review. So a
rule that's correct 90% of the time doesn't produce 10% mistakes; it produces a confident
sweep that someone has to catch line by line.

Three rules from these files show the shapes that failure takes:

- **The exception that looks like a contradiction.** "Don't promise future functionality"
  is our convention. Stated flatly, it strips "support for TLS 1.1 will be removed in a
  future release" — a notice customers depend on for migration lead time. The rule has to
  say that losses are in and gains are out, or it removes the wrong half.
- **The identifier that must not follow the prose rule.** "The product is Redis Software
  for Kubernetes" is correct, and applying it to `RedisEnterpriseCluster` breaks an API
  contract. Same for a literal `bdb` in a request path, or `crdb-cli`. The prose rule and
  the code rule are different rules.
- **The meta-rule that inverts.** Our general guidance is that consistent usage across a
  section wins until it's deliberately changed. In the Kubernetes pages the legacy product
  name *is* the consistent usage, so following it is exactly wrong. That file says so
  explicitly and overrides the general rule for that term.

None of these are edge cases an agent would stumble into rarely. They're the highest-
traffic terms in their directories, which is why the exceptions are the most valuable
lines in the files.

It's also why this isn't just the style guide pasted into the repo. A guide written for
people can leave the exceptions implicit, because people supply the judgment. These files
have to state them, because the reader won't.

## They never reach the site

Hugo renders any `.md` under `content/` as a page, so the files are excluded in
`config.toml` alongside the existing build-output exclusions. Verified on the branch: a
full build produces 5,940 pages and none of them is an `AGENTS.md` or `CLAUDE.md`.

## Nothing here is a new decision

Every rule in these files is a convention our pages already follow — the style guide and
our established terminology, restated where a drafting tool can read them.

So if a rule is wrong, missing, or out of date, change it in the PR where you hit it. No
process, no gate, and nothing to ask anyone's permission for.

## What I'm asking for

A read on one PR. **You don't need to read all ten files** — start with the Kubernetes
one. It's short, and it's the best test of the shape, since the legacy product name is
still the majority usage in that directory. If the shape is right, the rest follow it.

Flag anything you'd want different and I'll fold it in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contributor-only convention files and Hugo ignore rules; no changes to published documentation or runtime behavior.
> 
> **Overview**
> Adds **layered `AGENTS.md` files** so coding agents inherit Redis docs house style and product-specific rules when drafting in a directory, without contributors installing anything new.
> 
> A **repo-root `AGENTS.md`** covers universal style, `relref` usage, frontmatter habits, editing scope, and when to flag instead of fix. **Per-product files** under `content/operate/kubernetes/`, `content/operate/rs/`, and Feature Form (`content/develop/ai/featureform/` plus an identical copy in `content/operate/featureform/`) add terminology, disclosure, and carve-outs (for example mid-rebrand naming, CRDB vs Active-Active, private source, no roadmap promises).
> 
> Each of those directories also gets a one-line **`CLAUDE.md`** that imports the local `AGENTS.md` so Claude Code and other tools share the same instructions.
> 
> **`config.toml`** extends `ignoreFiles` so `AGENTS.md`, `CLAUDE.md`, and `CLAUDE.local.md` under `content/` are not published as Hugo pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 462f9ae5415a59ab4f1458be28b8b3dab2182e55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->