### PR TITLE
DOC-6996 Document the go-redis pipeline connection pool [PARKED]

### DIFF
--- a/content/develop/clients/go/autopipeline.md
+++ b/content/develop/clients/go/autopipeline.md
@@ -154,10 +154,10 @@ commands instead of 200. As soon as you supply `AutoPipelineOptions`, either on
 the client or to `AutoPipelineWithOptions()`, that preset no longer applies, and
 a `MaxBatchSize` you leave unset means 200.
 
-Connection and buffer tuning is not part of `AutoPipelineOptions`. Batches use
-the client's pipeline connections, which you size with the
-`PipelineReadBufferSize`, `PipelineWriteBufferSize`, and `PipelinePoolSize`
-fields of the client's options.
+Connection and buffer tuning is not part of `AutoPipelineOptions`. Batches run
+on the client's separate pipeline connection pool, which you size with the
+fields described in
+[Connection pooling]({{< relref "/develop/clients/go/produsage#connection-pooling" >}}).
 
 Each client holds at most two autopipeliners: one for the blocking method and
 one for the asynchronous method. Each of them is a

--- a/content/develop/clients/go/produsage.md
+++ b/content/develop/clients/go/produsage.md
@@ -133,44 +133,47 @@ response that will never arrive.
 `go-redis` manages connections for you with a
 [connection pool]({{< relref "/develop/clients/pools-and-muxing" >}}), so your
 app doesn't have to cache and reuse open connections itself. The `PoolSize`
-field of `Options` sets the number of connections the main pool keeps, which
-defaults to ten times the value of `GOMAXPROCS`. `MinIdleConns` sets how many
+field of `Options` sets the number of
+connections the main pool keeps (with a default of ten times the value of `GOMAXPROCS`). `MinIdleConns` sets how many
 connections to open before your app asks for them, `MaxActiveConns` caps the
 total number of connections, and `PoolTimeout` sets how long a command waits
 for a free connection. By default, no connections are opened in advance, the
 total is uncapped, and a command waits one second longer than `ReadTimeout`.
 
-Pipelines don't use the main pool. Every client also creates a separate
-*pipeline pool* that
+By default, pipelines don't use the main pool. Every client also creates a
+separate *pipeline pool* that
 [pipelines and transactions]({{< relref "/develop/clients/go/transpipe" >}}) and
 [automatic pipelining]({{< relref "/develop/clients/go/autopipeline" >}}) use
-for each batch they run. This keeps a burst of batches from competing with your
-ordinary commands for the same connections. You don't have to enable it.
+for each batch they run. This prevents a burst of batches from competing with your
+ordinary commands for the same connections.
 
-The pipeline pool is sized with these fields of `Options`:
+{{< note >}}The pipeline pool is available in `github.com/redis/go-redis/v9` vX.Y.Z or later.
+<!--DOC-6996: replace vX.Y.Z with the release that ships go-redis PR #3959 (merged 2026-08-24, unreleased as of v9.22.0) when this branch is unparked.-->
+{{< / note >}}
+Use the following fields of `Options` to size the pipeline pool:
 
 | Field | Description |
 | :---- | :---------- |
-| `PipelinePoolSize` | Number of connections the pipeline pool keeps. Defaults to 10. Set it to `-1` to do without a pipeline pool, which returns pipelines to the main pool. |
-| `PipelineReadBufferSize` | Size of the read buffer for each pipeline connection. Defaults to the larger of `ReadBufferSize` and 64 KiB, because a batch brings back many replies in a single round trip. A value smaller than the minimum that the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}}) protocol needs for push messages is raised to that minimum. |
+| `PipelinePoolSize` | Number of connections the pipeline pool keeps. Defaults to 10. Set it to `0` to use the default number of connections, or to `-1` to disable the separate pipeline pool (which means connections are allocated to pipelines from the main pool). |
+| `PipelineReadBufferSize` | Size of the read buffer for each pipeline connection. Defaults to the larger of `ReadBufferSize` and 64 KiB, because a batch of commands can return many replies in a single round trip. If the value is set smaller than the minimum required by the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}}) protocol for push messages then that minimum is used instead. |
 | `PipelineWriteBufferSize` | Size of the write buffer for each pipeline connection. Defaults to the larger of `WriteBufferSize` and 64 KiB. |
 
