### PR TITLE
Improving the wording regarding use of active-active db

### DIFF
--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -62,11 +62,21 @@ replica of an Active-Active replication setup or an Auto tiering database.
 
 ## Can I use Active-Active for the RDI database?
 
-Yes, starting with RDI 1.16.0, you can use Active-Active for the RDI database. This is useful if you
-want to create a disaster recovery setup for RDI using Google Cloud Storage (GCS) to provide a reliable lease mechanism for leader election.
-The configuration for the GCS is available only for [Helm based installations]({{< relref "/integrate/redis-data-integration/installation/install-k8s" >}}).
+Yes, starting with RDI 1.16.0, you can use Active-Active for the RDI database. This is
+supported whether or not you also run a disaster recovery (DR) setup for RDI.
 
-**Important:** You should only use this configuration when both sites use the same source configuration.
+Two RDI instances sharing a single RDI database use that database for leader election, so
+they need no other lease mechanism. This is how high availability (HA) works for VM
+installations. See
+[Installing with High Availability]({{< relref "/integrate/redis-data-integration/installation/install-vm#installing-with-high-availability" >}}).
+
+In a DR setup, each site runs its own RDI instance against its local instance of the
+Active-Active RDI database, so leader election needs an external lease. Google Cloud Storage
+(GCS) is currently the only supported lease mechanism, and you can configure it only for
+[Helm based installations]({{< relref "/integrate/redis-data-integration/installation/install-k8s" >}}).
+
+**Important:** Use a DR setup only when both sites capture changes from the same source
+database server. Both RDI instances must point at that same server, not at a replica of it.
 
 ## Can I run multiple RDI installations in the same Kubernetes cluster?
 

--- a/content/integrate/redis-data-integration/faq.md
+++ b/content/integrate/redis-data-integration/faq.md
@@ -65,7 +65,7 @@ replica of an Active-Active replication setup or an Auto tiering database.
 Yes, starting with RDI 1.16.0, you can use Active-Active for the RDI database. This is
 supported whether or not you also run a disaster recovery (DR) setup for RDI.
 
-Two RDI instances sharing a single RDI database use that database for leader election, so
+If you have two RDI instances sharing a single RDI database then they will use that database for leader election, so
 they need no other lease mechanism. This is how high availability (HA) works for VM
 installations. See
 [Installing with High Availability]({{< relref "/integrate/redis-data-integration/installation/install-vm#installing-with-high-availability" >}}).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only FAQ wording; no product or security behavior changes.
> 
> **Overview**
> Clarifies the **Can I use Active-Active for the RDI database?** FAQ so Active-Active is supported with or without a disaster recovery (DR) setup, not only as a GCS-based DR pattern.
> 
> Separates **HA** (two RDI instances sharing one RDI database for leader election, as on VMs) from **DR** (each site uses a local Active-Active replica and needs an external GCS lease, Helm only). Tightens the warning: both sites must capture from the **same source server**, not a replica.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ab0f71a804b1edbbd435ed951d1eea7f9a6f0c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->