### PR TITLE
OP: update Homebrew instructions

### DIFF
--- a/content/operate/oss_and_stack/install/install-stack/_index.md
+++ b/content/operate/oss_and_stack/install/install-stack/_index.md
@@ -118,14 +118,13 @@ docker run -d --name redis -p 6379:6379 redis
 #### Homebrew
 
 ```bash
-brew tap redis/redis
-brew install --cask redis
+brew install redis
 ```
 
 Start Redis:
 
 ```bash
-redis-server $(brew --prefix)/etc/redis.conf
+brew services start redis
 ```
 
 [Full Homebrew installation guide]({{< relref "/operate/oss_and_stack/install/install-stack/homebrew" >}})

--- a/content/operate/oss_and_stack/install/install-stack/homebrew.md
+++ b/content/operate/oss_and_stack/install/install-stack/homebrew.md
@@ -36,7 +36,7 @@ brew install redis
 This installs the latest Redis Open Source release, including Redis Search and the JSON, time series, probabilistic, and vector set data structures.
 
 {{< note >}}
-The formula always installs the latest Redis Open Source release. Support for the query engine and the additional data structures was added to the formula in Redis Open Source 8.10.1, so earlier versions installed through the formula do not include them. To install an earlier version, use one of the other [installation methods]({{< relref "/operate/oss_and_stack/install/install-stack" >}}).
+The formula always installs the latest Redis Open Source release. Support for Redis Search and the additional data structures was added to the formula in Redis Open Source 8.10.1, so earlier versions installed through the formula do not include them. To install an earlier version, use one of the other [installation methods]({{< relref "/operate/oss_and_stack/install/install-stack" >}}).
 {{< /note >}}
 
 If you already have Redis installed through Homebrew, see [Upgrade an existing installation](#upgrade-an-existing-installation) instead.
@@ -45,13 +45,13 @@ If you already have Redis installed through Homebrew, see [Upgrade an existing i
 
 ### Upgrade from an earlier version of the formula
 
-If you previously installed Redis using the `redis` formula, upgrade it:
+If you previously installed Redis using the `redis` formula, upgrade it with the following command:
 
 {{< highlight bash >}}
 brew upgrade redis
 {{< /highlight >}}
 
-Homebrew does not overwrite a configuration file that you might have changed. It leaves your existing `redis.conf` in place and writes the new default configuration to `redis.conf.default`. Because the older configuration file does not contain the `loadmodule` directives, the query engine and the additional data structures stay disabled until you use the new default.
+Homebrew does not overwrite a configuration file that you might have changed. It leaves your existing `redis.conf` in place and writes the new default configuration to `redis.conf.default`. Because the older configuration file does not contain the `loadmodule` directives, Redis Search and the additional data structures stay disabled until you use the new default.
 
 1. Compare your configuration file with the new default:
     ```bash

--- a/content/operate/oss_and_stack/install/install-stack/homebrew.md
+++ b/content/operate/oss_and_stack/install/install-stack/homebrew.md
@@ -20,25 +20,74 @@ weight: 6
 If you only need the Redis CLI (`redis-cli`) and not the full Redis Open Source distribution, see [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}).
 {{< /note >}}
 
-To install Redis Open Source on macOS, use [Homebrew](https://brew.sh/).
-Make sure that you have [Homebrew installed](https://docs.brew.sh/Installation) before starting on the installation instructions below.
+To install Redis Open Source on macOS, use the [Homebrew](https://brew.sh/) formula called `redis`.
+Make sure that you have [Homebrew installed](https://docs.brew.sh/Installation) before you start.
 
-## Remove any existing Redis installation files
+The formula is the preferred way to install Redis Open Source on macOS. A [Homebrew cask](#alternative-install-using-the-redis-cask) is also available, but it is not integrated with `brew services` and requires a separate tap.
 
-If you had previously installed Redis on your system using the default Homebrew formula called "redis", you need to remove it before installing Redis Open Source 8.x.
+## Install using Homebrew {#install-using-homebrew}
 
-Follow these steps to remove any existing Redis installation files:
+Run `brew install`:
 
-1. Uninstall Redis:
+{{< highlight bash >}}
+brew install redis
+{{< /highlight >}}
+
+This installs the latest Redis Open Source release, including Redis Search and the JSON, time series, probabilistic, and vector set data structures.
+
+{{< note >}}
+The formula always installs the latest Redis Open Source release. Support for the query engine and the additional data structures was added to the formula in Redis Open Source 8.10.1, so earlier versions installed through the formula do not include them. To install an earlier version, use one of the other [installation methods]({{< relref "/operate/oss_and_stack/install/install-stack" >}}).
+{{< /note >}}
+
+If you already have Redis installed through Homebrew, see [Upgrade an existing installation](#upgrade-an-existing-installation) instead.
+
+## Upgrade an existing installation {#upgrade-an-existing-installation}
+
+### Upgrade from an earlier version of the formula
+
+If you previously installed Redis using the `redis` formula, upgrade it:
+
+{{< highlight bash >}}
+brew upgrade redis
+{{< /highlight >}}
+
+Homebrew does not overwrite a configuration file that you might have changed. It leaves your existing `redis.conf` in place and writes the new default configuration to `redis.conf.default`. Because the older configuration file does not contain the `loadmodule` directives, the query engine and the additional data structures stay disabled until you use the new default.
+
+1. Compare your configuration file with the new default:
     ```bash
-    brew uninstall redis
+    diff $(brew --prefix)/etc/redis.conf $(brew --prefix)/etc/redis.conf.default
     ```
-1. Next check if the `redis.conf` file is still installed:
+1. Back up your configuration file:
+    ```bash
+    cp $(brew --prefix)/etc/redis.conf $(brew --prefix)/etc/redis.conf.backup
+    ```
+1. Replace your configuration file with the new default:
+    ```bash
+    cp $(brew --prefix)/etc/redis.conf.default $(brew --prefix)/etc/redis.conf
+    ```
+
+    If you had customized any settings, reapply them to the new file.
+
+1. Restart Redis, then check the results as described in [Verify that all modules are loaded correctly](#verify-that-all-modules-are-loaded-correctly).
+
+### Migrate from the Redis cask
+
+If you previously installed Redis Open Source using the Redis Homebrew cask, remove it before you install the formula. Both provide the `redis-server` and `redis-cli` binaries in the same location.
+
+1. Uninstall the cask:
+    ```bash
+    brew uninstall --cask redis
+    ```
+1. Remove the tap:
+    ```bash
+    brew untap redis/redis
+    ```
+1. Check if the `redis.conf` file is still installed:
     ```bash
     ls -l $(brew --prefix)/etc/redis.conf
     ```
 
-    If you get output similar to the following, then it’s still there:
+    If you get output similar to the following, then it's still there:
 
     ```bash
     -rw-r--r--@ 1 user  admin  122821  2 Oct 16:07 /opt/homebrew/etc/redis.conf
@@ -50,21 +99,9 @@ Follow these steps to remove any existing Redis installation files:
     rm -iv $(brew --prefix)/etc/redis.conf
     ```
 
-Next, follow the instructions in the [next section](#install-using-homebrew) to install Redis Open Source 8.x using the Redis Homebrew cask.
+    The configuration file installed by the cask loads the modules from a directory that the cask removes when you uninstall it. If you leave the file in place, `redis-server` fails to start, and Homebrew does not replace it.
 
-## Install using Homebrew {#install-using-homebrew}
-
-First, tap the Redis Homebrew cask:
-
-{{< highlight bash >}}
-brew tap redis/redis
-{{< /highlight >}}
-
-Next, run `brew install`:
-
-{{< highlight bash >}}
-brew install --cask redis
-{{< /highlight >}}
+Next, follow the instructions in [Install using Homebrew](#install-using-homebrew).
 
 ## Run Redis
 
@@ -84,17 +121,23 @@ Open the file `~/.bashrc` or `~/.zshrc` (depending on your shell), and add the f
 export PATH=$(brew --prefix)/bin:$PATH
 {{< /highlight >}}
 
-You can now start the Redis server as follows:
+You can now start Redis in one of two ways.
+
+To start Redis now and restart it at login, run it as a Homebrew service:
+
+{{< highlight bash >}}
+brew services start redis
+{{< /highlight >}}
+
+The service runs `redis-server` with the configuration file at `$(brew --prefix)/etc/redis.conf`.
+
+If you don't need a background service, start the server directly:
 
 {{< highlight bash >}}
 redis-server $(brew --prefix)/etc/redis.conf
 {{< /highlight >}}
 
 The server will run in the background.
-
-{{< note >}}
-Because Redis is installed using a Homebrew cask with the `brew tap` command, it will not be integrated with the `brew services` command.
-{{< /note >}}
 
 ## Connect to Redis
 
@@ -113,32 +156,34 @@ PONG
 
 ### Verify that all modules are loaded correctly
 
-If you had previously installed earlier versions of Redis using Homebrew, for example 7.2.x or 7.4.x, you should test to see if all the modules are loaded correctly by running the following command. Your output should look similar to the following:
+If you upgraded from an earlier Redis installation, for example 7.2.x or 7.4.x, test to see if all the modules are loaded correctly by running the following command. Your output should look similar to the following:
+
+<!-- TODO: replace with MODULE LIST output from local 8.10 instance -->
 
 {{< highlight bash  >}}
 $ redis-cli MODULE LIST
 1) 1) "name"
-   2) "bf"
-   3) "ver"
-   4) (integer) 80200
-   5) "path"
-   6) "/usr/local/lib/redis/modules//redisbloom.so"
-   7) "args"
-   8) (empty array)
-2) 1) "name"
    2) "timeseries"
    3) "ver"
-   4) (integer) 80200
+   4) (integer) 80991
    5) "path"
    6) "/usr/local/lib/redis/modules//redistimeseries.so"
    7) "args"
    8) (empty array)
-3) 1) "name"
+2) 1) "name"
    2) "search"
    3) "ver"
-   4) (integer) 80201
+   4) (integer) 80990
    5) "path"
    6) "/usr/local/lib/redis/modules//redisearch.so"
+   7) "args"
+   8) (empty array)
+3) 1) "name"
+   2) "bf"
+   3) "ver"
+   4) (integer) 80990
+   5) "path"
+   6) "/usr/local/lib/redis/modules//redisbloom.so"
    7) "args"
    8) (empty array)
 4) 1) "name"
@@ -152,16 +197,24 @@ $ redis-cli MODULE LIST
 5) 1) "name"
    2) "ReJSON"
    3) "ver"
-   4) (integer) 80200
+   4) (integer) 80990
    5) "path"
    6) "/usr/local/lib/redis/modules//rejson.so"
    7) "args"
    8) (empty array)
 {{< /highlight >}}
 
+If the list is empty, your configuration file does not load the modules. See [Upgrade from an earlier version of the formula](#upgrade-from-an-earlier-version-of-the-formula).
+
 ## Stop Redis
 
-Run the following command:
+If you started Redis as a Homebrew service, run:
+
+{{< highlight bash  >}}
+brew services stop redis
+{{< /highlight >}}
+
+Otherwise, run:
 
 {{< highlight bash  >}}
 redis-cli SHUTDOWN
@@ -169,10 +222,56 @@ redis-cli SHUTDOWN
 
 ## Uninstall Redis Open Source
 
+If you started Redis as a Homebrew service, stop the service first:
+
+{{< highlight bash >}}
+brew services stop redis
+{{< /highlight >}}
+
 To uninstall Redis, run:
 
 {{< highlight bash >}}
 brew uninstall redis
+{{< /highlight >}}
+
+## Alternative: install using the Redis cask {#alternative-install-using-the-redis-cask}
+
+{{< note >}}
+The Homebrew formula described in [Install using Homebrew](#install-using-homebrew) is the preferred way to install Redis Open Source on macOS.
+{{< /note >}}
+
+Redis also provides a Homebrew cask. First, tap the Redis Homebrew cask:
+
+{{< highlight bash >}}
+brew tap redis/redis
+{{< /highlight >}}
+
+On Homebrew 6.0 and later, you also need to trust the tap. This step is not required on earlier versions of Homebrew.
+
+{{< highlight bash >}}
+brew trust redis/redis
+{{< /highlight >}}
+
+Next, run `brew install`:
+
+{{< highlight bash >}}
+brew install --cask redis
+{{< /highlight >}}
+
+Start the server with the configuration file that the cask installs:
+
+{{< highlight bash >}}
+redis-server $(brew --prefix)/etc/redis.conf
+{{< /highlight >}}
+
+{{< note >}}
+Because Redis is installed using a Homebrew cask with the `brew tap` command, it is not integrated with the `brew services` command.
+{{< /note >}}
+
+To uninstall the cask, run:
+
+{{< highlight bash >}}
+brew uninstall --cask redis
 brew untap redis/redis
 {{< /highlight >}}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only install instructions; no product or security code changes.
> 
> **Overview**
> Switches macOS Homebrew docs so the default install is the `redis` formula (`brew install redis` / `brew services`), not the Redis cask.
> 
> The full Homebrew guide now treats the formula as preferred, with upgrade steps for existing formula installs (merge `redis.conf.default` so modules load) and migration from the cask (uninstall, untap, remove leftover config). The cask path remains as an alternative, including `brew trust redis/redis` on Homebrew 6+. Quick-start on the install overview matches the new commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 414e50fadd9ef12e4281cce9b249391a71f01af6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->