-The pipeline pool costs you nothing while you aren't pipelining. It never opens
-connections in advance, whatever `MinIdleConns` you set, so an idle pipeline
-pool holds no connections at all. It also doesn't take its cap from
-`MaxActiveConns`, which would double the number of connections your client can
-open. The limit is instead `MaxActiveConns` plus `PipelinePoolSize`.
-`ClusterClient` and `Ring` create a pipeline pool for each node, so count that
-addition once per node rather than once per client.
+The pipeline pool costs you nothing while you are not using pipelining. It never opens
+connections in advance regardless of the value of `MinIdleConns`, so an idle pipeline
+pool holds no connections at all. Also, it doesn't use
+`MaxActiveConns` as its upper limit (which would double the number of connections your client can
+open). The limit is instead the value of `MaxActiveConns` plus `PipelinePoolSize`.
+`ClusterClient` and `Ring` create a pipeline pool for each node, so this limit
+applies for each node rather than for each client.
 
-When every pipeline connection is busy, a batch waits 100 milliseconds and then
-runs on the main pool rather than queuing for a pipeline connection. A
-`PoolTimeout` shorter than 100 milliseconds shortens that wait as well. The main
-pool still applies `MaxActiveConns` to a batch that reaches it this way, and a
-`Limiter` counts such a batch once rather than twice.
+If every pipeline connection is busy, a batch will wait for the number of milliseconds
+specified in `PoolTimeout` (up to a maximum of 100 milliseconds) and then
+run on the main pool rather than queuing for a pipeline connection. The main
+pool still applies the `MaxActiveConns` limit when a batch is allocated a connection in
+ this way, and a `Limiter` counts such a batch once rather than twice.
 
-To find out whether the pipeline pool is the right size, read `PipelineStats`
-from the client's pool statistics:
+You can find out the current size of the pipeline pool using the `PipelineStats`
+field from the client's pool statistics:
 
 ```go
 stats := client.PoolStats()
@@ -182,14 +185,12 @@ if ps := stats.PipelineStats; ps != nil {
 }
 ```
 
-A growing `Timeouts` count on the pipeline pool means batches are waiting for a
-connection and then running on the main pool, so try a larger
-`PipelinePoolSize`.
-`PipelineStats` is `nil` when you set `PipelinePoolSize` to `-1`, and combines
-the figures from every node for `ClusterClient` and `Ring`.
-
-The pipeline pool requires `github.com/redis/go-redis/v9` vX.Y.Z or later.
-<!--DOC-6996: replace vX.Y.Z with the release that ships go-redis PR #3959 (merged 2026-08-24, unreleased as of v9.22.0) when this branch is unparked.-->
+The `PipelineStats.Timeouts` field indicates how many pipelines have timed out while
+waiting for a connection and have consequently run on the main pool. Increase
+`PipelinePoolSize` if the number of timeouts is growing rapidly.
+Note that `PipelineStats` is `nil` when you disable the pipeline pool (by setting
+`PipelinePoolSize` to `-1`). It also combines
+the figures from every node for `ClusterClient` and `Ring` into the same count.
 
 ### Smart client handoffs
 

