### PR TITLE
FF: Document production Kubernetes deployment for Feature Form

### DIFF
--- a/content/operate/featureform/configure-auth.md
+++ b/content/operate/featureform/configure-auth.md
@@ -23,35 +23,34 @@ A [workspace]({{< relref "/develop/ai/featureform/concepts#workspaces" >}}) isol
 The sequence:
 
 1. [Configure OIDC at deploy time](#configure-oidc-at-deploy-time)
-2. [Sign in with the CLI](#sign-in-with-the-cli)
-3. [Pick built-in roles for users and groups](#built-in-roles)
-4. [Provision the first global admin](#provision-the-first-global-admin)
-5. [Set up service accounts for non-human identities](#service-accounts-and-machine-credentials)
-6. [Read the audit log](#audit)
+2. [Register a CLI client](#register-a-cli-client)
+3. [Sign in with the CLI](#sign-in-with-the-cli)
+4. [Pick built-in roles for users and groups](#built-in-roles)
+5. [Provision the first global admin](#provision-the-first-global-admin)
+6. [Set up service accounts for non-human identities](#service-accounts-and-machine-credentials)
+7. [Read the audit log](#audit)
 
 ## Authentication
 
 ### Configure OIDC at deploy time
 
-Set Feature Form's OIDC parameters in the Helm chart's `auth` block. At minimum, you need an issuer URL and a server-side client ID:
+Set Feature Form's OIDC parameters in the Helm chart's `auth` block. `auth.oidcClientID` is the audience that Feature Form requires in access tokens. `auth.oidcCLIClientID` is the separate client that users sign in through.
 
 ```yaml
 auth:
   enabled: true
   oidcIssuerURL: "https://idp.example.com/realms/featureform"
-  oidcClientID: "featureform-server"
+  oidcClientID: "featureform-api"
 
-  # CLI client. Defaults to "featureform-cli".
   oidcCLIClientID: "featureform-cli"
-
-  # Comma-separated list. Restricts which flows the CLI offers.
-  # Supported values: device_code, authorization_code_pkce
-  oidcCLILoginMethods: "device_code,authorization_code_pkce"
-
-  # Required only if you use authorization_code_pkce. Must be
-  # registered with the IdP for the CLI client.
-  oidcCLIRedirectURI: "http://localhost:8080/callback"
+  oidcCLIScopes: "openid profile offline_access"
+  oidcCLILoginMethods: "device_code"
+  deploymentID: "acme-featureform-prod-us-west-2"
 ```
+
+Configure the IdP to include the `featureform-api` audience in access tokens issued to `featureform-cli`. Otherwise, login can succeed at the IdP while Feature Form rejects the token.
+
+Use a unique, stable `auth.deploymentID` for each environment. See [Deploy]({{< relref "/operate/featureform/deploy" >}}) for naming and lifecycle guidance.
 
 For deployments where internal services reach the IdP at a different URL than external clients, use `oidcDiscoveryURL`, `oidcPublicIssuerURL`, and `oidcPublicDiscoveryURL` to split the discovery and issuer endpoints. The `oidcSkipIssuerCheck: true` flag disables issuer-claim validation. Use it only during local development.
 
@@ -64,21 +63,39 @@ Feature Form reads role information from JWT claims on each request. It checks t
 
 If any of those claims contain `global_admin`, Feature Form treats the user as a global admin for that token's lifetime without a database binding. This is the typical way operators bootstrap the first admin — see [Provision the first global admin](#provision-the-first-global-admin).
 
+### Register a CLI client
+
+Register a dedicated CLI client with the IdP. The client settings must match the login methods advertised through `auth.oidcCLILoginMethods`.
+
+| Login method | IdP client requirements | Helm settings |
+| --- | --- | --- |
+| `device_code` | Use a public or native client with client authentication disabled. Enable the OAuth 2.0 Device Authorization Grant. No client secret or redirect URI is used. | Set `auth.oidcCLIClientID` and `auth.oidcCLILoginMethods: "device_code"`. |
+| `authorization_code_pkce` | Enable the Authorization Code Grant and Proof Key for Code Exchange (PKCE) with the SHA-256 (`S256`) challenge method. Register the exact redirect URI used by the CLI. A public client is recommended. | Set `auth.oidcCLIClientID`, `auth.oidcCLILoginMethods: "authorization_code_pkce"`, and `auth.oidcCLIRedirectURI`. |
+
+The IdP must allow every scope in `auth.oidcCLIScopes`. The default scopes are `openid profile offline_access`. The `offline_access` scope lets the CLI request a refresh token. Remove it when the IdP doesn't support offline access; users must sign in again after their access token expires.
+
+If the IdP requires a confidential client for PKCE, provide its secret only at login through `FEATUREFORM_LOGIN_CLIENT_SECRET` or `--login-client-secret`. Don't put the CLI client secret in Helm values. The CLI doesn't persist the secret or the refresh token from that login.
+
+To configure PKCE instead of device authorization:
+
+```yaml
+auth:
+  oidcCLIClientID: "featureform-cli"
+  oidcCLILoginMethods: "authorization_code_pkce"
+  oidcCLIRedirectURI: "http://localhost:8080/callback"
+```
+
 ### Sign in with the CLI
 
 The `ff auth` commands handle login, session inspection, and token retrieval:
 
 ```bash
-# Interactive login. Defaults to device-code flow if the IdP
-# supports it; falls back to authorization_code_pkce otherwise.
+# Interactive login. Uses the first method advertised by Feature Form.
 ff auth login
 
 # Force a specific flow.
 ff auth login --login-method device_code
 ff auth login --login-method authorization_code_pkce
-
-# Non-interactive password grant for continuous-integration scripts.
-ff auth login --username alice@example.com --password-stdin
 
 # Inspect the current session.
 ff auth status
@@ -96,9 +113,46 @@ Pick a login method based on your environment:
 
 - **device-code** for headless terminals or shared shells where a local browser callback can't be reached.
 - **authorization_code_pkce** when a local browser callback works (typical for developer desktops).
-- **password-stdin** for non-interactive automation like CI scripts.
+
+Feature Form advertises the methods in `auth.oidcCLILoginMethods`. The CLI selects the first advertised method it supports unless you pass `--login-method`. It doesn't retry another method when the IdP rejects the selected method.
+
+Username and password login is a development-only compatibility path. It requires the IdP's password grant and an appropriate client ID. For production automation, use a service account instead of storing a user's password.
 
 CLI sessions are stored in the CLI's local config (per profile). To skip interactive login entirely, set `FEATUREFORM_TOKEN` to a valid access token, or configure a service account with client credentials (see [Service accounts and machine credentials](#service-accounts-and-machine-credentials)).
+
+### Troubleshoot CLI login
+
+Inspect the authentication metadata advertised by Feature Form through a reachable REST endpoint:
+
+```bash
+curl --fail --silent --show-error \
+  https://api.example.com/api/v1/auth/metadata | python3 -m json.tool
+```
+
+If REST isn't public, port-forward the REST service and query `http://localhost:8080/api/v1/auth/metadata` instead:
+
+```bash
+kubectl --namespace <namespace> port-forward \
+  service/featureform-featureform-rest 8080:8080
+```
+
+Confirm that `cli_client_id`, `supported_login_methods`, `scopes`, and `audience` match the IdP client. For PKCE, also confirm `cli_redirect_uri`. Then inspect the IdP discovery document:
+
+```bash
+curl --fail --silent --show-error \
+  https://idp.example.com/realms/featureform/.well-known/openid-configuration \
+  | python3 -m json.tool
+```
+
+For device authorization, the document must contain `device_authorization_endpoint`. For PKCE, it must contain `authorization_endpoint` and `token_endpoint`, and advertise SHA-256 support in `code_challenge_methods_supported` when that field is present.
+
+| Symptom | Check and action |
+| --- | --- |
+| `invalid_client` | Confirm `auth.oidcCLIClientID` exactly matches the IdP client. For a public client, disable client authentication. For confidential PKCE, supply the current secret at login. |
+| `unauthorized_client` | Enable the grant required by the selected method: Device Authorization Grant for `device_code`, or Authorization Code Grant with PKCE for `authorization_code_pkce`. |
+| Feature Form doesn't advertise the requested login method | Set `auth.oidcCLILoginMethods` to a method supported by both the CLI and IdP, upgrade the release, and inspect the Feature Form metadata again. |
+| Redirect URI mismatch | Make `auth.oidcCLIRedirectURI` exactly match a redirect URI registered for the IdP client, including its scheme, host, port, path, and query parameters. |
+| `invalid_scope` | Allow every value in `auth.oidcCLIScopes` at the IdP, or remove unsupported optional scopes. |
 
 ## RBAC
 

--- a/content/operate/featureform/configure-auth.md
+++ b/content/operate/featureform/configure-auth.md
@@ -76,7 +76,7 @@ The IdP must allow every scope in `auth.oidcCLIScopes`. The default scopes are `
 
 If the IdP requires a confidential client for PKCE, provide its secret only at login through `FEATUREFORM_LOGIN_CLIENT_SECRET` or `--login-client-secret`. Don't put the CLI client secret in Helm values. The CLI doesn't persist the secret or the refresh token from that login.
 
-To configure PKCE instead of device authorization:
+In the Helm values file for the Feature Form release, use these settings to configure PKCE instead of device authorization:
 
 ```yaml
 auth:
@@ -114,22 +114,22 @@ Pick a login method based on your environment:
 - **device-code** for headless terminals or shared shells where a local browser callback can't be reached.
 - **authorization_code_pkce** when a local browser callback works (typical for developer desktops).
 
-Feature Form advertises the methods in `auth.oidcCLILoginMethods`. The CLI selects the first advertised method it supports unless you pass `--login-method`. It doesn't retry another method when the IdP rejects the selected method.
+Feature Form lists the methods in `auth.oidcCLILoginMethods`. The CLI selects the first advertised method it supports unless you pass `--login-method`. It doesn't retry another method when the IdP rejects the selected method.
 
-Username and password login is a development-only compatibility path. It requires the IdP's password grant and an appropriate client ID. For production automation, use a service account instead of storing a user's password.
+Username and password login is not recommended for production environments. For production automation, use a service account instead of storing a user's password.
 
 CLI sessions are stored in the CLI's local config (per profile). To skip interactive login entirely, set `FEATUREFORM_TOKEN` to a valid access token, or configure a service account with client credentials (see [Service accounts and machine credentials](#service-accounts-and-machine-credentials)).
 
 ### Troubleshoot CLI login
 
-Inspect the authentication metadata advertised by Feature Form through a reachable REST endpoint:
+Inspect the authentication metadata provided by Feature Form through a reachable REST endpoint:
 
 ```bash
 curl --fail --silent --show-error \
   https://api.example.com/api/v1/auth/metadata | python3 -m json.tool
 ```
 
-If REST isn't public, port-forward the REST service and query `http://localhost:8080/api/v1/auth/metadata` instead:
+If the REST API isn't public, port-forward the REST API service and query `http://localhost:8080/api/v1/auth/metadata` instead:
 
 ```bash
 kubectl --namespace <namespace> port-forward \
@@ -144,13 +144,13 @@ curl --fail --silent --show-error \
   | python3 -m json.tool
 ```
 
-For device authorization, the document must contain `device_authorization_endpoint`. For PKCE, it must contain `authorization_endpoint` and `token_endpoint`, and advertise SHA-256 support in `code_challenge_methods_supported` when that field is present.
+For device authorization, the document must contain `device_authorization_endpoint`. For PKCE, it must contain `authorization_endpoint` and `token_endpoint`, and have SHA-256 support in `code_challenge_methods_supported` when that field is present.
 
 | Symptom | Check and action |
 | --- | --- |
-| `invalid_client` | Confirm `auth.oidcCLIClientID` exactly matches the IdP client. For a public client, disable client authentication. For confidential PKCE, supply the current secret at login. |
+| `invalid_client` | Confirm `auth.oidcCLIClientID` exactly matches the IdP client. For a public client, turn off client authentication. For confidential PKCE, supply the current secret at login. |
 | `unauthorized_client` | Enable the grant required by the selected method: Device Authorization Grant for `device_code`, or Authorization Code Grant with PKCE for `authorization_code_pkce`. |
-| Feature Form doesn't advertise the requested login method | Set `auth.oidcCLILoginMethods` to a method supported by both the CLI and IdP, upgrade the release, and inspect the Feature Form metadata again. |
+| Feature Form doesn't show the requested login method | Set `auth.oidcCLILoginMethods` to a method supported by both the CLI and IdP, upgrade the release, and inspect the Feature Form metadata again. |
 | Redirect URI mismatch | Make `auth.oidcCLIRedirectURI` exactly match a redirect URI registered for the IdP client, including its scheme, host, port, path, and query parameters. |
 | `invalid_scope` | Allow every value in `auth.oidcCLIScopes` at the IdP, or remove unsupported optional scopes. |
 

--- a/content/operate/featureform/deploy.md
+++ b/content/operate/featureform/deploy.md
@@ -16,7 +16,9 @@ Install Redis Feature Form on Kubernetes with the Helm chart, durable PostgreSQL
 
 ## Install
 
-For production, use an external PostgreSQL database and keep credentials and the license key in Kubernetes Secrets. After meeting the prerequisites:
+Prerequisites: For production environments, use an external PostgreSQL database and keep credentials and the license key in Kubernetes Secrets.
+
+To get started:
 
 1. Get the chart.
 2. Create the namespace and Secrets.
@@ -58,6 +60,8 @@ Use your normal secret-management process to create these Secrets in the same na
 - `featureform-postgres`, with a `POSTGRES_URL` key containing the PostgreSQL connection URL. Require TLS according to your database policy.
 - `featureform-license`, with the license key stored in `license.key`.
 
+The Secret names and local file paths in these examples aren't required. If you choose different Secret names or keys, update the matching `postgres.*` and `license.*` settings in the values file. You can also choose a different values filename and pass it to Helm with `--values`.
+
 For example, create the PostgreSQL Secret from a restricted environment file whose entry is `POSTGRES_URL=<postgres-connection-url>`:
 
 ```bash
@@ -83,9 +87,9 @@ imagePullSecrets:
 
 ### 3. Create a values file
 
-Create `values-production.yaml`. `auth.deploymentID` identifies one logical Feature Form deployment. It isn't a workspace, replica, Kubernetes namespace, Helm release, or OIDC client ID.
+Create `values-production.yaml` and set `auth.deploymentID` to a stable, lowercase ASCII identifier for this Feature Form environment, such as `acme-featureform-prod-us-west-2`. Keep the value the same across replicas and upgrades, and use a different value for each environment.
 
-Feature Form requires a value that isn't empty after trimming whitespace. It doesn't enforce another format. Use a stable, lowercase ASCII slug such as `acme-featureform-prod-us-west-2`. Keep the value the same across replicas and upgrades, and don't reuse it for a separate environment. Changing it requires CLI users to sign in again.
+Feature Form accepts any value that isn't empty after trimming whitespace. Changing it requires CLI users to sign in again.
 
 ```yaml
 stateBackend: postgres
@@ -141,9 +145,9 @@ grpc:
           - grpc.example.com
 ```
 
-Use the ingress class and gRPC backend annotation required by your maintained ingress controller. The controller must support gRPC backends and TLS termination.
+In `values-production.yaml`, replace the ingress class and gRPC backend annotation placeholders with the values required by your maintained ingress controller. The controller must support gRPC backends and TLS termination.
 
-`auth.publicRestEndpoint` and `auth.publicGrpcEndpoint` advertise the public endpoints through authentication discovery. Use addresses reachable by your CLI users. If internal services reach the identity provider through a different URL, configure the internal and public OIDC URLs as described in [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}).
+`auth.publicRestEndpoint` and `auth.publicGrpcEndpoint` show the public endpoints through authentication discovery. Use addresses reachable by your CLI users. If internal services reach the identity provider through a different URL, configure the internal and public OIDC URLs as described in [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}).
 
 ### 4. Render and install the release
 
@@ -224,7 +228,7 @@ pip install redis-featureform==<featureform-version>
 ff version --client-only
 ```
 
-Use the public gRPC endpoint when you expose it. gRPC is the CLI default, but the explicit transport makes the saved profile clear:
+When you expose the gRPC endpoint publicly, connect the CLI through that endpoint. gRPC is the CLI default, but the explicit transport makes the saved profile clear:
 
 ```bash
 ff --server grpc.example.com:443 --transport grpc \
@@ -268,7 +272,7 @@ Use external PostgreSQL so Feature Form state survives restarts and remains cons
 
 This database stores durable Feature Form application state. Register production data providers separately after deploying Feature Form.
 
-The chart runs pending schema migrations in an init container before starting the server. The database role must be able to create and alter the Feature Form schema. A migration failure keeps the server pod from becoming ready.
+Before starting the server, the chart runs an init container that applies all pending schema migrations. The database role must be able to create and alter the Feature Form schema. A migration failure keeps the server pod from becoming ready.
 
 ## Configure external access
 
@@ -295,7 +299,7 @@ The dashboard Secret keys default to `FEATUREFORM_OIDC_CLIENT_SECRET` and `FEATU
 
 ## Configure availability and capacity
 
-The chart defaults to one server replica. For multiple replicas, use PostgreSQL state and configure resource requests before enabling horizontal autoscaling. Each server replica also runs scheduler workers, so adding replicas increases both API and job-processing capacity.
+The chart defaults to one server replica. For multiple replicas, use PostgreSQL state. Configure resource requests before enabling horizontal autoscaling. Each server replica also runs scheduler workers, so adding replicas increases both API and job-processing capacity.
 
 This example sets resource boundaries, two or more replicas, and a PodDisruptionBudget:
 
@@ -321,11 +325,11 @@ podDisruptionBudget:
 
 Horizontal Pod Autoscaling requires the Kubernetes resource metrics API. Use `server.nodeSelector`, `server.tolerations`, `server.affinity`, or `server.topologySpreadConstraints` when your cluster requires workload placement controls.
 
-By default, each server process starts two effective scheduler workers. Use `scheduler.workerCount` and `scheduler.workerMaxInflight` to bound per-replica job concurrency. Tune these values with server replica count and downstream provider capacity; increasing API replicas also increases the number of workers that can claim jobs.
+By default, each server process starts two effective scheduler workers. To bound per-replica job concurrency, use `scheduler.workerCount` and `scheduler.workerMaxInflight`. Tune these values with server replica count and downstream provider capacity; increasing API replicas also increases the number of workers that can claim jobs.
 
 ## Configure Kubernetes Secret access
 
-The chart doesn't mount a Kubernetes service-account token by default. No token is needed to consume Secrets already referenced by pod environment variables or volumes.
+No token is needed to consume Secrets already referenced by pod environment variables or volumes. The chart doesn't mount a Kubernetes service-account token by default.
 
 If you register a Kubernetes secret provider for server-side secret resolution, enable the token mount and grant the Feature Form service account `get` access to the required Secret objects. For Secrets in the release namespace:
 
@@ -342,11 +346,13 @@ rbac:
       verbs: ["get"]
 ```
 
+{{< note >}}
 These `rbac.*` values configure Kubernetes permissions. Feature Form application roles are configured separately in [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}).
+{{< /note >}}
 
 ## Configure observability
 
-The server exports metrics and traces through OpenTelemetry Protocol (OTLP). Setting only the endpoint isn't sufficient because the Helm chart disables both signals by default. Configure an external collector with an authority that doesn't include a URL scheme:
+The server exports metrics and traces through OpenTelemetry Protocol (OTLP). Because the Helm chart disables both signals by default, set the endpoint and enable the signals you want. Configure an external collector using an authority without a URL scheme:
 
 ```yaml
 observability:

--- a/content/operate/featureform/deploy.md
+++ b/content/operate/featureform/deploy.md
@@ -30,7 +30,7 @@ For production, use an external PostgreSQL database and keep credentials and the
 - Kubernetes 1.27+.
 - Helm 3.14+.
 - Network access to the chart and image repositories. Configure `imagePullSecrets` if your cluster requires registry credentials.
-- An OIDC issuer URL and client ID. See [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}).
+- An OIDC issuer URL, an API audience, and a CLI client configured for device authorization. See [Register a CLI client]({{< relref "/operate/featureform/configure-auth#register-a-cli-client" >}}).
 - An external PostgreSQL database for production state. Its role must be able to create and alter Feature Form tables during migrations.
 - A Feature Form license key from your Redis account team.
 - A public domain name and Transport Layer Security (TLS) certificate for each externally exposed endpoint.
@@ -83,7 +83,9 @@ imagePullSecrets:
 
 ### 3. Create a values file
 
-Create `values-production.yaml`. The deployment ID identifies this Feature Form installation to clients. Choose a unique, nonempty value once and keep it unchanged across upgrades.
+Create `values-production.yaml`. `auth.deploymentID` identifies one logical Feature Form deployment. It isn't a workspace, replica, Kubernetes namespace, Helm release, or OIDC client ID.
+
+Feature Form requires a value that isn't empty after trimming whitespace. It doesn't enforce another format. Use a stable, lowercase ASCII slug such as `acme-featureform-prod-us-west-2`. Keep the value the same across replicas and upgrades, and don't reuse it for a separate environment. Changing it requires CLI users to sign in again.
 
 ```yaml
 stateBackend: postgres
@@ -92,6 +94,9 @@ auth:
   enabled: true
   oidcIssuerURL: "https://idp.example.com/realms/featureform"
   oidcClientID: "featureform-api"
+  oidcCLIClientID: "featureform-cli"
+  oidcCLIScopes: "openid profile offline_access"
+  oidcCLILoginMethods: "device_code"
   deploymentID: "<stable-deployment-id>"
   publicRestEndpoint: "https://api.example.com"
   publicGrpcEndpoint: "grpc.example.com:443"
@@ -176,6 +181,16 @@ kubectl --namespace <namespace> get pods
 kubectl --namespace <namespace> get services
 ```
 
+Confirm that the `migrate` init container completed with exit code `0` for every server pod:
+
+```bash
+kubectl --namespace <namespace> get pods \
+  --selector app.kubernetes.io/instance=featureform,app.kubernetes.io/component=server \
+  --output jsonpath='{range .items[*]}{.metadata.name}{"\t"}{range .status.initContainerStatuses[?(@.name=="migrate")]}{.state.terminated.reason}{"\t"}{.state.terminated.exitCode}{"\n"}{end}{end}'
+```
+
+Each line must end with `Completed` and `0`. If the status fields are empty, wait for the init container to finish and run the command again.
+
 If migration fails, inspect its logs before restarting the pod:
 
 ```bash
@@ -209,11 +224,37 @@ pip install redis-featureform==<featureform-version>
 ff version --client-only
 ```
 
-Log in through the public gRPC endpoint, verify the authenticated principal, and test gRPC health:
+Use the public gRPC endpoint when you expose it. gRPC is the CLI default, but the explicit transport makes the saved profile clear:
 
 ```bash
 ff --server grpc.example.com:443 --transport grpc \
   auth login --profile production
+```
+
+If you expose only REST, log in through that endpoint instead:
+
+```bash
+ff --server https://api.example.com --transport rest \
+  auth login --profile production
+```
+
+If neither endpoint is public, forward the gRPC service from one terminal:
+
+```bash
+kubectl --namespace <namespace> port-forward \
+  service/featureform-featureform-grpc 9090:9090
+```
+
+Then log in from another terminal:
+
+```bash
+ff --server localhost:9090 --transport grpc \
+  auth login --profile production
+```
+
+After login, verify the authenticated principal and the selected endpoint:
+
+```bash
 ff auth status
 ff auth whoami
 ff ping

--- a/content/operate/featureform/deploy.md
+++ b/content/operate/featureform/deploy.md
@@ -12,171 +12,342 @@ bannerText: Feature Form is currently in preview and subject to change. Feature 
 bannerChildren: true
 ---
 
-Install Feature Form on Kubernetes with the Helm chart and verify the core services.
+Install Redis Feature Form on Kubernetes with the Helm chart, durable PostgreSQL state, OpenID Connect (OIDC) authentication, and a license key.
 
 ## Install
 
-These steps install Feature Form with OIDC authentication and PostgreSQL-backed durable state — the recommended production configuration. The install sequence (after meeting the prerequisites):
+For production, use an external PostgreSQL database and keep credentials and the license key in Kubernetes Secrets. After meeting the prerequisites:
 
-1. Get the chart
-2. Choose auth and state values
-3. Pick the base chart or a profile
-4. Install with Helm
-5. Validate pods and services
-6. Record the endpoints
-7. Install the `ff` CLI
+1. Get the chart.
+2. Create the namespace and Secrets.
+3. Create a values file.
+4. Render and install the release.
+5. Verify the deployment.
+6. Install and connect the `ff` command-line interface (CLI).
 
 ### Prerequisites
 
 - Kubernetes 1.27+.
 - Helm 3.14+.
-- An OIDC issuer URL and client ID — see [Configure authentication and RBAC]({{< relref "/operate/featureform/configure-auth" >}}) to set one up before installing.
-- A PostgreSQL connection path or existing secret.
+- Network access to the chart and image repositories. Configure `imagePullSecrets` if your cluster requires registry credentials.
+- An OIDC issuer URL and client ID. See [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}).
+- An external PostgreSQL database for production state. Its role must be able to create and alter Feature Form tables during migrations.
+- A Feature Form license key from your Redis account team.
+- A public domain name and Transport Layer Security (TLS) certificate for each externally exposed endpoint.
 
 ### 1. Get the chart
 
-The Feature Form Helm chart is published as an OCI artifact on Docker Hub:
+The Feature Form Helm chart is published as an Open Container Initiative (OCI) artifact on Docker Hub:
 
 ```text
 oci://registry-1.docker.io/redisfeatureform/featureform
 ```
 
-Helm pulls the chart directly from this path with the `--version` flag — no `helm pull` step is required unless you want a local copy. Pin to the same version as the server and dashboard images you intend to run.
+Install the chart directly from this path. Always pin `--version` to the Feature Form version you intend to run.
 
-### 2. Choose auth and state values
+### 2. Create the namespace and Secrets
 
-Pick one PostgreSQL-backed state path before installation:
+Create the release namespace before creating referenced Secrets:
 
-- `postgres.url` for a connection string.
-- `postgres.secretName` to point at an existing Kubernetes secret holding the connection details.
-- `addons.statePostgres.enabled=true` to install the chart's bundled state PostgreSQL.
+```bash
+kubectl create namespace <namespace>
+```
 
-External PostgreSQL is the documented durable default.
+Use your normal secret-management process to create these Secrets in the same namespace as Feature Form:
 
-### 3. Pick the base chart or a profile
+- `featureform-postgres`, with a `POSTGRES_URL` key containing the PostgreSQL connection URL. Require TLS according to your database policy.
+- `featureform-license`, with the license key stored in `license.key`.
 
-Pick one based on what infrastructure already exists in your cluster and what observability you need:
+For example, create the PostgreSQL Secret from a restricted environment file whose entry is `POSTGRES_URL=<postgres-connection-url>`:
 
-- **Base chart** — for environments where Postgres, Redis, and other provider infrastructure already exist.
-- **`profiles/memory.yaml`** — local or test-only installs; uses in-memory state (not durable).
-- **`profiles/provider-stack.yaml`** — adds bundled Postgres and Redis addons so you don't need external infrastructure.
-- **`profiles/observability-postgres.yaml`** — adds Prometheus and Grafana with durable Postgres state.
-- **`profiles/provider-observability.yaml`** — both bundled providers and observability.
+```bash
+kubectl --namespace <namespace> create secret generic featureform-postgres \
+  --from-env-file=<path-to-postgres-secret-env-file>
+```
 
-### 4. Install with Helm
+Create the license Secret from a restricted key file:
+
+```bash
+kubectl --namespace <namespace> create secret generic featureform-license \
+  --from-file=license.key=<path-to-license-key-file>
+```
+
+Create an image-pull Secret as well if your cluster requires registry authentication.
+
+Add this entry when you create `values-production.yaml`:
+
+```yaml
+imagePullSecrets:
+  - name: <registry-secret-name>
+```
+
+### 3. Create a values file
+
+Create `values-production.yaml`. The deployment ID identifies this Feature Form installation to clients. Choose a unique, nonempty value once and keep it unchanged across upgrades.
+
+```yaml
+stateBackend: postgres
+
+auth:
+  enabled: true
+  oidcIssuerURL: "https://idp.example.com/realms/featureform"
+  oidcClientID: "featureform-api"
+  deploymentID: "<stable-deployment-id>"
+  publicRestEndpoint: "https://api.example.com"
+  publicGrpcEndpoint: "grpc.example.com:443"
+
+postgres:
+  url: ""
+  secretName: featureform-postgres
+  secretKey: POSTGRES_URL
+
+license:
+  existingSecret: featureform-license
+  secretKey: license.key
+
+rest:
+  ingress:
+    enabled: true
+    className: "<ingress-class-name>"
+    hosts:
+      - host: api.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: featureform-api-tls
+        hosts:
+          - api.example.com
+
+grpc:
+  ingress:
+    enabled: true
+    className: "<ingress-class-name>"
+    annotations:
+      "<grpc-backend-annotation>": "<grpc-backend-value>"
+    hosts:
+      - host: grpc.example.com
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+    tls:
+      - secretName: featureform-grpc-tls
+        hosts:
+          - grpc.example.com
+```
+
+Use the ingress class and gRPC backend annotation required by your maintained ingress controller. The controller must support gRPC backends and TLS termination.
+
+`auth.publicRestEndpoint` and `auth.publicGrpcEndpoint` advertise the public endpoints through authentication discovery. Use addresses reachable by your CLI users. If internal services reach the identity provider through a different URL, configure the internal and public OIDC URLs as described in [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}).
+
+### 4. Render and install the release
+
+Render the chart before changing the cluster:
+
+```bash
+helm template featureform \
+  oci://registry-1.docker.io/redisfeatureform/featureform \
+  --version <featureform-version> \
+  --namespace <namespace> \
+  --values values-production.yaml \
+  > /tmp/featureform-rendered.yaml
+```
+
+Install the release and wait for its workloads to become ready:
 
 ```bash
 helm upgrade --install featureform \
   oci://registry-1.docker.io/redisfeatureform/featureform \
   --version <featureform-version> \
-  --set postgres.url=postgres://featureform:featureform@my-postgres:5432/featureform?sslmode=disable \
-  --set auth.oidcIssuerURL=https://idp.example.com/realms/featureform \
-  --set auth.oidcClientID=featureform-api \
-  --set rest.ingress.enabled=true \
-  --set rest.ingress.className=nginx \
-  --set rest.ingress.hosts[0].host=api.example.com \
-  --set rest.ingress.hosts[0].paths[0].path=/ \
-  --set rest.ingress.hosts[0].paths[0].pathType=Prefix
+  --namespace <namespace> \
+  --values values-production.yaml \
+  --wait \
+  --timeout 10m
 ```
 
-### 5. Validate pods and services
+### 5. Verify the deployment
+
+Confirm the server rollout, services, and PostgreSQL migration init container:
 
 ```bash
-kubectl get pods -n <namespace>
-kubectl get svc -n <namespace>
-kubectl describe deployment featureform-featureform-server -n <namespace>
+kubectl --namespace <namespace> rollout status \
+  deployment/featureform-featureform-server
+kubectl --namespace <namespace> get pods
+kubectl --namespace <namespace> get services
 ```
 
-The deployment is healthy when:
-
-- Pods show `STATUS Running` with `READY 1/1`.
-- Both REST and gRPC services are present.
-- When PostgreSQL state is enabled, the migration init container shows `STATUS Completed` (`kubectl logs <pod> -c migrate` for details).
-
-### 6. Record the endpoints
-
-Capture the URLs or hosts your teams will need:
-
-- REST API endpoint
-- gRPC endpoint
-- dashboard URL if enabled
-- Grafana URL if enabled
-
-Find them with:
+If migration fails, inspect its logs before restarting the pod:
 
 ```bash
-kubectl get ingress -n <namespace>   # ingress hosts
-kubectl get svc -n <namespace>       # LoadBalancer EXTERNAL-IPs
+kubectl --namespace <namespace> logs <server-pod> --container migrate
 ```
 
-### 7. Install the `ff` CLI
-
-The Feature Form CLI ships as the `redis-featureform` package on PyPI. **Don't run `pip install featureform`** — that installs an unrelated upstream project. Install into a virtual environment, pinned to the same version as your deployment:
+Verify the mounted license. Inspect the printed `Status:` value rather than relying only on the command's exit status:
 
 ```bash
-python3 -m venv .venv && source .venv/bin/activate
+kubectl --namespace <namespace> exec \
+  deployment/featureform-featureform-server \
+  -- featureformctl license status
+```
+
+Then verify REST readiness through the public endpoint:
+
+```bash
+curl --fail --silent --show-error https://api.example.com/health/ready
+```
+
+The readiness endpoint checks the server and registered scheduler dependencies. It doesn't prove that every external provider is healthy.
+
+### 6. Install and connect the `ff` CLI
+
+The Feature Form CLI ships as the `redis-featureform` package on PyPI. **Don't run `pip install featureform`** — that installs an unrelated upstream project. Install it in a virtual environment and pin it to the deployment version:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
 pip install redis-featureform==<featureform-version>
-ff --help
+ff version --client-only
 ```
 
-### Common pitfalls
+Log in through the public gRPC endpoint, verify the authenticated principal, and test gRPC health:
 
-- **One shared server deployment exposes both REST and gRPC.** They're not separate deployments — don't try to scale them independently or expose them on different services.
-- **`auth.enabled=false` is not supported.** The chart refuses to render. Configure OIDC and set `auth.enabled=true`.
-- **`stateBackend=memory` is not durable.** Workspace state, applied resources, and serving metadata are lost on pod restart. Use this only for ephemeral testing.
-- **`dashboard.enabled=true` alone won't render the dashboard.** You also need `dashboard.publicAPIURL`, `dashboard.auth.*`, and a resolvable auth URL — see [Dashboard requirements](#dashboard-requirements).
+```bash
+ff --server grpc.example.com:443 --transport grpc \
+  auth login --profile production
+ff auth status
+ff auth whoami
+ff ping
+```
+
+Login creates or updates the `production` profile and makes it active for subsequent commands. `ff ping` returns a failure status when the selected endpoint is unavailable.
+
+## Configure production state
+
+Use external PostgreSQL so Feature Form state survives restarts and remains consistent across server replicas. Protect the database with your normal TLS, availability, monitoring, backup, and restore controls. Back up the database before upgrading Feature Form.
+
+This database stores durable Feature Form application state. Register production data providers separately after deploying Feature Form.
+
+The chart runs pending schema migrations in an init container before starting the server. The database role must be able to create and alter the Feature Form schema. A migration failure keeps the server pod from becoming ready.
 
 ## Configure external access
 
-After installation, publish the right Feature Form endpoints for users, automation, and optional UI access.
+All services default to `ClusterIP`. Choose one exposure model:
 
-### REST ingress example
+- Use `rest.ingress.*`, `grpc.ingress.*`, and `dashboard.ingress.*` for separate hosts.
+- Use `ingress.*` for one host with chart-managed paths for the API and dashboard.
+- Use the service `type=LoadBalancer` values when your platform terminates TLS at a load balancer.
 
-Append these flags to the `helm upgrade --install` command to publish REST through ingress:
+Don't combine `ingress.*` with service-specific ingress settings. The chart rejects that configuration.
 
-```bash
---set rest.ingress.enabled=true \
---set rest.ingress.className=nginx \
---set rest.ingress.hosts[0].host=api.example.com \
---set rest.ingress.hosts[0].paths[0].path=/ \
---set rest.ingress.hosts[0].paths[0].pathType=Prefix
-```
-
-### gRPC exposure guidance
-
-Use `grpc.ingress.*` only with an ingress controller that supports gRPC backends. If ingress isn't an option, use `grpc.service.type=LoadBalancer`.
+Terminate TLS at the ingress controller or load balancer. Use `grpc.ingress.*` only with a controller that supports gRPC backends. If ingress isn't suitable, use `grpc.service.type=LoadBalancer` and `rest.service.type=LoadBalancer`.
 
 ### Dashboard requirements
 
 Enabling the dashboard requires:
 
-- `dashboard.enabled=true`
-- a resolvable public API URL
-- dashboard auth secrets
-- a resolvable auth URL
+- `dashboard.enabled=true`.
+- `dashboard.publicAPIURL`, a REST ingress host, or unified `ingress.*` configuration.
+- A resolvable dashboard authentication URL.
+- An OIDC client secret and dashboard session secret. Use `dashboard.auth.existingSecret` for production.
 
-### Unified ingress
+The dashboard Secret keys default to `FEATUREFORM_OIDC_CLIENT_SECRET` and `FEATUREFORM_DASHBOARD_AUTH_SECRET`.
 
-Unified ingress publishes one host with chart-managed paths for API, dashboard, and optionally Grafana. Do not combine it with service-specific ingress settings.
+## Configure availability and capacity
 
-### Direct load balancers
+The chart defaults to one server replica. For multiple replicas, use PostgreSQL state and configure resource requests before enabling horizontal autoscaling. Each server replica also runs scheduler workers, so adding replicas increases both API and job-processing capacity.
 
-If your platform prefers direct external services, expose:
+This example sets resource boundaries, two or more replicas, and a PodDisruptionBudget:
 
-- `rest.service.type=LoadBalancer`
-- `grpc.service.type=LoadBalancer`
-- `dashboard.service.type=LoadBalancer`
+```yaml
+server:
+  resources:
+    requests:
+      cpu: <server-cpu-request>
+      memory: <server-memory-request>
+    limits:
+      cpu: <server-cpu-limit>
+      memory: <server-memory-limit>
+  autoscaling:
+    enabled: true
+    minReplicas: 2
+    maxReplicas: <maximum-server-replicas>
+    targetCPUUtilizationPercentage: 80
 
-### Troubleshooting
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
 
-- **Missing ingress hosts.** Set `rest.ingress.hosts[0].host` and `paths`. If ingress isn't a fit, switch to `rest.service.type=LoadBalancer` instead.
-- **Unified ingress mixed with service-specific ingresses.** Pick one — either configure `unifiedIngress.*`, or the per-service `rest.ingress.*` / `grpc.ingress.*` / `dashboard.ingress.*`, never both.
-- **Dashboard enabled without API URL or auth secrets.** `dashboard.enabled=true` also requires `dashboard.publicAPIURL` and the `dashboard.auth.*` settings listed in [Dashboard requirements](#dashboard-requirements).
-- **Grafana ingress configured without the observability stack enabled.** Enable observability via `profiles/observability-postgres.yaml` (or the matching `observability.*` keys) before adding Grafana ingress.
+Horizontal Pod Autoscaling requires the Kubernetes resource metrics API. Use `server.nodeSelector`, `server.tolerations`, `server.affinity`, or `server.topologySpreadConstraints` when your cluster requires workload placement controls.
+
+By default, each server process starts two effective scheduler workers. Use `scheduler.workerCount` and `scheduler.workerMaxInflight` to bound per-replica job concurrency. Tune these values with server replica count and downstream provider capacity; increasing API replicas also increases the number of workers that can claim jobs.
+
+## Configure Kubernetes Secret access
+
+The chart doesn't mount a Kubernetes service-account token by default. No token is needed to consume Secrets already referenced by pod environment variables or volumes.
+
+If you register a Kubernetes secret provider for server-side secret resolution, enable the token mount and grant the Feature Form service account `get` access to the required Secret objects. For Secrets in the release namespace:
+
+```yaml
+serviceAccount:
+  automountServiceAccountToken: true
+
+rbac:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: ["secrets"]
+      resourceNames: ["<provider-secret-name>"]
+      verbs: ["get"]
+```
+
+These `rbac.*` values configure Kubernetes permissions. Feature Form application roles are configured separately in [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}).
+
+## Configure observability
+
+The server exports metrics and traces through OpenTelemetry Protocol (OTLP). Setting only the endpoint isn't sufficient because the Helm chart disables both signals by default. Configure an external collector with an authority that doesn't include a URL scheme:
+
+```yaml
+observability:
+  otlpEndpoint: "otel-collector.telemetry.svc.cluster.local:4317"
+  tracingEnabled: true
+  metricsEnabled: true
+  serviceName: featureform
+  serviceVersion: "<featureform-version>"
+  environment: production
+  logLevel: info
+  traceSampleRate: 0.1
+```
+
+Feature Form writes server logs to standard output and standard error. Collect them with your Kubernetes logging system.
+
+## Upgrade and roll back
+
+Before upgrading:
+
+1. Back up the Feature Form PostgreSQL database.
+2. Confirm the license key is valid for the target release.
+3. Render the target chart version with the current values file.
+4. Upgrade with an explicit `--version`, `--wait`, and `--timeout`.
+5. Verify the migration init container, server rollout, license status, REST readiness, and `ff ping`.
+
+Keep the server, dashboard, chart, and `ff` versions aligned. Replacing an external license Secret doesn't restart the server; roll out the server deployment after updating the key.
+
+Helm rollback restores chart-managed resources, but it doesn't reverse PostgreSQL migrations or restore externally managed Secrets. Preserve the database backup, previous license key, image version, and Helm revision until the rollback window closes.
+
+## Troubleshoot installation
+
+- **Helm reports missing authentication values.** Set `auth.enabled=true`, `auth.oidcIssuerURL`, `auth.oidcClientID`, and a stable `auth.deploymentID`.
+- **A pod shows `ImagePullBackOff`.** Confirm registry network access and configure `imagePullSecrets` when credentials are required.
+- **The migration init container fails.** Check PostgreSQL reachability, TLS settings, credentials, and the database role's schema permissions.
+- **The server reports a missing or invalid license.** Check the Secret name and `license.key` entry, then inspect `featureformctl license status` without printing the key.
+- **OIDC discovery or login fails.** Verify the internal and public issuer URLs, client IDs, redirect URIs, and endpoint reachability.
+- **The dashboard fails chart validation.** Supply its public API URL, authentication URL, OIDC client secret, and session secret.
+- **Ingress values conflict.** Configure either unified `ingress.*` or service-specific ingress settings, not both.
 
 ## Next steps
 
-- [Configure authentication and RBAC]({{< relref "/operate/featureform/configure-auth" >}}) — set up OIDC and grant roles.
+- [Configure authentication and role-based access control]({{< relref "/operate/featureform/configure-auth" >}}) — set up OIDC and grant roles.
 - [Manage workspaces]({{< relref "/develop/ai/featureform/manage-workspace" >}}) — create your first workspace.
-- [Register providers]({{< relref "/develop/ai/featureform/register-providers" >}}) — connect Postgres, Redis, S3, and other backends.
+- [Register providers]({{< relref "/develop/ai/featureform/register-providers" >}}) — connect production data infrastructure.
 - [Quickstart]({{< relref "/develop/ai/featureform/quickstart" >}}) — verify the install end to end.


### PR DESCRIPTION
## Summary

- Document the required authentication, license key, PostgreSQL state, and external-access configuration for Kubernetes deployments.
- Clarify CLI connectivity, OIDC client registration and troubleshooting, deployment identity, and migration verification.
- Add production operations guidance for scaling, observability, upgrades, and troubleshooting.

## Verification

- Confirmed local previews at /operate/featureform/deploy/ and /operate/featureform/configure-auth/.
- Ran Hugo render-to-memory validation.
- Rendered the production values example with the Feature Form Helm chart.
- Ran Git diff validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Hugo content; no application or chart code is modified.
> 
> **Overview**
> **Expands Feature Form operate docs** toward a **production Kubernetes** path: external PostgreSQL and license Secrets, a full `values-production.yaml` example (OIDC, `deploymentID`, public REST/gRPC endpoints, ingress/TLS), `helm template` before install, and verification steps for migrations, license status, REST readiness, and CLI login over gRPC, REST, or port-forward.
> 
> **`configure-auth.md`** adds **Register a CLI client** and **Troubleshoot CLI login**: separates API audience (`oidcClientID`) from the CLI client, documents device code vs PKCE (scopes, redirect URI, confidential PKCE secrets at login only), clarifies that the CLI picks the first advertised login method without fallback, and removes **password-stdin** from the recommended flows.
> 
> **`deploy.md`** also adds guidance on production state, external access models (unified vs per-service ingress), dashboard Secret requirements, scaling/HPA/PDB and scheduler worker tuning, Kubernetes Secret RBAC for secret providers, OTLP observability, upgrade/rollback caveats, and an expanded installation troubleshooting list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5f777d381329aa8a6fbfa3fd1ebbe5d22a5d44c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->