### PR TITLE
RDSC-5962: Document AWS CIDR requirements for Cloud RDI workspaces

### DIFF
--- a/content/embeds/rc-rdi-create-rdi-workspace.md
+++ b/content/embeds/rc-rdi-create-rdi-workspace.md
@@ -16,7 +16,16 @@ To create a Data Integration workspace for an existing [Pro subscription]({{< re
 
     {{<image filename="images/rc/rdi/rdi-create-workspace-select-subscription.png" alt="The select pro subscription drop down." width=80% >}}
 
-3. A **Data Integration subnet (CIDR)** is automatically generated for you. If, for any reason, a CIDR is not generated, enter a valid CIDR that does not conflict with your applications or other databases.
+3. A **Data Integration subnet (CIDR)** is automatically generated for you. Each RDI workspace uses a dedicated `/22` CIDR.
+
+    For AWS, the RDI workspace CIDR must:
+
+    - Be in the same [RFC 1918 private address range](https://datatracker.ietf.org/doc/html/rfc1918#section-3) as the subscription VPC's primary CIDR: `10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16`.
+    - Not overlap with existing subscription, peering, transit gateway (TGW), application, database, or RDI workspace CIDR ranges.
+
+    For example, if the subscription VPC's primary CIDR is `10.238.252.0/24`, then `192.168.0.0/22` is invalid because it is in a different RFC 1918 range. An unused range such as `10.239.0.0/22` is valid.
+
+    If the automatic suggestion is missing or unsuitable, select another unused `/22` CIDR in the same private range. For more information, see [VPC CIDR block association restrictions](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-cidr-blocks.html#vpc-resize).
 
     {{<image filename="images/rc/rdi/rdi-create-workspace-cidr.png" alt="The select pro subscription drop down." width=80% >}}
 


### PR DESCRIPTION
## Summary

- Document that each Cloud RDI workspace uses a dedicated `/22` CIDR.
- Explain the AWS requirement to use the same RFC 1918 private range as the subscription VPC primary CIDR.
- Describe non-overlap requirements and include valid and invalid examples.
- Link to the AWS VPC CIDR association restrictions.

## Why

AWS rejects a secondary VPC CIDR when it is in a different RFC 1918 range from the VPC primary CIDR. The previous documentation only said that the CIDR must not conflict with applications or databases, so it did not provide enough guidance when the automatic suggestion was missing or unsuitable.

## User impact

The shared workspace creation content is used by both the Cloud RDI workspace page and the quick start. Users now have the same CIDR selection guidance in both places.

## Validation

- `git diff --check`
- Rendered both affected pages with Hugo v0.143.1 and verified the `/22`, same-range, non-overlap, example, and link content in the generated HTML.
- Verified the RFC 1918 and AWS restriction links return HTTP 200.
- The full repository build reaches and renders both affected pages, then stops on unrelated missing generated examples in existing client documentation.

Jira: https://redislabs.atlassian.net/browse/RDSC-5962

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to RDI workspace creation guidance; no application or infrastructure code.
> 
> **Overview**
> Expands the shared **Create workspace** embed (`rc-rdi-create-rdi-workspace.md`) so step 3 documents **dedicated `/22` CIDRs** per RDI workspace and **AWS-specific rules** when auto-suggestion is missing or wrong.
> 
> **AWS guidance added:** the workspace CIDR must stay in the **same RFC 1918 private range** as the subscription VPC primary CIDR, must **not overlap** subscription/peering/TGW/app/database/other workspace ranges, includes **valid/invalid examples** (e.g. `10.238.252.0/24` VPC vs `192.168.0.0/22` vs `10.239.0.0/22`), and links to **AWS VPC CIDR association restrictions**. A trailing newline fix is included on the closing paragraph.
> 
> Because the embed is reused on **create-workspace** and **quick-start**, both flows get the same CIDR guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f979f4386927ea2b6678d869ea67fc1791cf7af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->