--- a/content/develop/clients/go/produsage.md
+++ b/content/develop/clients/go/produsage.md
@@ -30,7 +30,8 @@ progress in implementing the recommendations.
 - [ ] [Monitor performance and errors](#monitor-performance-and-errors)
 - [ ] [Retries](#retries)
 - [ ] [Timeouts](#timeouts)
-- [ ] [Smart client handoffs](#seamless-client-experience)
+- [ ] [Connection pooling](#connection-pooling)
+- [ ] [Smart client handoffs](#smart-client-handoffs)
 ```
 
 ## Recommendations
@@ -126,6 +127,69 @@ for your application. If timeouts are set too short, then `go-redis`
 might retry commands that would have succeeded if given more time. However,
 if they are too long, your app might hang unnecessarily while waiting for a
 response that will never arrive.
+
+### Connection pooling
+
+`go-redis` manages connections for you with a
+[connection pool]({{< relref "/develop/clients/pools-and-muxing" >}}), so your
+app doesn't have to cache and reuse open connections itself. The `PoolSize`
+field of `Options` sets the number of connections the main pool keeps, which
+defaults to ten times the value of `GOMAXPROCS`. `MinIdleConns` sets how many
+connections to open before your app asks for them, `MaxActiveConns` caps the
+total number of connections, and `PoolTimeout` sets how long a command waits
+for a free connection. By default, no connections are opened in advance, the
+total is uncapped, and a command waits one second longer than `ReadTimeout`.
+
+Pipelines don't use the main pool. Every client also creates a separate
+*pipeline pool* that
+[pipelines and transactions]({{< relref "/develop/clients/go/transpipe" >}}) and
+[automatic pipelining]({{< relref "/develop/clients/go/autopipeline" >}}) use
+for each batch they run. This keeps a burst of batches from competing with your
+ordinary commands for the same connections. You don't have to enable it.
+
+The pipeline pool is sized with these fields of `Options`:
+
+| Field | Description |
+| :---- | :---------- |
+| `PipelinePoolSize` | Number of connections the pipeline pool keeps. Defaults to 10. Set it to `-1` to do without a pipeline pool, which returns pipelines to the main pool. |
+| `PipelineReadBufferSize` | Size of the read buffer for each pipeline connection. Defaults to the larger of `ReadBufferSize` and 64 KiB, because a batch brings back many replies in a single round trip. A value smaller than the minimum that the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}}) protocol needs for push messages is raised to that minimum. |
+| `PipelineWriteBufferSize` | Size of the write buffer for each pipeline connection. Defaults to the larger of `WriteBufferSize` and 64 KiB. |
+
+The pipeline pool costs you nothing while you aren't pipelining. It never opens
+connections in advance, whatever `MinIdleConns` you set, so an idle pipeline
+pool holds no connections at all. It also doesn't take its cap from
+`MaxActiveConns`, which would double the number of connections your client can
+open. The limit is instead `MaxActiveConns` plus `PipelinePoolSize`.
+`ClusterClient` and `Ring` create a pipeline pool for each node, so count that
+addition once per node rather than once per client.
+
+When every pipeline connection is busy, a batch waits 100 milliseconds and then
+runs on the main pool rather than queuing for a pipeline connection. A
+`PoolTimeout` shorter than 100 milliseconds shortens that wait as well. The main
+pool still applies `MaxActiveConns` to a batch that reaches it this way, and a
+`Limiter` counts such a batch once rather than twice.
+
+To find out whether the pipeline pool is the right size, read `PipelineStats`
+from the client's pool statistics:
+
+```go
+stats := client.PoolStats()
+fmt.Printf("Main pool hits: %d, misses: %d, timeouts: %d\n",
+    stats.Hits, stats.Misses, stats.Timeouts)
+if ps := stats.PipelineStats; ps != nil {
+    fmt.Printf("Pipeline pool connections: %d, hits: %d, timeouts: %d\n",
+        ps.TotalConns, ps.Hits, ps.Timeouts)
+}
+```
+
+A growing `Timeouts` count on the pipeline pool means batches are waiting for a
+connection and then running on the main pool, so try a larger
+`PipelinePoolSize`.
+`PipelineStats` is `nil` when you set `PipelinePoolSize` to `-1`, and combines
+the figures from every node for `ClusterClient` and `Ring`.
+
+The pipeline pool requires `github.com/redis/go-redis/v9` vX.Y.Z or later.
+<!--DOC-6996: replace vX.Y.Z with the release that ships go-redis PR #3959 (merged 2026-08-24, unreleased as of v9.22.0) when this branch is unparked.-->
 
 ### Smart client handoffs
 

--- a/content/develop/clients/go/transpipe.md
+++ b/content/develop/clients/go/transpipe.md
@@ -32,6 +32,12 @@ If you want the client to batch concurrent commands into pipelines for you
 without writing any pipeline code, see
 [Automatic pipelining]({{< relref "/develop/clients/go/autopipeline" >}}).
 
+Both types of batch run on a separate pool of connections that the client keeps
+for them, so a burst of batches doesn't compete with your ordinary commands for
+the same connections. See
+[Connection pooling]({{< relref "/develop/clients/go/produsage#connection-pooling" >}})
+for how to size that pool.
+
 ## Execute a pipeline
 
 To execute commands in a pipeline, you first create a pipeline object


### PR DESCRIPTION
Documents the dedicated pipeline connection pool that
[go-redis#3959](https://github.com/redis/go-redis/pull/3959) makes default-on.

Adds a `### Connection pooling` section to the go-redis **Production usage** page — the Go
guide had no pooling prose anywhere before this — and points the two pipeline pages at it:

- `content/develop/clients/go/produsage.md` — new section, plus a checklist entry. Also fixes a
  pre-existing broken anchor in that checklist (`#seamless-client-experience` never matched the
  "Smart client handoffs" heading).
- `content/develop/clients/go/autopipeline.md` — the paragraph that listed the three pipeline
  fields inline now links to the new section.
- `content/develop/clients/go/transpipe.md` — one sentence noting that hand-built pipelines and
  transactions use the pool too.

The ticket proposed expanding the autopipeline paragraph instead. That was the wrong home:
`Pipeline()` and `TxPipeline()` both route through `withPipelineConn`, so the pool serves
hand-built pipelines and MULTI/EXEC as well as automatic pipelining, and `autopipeline.md`
carries an "experimental feature" banner that would have wrongly colored default-on behavior.

> [!WARNING]
> **DO NOT MERGE.** #3959 is merged to `master` but **not in any release**. v9.22.0 shipped
> 2026-08-03; #3959 merged 2026-08-24. On v9.22.0 there is no pipeline pool by default, so this
> section describes behavior no reader can observe yet. The version line is a deliberate
> `vX.Y.Z` placeholder.

<!-- park-manifest -->
## Park manifest

Ticket: DOC-6996
Parked at: 2026-08-25
Trigger to pick up: go-redis merge commit `bd0cea4` is an ancestor of a **non-prerelease** go-redis tag (a beta does not satisfy this)

> ⚠️ **Forward risk noted — 2026-09-03 (`/pr-scan-review`).** Open PR
> [redis/go-redis#4002](https://github.com/redis/go-redis/pull/4002) ("full duplex flusher",
> not yet merged) edits `pipelinePoolOptions()` in `redis.go` — the same internal function this
> manifest pins as load-bearing-but-unnamed for the `MaxActiveConns`/`PipelinePoolSize` ceiling
> claim — and adds a new `MaxConcurrentDials` dial-cap derived from `PipelinePoolSize`
> (`gh pr diff 4002` shows edits at `redis.go` around `pipelinePoolOptions`, plus new tests
> `TestClusterPipelinePoolSizePropagates` and dial-cap reuse tests). Confirmed by reading the
> diff, not assumed. This does not change the pick-up trigger above, but on unpark, re-verify the
> `pipelinePoolOptions()` semantics row against whichever of #3959/#4002 is canonical at the
> shipping tag — #4002 may still be open or may have merged with different dial-cap behavior.
Labels: `parked`, `do not merge yet`

### Pinned sources (state observed at park time)

| Source | State at park time | Re-fetch |
| :-- | :-- | :-- |
| [redis/go-redis#3959](https://github.com/redis/go-redis/pull/3959) — "chore(pipeline): Create pipeline pool even without specific buffer passed" | `state: closed`, `merged: true`, `merged_at: 2026-08-24T11:42:41Z`, `head_sha: ae9488a650b7b4b23f7b67b71da7bb0431bb62e4`, `merge_commit_sha: bd0cea4ea87b81452618aa0704a808cd7b129215`, `base: master`, `milestone: null` | `gh api repos/redis/go-redis/pulls/3959 --jq '{state, merged, head_sha: .head.sha, base: .base.ref, milestone: .milestone.title, merge_commit_sha}'` |
| go-redis releases — newest non-prerelease is **v9.22.0** (2026-08-03), which predates the merge | `master` is 15 commits ahead of v9.22.0; no tag contains `bd0cea4` | `gh api repos/redis/go-redis/releases --jq '.[0:6][] \| "\(.tag_name)\t\(.published_at)\t\(.prerelease)"'` |

**Trigger test (mechanical).** Base is `master`, so the release is cut from the branch the PR
landed on — no integration-branch indirection to watch:

```
gh api "repos/redis/go-redis/compare/bd0cea4ea87b81452618aa0704a808cd7b129215...<tag>" \
  --jq '{status, ahead_by, behind_by}'
```

At park time, against v9.22.0: `{"status":"behind","ahead_by":0,"behind_by":15}`. The trigger is
met when a non-prerelease tag returns **`behind_by: 0`**.

### Observed shape the page assumes

**Semantics — confidence HIGH.** Unusually high for a parked page, because #3959 is already
merged and these were verified at runtime, not read off a diff. Compiled and ran the documented
snippet against `go-redis v9.22.1-0.20260824140911-18837034a1b9` (master, post-merge) and Redis
8.8.0:

| Claim | How verified |
| :-- | :-- |
| Pipeline pool exists by default, no option set | **Run** — `PoolStats().PipelineStats` non-nil |
| Idle pipeline pool holds zero connections | **Run** — `TotalConns=0` before any pipeline |
| A plain command uses only the main pool | **Run** — pipeline `TotalConns` stayed 0, main went to 1 |
| `Pipeline()` **and** `TxPipeline()` both use the pool | **Run** — pipeline pool hits/misses moved for both |
| `PipelinePoolSize: -1` opts out | **Run** — `PipelineStats == nil`, pipeline ran on main pool |
| Default size is 10 | **Run** — 60 concurrent pipelines capped `TotalConns` at 10 |
| Saturation waits, then runs on the main pool | **Run** — forced with `PipelinePoolSize: 1` + `BLPOP` batches: `Timeouts=5`, 5 batches on the main pool. Note a plain 60-pipeline burst did **not** reproduce this (`Timeouts=0`) — fast batches never hold a connection past the 100 ms wait |
| Not released: no pool by default on v9.22.0 | **Run (negative check)** — `PipelineStats` nil by default *and* nil with `PipelinePoolSize: 10` alone, since the released version only builds the pool when a buffer field is set |
| Buffers default to max(regular, 64 KiB); RESP3 minimum clamp | **Source only** — `pipelinePoolOptions`, `redis.go:628` |
| `MinIdleConns` forced to 0; `MaxActiveConns` not inherited; ceiling = `MaxActiveConns + PipelinePoolSize` | **Source only** — `pipelinePoolOptions`, and `Options.init` at `options.go:629-644` |
| `Limiter` charged once across the fallback | **Source only** — `withPipelineConn`, `redis.go:1268-1292` |
| Per-node pool and folded `PipelineStats` for `ClusterClient` / `Ring` | **Source only** — nodes built via `clOpt.NewClient()` (`osscluster.go:518`) with `PipelinePoolSize` passed through (`osscluster.go:481`); folding at `osscluster.go:1548`, `ring.go:707` |

**Identifiers — confidence MEDIUM.** Merged rather than in-review, so less exposed than the
usual parked page, but DOC-6832 is the precedent: on that page the semantics survived to release
while nearly every name had moved. Tick these off one at a time; locations are given because
"never existed here" and "renamed" look identical in a snapshot.

Public, named on the page:

- `Options.PipelinePoolSize` — `options.go:278`
- `Options.PipelineReadBufferSize` — `options.go:227`
- `Options.PipelineWriteBufferSize` — `options.go:246`
- `Options.PoolSize`, `MinIdleConns`, `MaxActiveConns`, `PoolTimeout`, `ReadBufferSize`, `WriteBufferSize` — pre-existing, named in the new prose
- `PoolStats.PipelineStats` — declared on `internal/pool.Stats` (`internal/pool/pool.go`), surfaced through `type PoolStats pool.Stats`; assigned in `Client.PoolStats()` at `redis.go:2356-2361`
- `Stats.TotalConns` / `.Hits` / `.Misses` / `.Timeouts` — `internal/pool/pool.go`, used in the snippet
- `Limiter` — pre-existing public type, named in the fallback paragraph

Values quoted as bare numbers in the prose and table (each must be re-read at the shipping tag):

- `DefaultPipelinePoolSize` = **10** — `options.go:481`
- `DefaultPipelineBufferSize` = **64 KiB** (`64 * 1024`) — `options.go:490`
- `DefaultPipelinePoolTimeout` = **100 ms** — `options.go:504`

Internal, deliberately **not** named on the page but load-bearing for its claims — if these move,
the behavior described may have changed even when public names are stable:

- `pipelinePoolOptions` — `redis.go:628`
- `withPipelineConn` — `redis.go:1217`
- the `if opt.PipelinePoolSize >= 0` gate in `NewClient` — `redis.go`, and mirrored in `Options.init` at `options.go:634`
- `isPipelinePoolConn` CSC guard — `redis.go:948`

### Re-check checklist

Highest risk first.

- [ ] **Replace the `vX.Y.Z` placeholder** in `produsage.md` with the shipping version and delete the `<!--DOC-6996: ...-->` HTML comment. The page is wrong as written until this is done.
- [ ] **Re-read the three default values** (`DefaultPipelinePoolSize` 10, `DefaultPipelineBufferSize` 64 KiB, `DefaultPipelinePoolTimeout` 100 ms) at the shipping tag. They are quoted as bare numbers in both the prose and the table, so a tuned default silently falsifies the page.
- [ ] **Re-run the runtime probe** against the released tag, not master: default pool non-nil, idle `TotalConns` 0, both `Pipeline()` and `TxPipeline()` on the pool, `PipelinePoolSize: -1` → nil, burst capped at the default size, and the forced-saturation fallback (`PipelinePoolSize: 1` + `BLPOP`, expect `Timeouts` > 0 and the main pool used).
- [ ] **Confirm the snippet still compiles** with `if ps := stats.PipelineStats; ps != nil`. `PipelineStats` is `*internal/pool.Stats`, so inference is the only form available to a reader outside the module — if the type is ever exported, the snippet can be simplified but does not have to be.
- [ ] Verify the **source-only** rows above that no runtime check covered: the 64 KiB buffer resolution and RESP3 clamp, `MinIdleConns` forced to 0, `MaxActiveConns` not inherited, the `MaxActiveConns + PipelinePoolSize` ceiling, and the Limiter-charged-once claim. *(from `Gaps:`)*
- [ ] Verify the **per-node** claims for `ClusterClient` and `Ring` against a real cluster — that each node gets a pool and that `PipelineStats` aggregates. Read from source only; the page tells readers to budget the connection ceiling per node, which is the costliest thing on the page to get wrong.
- [ ] Check whether the **URL query params** (`pipeline_pool_size`, `pipeline_read_buffer_size`, `pipeline_write_buffer_size`, `options.go:941-943`) are still deferred by choice. Excluded here because documenting them pulls in `ParseURL` coverage the Go guide has never had.
- [ ] Re-check the **client-side caching** decision. Pipeline connections skip `CLIENT TRACKING` (`redis.go:942-949`), but pipelined commands did not consult or populate the cache on v9.22.0 either, so `connect.md` was left alone. If the shipping release changes the cached-command path, that call needs revisiting.
- [ ] Confirm `produsage.md` should still have **no page-level `bannerText`**. Deliberate: the page's Health checks, Retries and Timeouts sections are long-released, and a page banner would mislabel them. The version requirement is stated in-section instead.

### Upstream report worth filing

`osscluster.go:148` still documents the pipeline pool as "created only when
`PipelineReadBufferSize` or `PipelineWriteBufferSize` is set", which is stale after #3959 and
contradicts `ring.go:154`. Not blocking this PR — the docs follow the code, not the comment — but
worth a note to go-redis.

### On unpark, then

Run `/unpark <this PR>`. It reconciles the docs against the settled source and takes the PR
through the normal `/reflect` → `/finalize` pipeline. `/finalize` is **deferred until then** — the
episodic `Recheck:` / `Gaps:` / `Directive:` trailers on this branch's commit are what unpark
reads, and finalizing now would squash them away. The `do not merge yet` guard holds until
`/finalize` completes.
<!-- /park-manifest -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact; the only caveat is the parked placeholder version until go-redis releases the pipeline pool behavior.
> 
> **Overview**
> Adds **go-redis production guidance for connection pooling**, including the default-on **pipeline connection pool** from go-redis PR #3959, and wires the pipeline docs to that single section instead of repeating option names inline.
> 
> On **Production usage** (`produsage.md`), a new **Connection pooling** checklist item and section explain the main pool (`PoolSize`, `MinIdleConns`, `MaxActiveConns`, `PoolTimeout`) and the separate pipeline pool (`PipelinePoolSize`, buffer sizes), fallback to the main pool under saturation, per-node behavior for cluster/ring, and monitoring via `PoolStats().PipelineStats`. A version note uses a **`vX.Y.Z` placeholder** until the feature ships in a release. The checklist link for smart client handoffs is corrected from a broken `#seamless-client-experience` anchor to **`#smart-client-handoffs`**.
> 
> **Automatic pipelining** and **Pipelines/transactions** now briefly state that batches use the pipeline pool and link to the new section rather than listing the three `Pipeline*` fields in autopipeline alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48490fec351a23cfc932903ac0b6a8b31f78f61d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
