### PR TITLE
RS: add missing CVE

### DIFF
--- a/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-133.md
+++ b/content/operate/rs/release-notes/rs-7-22-releases/rs-7-22-2-133.md
@@ -135,6 +135,8 @@ Active defragmentation does not stop mid-key for JSON data. Large keys are defra
 
 ## Security
 
+Redis Software 7.22.2-133 updates pyOpenSSL to 26.0.0, which fixes a buffer overflow in the DTLS cookie-generation callback (CVE-2026-27459 / GHSA-5pwr-322w-8jr4).
+
 #### Open source Redis security fixes compatibility
 
 As part of Redis's commitment to security, Redis Software implements the latest [security fixes](https://github.com/redis/redis/releases) available with [open source Redis](https://github.com/redis/redis). Redis Software has already included the fixes for the relevant CVEs.

--- a/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-263.md
+++ b/content/operate/rs/release-notes/rs-7-8-releases/rs-7-8-6-263.md
@@ -123,6 +123,8 @@ If one or more fields of a hash key expire after an `FT.SEARCH` or `FT.AGGREGATE
 
 ## Security
 
+Redis Software 7.8.6-263 updates pyOpenSSL to 26.0.0, which fixes a buffer overflow in the DTLS cookie-generation callback (CVE-2026-27459 / GHSA-5pwr-322w-8jr4).
+
 #### Open source Redis security fixes compatibility
 
 As part of Redis's commitment to security, Redis Software implements the latest [security fixes](https://github.com/redis/redis/releases) available with [open source Redis](https://github.com/redis/redis). Redis Software has already included the fixes for the relevant CVEs.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-19.md
@@ -238,6 +238,8 @@ The following legacy UI features are not yet available in the new Cluster Manage
 
 ## Security
 
+Redis Software 8.0.20-19 includes pyOpenSSL 26.0.0, which fixes a buffer overflow in the DTLS cookie-generation callback (CVE-2026-27459 / GHSA-5pwr-322w-8jr4).
+
 #### Redis Open Source security fixes compatibility
 
 As part of Redis's commitment to security, Redis Software implements the latest [security fixes](https://github.com/redis/redis/releases) available with [Redis Open Source](https://github.com/redis/redis). Redis Software has already included the fixes for the relevant CVEs.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to release notes; no product code or configuration changes.
> 
> **Overview**
> Adds a **Security** section lead-in to three Redis Software release-note pages so they explicitly call out **pyOpenSSL 26.0.0** and **CVE-2026-27459** (DTLS cookie-generation buffer overflow; GHSA-5pwr-322w-8jr4).
> 
> The new text appears at the top of **Security** in `rs-7-22-2-133.md`, `rs-7-8-6-263.md`, and `rs-8-0-20-19.md`. Wording matches each build: 7.22 and 7.8 say the release *updates* pyOpenSSL; 8.0 says it *includes* pyOpenSSL 26.0.0. No other sections or CVE lists are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4245468583260889f37f7069c98418ab932d531c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->