### PR TITLE
RS: document the Active-Active upgrade API on the upgrade page

### DIFF
--- a/content/operate/rs/8.0/installing-upgrading/upgrading/upgrade-active-active.md
+++ b/content/operate/rs/8.0/installing-upgrading/upgrading/upgrade-active-active.md
@@ -13,7 +13,45 @@ url: '/operate/rs/8.0/installing-upgrading/upgrading/upgrade-active-active/'
 
 ## Upgrade an Active-Active database
 
-To upgrade an [Active-Active (CRDB) database]({{< relref "/operate/rs/8.0/databases/active-active" >}}):
+To upgrade an [Active-Active (CRDB) database]({{< relref "/operate/rs/8.0/databases/active-active" >}}), you can upgrade all database instances with a single REST API request or upgrade each instance separately with `rladmin` and `crdb-cli`. The REST API method requires Redis Software version 8.0.18 or later.
+
+{{< multitabs id="upgrade-active-active-db"
+    tab1="REST API"
+    tab2="rladmin and crdb-cli" >}}
+
+1. [Upgrade Redis Software]({{< relref "/operate/rs/8.0/installing-upgrading/upgrading/upgrade-cluster" >}}) on each node in the clusters where the Active-Active instances are located.
+
+1. [Check the status](#check-database-status) of all Active-Active database instances.
+
+1. Find the `<CRDB-GUID>` of your Active-Active database with the [`crdb-cli crdb list`]({{<relref "/operate/rs/8.0/references/cli-utilities/crdb-cli/crdb/list">}}) command:
+
+    ```sh
+    crdb-cli crdb list
+    ```
+
+    Look for the fully qualified domain name (`CLUSTER-FQDN`) of your cluster and use the associated `GUID`.
+
+1. Use an [upgrade Active-Active database]({{< relref "/operate/rs/8.0/references/rest-api/requests/crdbs/upgrade" >}}) REST API request. The request upgrades the Redis version and modules of all database instances across regions, then upgrades the feature set version after all instances are upgraded.
+
+    ```sh
+    POST https://<host>:<port>/v1/crdbs/<crdb-guid>/upgrade
+    {
+        "preserve_roles": true,
+        // Additional fields
+    }
+    ```
+
+    For additional upgrade options, see the [request body]({{<relref "/operate/rs/8.0/references/rest-api/requests/crdbs/upgrade#request-body">}}) section of the Active-Active database upgrade requests reference.
+
+1. Check the upgrade's progress with the ID of the [CRDB task]({{< relref "/operate/rs/8.0/references/rest-api/requests/crdb_tasks#get-crdb_task" >}}) returned by the upgrade request:
+
+    ```sh
+    GET https://<host>:<port>/v1/crdb_tasks/<task-id>
+    ```
+
+    The task's `status` is `finished` when the upgrade is complete.
+
+-tab-sep-
 
 1. [Upgrade Redis Software]({{< relref "/operate/rs/8.0/installing-upgrading/upgrading/upgrade-cluster" >}}) on each node in the clusters where the Active-Active instances are located.
 
@@ -28,6 +66,8 @@ To upgrade an [Active-Active (CRDB) database]({{< relref "/operate/rs/8.0/databa
     ```sh
     rladmin status modules db { db:<ID> | <database-name> }
     ```
+
+{{< /multitabs >}}
 
 ## Check database status
 

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-active-active.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-active-active.md
@@ -12,7 +12,45 @@ weight: 70
 
 ## Upgrade an Active-Active database
 
-To upgrade an [Active-Active (CRDB) database]({{< relref "/operate/rs/databases/active-active" >}}):
+To upgrade an [Active-Active (CRDB) database]({{< relref "/operate/rs/databases/active-active" >}}), you can upgrade all database instances with a single REST API request or upgrade each instance separately with `rladmin` and `crdb-cli`. The REST API method requires Redis Software version 8.0.18 or later.
+
+{{< multitabs id="upgrade-active-active-db"
+    tab1="REST API"
+    tab2="rladmin and crdb-cli" >}}
+
+1. [Upgrade Redis Software]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-cluster" >}}) on each node in the clusters where the Active-Active instances are located.
+
+1. [Check the status](#check-database-status) of all Active-Active database instances.
+
+1. Find the `<CRDB-GUID>` of your Active-Active database with the [`crdb-cli crdb list`]({{<relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/list">}}) command:
+
+    ```sh
+    crdb-cli crdb list
+    ```
+
+    Look for the fully qualified domain name (`CLUSTER-FQDN`) of your cluster and use the associated `GUID`.
+
+1. Use an [upgrade Active-Active database]({{< relref "/operate/rs/references/rest-api/requests/crdbs/upgrade" >}}) REST API request. The request upgrades the Redis version and modules of all database instances across regions, then upgrades the feature set version after all instances are upgraded.
+
+    ```sh
+    POST https://<host>:<port>/v1/crdbs/<crdb-guid>/upgrade
+    {
+        "preserve_roles": true,
+        // Additional fields
+    }
+    ```
+
+    For additional upgrade options, see the [request body]({{<relref "/operate/rs/references/rest-api/requests/crdbs/upgrade#request-body">}}) section of the Active-Active database upgrade requests reference.
+
+1. Check the upgrade's progress with the ID of the [CRDB task]({{< relref "/operate/rs/references/rest-api/requests/crdb_tasks#get-crdb_task" >}}) returned by the upgrade request:
+
+    ```sh
+    GET https://<host>:<port>/v1/crdb_tasks/<task-id>
+    ```
+
+    The task's `status` is `finished` when the upgrade is complete.
+
+-tab-sep-
 
 1. [Upgrade Redis Software]({{< relref "/operate/rs/installing-upgrading/upgrading/upgrade-cluster" >}}) on each node in the clusters where the Active-Active instances are located.
 
@@ -27,6 +65,8 @@ To upgrade an [Active-Active (CRDB) database]({{< relref "/operate/rs/databases/
     ```sh
     rladmin status modules db { db:<ID> | <database-name> }
     ```
+
+{{< /multitabs >}}
 
 ## Check database status
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 627b3e5489aec67909f6123816645a4d7552ec4d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->