### PR TITLE
DOC-6994 Document JSON HIGHLIGHT/SUMMARIZE support and limitations [PARKED]

### DIFF
--- a/content/commands/ft.search.md
+++ b/content/commands/ft.search.md
@@ -399,13 +399,13 @@ limits the attributes returned from the document. `num` is the number of attribu
 <details open>
 <summary><code>SUMMARIZE ...</code></summary>
 
-returns only the sections of the attribute that contain the matched text. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight" >}}) for more information.
+returns only the sections of the attribute that contain the matched text. On a JSON index, `SUMMARIZE` requires `RETURN` with explicit attribute names and does not support multi-value JSONPaths. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight" >}}) for more information.
 </details>
 
 <details open>
 <summary><code>HIGHLIGHT ...</code></summary>
 
-formats occurrences of matched text. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight" >}}) for more information.
+formats occurrences of matched text. On a JSON index, `HIGHLIGHT` requires `RETURN` with explicit attribute names and does not support multi-value JSONPaths. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight" >}}) for more information.
 </details>
 
 <details open>

--- a/content/commands/ft.search.md
+++ b/content/commands/ft.search.md
@@ -399,13 +399,13 @@ limits the attributes returned from the document. `num` is the number of attribu
 <details open>
 <summary><code>SUMMARIZE ...</code></summary>
 
-returns only the sections of the attribute that contain the matched text. On a JSON index, `SUMMARIZE` requires `RETURN` with explicit attribute names and does not support multi-value JSONPaths. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight" >}}) for more information.
+returns only the sections of the attribute that contain the matched text. On a JSON index, `SUMMARIZE` requires `RETURN` with explicit attribute names and does not support multi-value JSONPaths; JSON support was added in the 8.4 maintenance line (v8.4.14) and the 8.6, 8.8, and 8.10 lines. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight#json-indexes" >}}) for the exact versions and the full rules.
 </details>
 
 <details open>
 <summary><code>HIGHLIGHT ...</code></summary>
 
-formats occurrences of matched text. On a JSON index, `HIGHLIGHT` requires `RETURN` with explicit attribute names and does not support multi-value JSONPaths. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight" >}}) for more information.
+formats occurrences of matched text. On a JSON index, `HIGHLIGHT` requires `RETURN` with explicit attribute names and does not support multi-value JSONPaths; JSON support was added in the 8.4 maintenance line (v8.4.14) and the 8.6, 8.8, and 8.10 lines. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight#json-indexes" >}}) for the exact versions and the full rules.
 </details>
 
 <details open>

--- a/content/develop/ai/search-and-query/administration/overview.md
+++ b/content/develop/ai/search-and-query/administration/overview.md
@@ -297,6 +297,8 @@ Summarization will fragment the text into smaller sized snippets. Each snippet w
 
 Highlighting will highlight the found term and its variants with a user-defined tag. This may be used to display the matched text in a different typeface using a markup language, or to otherwise make the text appear differently.
 
+JSON indexes have additional requirements. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight#json-indexes" >}}).
+
 ## Autocomplete
 
 Another important feature for Redis Open Source is its autocomplete engine. This allows users to create dictionaries of weighted terms, and then query them for completion suggestions to a given user prefix. Completions can have payloads, which are user-provided pieces of data that can be used for display. For example, completing the names of users, it is possible to add extra metadata about users to be displayed.

--- a/content/develop/ai/search-and-query/advanced-concepts/highlight.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/highlight.md
@@ -115,9 +115,9 @@ Three rules apply to JSON indexes but not to hash indexes:
     no single value to highlight. The error applies to any field in the returned or
     highlighted set, whatever its schema type.
 
-* **Raw JSONPath aliases cannot be highlighted.** In `RETURN 3 $.name AS alias`, the alias
+* **Raw JSONPath aliases cannot be highlighted.** In a `RETURN` clause such as`RETURN 3 $.name AS alias`, the alias
     `alias` is not a schema field, so naming it in `HIGHLIGHT FIELDS` or `SUMMARIZE FIELDS`
