### PR TITLE
RS: add end-of-life notices

### DIFF
--- a/content/operate/rs/7.22/installing-upgrading/product-lifecycle.md
+++ b/content/operate/rs/7.22/installing-upgrading/product-lifecycle.md
@@ -41,7 +41,7 @@ This update to the EOL policy allows a lead time of at least 24 months to upgrad
 
 | Version - Release date | End of Life (EOL)  |
 | ----------------------------------------- | ------------------ |
-| 7.22 – May 2025				            | - |
+| 7.22 – May 2025				            | October 30, 2027 |
 | 7.8 – November 2024				        | May 30, 2027 |
 | 7.4 – February 2024				        | November 30, 2026 |
 | 7.2 – August 2023				            | February 28, 2026 |

--- a/content/operate/rs/7.4/_index.md
+++ b/content/operate/rs/7.4/_index.md
@@ -10,7 +10,7 @@ hideListLinks: true
 weight: 10
 url: '/operate/rs/7.4/'
 linkTitle: 7.4
-bannerText: This documentation applies to Redis Software versions 7.4.x.
+bannerText: This documentation applies to Redis Software versions 7.4.x, which reach end of life on November 30, 2026. See the [product lifecycle](/operate/rs/installing-upgrading/product-lifecycle/#endoflife-schedule) for supported versions.
 bannerChildren: true
 ---
 

--- a/content/operate/rs/7.4/installing-upgrading/product-lifecycle.md
+++ b/content/operate/rs/7.4/installing-upgrading/product-lifecycle.md
@@ -41,7 +41,7 @@ This update to the EOL policy allows a lead time of at least 24 months to upgrad
 
 | Version - Release date | End of Life (EOL)  |
 | ----------------------------------------- | ------------------ |
-| 7.4 – February 2024				        | - |
+| 7.4 – February 2024				        | November 30, 2026 |
 | 7.2 – August 2023				            | February 28, 2026 |
 | 6.4 – February 2023						| August 31, 2025 |
 | 6.2 – August 2021                         | February 28, 2025  |

--- a/content/operate/rs/7.8/installing-upgrading/product-lifecycle.md
+++ b/content/operate/rs/7.8/installing-upgrading/product-lifecycle.md
@@ -41,7 +41,7 @@ This update to the EOL policy allows a lead time of at least 24 months to upgrad
 
 | Version - Release date | End of Life (EOL)  |
 | ----------------------------------------- | ------------------ |
-| 7.8 – November 2024				        | - |
+| 7.8 – November 2024				        | May 30, 2027 |
 | 7.4 – February 2024				        | November 30, 2026 |
 | 7.2 – August 2023				            | February 28, 2026 |
 | 6.4 – February 2023						| August 31, 2025 |

--- a/content/operate/rs/8.0/installing-upgrading/product-lifecycle.md
+++ b/content/operate/rs/8.0/installing-upgrading/product-lifecycle.md
@@ -45,7 +45,7 @@ This update to the EOL policy allows a lead time of at least 24 months to upgrad
 
 | Version - Release date | End of Life (EOL)  |
 | ----------------------------------------- | ------------------ |
-| 8.0 – October 2025				        | July 31, 2028 |
+| 8.0 – October 2025				        | - |
 | 7.22 – May 2025				            | October 30, 2027 |
 | 7.8 – November 2024				        | May 30, 2027 |
 | 7.4 – February 2024				        | November 30, 2026 |
@@ -60,7 +60,7 @@ This update to the EOL policy allows a lead time of at least 24 months to upgrad
 The following timeline chart visualizes the Redis Software product lifecycle, showing release dates and end-of-life dates for each major version:
 
 ```timeline {title="Redis Software product lifecycle"}
-8.0: Oct 2025 - Jul 31, 2028
+8.0: Oct 2025 - TBD
 7.22: May 2025 - Oct 30, 2027
 7.8: Nov 2024 - May 30, 2027
 7.4: Feb 2024 - Nov 30, 2026

--- a/content/operate/rs/8.0/installing-upgrading/product-lifecycle.md
+++ b/content/operate/rs/8.0/installing-upgrading/product-lifecycle.md
@@ -45,7 +45,7 @@ This update to the EOL policy allows a lead time of at least 24 months to upgrad
 
 | Version - Release date | End of Life (EOL)  |
 | ----------------------------------------- | ------------------ |
-| 8.0 – October 2025				        | - |
+| 8.0 – October 2025				        | July 31, 2028 |
 | 7.22 – May 2025				            | October 30, 2027 |
 | 7.8 – November 2024				        | May 30, 2027 |
 | 7.4 – February 2024				        | November 30, 2026 |
@@ -60,7 +60,7 @@ This update to the EOL policy allows a lead time of at least 24 months to upgrad
 The following timeline chart visualizes the Redis Software product lifecycle, showing release dates and end-of-life dates for each major version:
 
 ```timeline {title="Redis Software product lifecycle"}
-8.0: Oct 2025 - TBD
+8.0: Oct 2025 - Jul 31, 2028
 7.22: May 2025 - Oct 30, 2027
 7.8: Nov 2024 - May 30, 2027
 7.4: Feb 2024 - Nov 30, 2026

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/_index.md
@@ -15,6 +15,18 @@ toc: 'true'
 weight: 73
 ---
 
+{{< warning >}}
+Redis Software 6.2 reached end of life on February 28, 2025. It no longer
+receives security patches, CVE fixes, bug fixes, or maintenance releases.
+Support for 6.2-specific issues is limited per your subscription agreement,
+and you may be asked to upgrade before an issue can be investigated.
+
+Upgrade to a supported version. Reaching the latest version may require an
+intermediate upgrade first — see the
+[supported upgrade paths]({{< relref "/operate/rs/references/upgrade-paths" >}})
+and the [Redis Software product lifecycle]({{< relref "/operate/rs/installing-upgrading/product-lifecycle#endoflife-schedule" >}}).
+{{< /warning >}}
+
 [Redis Enterprise Software version 6.2.18](https://redislabs.com/redis-enterprise-software/download-center/software/) is now available! 
 
 This version of Redis Enterprise Software offers:

--- a/content/operate/rs/release-notes/rs-6-2-18-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-6-2-18-releases/_index.md
@@ -17,7 +17,7 @@ weight: 73
 
 {{< warning >}}
 Redis Software 6.2 reached end of life on February 28, 2025. It no longer
-receives security patches, CVE fixes, bug fixes, or maintenance releases.
+receives security patches, bug fixes, or maintenance releases.
 Support for 6.2-specific issues is limited per your subscription agreement,
 and you may be asked to upgrade before an issue can be investigated.
 

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/_index.md
@@ -17,7 +17,7 @@ weight: 72
 
 {{< warning >}}
 Redis Software 6.4 reached end of life on August 31, 2025. It no longer
-receives security patches, CVE fixes, bug fixes, or maintenance releases.
+receives security patches, bug fixes, or maintenance releases.
 Support for 6.4-specific issues is limited per your subscription agreement,
 and you may be asked to upgrade before an issue can be investigated.
 

--- a/content/operate/rs/release-notes/rs-6-4-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-6-4-2-releases/_index.md
@@ -15,6 +15,18 @@ toc: 'true'
 weight: 72
 ---
 
+{{< warning >}}
+Redis Software 6.4 reached end of life on August 31, 2025. It no longer
+receives security patches, CVE fixes, bug fixes, or maintenance releases.
+Support for 6.4-specific issues is limited per your subscription agreement,
+and you may be asked to upgrade before an issue can be investigated.
+
+Upgrade to a supported version. Reaching the latest version may require an
+intermediate upgrade first — see the
+[supported upgrade paths]({{< relref "/operate/rs/references/upgrade-paths" >}})
+and the [Redis Software product lifecycle]({{< relref "/operate/rs/installing-upgrading/product-lifecycle#endoflife-schedule" >}}).
+{{< /warning >}}
+
 ​[​Redis Enterprise Software version 6.4.2](https://redis.io/downloads/#software) is now available!
 
 This version offers:

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -17,6 +17,17 @@ toc: 'true'
 weight: 71
 ---
 
+{{< warning >}}
+Redis Software 7.2 reached end of life on February 28, 2026. It no longer
+receives security patches, CVE fixes, bug fixes, or maintenance releases.
+Support for 7.2-specific issues is limited per your subscription agreement,
+and you may be asked to upgrade before an issue can be investigated.
+
+Upgrade to a supported version. See the
+[supported upgrade paths]({{< relref "/operate/rs/references/upgrade-paths" >}})
+and the [Redis Software product lifecycle]({{< relref "/operate/rs/installing-upgrading/product-lifecycle#endoflife-schedule" >}}).
+{{< /warning >}}
+
 ​[​Redis Enterprise Software version 7.2.4](https://redis.io/downloads/#software) is now available!
 
 ## Highlights

--- a/content/operate/rs/release-notes/rs-7-2-4-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-2-4-releases/_index.md
@@ -19,7 +19,7 @@ weight: 71
 
 {{< warning >}}
 Redis Software 7.2 reached end of life on February 28, 2026. It no longer
-receives security patches, CVE fixes, bug fixes, or maintenance releases.
+receives security patches, bug fixes, or maintenance releases.
 Support for 7.2-specific issues is limited per your subscription agreement,
 and you may be asked to upgrade before an issue can be investigated.
 

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -18,9 +18,9 @@ weight: 70
 
 {{< note >}}
 Redis Software 7.4 reaches end of life on November 30, 2026. After that date,
-7.4.x clusters no longer receive security patches, CVE fixes, bug fixes, or
-maintenance releases, and support for 7.4-specific issues is limited per your
-subscription agreement.
+7.4.x clusters no longer receive security patches, bug fixes, or maintenance
+releases, and support for 7.4-specific issues is limited per your subscription
+agreement.
 
 Plan your upgrade to a supported version. See the
 [supported upgrade paths]({{< relref "/operate/rs/references/upgrade-paths" >}})

--- a/content/operate/rs/release-notes/rs-7-4-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-7-4-2-releases/_index.md
@@ -16,6 +16,17 @@ toc: 'true'
 weight: 70
 ---
 
+{{< note >}}
+Redis Software 7.4 reaches end of life on November 30, 2026. After that date,
+7.4.x clusters no longer receive security patches, CVE fixes, bug fixes, or
+maintenance releases, and support for 7.4-specific issues is limited per your
+subscription agreement.
+
+Plan your upgrade to a supported version. See the
+[supported upgrade paths]({{< relref "/operate/rs/references/upgrade-paths" >}})
+and the [Redis Software product lifecycle]({{< relref "/operate/rs/installing-upgrading/product-lifecycle#endoflife-schedule" >}}).
+{{< /note >}}
+
 ​[​Redis Enterprise Software version 7.4](https://redis.io/downloads/#software) is now available!
 
 ## Highlights


### PR DESCRIPTION
For 7.4 entering EOL in Nov: 
- Added to banner for 7.4 versioned docs notifying users of Nov EOL
- Adds an approaching EOL notice to 7.4.x release notes page

For versions already EOL: 
- Adds out of support notices to release notes pages for 6.2.18, 6.4.2, 7.2.4 
- Updates product lifecycle pages with EOL dates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to EOL messaging and dates; no product, API, or runtime behavior.
> 
> **Overview**
> Adds **Redis Software end-of-life (EOL) visibility** across versioned docs and release notes so customers see support status and upgrade guidance.
> 
> **Product lifecycle tables** now list concrete EOL dates where they were previously `-`: **7.22** (Oct 30, 2027), **7.8** (May 30, 2027), **7.4** (Nov 30, 2026), and **8.0** (Jul 31, 2028), including the **8.0** lifecycle timeline chart update from TBD to that date.
> 
> **7.4.x docs** get a **banner** on the version hub stating **November 30, 2026** EOL with a link to the lifecycle schedule.
> 
> **Release notes** gain prominent callouts: **`warning`** blocks for **6.2**, **6.4**, and **7.2** (already past EOL—no patches, limited support, links to upgrade paths and lifecycle); a **`note`** on **7.4.x** for approaching EOL with the same upgrade pointers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0075ec37e71ae51e2ffe56dc2ed73da8a6fb7d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->