### PR TITLE
RDSC-5979: Add Cloud RDI Networking section with AWS PrivateLink ref 

### DIFF
--- a/content/operate/rc/rdi/networking/_index.md
+++ b/content/operate/rc/rdi/networking/_index.md
@@ -1,0 +1,16 @@
+---
+Title: Networking
+alwaysopen: false
+categories:
+- docs
+- operate
+- rc
+description: Network reference for connecting a Data Integration pipeline to your source database.
+hideListLinks: true
+linkTitle: Networking
+weight: 4
+---
+
+Your Data Integration pipeline runs on Redis Cloud and connects to your source database over [AWS PrivateLink]({{<relref "/operate/rc/rdi/setup#set-up-connectivity">}}). The following guides explain how the network path works and how to keep it available:
+
+- [AWS PrivateLink reference]({{<relref "/operate/rc/rdi/networking/aws-privatelink">}}): How traffic flows between the pipeline and your database, which address each component sees, and how to keep the connection available when your database fails over.

--- a/content/operate/rc/rdi/networking/aws-privatelink.md
+++ b/content/operate/rc/rdi/networking/aws-privatelink.md
@@ -1,0 +1,74 @@
+---
+Title: AWS PrivateLink reference
+alwaysopen: false
+categories:
+- docs
+- operate
+- rc
+description: How traffic flows over AWS PrivateLink between a Data Integration pipeline and your source database, and how to keep the connection available during failover.
+hideListLinks: true
+linkTitle: AWS PrivateLink
+weight: 1
+---
+
+This page explains how a Data Integration pipeline reaches your source database over AWS PrivateLink, and how to keep the connection available when your database fails over. For the steps to create the PrivateLink connection, see [Set up connectivity]({{<relref "/operate/rc/rdi/setup#set-up-connectivity">}}).
+
+## How traffic flows {#how-traffic-flows}
+
+With PrivateLink, the pipeline and your database are in separate address spaces that never mix. Each component only connects to one address, and that address does not change during a failover.
+
+```text
+Redis Cloud                     Your AWS VPC
+┌───────────────┐              ┌─────────────────────────────────────┐
+│ RDI pipeline  │              │  ┌───────────────┐   ┌───────────┐   │
+│      │        │  PrivateLink │  │ Network Load  │──▶│ Source    │   │
+│      ▼        │ ───────────▶ │  │ Balancer      │   │ database  │   │
+│ VPC endpoint  │              │  │ (private IPs) │   │           │   │
+└───────────────┘              │  └───────────────┘   └───────────┘   │
+                               └─────────────────────────────────────┘
+```
+
+The following table shows which address each component sees:
+
+| Component | Connects to | What it sees |
+|:--|:--|:--|
+| RDI pipeline | The VPC endpoint for your endpoint service | Only the endpoint's addresses, which come from the workspace CIDR. It never sees your database's real IP address. |
+| Network Load Balancer | The registered target (instance or IP address) | Your database's real address. The target group is the only place where that address appears, and the only thing that changes during a failover. |
+| Source database | Nothing. It only receives connections. | Incoming connections from the **NLB's private IP addresses**, and never from Redis Cloud addresses. Allow the NLB subnets in your database's firewall or allow list. |
+
+Your database always receives the connection from the NLB's own private IP address, never from a Redis Cloud address. PrivateLink and the NLB rewrite the source address as the traffic passes through (network address translation), so Redis Cloud addresses are never visible anywhere in your network. The only firewall rule your database needs is to allow connections from the NLB's subnets.
+
+Because PrivateLink translates addresses instead of routing between the two networks, the workspace CIDR can overlap with your own VPC or on-premises ranges without any conflict. It only needs to be valid on the Redis Cloud side. See [Create a Data Integration workspace]({{<relref "/operate/rc/rdi/create-workspace">}}) for the workspace CIDR requirements.
+
+## Connect to a database outside the VPC {#connect-to-a-database-outside-the-vpc}
+
+Your source database does not have to run inside the VPC. It can be anywhere your VPC can privately route to, such as an on-premises data center reached over [AWS Direct Connect](https://aws.amazon.com/directconnect/) or a [Site-to-Site VPN](https://docs.aws.amazon.com/vpn/latest/s2svpn/VPC_VPN.html), or another network reachable through your VPC's routing.
+
+The core rule is the same in every case: the NLB uses an IP address target that is reachable from the VPC, and the database receives the connection from the NLB's private IP address. The database never sees a Redis Cloud address.
+
+```text
+Redis Cloud            Your AWS VPC              Network reachable from the VPC
+┌──────────────┐      ┌──────────────┐            ┌──────────────┐
+│ RDI pipeline │Private│ ┌──────────┐ │  Private   │ ┌──────────┐ │
+│      │       │ Link  │ │ NLB      │─┼──route────▶│ │ Source   │ │
+│      ▼       │──────▶│ │ (IP      │ │            │ │ database │ │
+│ VPC endpoint │      │ │  target) │ │            │ └──────────┘ │
+└──────────────┘      │ └──────────┘ │            └──────────────┘
+                      └──────────────┘
+```
+
+To set this up:
+
+- When you [create the network load balancer]({{<relref "/operate/rc/rdi/setup#set-up-connectivity">}}), create a target group with target type **IP addresses** and register the database's IP address.
+- Make sure the VPC can route to that IP address and port, and that the database's firewall or allow list accepts connections from the NLB's subnets.
+
+## Why failover needs an IP address update {#automate-failover}
+
+The NLB target group points to one database address at a time. If your database moves to another server, its address changes, but the target group still points to the old address, so the pipeline can no longer reach the database. This happens, for example, when a high availability replica is promoted, or when a disaster recovery server is restored from backup with a new IP address.
+
+To recover, the NLB target group must be updated to point to the new address. This is the only change needed. Nothing changes on the Redis Cloud side: the pipeline keeps connecting to the same VPC endpoint, retries while the path is down, and catches up automatically once the target group points to a healthy server.
+
+How you update the target group depends on your database:
+
+- **AWS RDS or Aurora**: Use the [Lambda function]({{<relref "/operate/rc/rdi/setup#setup-lambda-function">}}) that responds to RDS failover events and updates the target group automatically.
+- **Self-managed database (EC2 or on premises)**: Update the target group from your own failover process. You can trigger the update from your database's failover events or from the NLB's health checks. For a worked example with SQL Server, see [Connect a data pipeline to on-premises SQL Server and handle failover]({{<relref "/operate/rc/rdi/use-cases/sql-server-failover">}}).

--- a/content/operate/rc/rdi/setup.md
+++ b/content/operate/rc/rdi/setup.md
@@ -70,7 +70,7 @@ Select **Save & exit** to exit pipeline setup. You'll come back here when you [d
 If your source database is accessible via a public endpoint and you want to use public connectivity for your data pipeline, proceed to [Share source database credentials](#share-source-database-credentials).
 {{< /note >}} 
 
-If your source database is not accessible via a public endpoint, you need to set up an endpoint service through AWS PrivateLink to be able to connect to it.
+If your source database is not accessible via a public endpoint, you need to set up an endpoint service through AWS PrivateLink to be able to connect to it. For how traffic flows over PrivateLink, how to connect to an on-premises database over AWS Direct Connect, and how to keep the connection available during failover, see the [AWS PrivateLink reference]({{<relref "/operate/rc/rdi/networking/aws-privatelink">}}).
 
 The following diagrams show the network setup for the different database setups:
 


### PR DESCRIPTION
…rence

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition and a single cross-link in existing setup docs; no product or security-code changes.
> 
> **Overview**
> Adds a **Networking** section for Redis Cloud Data Integration that explains how AWS PrivateLink traffic actually works, instead of only documenting setup steps.
> 
> The new AWS PrivateLink reference covers address spaces (pipeline vs NLB vs source DB), NAT so Redis Cloud IPs never appear on the customer network, overlapping CIDRs, connecting to databases outside the VPC (Direct Connect / VPN), and why failover requires updating the NLB target group. Setup docs now link here for that conceptual material.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56f923eb1a53c2a8aa3025b06b9f7026d8af6a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->