-    fails with ``Property `alias` is not in schema``. Name the schema field instead.
+    fails with ``Property `alias` is not in schema``. Name the schema field explicitly instead of using the alias.
 
 A single-value JSONPath that resolves to a JSON array or object, such as `$.colors` where
 `colors` is an array, is accepted but not highlighted. Redis returns the loaded value

--- a/content/develop/ai/search-and-query/advanced-concepts/highlight.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/highlight.md
@@ -90,3 +90,92 @@ The `RETURN` keyword is treated specially, as it overrides any fields specified 
 In the command `RETURN 1 foo SUMMARIZE FIELDS 1 bar HIGHLIGHT FIELDS 1 baz`, the fields `foo` is returned as-is, while `bar` and `baz` are not returned, because `RETURN` was specified, but did not include those fields.
 
 In the command `SUMMARIZE FIELDS 1 bar HIGHLIGHT FIELDS 1 baz`, `bar` is returned summarized and `baz` is returned highlighted.
+
+## JSON indexes
+
+<!-- TODO(DOC-6994): confirm the maintenance lines and the first patch version in each before
+publishing, then replace the sentence below. DOC-6994 says "8.4 onward", the 8.2 backport
+merged but has no Jira fix version, and the 8.6 backport was still open. Follow the wording
+pattern used for search-bg-index-sleep-duration-us in administration/configuration. -->
+
+`HIGHLIGHT` and `SUMMARIZE` work on a JSON index when the field maps to a single-value
+[JSONPath]({{< relref "/develop/data-types/json/path" >}}) such as `$.name`. Earlier releases
+reject `HIGHLIGHT` and `SUMMARIZE` on every JSON index.
+
+Three rules apply to JSON indexes but not to hash indexes:
+
+* **`RETURN` is required.** Pass `RETURN` with explicit field names. Without it, Redis loads
+    the document as a single serialized value, so the individual fields are not available to
+    the highlighter. `HIGHLIGHT` or `SUMMARIZE` with no `RETURN`, or with `RETURN 0`, fails
+    with `HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names`.
+
+* **Multi-value JSONPaths are rejected.** A path such as `$.tags[*]` or `$..name` fails with
+    `HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath`. Each
+    value in a multi-value path is indexed separately, with its own byte offsets, so there is
+    no single value to highlight. The error applies to any field in the returned or
+    highlighted set, whatever its schema type.
+
+* **Raw JSONPath aliases cannot be highlighted.** In `RETURN 3 $.name AS alias`, the alias
+    `alias` is not a schema field, so naming it in `HIGHLIGHT FIELDS` or `SUMMARIZE FIELDS`
+    fails with ``Property `alias` is not in schema``. Name the schema field instead.
+
+A single-value JSONPath that resolves to a JSON array or object, such as `$.colors` where
+`colors` is an array, is accepted but not highlighted. Redis returns the loaded value
+unchanged, without an error.
+
+Hash indexes keep their existing behavior. `RETURN` is optional, and `HIGHLIGHT` without
+`RETURN` highlights every returned `TEXT` field.
+
+### JSON examples
+
+Index two fields with single-value JSONPaths and one with a multi-value JSONPath:
+
+```sql
+127.0.0.1:6379> JSON.SET item:1 $ '{"name":"Noise-cancelling Bluetooth headphones","description":"Wireless Bluetooth headphones with noise-cancelling technology","tags":["audio","wireless"]}'
+OK
+127.0.0.1:6379> FT.CREATE itemIdx ON JSON PREFIX 1 item: SCHEMA $.name AS name TEXT $.description AS description TEXT $.tags[*] AS tags TEXT
+OK
+```
+
+`RETURN` names both fields, and `HIGHLIGHT FIELDS` highlights only `name`:
+
+```sql
+127.0.0.1:6379> FT.SEARCH itemIdx '@name:(bluetooth)' RETURN 2 name description HIGHLIGHT FIELDS 1 name TAGS '<b>' '</b>'
+1) "1"
+2) "item:1"
+3) 1) "name"
+   2) "Noise-cancelling <b>Bluetooth</b> headphones"
+   3) "description"
+   4) "Wireless Bluetooth headphones with noise-cancelling technology"
+```
+
+Without `RETURN`, the same query fails:
+
+```sql
+127.0.0.1:6379> FT.SEARCH itemIdx '@name:(bluetooth)' HIGHLIGHT
+(error) HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names
+```
+
+Highlighting `tags`, which uses the multi-value JSONPath `$.tags[*]`, also fails:
+
+```sql
+127.0.0.1:6379> FT.SEARCH itemIdx 'bluetooth' RETURN 1 tags HIGHLIGHT FIELDS 1 tags
+(error) HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath
+```
+
+The equivalent hash index needs no `RETURN`:
+
+```sql
+127.0.0.1:6379> HSET item:hash name "Noise-cancelling Bluetooth headphones"
+(integer) 1
+127.0.0.1:6379> FT.CREATE hashIdx ON HASH PREFIX 1 item:hash SCHEMA name TEXT
+OK
+127.0.0.1:6379> FT.SEARCH hashIdx '@name:(bluetooth)' HIGHLIGHT FIELDS 1 name TAGS '<b>' '</b>'
+1) "1"
+2) "item:hash"
+3) 1) "name"
+   2) "Noise-cancelling <b>Bluetooth</b> headphones"
+```
+
+For more about indexing and querying JSON documents, see
+[Index and query JSON documents]({{< relref "/develop/ai/search-and-query/indexing/" >}}).

--- a/content/develop/ai/search-and-query/advanced-concepts/highlight.md
+++ b/content/develop/ai/search-and-query/advanced-concepts/highlight.md
@@ -93,13 +93,12 @@ In the command `SUMMARIZE FIELDS 1 bar HIGHLIGHT FIELDS 1 baz`, `bar` is returne
 
 ## JSON indexes
 
-<!-- TODO(DOC-6994): confirm the maintenance lines and the first patch version in each before
-publishing, then replace the sentence below. DOC-6994 says "8.4 onward", the 8.2 backport
-merged but has no Jira fix version, and the 8.6 backport was still open. Follow the wording
-pattern used for search-bg-index-sleep-duration-us in administration/configuration. -->
-
 `HIGHLIGHT` and `SUMMARIZE` work on a JSON index when the field maps to a single-value
-[JSONPath]({{< relref "/develop/data-types/json/path" >}}) such as `$.name`. Earlier releases
+[JSONPath]({{< relref "/develop/data-types/json/path" >}}) such as `$.name`.
+
+Added in the 8.4 maintenance line (v8.4.14), the 8.6 line (v8.6.10), the 8.8 line (v8.8.1),
+the 8.10 line (v8.10.1), and Redis Open Source 8.12. Not available in Redis Open Source 8.2
+or earlier, and not present in the initial 8.4.0, 8.6.0, 8.8.0, or 8.10.0 releases, which
 reject `HIGHLIGHT` and `SUMMARIZE` on every JSON index.
 
 Three rules apply to JSON indexes but not to hash indexes:
@@ -115,7 +114,7 @@ Three rules apply to JSON indexes but not to hash indexes:
     no single value to highlight. The error applies to any field in the returned or
     highlighted set, whatever its schema type.
 
-* **Raw JSONPath aliases cannot be highlighted.** In a `RETURN` clause such as`RETURN 3 $.name AS alias`, the alias
+* **Projection aliases created from raw JSONPath cannot be highlighted.** In a `RETURN` clause such as `RETURN 3 $.name AS alias`, the alias
     `alias` is not a schema field, so naming it in `HIGHLIGHT FIELDS` or `SUMMARIZE FIELDS`
     fails with ``Property `alias` is not in schema``. Name the schema field explicitly instead of using the alias.
 

--- a/content/develop/ai/search-and-query/indexing/_index.md
+++ b/content/develop/ai/search-and-query/indexing/_index.md
@@ -592,12 +592,16 @@ This query returns the field as the alias `"stock"` instead of the JSONPath expr
 
 You can [highlight]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight" >}}) relevant search terms in any indexed `TEXT` attribute.
 
-For JSON documents, you must use the `RETURN` parameter to specify the attributes, followed by `HIGHLIGHT` to indicate which of those attributes to highlight.
+For JSON documents, you must use the `RETURN` parameter to specify the attributes, followed by `HIGHLIGHT` to indicate which of those attributes to highlight. A query with no `RETURN`, or with `RETURN 0`, is rejected.
 
 Use the optional `TAGS` keyword to specify the strings that will surround (or highlight) the matching search terms.
 
+<!-- TODO(DOC-6994): add a version statement here once the maintenance lines are confirmed.
+Earlier releases reject HIGHLIGHT and SUMMARIZE on every JSON index. See the matching TODO in
+advanced-concepts/highlight. -->
+
 {{< note >}}
-`HIGHLIGHT` and `SUMMARIZE` are not supported when the JSONPath leads to multiple values (such as arrays indexed as `TEXT`). See [Index limitations](#index-limitations) for details.
+`HIGHLIGHT` and `SUMMARIZE` are not supported when the JSONPath leads to multiple values (such as arrays indexed as `TEXT`). A single-value JSONPath that resolves to an array or object is accepted, but the value is returned unhighlighted. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight#json-indexes" >}}) for the full rules and error messages, and [Index limitations](#index-limitations) for other multi-value behavior.
 {{< /note >}}
 
 For example, highlight the word "bluetooth" with bold HTML tags in item names and descriptions:
@@ -698,7 +702,7 @@ During index creation, you need to map the JSON elements to `SCHEMA` fields as f
 
 When a JSONPath leads to an array or to multiple values:
 
-- No `HIGHLIGHT` and `SUMMARIZE` support.
+- No `HIGHLIGHT` and `SUMMARIZE` support. Such a query fails with `HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath`. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight#json-indexes" >}}).
 - `SORTBY` only sorts by the first value.
 - `RETURN` of a schema attribute returns the values as a JSON string.
 - If a JSONPath is specified by the `RETURN`, instead of a schema attribute, all values are returned (as a JSON string).

--- a/content/develop/ai/search-and-query/indexing/_index.md
+++ b/content/develop/ai/search-and-query/indexing/_index.md
@@ -14,6 +14,7 @@ categories:
 - kubernetes
 - clients
 description: How to index and search JSON documents
+hideListLinks: true
 linkTitle: Indexing
 title: Indexing
 weight: 3

--- a/content/develop/ai/search-and-query/indexing/_index.md
+++ b/content/develop/ai/search-and-query/indexing/_index.md
@@ -597,12 +597,10 @@ For JSON documents, you must use the `RETURN` parameter to specify the attribute
 
 Use the optional `TAGS` keyword to specify the strings that will surround (or highlight) the matching search terms.
 
-<!-- TODO(DOC-6994): add a version statement here once the maintenance lines are confirmed.
-Earlier releases reject HIGHLIGHT and SUMMARIZE on every JSON index. See the matching TODO in
-advanced-concepts/highlight. -->
+JSON support for `HIGHLIGHT` and `SUMMARIZE` was added in the 8.4, 8.6, 8.8, and 8.10 maintenance lines. Redis Open Source 8.2 and earlier reject both options on every JSON index.
 
 {{< note >}}
-`HIGHLIGHT` and `SUMMARIZE` are not supported when the JSONPath leads to multiple values (such as arrays indexed as `TEXT`). A single-value JSONPath that resolves to an array or object is accepted, but the value is returned unhighlighted. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight#json-indexes" >}}) for the full rules and error messages, and [Index limitations](#index-limitations) for other multi-value behavior.
+`HIGHLIGHT` and `SUMMARIZE` are not supported when the JSONPath leads to multiple values (such as arrays indexed as `TEXT`). A single-value JSONPath that resolves to an array or object is accepted, but the value is returned unhighlighted. See [Highlighting]({{< relref "/develop/ai/search-and-query/advanced-concepts/highlight#json-indexes" >}}) for the full rules, error messages, and the exact version in each maintenance line, and [Index limitations](#index-limitations) for other multi-value behavior.
 {{< /note >}}
 
 For example, highlight the word "bluetooth" with bold HTML tags in item names and descriptions:


### PR DESCRIPTION
Documents JSON `HIGHLIGHT`/`SUMMARIZE` behaviour after [MOD-16530](https://redislabs.atlassian.net/browse/MOD-16530) relaxes the engine's blanket rejection.

The canonical rules live in one `## JSON indexes` section on the Highlighting page; `indexing/_index.md`, `ft.search.md` and `administration/overview.md` point at it instead of restating. Before this change all three disagreed with each other *and* with the engine — `indexing/_index.md` already described roughly the post-fix behaviour and shipped a worked example, while the engine had rejected every JSON highlight since 2024. Two rules were never documented anywhere: JSON requires an explicit `RETURN`, and a single-value JSONPath resolving to an array or object is accepted but silently skipped.

## ⚠️ Do not merge yet

The engine work is **done** — every backport has merged and MOD-16530 is Closed/Done — but **nothing has shipped**. The latest tags on the affected lines are `v8.4.10`, `v8.6.8`, `v8.8.0`, `v8.10.0`. Every Jira fix version is still `released: false`, with 8.4.14 / rse 8.6.12 / rse 8.8.6 targeting 2026-09-30 and Open Source 8.12 targeting 2026-10-30.

Merging now would tell every current reader that JSON highlighting works when the engine still returns `HIGHLIGHT/SUMMARIZE is not supported with JSON indexes`.

**Open question blocking merge:** the pages now assert specific patch versions, and the 8.4 number is disputed — see checklist item 1.

<!-- park-manifest -->
## Park manifest

Ticket: DOC-6994
Parked at: 2026-08-25 (re-parked 2026-09-08)
Trigger to pick up: a **non-prerelease 8.4.x tag exists whose ancestry includes PR #11048's merge commit** `d526e7ec03931f36469a7f216b76e1ec089f67da`. Deliberately phrased as an ancestry check rather than a tag name, because the target patch number has already moved once (8.4.13 → 8.4.14) and is still disputed. Test it by finding the first 8.4.x tag above `v8.4.10` and running `gh api repos/RediSearch/RediSearch/compare/d526e7ec03931f36469a7f216b76e1ec089f67da...<tag> --jq '{status,behind_by}'`, expecting `behind_by: 0`. As of 2026-09-08 no such tag exists (`v8.4.11`, `v8.4.13`, `v8.4.14` all 404).
Labels: parked, do not merge yet

### Pinned sources (state observed at re-park time, 2026-09-08)

Backports target the release branches directly, so these *are* the branches the releases are cut from. **Changes since the 2026-08-25 park are marked ▲.**

| Source | State at re-park time | Re-fetch |
|---|---|---|
| [RediSearch#9410](https://github.com/RediSearch/RediSearch/pull/9410) — primary impl, `master` | merged, merge `bd3ec5dca46c22b54f0673104b64fd9020febade`, updated 2026-08-21T16:29:33Z | `gh api repos/RediSearch/RediSearch/pulls/9410 --jq '{state,merged,merge_commit_sha,updated_at}'` |
| [RediSearch#11106](https://github.com/RediSearch/RediSearch/pull/11106) — follow-up, `master` | merged, merge `a3a09eb58e2ec51940fbd1c1402a2c80a8032a04`, updated 2026-08-24T23:54:41Z | `gh api repos/RediSearch/RediSearch/pulls/11106 --jq '{state,merged,merge_commit_sha,updated_at}'` |
| [RediSearch#11048](https://github.com/RediSearch/RediSearch/pull/11048) — backport, base `8.4` | merged 2026-08-25T00:57:38Z, merge `d526e7ec03931f36469a7f216b76e1ec089f67da` — **this is the trigger commit** | `gh api repos/RediSearch/RediSearch/pulls/11048 --jq '{state,merged,merge_commit_sha,merged_at}'` |
| [RediSearch#11046](https://github.com/RediSearch/RediSearch/pull/11046) — backport, base `8.6` | ▲ **merged** 2026-08-30T11:58:54Z by oshadmi, merge `25d7b56de47e896ee9a60677459aa1148128c1d2`. Was OPEN at park time and recorded as "the blocker" — that half of the old trigger is now satisfied. Landed with 3 cherry-pick conflicts resolved (Rust `rlookup` loader absent from 8.6, so those file changes were dropped; C loader used instead). | `gh api repos/RediSearch/RediSearch/pulls/11046 --jq '{state,merged,merge_commit_sha,merged_at}'` |
| [RediSearch#11044](https://github.com/RediSearch/RediSearch/pull/11044) — backport, base `8.8` | merged, merge `fe67f90b86ab478c0060e649670ee1b83e76b2b9` | `gh api repos/RediSearch/RediSearch/pulls/11044 --jq '{state,merged,merge_commit_sha,updated_at}'` |
| [RediSearch#11043](https://github.com/RediSearch/RediSearch/pull/11043) — backport, base `8.10` | merged, merge `553687a37d9905d6a1538aa22a01f137e8c14a5c` | `gh api repos/RediSearch/RediSearch/pulls/11043 --jq '{state,merged,merge_commit_sha,updated_at}'` |
| [RediSearch#11049](https://github.com/RediSearch/RediSearch/pull/11049) — backport, base `8.2` | **closed WITHOUT merging** (`merged: false`). Confirmed by oshadmi in review: "8.2 doesn't include the fix." | `gh api repos/RediSearch/RediSearch/pulls/11049 --jq '{state,merged,updated_at}'` |
| [RediSearch#11047](https://github.com/RediSearch/RediSearch/pull/11047) — backport, base `8.6-rse` | merged, merge `518ca89cbc9830d505cea94f35bd999f4ad396f8` | `gh api repos/RediSearch/RediSearch/pulls/11047 --jq '{state,merged,merge_commit_sha,updated_at}'` |
| [RediSearch#11045](https://github.com/RediSearch/RediSearch/pull/11045) — backport, base `8.8-rse` | merged, merge `bfb2aa1186d9272166f6e76bedc12805ef04a01a` | `gh api repos/RediSearch/RediSearch/pulls/11045 --jq '{state,merged,merge_commit_sha,updated_at}'` |
| Release tags on affected lines | latest are `v8.4.10`, `v8.6.8`, `v8.8.0`, `v8.10.0`. **Nothing shipped** — unchanged since park. | `gh api 'repos/RediSearch/RediSearch/tags?per_page=100' --jq '.[].name' \| grep -E '^v8\.(4\|6\|8\|10)\.'` |
| [MOD-16530](https://redislabs.atlassian.net/browse/MOD-16530) | ▲ status **Closed**, resolution **Done** (was "In Backport, unresolved"). ▲ Fix versions now: RediSearch **v8.4.14** (2026-09-30), v8.6.10, v8.8.1, v8.10.1, RediSearchEnterprise **v8.6.12** / **v8.8.6** (both 2026-09-30), Open Source 8.12 (2026-10-30). All `released: false`. **v8.4.13 has been removed from the list**, and rse 8.6.11 / 8.8.5 were replaced by 8.6.12 / 8.8.6. Jira updated 2026-08-31. | Atlassian MCP `getJiraIssue MOD-16530` |
| [MOD-17663](https://redislabs.atlassian.net/browse/MOD-17663) — projection-alias support | status **To Do**, no fix versions, updated 2026-08-16. Unchanged. Would invalidate the projection-alias bullet if it lands. | Atlassian MCP `getJiraIssue MOD-17663` |

### Observed shape the page assumes

**Semantics — confidence HIGH.** Held identically across dialects 1–3+ in the merged test suite; this is the shape of the page and it survived review unchanged:

- Single-value JSONPath to a scalar, with `RETURN` naming the field → works, output matches HASH for the same content.
- No `RETURN`, or `RETURN 0` → rejected. Rationale on the page: without `RETURN`, JSON loads as one serialized value so individual fields never reach the highlighter.
- Multi-value JSONPath anywhere in the returned/highlighted set → rejected. Rationale: each value is indexed separately with its own byte offsets.
- Single-value JSONPath resolving to a JSON array or object → accepted, highlighting skipped, original loaded value returned, **no error**.
- HASH unchanged; `RETURN` not required.

**Version identifiers — confidence LOW, and NEW since the last park.** The pages did not assert version numbers at park time; they now assert five, none of which can be checked against a tag because nothing has shipped. Tick each off individually:

- V1. `v8.4.14` for the 8.4 line — **disputed.** oshadmi's review comment (2026-08-30) said 8.4.13; Jira's fix version changed to 8.4.14 on 2026-08-31, the day after. The pages currently say 8.4.14, following Jira as the system of record. Not confirmed by a human.
- V2. `v8.6.10` for the 8.6 line — from Jira fix versions only.
- V3. `v8.8.1` for the 8.8 line — from Jira fix versions only.
- V4. `v8.10.1` for the 8.10 line — from Jira fix versions only.
- V5. "Redis Open Source 8.12" and "not available in 8.2 or earlier" — 8.2 exclusion confirmed by oshadmi in review *and* by #11049 being closed unmerged. This is the best-supported version claim on the page.

**Behaviour identifiers — confidence LOW.** Transcribed from a diff and a test suite, never from a running engine. Error strings are prose inside `QueryError_SetError` calls, exactly what gets reworded before release:

1. `HIGHLIGHT/SUMMARIZE on JSON indexes requires RETURN with explicit field names` — `src/aggregate/aggregate_request.c`, `AREQ_ApplyContext`, PR #9410 diff; asserted as `no_return_error` in `tests/pytests/test_json.py`.
2. `HIGHLIGHT/SUMMARIZE is not supported for JSON fields with multi-value JSONPath` — `src/aggregate/aggregate_request.c`, `AREQ_HasMultiValueHighlightFields`, PR #9410 diff; asserted as `multi_value_error`.
3. ``Property `alias` is not in schema`` — asserted as `alias_error` in `tests/pytests/test_json.py`. **Pre-existing schema validation, not added by #9410** — if it's absent on unpark, the cause is a *different* change, not a rename.
4. Reply body `Noise-cancelling <b>Bluetooth</b> headphones`, and `description` left un-highlighted under `HIGHLIGHT FIELDS 1 name` — output shape from `test_highlight_single_value_json`. The doc example reuses that fixture's *content* but its own key (`item:1`) and index name (`itemIdx`).
5. `RETURN 0` producing the *same* error as omitting `RETURN` — asserted in `test_json.py`, not separately stated in the C diff.
6. Multi-value rejection applying **regardless of schema field type** — from #11106 on `master`. ▲ **Partial evidence gained:** the 8.6 backport carries commit `b8bf56a87f20f7f307d06aea4247bff103a3e9cc` "Validate multi-value JSONPath for all highlighted fields", so follow-up validation *is* on the release branches. But that commit's subject is about validating *all highlighted fields*, which is not verbatim #11106's "independent of the schema field type" — so treat this as supporting, not confirming.

**Two traps for whoever unparks this:**

- **The release-branch commit message is stale about dialects.** The squashed #9410 commit on the backport branches says "Reject DIALECT 3+ (can't distinguish scalar-at-path from array-at-path)". That describes an intermediate state; later commits in the same PR ("Restore JSON non-scalar RSValue type", "Expand MOD1544 highlight dialect coverage") changed it, and the final test suite loops `for dialect in range(1, MAX_DIALECT + 1)` asserting success. The page correctly says nothing about dialects — **do not "fix" it to claim DIALECT 3+ is rejected** on the strength of that commit message.
- **Trust `merged`, not closure.** The PR list makes #11049 look like a merged 8.2 backport. It is `merged: false`.

### Re-check checklist

Harvested from the branch's `/reflect` trailers (commit `999fc5008`), plus review outcomes and predicted-to-change items. **Two items from the previous manifest are now done and dropped:** both `<!-- TODO(DOC-6994) -->` comments are resolved and deleted from the content, and the 8.6-backport half of the old trigger is satisfied.

**Highest risk:**

- [ ] **Settle the 8.4 patch version (V1).** oshadmi said 8.4.13 in review; Jira says 8.4.14. The pages say 8.4.14. **This question now has no home in the repo** — the inline TODO that carried it was deleted — so this checklist item is the only record. Confirm with Omer Shadmi before merge, ideally on [thread r3889516184](https://github.com/redis/docs/pull/3858#discussion_r3889516184).
- [ ] **Re-verify V1–V5 against actual shipped tags**, not Jira. Fix versions have already moved once.
- [ ] **Re-verify behaviour identifiers 1–6**, one verdict each, against a build that has the fix.
- [ ] **Finish confirming identifier 6** — read `AREQ_HasMultiValueHighlightFields` on the shipped 8.4 tag rather than relying on `b8bf56a8`'s subject line.
- [ ] **Run the four JSON examples on a real build** and replace any transcribed reply that differs. From the `Constraint` trailer: every `FT.SEARCH` reply on the Highlighting page came from pytest assertions, not execution.

**Also:**
- [ ] From the `Directive` trailer: a SUMMARIZE reply body and the array-skip reply were **deliberately omitted** — their output is dialect-dependent and the tests only assert substring containment. Add them only with a real build; do not reconstruct them by hand.
- [ ] Check whether MOD-17663 shipped in the same release. If so, the projection-alias bullet on `highlight.md` is stale.
- [ ] Re-sync `data/commands_redisearch.json` (~1061, ~1112) and `data/commands_core.json` (~11354, ~11409). They still carry the old blanket "not currently supported" summaries; upstream `commands.json` was updated in #9410. Deliberately not hand-edited — regenerated at release-docs time, so an edit now would be silently superseded.
- [ ] Confirm the `bannerText` substitution still reads correctly. `/park` Step 4 normally wants a page-level `bannerText`; it was **deliberately not added**, because it banners the entire page and would misdescribe ~900 lines of GA content on `ft.search.md`. The section-level version statement is the guard instead. **Not an oversight.**
- [ ] From the `Gaps` trailer: `tmp/RediSearch` was last fetched 2026-07-30 and its `master` **predates and contradicts** this fix. Do not use it to verify — re-fetch, or read upstream via `gh`.
- [ ] Re-run `hugo` and confirm the cross-links still resolve (`#json-indexes` on `highlight.md`, linked from `indexing/_index.md` ×2, `ft.search.md` ×2, and `administration/overview.md`).

### On unpark, then

When the trigger fires, run `/unpark 3858`. It reconciles the docs against the now-settled source and takes the PR through the normal `/reflect` → `/finalize` pipeline to merge. `/finalize` is **deferred** until then — squashing now would discard the episodic trailers this manifest was built from. The `do not merge yet` guard holds until `/finalize` completes.
<!-- /park-manifest -->


[MOD-16530]: https://redislabs.atlassian.net/browse/MOD-16530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-16530]: https://redislabs.atlassian.net/browse/MOD-16530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