### PR TITLE
DOC-6999: port alternative rate limiter algorithms to the other eight client pages

### DIFF
--- a/content/develop/use-cases/rate-limiter/dotnet/_index.md
+++ b/content/develop/use-cases/rate-limiter/dotnet/_index.md
@@ -328,6 +328,243 @@ catch (RedisException ex)
 }
 ```
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```csharp
+using StackExchange.Redis;
+
+const string FixedWindowScript = @"
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('EXPIRE', key, window)
+end
+
+local ttl = redis.call('PTTL', key)
+
+if count > limit then
+    return {0, ttl}
+end
+return {1, ttl}
+";
+
+// Returns (allowed, retryAfterMs). retryAfterMs is 0 when the request is allowed.
+static (bool Allowed, long RetryAfterMs) FixedWindowAllow(
+    IDatabase db, string key, int limit, int windowSeconds)
+{
+    var result = (RedisResult[])db.ScriptEvaluate(
+        FixedWindowScript,
+        new RedisKey[] { key },
+        new RedisValue[] { limit, windowSeconds });
+
+    var allowed = (long)result[0] == 1;
+    return (allowed, allowed ? 0 : (long)result[1]);
+}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```csharp
+using StackExchange.Redis;
+
+const string SlidingWindowLogScript = @"
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local member = ARGV[3]
+
+local t      = redis.call('TIME')
+local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+local cutoff = now - window
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+    redis.call('ZADD', key, now, member)
+    redis.call('EXPIRE', key, window * 2)
+    return {1, 0}
+end
+
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local retry_after_ms = 0
+if oldest[2] then
+    retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+end
+
+return {0, retry_after_ms}
+";
+
+static (bool Allowed, long RetryAfterMs) SlidingWindowLogAllow(
+    IDatabase db, string key, int limit, int windowSeconds)
+{
+    var member = Guid.NewGuid().ToString();
+
+    var result = (RedisResult[])db.ScriptEvaluate(
+        SlidingWindowLogScript,
+        new RedisKey[] { key },
+        new RedisValue[] { limit, windowSeconds, member });
+
+    return ((long)result[0] == 1, (long)result[1]);
+}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```csharp
+using StackExchange.Redis;
+
+const string SlidingWindowCounterScript = @"
+local base   = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local window_num = math.floor(now / window)
+local elapsed     = (now % window) / window
+
+local curr_key = base .. ':' .. window_num
+local prev_key = base .. ':' .. (window_num - 1)
+
+local prev = tonumber(redis.call('GET', prev_key) or 0)
+local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+local estimate = prev * (1 - elapsed) + curr
+
+if estimate >= limit then
+    return {0, 0}
+end
+
+local new_count = redis.call('INCR', curr_key)
+if new_count == 1 then
+    redis.call('EXPIRE', curr_key, window * 2)
+end
+
+return {1, 0}
+";
+
+static bool SlidingWindowCounterAllow(
+    IDatabase db, string key, int limit, int windowSeconds)
+{
+    var result = (RedisResult[])db.ScriptEvaluate(
+        SlidingWindowCounterScript,
+        new RedisKey[] { $"{{{key}}}" },
+        new RedisValue[] { limit, windowSeconds });
+
+    return (long)result[0] == 1;
+}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```csharp
+using StackExchange.Redis;
+
+const string LeakyBucketScript = @"
+local key       = KEYS[1]
+local capacity  = tonumber(ARGV[1])
+local leak_rate = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local data      = redis.call('HGETALL', key)
+local level     = 0
+local last_leak = now
+
+if #data > 0 then
+    for i = 1, #data, 2 do
+        if data[i] == 'level' then
+            level = tonumber(data[i+1])
+        elseif data[i] == 'last_leak' then
+            last_leak = tonumber(data[i+1])
+        end
+    end
+end
+
+local elapsed = now - last_leak
+level = math.max(0, level - elapsed * leak_rate)
+
+if level + 1 > capacity then
+    return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+end
+
+level = level + 1
+local ttl = math.ceil(capacity / leak_rate) + 1
+
+redis.call('HSET', key, 'level', level, 'last_leak', now)
+redis.call('EXPIRE', key, ttl)
+
+return {1, 0}
+";
+
+static (bool Allowed, long RetryAfterMs) LeakyBucketAllow(
+    IDatabase db, string key, int capacity, double leakRate)
+{
+    var result = (RedisResult[])db.ScriptEvaluate(
+        LeakyBucketScript,
+        new RedisKey[] { key },
+        new RedisValue[] { capacity, leakRate });
+
+    return ((long)result[0] == 1, (long)result[1]);
+}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts

--- a/content/develop/use-cases/rate-limiter/go/_index.md
+++ b/content/develop/use-cases/rate-limiter/go/_index.md
@@ -386,6 +386,276 @@ if err != nil {
 }
 ```
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```go
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const fixedWindowScript = `
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('EXPIRE', key, window)
+end
+
+local ttl = redis.call('PTTL', key)
+
+if count > limit then
+    return {0, ttl}
+end
+return {1, ttl}
+`
+
+// FixedWindowAllow reports whether key is within limit for the current window.
+// When a request is denied, it also returns the milliseconds until the window resets.
+func FixedWindowAllow(ctx context.Context, rdb *redis.Client, key string,
+	limit, windowSeconds int) (bool, int64, error) {
+
+	script := redis.NewScript(fixedWindowScript)
+	res, err := script.Run(ctx, rdb, []string{key}, limit, windowSeconds).Int64Slice()
+	if err != nil {
+		return false, 0, err
+	}
+
+	allowed := res[0] == 1
+	if allowed {
+		return true, 0, nil
+	}
+	return false, res[1], nil
+}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```go
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const slidingWindowLogScript = `
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local member = ARGV[3]
+
+local t      = redis.call('TIME')
+local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+local cutoff = now - window
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+    redis.call('ZADD', key, now, member)
+    redis.call('EXPIRE', key, window * 2)
+    return {1, 0}
+end
+
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local retry_after_ms = 0
+if oldest[2] then
+    retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+end
+
+return {0, retry_after_ms}
+`
+
+// SlidingWindowLogAllow reports whether key is within limit over the trailing
+// window, and the milliseconds until the oldest entry leaves it.
+func SlidingWindowLogAllow(ctx context.Context, rdb *redis.Client, key string,
+	limit, windowSeconds int) (bool, int64, error) {
+
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return false, 0, err
+	}
+	member := hex.EncodeToString(buf)
+
+	script := redis.NewScript(slidingWindowLogScript)
+	res, err := script.Run(ctx, rdb, []string{key}, limit, windowSeconds, member).Int64Slice()
+	if err != nil {
+		return false, 0, err
+	}
+	return res[0] == 1, res[1], nil
+}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```go
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const slidingWindowCounterScript = `
+local base   = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local window_num = math.floor(now / window)
+local elapsed     = (now % window) / window
+
+local curr_key = base .. ':' .. window_num
+local prev_key = base .. ':' .. (window_num - 1)
+
+local prev = tonumber(redis.call('GET', prev_key) or 0)
+local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+local estimate = prev * (1 - elapsed) + curr
+
+if estimate >= limit then
+    return {0, 0}
+end
+
+local new_count = redis.call('INCR', curr_key)
+if new_count == 1 then
+    redis.call('EXPIRE', curr_key, window * 2)
+end
+
+return {1, 0}
+`
+
+// SlidingWindowCounterAllow reports whether key is within limit, weighting the
+// previous window's count by how far the current window has progressed.
+func SlidingWindowCounterAllow(ctx context.Context, rdb *redis.Client, key string,
+	limit, windowSeconds int) (bool, error) {
+
+	script := redis.NewScript(slidingWindowCounterScript)
+	res, err := script.Run(ctx, rdb, []string{"{" + key + "}"}, limit, windowSeconds).Int64Slice()
+	if err != nil {
+		return false, err
+	}
+	return res[0] == 1, nil
+}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```go
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const leakyBucketScript = `
+local key       = KEYS[1]
+local capacity  = tonumber(ARGV[1])
+local leak_rate = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local data      = redis.call('HGETALL', key)
+local level     = 0
+local last_leak = now
+
+if #data > 0 then
+    for i = 1, #data, 2 do
+        if data[i] == 'level' then
+            level = tonumber(data[i+1])
+        elseif data[i] == 'last_leak' then
+            last_leak = tonumber(data[i+1])
+        end
+    end
+end
+
+local elapsed = now - last_leak
+level = math.max(0, level - elapsed * leak_rate)
+
+if level + 1 > capacity then
+    return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+end
+
+level = level + 1
+local ttl = math.ceil(capacity / leak_rate) + 1
+
+redis.call('HSET', key, 'level', level, 'last_leak', now)
+redis.call('EXPIRE', key, ttl)
+
+return {1, 0}
+`
+
+// LeakyBucketAllow adds one request to the bucket for key and reports whether it
+// fits. When the bucket is full it returns the milliseconds until it drains enough.
+func LeakyBucketAllow(ctx context.Context, rdb *redis.Client, key string,
+	capacity int, leakRate float64) (bool, int64, error) {
+
+	script := redis.NewScript(leakyBucketScript)
+	res, err := script.Run(ctx, rdb, []string{key}, capacity, leakRate).Int64Slice()
+	if err != nil {
+		return false, 0, err
+	}
+	return res[0] == 1, res[1], nil
+}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts

--- a/content/develop/use-cases/rate-limiter/java-jedis/_index.md
+++ b/content/develop/use-cases/rate-limiter/java-jedis/_index.md
@@ -331,6 +331,277 @@ try {
 }
 ```
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```java
+import java.util.List;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class FixedWindowLimiter {
+
+    private static final String SCRIPT = """
+            local key    = KEYS[1]
+            local limit  = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+
+            local count = redis.call('INCR', key)
+            if count == 1 then
+                redis.call('EXPIRE', key, window)
+            end
+
+            local ttl = redis.call('PTTL', key)
+
+            if count > limit then
+                return {0, ttl}
+            end
+            return {1, ttl}
+            """;
+
+    public record Decision(boolean allowed, long retryAfterMs) {}
+
+    @SuppressWarnings("unchecked")
+    public static Decision allow(JedisPool pool, String key, int limit, int windowSeconds) {
+        try (Jedis jedis = pool.getResource()) {
+            List<Long> result = (List<Long>) jedis.eval(
+                    SCRIPT,
+                    List.of(key),
+                    List.of(String.valueOf(limit), String.valueOf(windowSeconds)));
+
+            boolean allowed = result.get(0) == 1L;
+            return new Decision(allowed, allowed ? 0L : result.get(1));
+        }
+    }
+}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```java
+import java.util.List;
+import java.util.UUID;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class SlidingWindowLogLimiter {
+
+    private static final String SCRIPT = """
+            local key    = KEYS[1]
+            local limit  = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+            local member = ARGV[3]
+
+            local t      = redis.call('TIME')
+            local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+            local cutoff = now - window
+
+            redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+            local count = redis.call('ZCARD', key)
+
+            if count < limit then
+                redis.call('ZADD', key, now, member)
+                redis.call('EXPIRE', key, window * 2)
+                return {1, 0}
+            end
+
+            local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+            local retry_after_ms = 0
+            if oldest[2] then
+                retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+            end
+
+            return {0, retry_after_ms}
+            """;
+
+    public record Decision(boolean allowed, long retryAfterMs) {}
+
+    @SuppressWarnings("unchecked")
+    public static Decision allow(JedisPool pool, String key, int limit, int windowSeconds) {
+        try (Jedis jedis = pool.getResource()) {
+            List<Long> result = (List<Long>) jedis.eval(
+                    SCRIPT,
+                    List.of(key),
+                    List.of(String.valueOf(limit),
+                            String.valueOf(windowSeconds),
+                            UUID.randomUUID().toString()));
+
+            return new Decision(result.get(0) == 1L, result.get(1));
+        }
+    }
+}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```java
+import java.util.List;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class SlidingWindowCounterLimiter {
+
+    private static final String SCRIPT = """
+            local base   = KEYS[1]
+            local limit  = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+
+            local t   = redis.call('TIME')
+            local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+            local window_num = math.floor(now / window)
+            local elapsed     = (now % window) / window
+
+            local curr_key = base .. ':' .. window_num
+            local prev_key = base .. ':' .. (window_num - 1)
+
+            local prev = tonumber(redis.call('GET', prev_key) or 0)
+            local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+            local estimate = prev * (1 - elapsed) + curr
+
+            if estimate >= limit then
+                return {0, 0}
+            end
+
+            local new_count = redis.call('INCR', curr_key)
+            if new_count == 1 then
+                redis.call('EXPIRE', curr_key, window * 2)
+            end
+
+            return {1, 0}
+            """;
+
+    @SuppressWarnings("unchecked")
+    public static boolean allow(JedisPool pool, String key, int limit, int windowSeconds) {
+        try (Jedis jedis = pool.getResource()) {
+            List<Long> result = (List<Long>) jedis.eval(
+                    SCRIPT,
+                    List.of("{" + key + "}"),
+                    List.of(String.valueOf(limit), String.valueOf(windowSeconds)));
+
+            return result.get(0) == 1L;
+        }
+    }
+}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```java
+import java.util.List;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+public class LeakyBucketLimiter {
+
+    private static final String SCRIPT = """
+            local key       = KEYS[1]
+            local capacity  = tonumber(ARGV[1])
+            local leak_rate = tonumber(ARGV[2])
+
+            local t   = redis.call('TIME')
+            local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+            local data      = redis.call('HGETALL', key)
+            local level     = 0
+            local last_leak = now
+
+            if #data > 0 then
+                for i = 1, #data, 2 do
+                    if data[i] == 'level' then
+                        level = tonumber(data[i+1])
+                    elseif data[i] == 'last_leak' then
+                        last_leak = tonumber(data[i+1])
+                    end
+                end
+            end
+
+            local elapsed = now - last_leak
+            level = math.max(0, level - elapsed * leak_rate)
+
+            if level + 1 > capacity then
+                return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+            end
+
+            level = level + 1
+            local ttl = math.ceil(capacity / leak_rate) + 1
+
+            redis.call('HSET', key, 'level', level, 'last_leak', now)
+            redis.call('EXPIRE', key, ttl)
+
+            return {1, 0}
+            """;
+
+    public record Decision(boolean allowed, long retryAfterMs) {}
+
+    @SuppressWarnings("unchecked")
+    public static Decision allow(JedisPool pool, String key, int capacity, double leakRate) {
+        try (Jedis jedis = pool.getResource()) {
+            List<Long> result = (List<Long>) jedis.eval(
+                    SCRIPT,
+                    List.of(key),
+                    List.of(String.valueOf(capacity), String.valueOf(leakRate)));
+
+            return new Decision(result.get(0) == 1L, result.get(1));
+        }
+    }
+}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts

--- a/content/develop/use-cases/rate-limiter/java-lettuce/_index.md
+++ b/content/develop/use-cases/rate-limiter/java-lettuce/_index.md
@@ -423,6 +423,273 @@ try {
 
 Lettuce also supports automatic reconnection by default. If the connection to Redis is temporarily lost, Lettuce will attempt to reconnect and replay queued commands, providing better resilience than Jedis out of the box.
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```java
+import java.util.List;
+
+import io.lettuce.core.ScriptOutputType;
+import io.lettuce.core.api.sync.RedisCommands;
+
+public class FixedWindowLimiter {
+
+    private static final String SCRIPT = """
+            local key    = KEYS[1]
+            local limit  = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+
+            local count = redis.call('INCR', key)
+            if count == 1 then
+                redis.call('EXPIRE', key, window)
+            end
+
+            local ttl = redis.call('PTTL', key)
+
+            if count > limit then
+                return {0, ttl}
+            end
+            return {1, ttl}
+            """;
+
+    public record Decision(boolean allowed, long retryAfterMs) {}
+
+    public static Decision allow(RedisCommands<String, String> commands, String key,
+                                 int limit, int windowSeconds) {
+        List<Long> result = commands.eval(
+                SCRIPT,
+                ScriptOutputType.MULTI,
+                new String[]{key},
+                String.valueOf(limit), String.valueOf(windowSeconds));
+
+        boolean allowed = result.get(0) == 1L;
+        return new Decision(allowed, allowed ? 0L : result.get(1));
+    }
+}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```java
+import java.util.List;
+import java.util.UUID;
+
+import io.lettuce.core.ScriptOutputType;
+import io.lettuce.core.api.sync.RedisCommands;
+
+public class SlidingWindowLogLimiter {
+
+    private static final String SCRIPT = """
+            local key    = KEYS[1]
+            local limit  = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+            local member = ARGV[3]
+
+            local t      = redis.call('TIME')
+            local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+            local cutoff = now - window
+
+            redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+            local count = redis.call('ZCARD', key)
+
+            if count < limit then
+                redis.call('ZADD', key, now, member)
+                redis.call('EXPIRE', key, window * 2)
+                return {1, 0}
+            end
+
+            local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+            local retry_after_ms = 0
+            if oldest[2] then
+                retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+            end
+
+            return {0, retry_after_ms}
+            """;
+
+    public record Decision(boolean allowed, long retryAfterMs) {}
+
+    public static Decision allow(RedisCommands<String, String> commands, String key,
+                                 int limit, int windowSeconds) {
+        List<Long> result = commands.eval(
+                SCRIPT,
+                ScriptOutputType.MULTI,
+                new String[]{key},
+                String.valueOf(limit),
+                String.valueOf(windowSeconds),
+                UUID.randomUUID().toString());
+
+        return new Decision(result.get(0) == 1L, result.get(1));
+    }
+}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```java
+import java.util.List;
+
+import io.lettuce.core.ScriptOutputType;
+import io.lettuce.core.api.sync.RedisCommands;
+
+public class SlidingWindowCounterLimiter {
+
+    private static final String SCRIPT = """
+            local base   = KEYS[1]
+            local limit  = tonumber(ARGV[1])
+            local window = tonumber(ARGV[2])
+
+            local t   = redis.call('TIME')
+            local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+            local window_num = math.floor(now / window)
+            local elapsed     = (now % window) / window
+
+            local curr_key = base .. ':' .. window_num
+            local prev_key = base .. ':' .. (window_num - 1)
+
+            local prev = tonumber(redis.call('GET', prev_key) or 0)
+            local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+            local estimate = prev * (1 - elapsed) + curr
+
+            if estimate >= limit then
+                return {0, 0}
+            end
+
+            local new_count = redis.call('INCR', curr_key)
+            if new_count == 1 then
+                redis.call('EXPIRE', curr_key, window * 2)
+            end
+
+            return {1, 0}
+            """;
+
+    public static boolean allow(RedisCommands<String, String> commands, String key,
+                                int limit, int windowSeconds) {
+        List<Long> result = commands.eval(
+                SCRIPT,
+                ScriptOutputType.MULTI,
+                new String[]{"{" + key + "}"},
+                String.valueOf(limit), String.valueOf(windowSeconds));
+
+        return result.get(0) == 1L;
+    }
+}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```java
+import java.util.List;
+
+import io.lettuce.core.ScriptOutputType;
+import io.lettuce.core.api.sync.RedisCommands;
+
+public class LeakyBucketLimiter {
+
+    private static final String SCRIPT = """
+            local key       = KEYS[1]
+            local capacity  = tonumber(ARGV[1])
+            local leak_rate = tonumber(ARGV[2])
+
+            local t   = redis.call('TIME')
+            local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+            local data      = redis.call('HGETALL', key)
+            local level     = 0
+            local last_leak = now
+
+            if #data > 0 then
+                for i = 1, #data, 2 do
+                    if data[i] == 'level' then
+                        level = tonumber(data[i+1])
+                    elseif data[i] == 'last_leak' then
+                        last_leak = tonumber(data[i+1])
+                    end
+                end
+            end
+
+            local elapsed = now - last_leak
+            level = math.max(0, level - elapsed * leak_rate)
+
+            if level + 1 > capacity then
+                return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+            end
+
+            level = level + 1
+            local ttl = math.ceil(capacity / leak_rate) + 1
+
+            redis.call('HSET', key, 'level', level, 'last_leak', now)
+            redis.call('EXPIRE', key, ttl)
+
+            return {1, 0}
+            """;
+
+    public record Decision(boolean allowed, long retryAfterMs) {}
+
+    public static Decision allow(RedisCommands<String, String> commands, String key,
+                                 int capacity, double leakRate) {
+        List<Long> result = commands.eval(
+                SCRIPT,
+                ScriptOutputType.MULTI,
+                new String[]{key},
+                String.valueOf(capacity), String.valueOf(leakRate));
+
+        return new Decision(result.get(0) == 1L, result.get(1));
+    }
+}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts

--- a/content/develop/use-cases/rate-limiter/nodejs/_index.md
+++ b/content/develop/use-cases/rate-limiter/nodejs/_index.md
@@ -286,6 +286,229 @@ try {
 }
 ```
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```javascript
+const FIXED_WINDOW_SCRIPT = `
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('EXPIRE', key, window)
+end
+
+local ttl = redis.call('PTTL', key)
+
+if count > limit then
+    return {0, ttl}
+end
+return {1, ttl}
+`;
+
+// Returns { allowed, retryAfterMs }. retryAfterMs is 0 when the request is allowed.
+async function fixedWindowAllow(client, key, limit, windowSeconds) {
+  const [allowed, ttl] = await client.eval(FIXED_WINDOW_SCRIPT, {
+    keys: [key],
+    arguments: [String(limit), String(windowSeconds)],
+  });
+
+  return {
+    allowed: allowed === 1,
+    retryAfterMs: allowed === 1 ? 0 : Number(ttl),
+  };
+}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```javascript
+const { randomUUID } = require("crypto");
+
+const SLIDING_WINDOW_LOG_SCRIPT = `
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local member = ARGV[3]
+
+local t      = redis.call('TIME')
+local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+local cutoff = now - window
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+    redis.call('ZADD', key, now, member)
+    redis.call('EXPIRE', key, window * 2)
+    return {1, 0}
+end
+
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local retry_after_ms = 0
+if oldest[2] then
+    retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+end
+
+return {0, retry_after_ms}
+`;
+
+async function slidingWindowLogAllow(client, key, limit, windowSeconds) {
+  const [allowed, retryAfterMs] = await client.eval(SLIDING_WINDOW_LOG_SCRIPT, {
+    keys: [key],
+    arguments: [String(limit), String(windowSeconds), randomUUID()],
+  });
+
+  return { allowed: allowed === 1, retryAfterMs: Number(retryAfterMs) };
+}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```javascript
+const SLIDING_WINDOW_COUNTER_SCRIPT = `
+local base   = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local window_num = math.floor(now / window)
+local elapsed     = (now % window) / window
+
+local curr_key = base .. ':' .. window_num
+local prev_key = base .. ':' .. (window_num - 1)
+
+local prev = tonumber(redis.call('GET', prev_key) or 0)
+local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+local estimate = prev * (1 - elapsed) + curr
+
+if estimate >= limit then
+    return {0, 0}
+end
+
+local new_count = redis.call('INCR', curr_key)
+if new_count == 1 then
+    redis.call('EXPIRE', curr_key, window * 2)
+end
+
+return {1, 0}
+`;
+
+async function slidingWindowCounterAllow(client, key, limit, windowSeconds) {
+  const [allowed] = await client.eval(SLIDING_WINDOW_COUNTER_SCRIPT, {
+    keys: [`{${key}}`],
+    arguments: [String(limit), String(windowSeconds)],
+  });
+
+  return { allowed: allowed === 1 };
+}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```javascript
+const LEAKY_BUCKET_SCRIPT = `
+local key       = KEYS[1]
+local capacity  = tonumber(ARGV[1])
+local leak_rate = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local data      = redis.call('HGETALL', key)
+local level     = 0
+local last_leak = now
+
+if #data > 0 then
+    for i = 1, #data, 2 do
+        if data[i] == 'level' then
+            level = tonumber(data[i+1])
+        elseif data[i] == 'last_leak' then
+            last_leak = tonumber(data[i+1])
+        end
+    end
+end
+
+local elapsed = now - last_leak
+level = math.max(0, level - elapsed * leak_rate)
+
+if level + 1 > capacity then
+    return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+end
+
+level = level + 1
+local ttl = math.ceil(capacity / leak_rate) + 1
+
+redis.call('HSET', key, 'level', level, 'last_leak', now)
+redis.call('EXPIRE', key, ttl)
+
+return {1, 0}
+`;
+
+async function leakyBucketAllow(client, key, capacity, leakRate) {
+  const [allowed, retryAfterMs] = await client.eval(LEAKY_BUCKET_SCRIPT, {
+    keys: [key],
+    arguments: [String(capacity), String(leakRate)],
+  });
+
+  return { allowed: allowed === 1, retryAfterMs: Number(retryAfterMs) };
+}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts

--- a/content/develop/use-cases/rate-limiter/php/_index.md
+++ b/content/develop/use-cases/rate-limiter/php/_index.md
@@ -329,6 +329,245 @@ try {
 }
 ```
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```php
+<?php
+
+use Predis\Client;
+
+const FIXED_WINDOW_SCRIPT = <<<'LUA'
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('EXPIRE', key, window)
+end
+
+local ttl = redis.call('PTTL', key)
+
+if count > limit then
+    return {0, ttl}
+end
+return {1, ttl}
+LUA;
+
+/**
+ * @return array{allowed: bool, retry_after_ms: int}
+ */
+function fixedWindowAllow(Client $redis, string $key, int $limit, int $windowSeconds): array
+{
+    [$allowed, $ttl] = $redis->eval(FIXED_WINDOW_SCRIPT, 1, $key, $limit, $windowSeconds);
+
+    return [
+        'allowed' => $allowed === 1,
+        'retry_after_ms' => $allowed === 1 ? 0 : (int) $ttl,
+    ];
+}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```php
+<?php
+
+use Predis\Client;
+
+const SLIDING_WINDOW_LOG_SCRIPT = <<<'LUA'
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local member = ARGV[3]
+
+local t      = redis.call('TIME')
+local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+local cutoff = now - window
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+    redis.call('ZADD', key, now, member)
+    redis.call('EXPIRE', key, window * 2)
+    return {1, 0}
+end
+
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local retry_after_ms = 0
+if oldest[2] then
+    retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+end
+
+return {0, retry_after_ms}
+LUA;
+
+function slidingWindowLogAllow(Client $redis, string $key, int $limit, int $windowSeconds): array
+{
+    $member = bin2hex(random_bytes(16));
+
+    [$allowed, $retryAfterMs] = $redis->eval(
+        SLIDING_WINDOW_LOG_SCRIPT, 1, $key, $limit, $windowSeconds, $member
+    );
+
+    return ['allowed' => $allowed === 1, 'retry_after_ms' => (int) $retryAfterMs];
+}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```php
+<?php
+
+use Predis\Client;
+
+const SLIDING_WINDOW_COUNTER_SCRIPT = <<<'LUA'
+local base   = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local window_num = math.floor(now / window)
+local elapsed     = (now % window) / window
+
+local curr_key = base .. ':' .. window_num
+local prev_key = base .. ':' .. (window_num - 1)
+
+local prev = tonumber(redis.call('GET', prev_key) or 0)
+local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+local estimate = prev * (1 - elapsed) + curr
+
+if estimate >= limit then
+    return {0, 0}
+end
+
+local new_count = redis.call('INCR', curr_key)
+if new_count == 1 then
+    redis.call('EXPIRE', curr_key, window * 2)
+end
+
+return {1, 0}
+LUA;
+
+function slidingWindowCounterAllow(Client $redis, string $key, int $limit, int $windowSeconds): array
+{
+    [$allowed] = $redis->eval(
+        SLIDING_WINDOW_COUNTER_SCRIPT, 1, '{' . $key . '}', $limit, $windowSeconds
+    );
+
+    return ['allowed' => $allowed === 1];
+}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```php
+<?php
+
+use Predis\Client;
+
+const LEAKY_BUCKET_SCRIPT = <<<'LUA'
+local key       = KEYS[1]
+local capacity  = tonumber(ARGV[1])
+local leak_rate = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local data      = redis.call('HGETALL', key)
+local level     = 0
+local last_leak = now
+
+if #data > 0 then
+    for i = 1, #data, 2 do
+        if data[i] == 'level' then
+            level = tonumber(data[i+1])
+        elseif data[i] == 'last_leak' then
+            last_leak = tonumber(data[i+1])
+        end
+    end
+end
+
+local elapsed = now - last_leak
+level = math.max(0, level - elapsed * leak_rate)
+
+if level + 1 > capacity then
+    return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+end
+
+level = level + 1
+local ttl = math.ceil(capacity / leak_rate) + 1
+
+redis.call('HSET', key, 'level', level, 'last_leak', now)
+redis.call('EXPIRE', key, ttl)
+
+return {1, 0}
+LUA;
+
+function leakyBucketAllow(Client $redis, string $key, int $capacity, float $leakRate): array
+{
+    [$allowed, $retryAfterMs] = $redis->eval(
+        LEAKY_BUCKET_SCRIPT, 1, $key, $capacity, $leakRate
+    );
+
+    return ['allowed' => $allowed === 1, 'retry_after_ms' => (int) $retryAfterMs];
+}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts

--- a/content/develop/use-cases/rate-limiter/redis-py/_index.md
+++ b/content/develop/use-cases/rate-limiter/redis-py/_index.md
@@ -117,6 +117,14 @@ Without atomic execution, race conditions could occur:
 
 Using [`EVAL`]({{< relref "/commands/eval" >}}) or [`EVALSHA`]({{< relref "/commands/evalsha" >}}) ensures the entire operation executes atomically, making it safe for distributed systems.
 
+## Installation
+
+Install the `redis` package:
+
+```bash
+pip install redis
+```
+
 ## Using the Python module
 
 The `TokenBucket` class provides a simple interface for rate limiting
@@ -167,6 +175,28 @@ The `key` parameter identifies what you're rate limiting. Common patterns:
 * **Per IP address**: `ip:{ip_address}` - Limit by client IP
 * **Per API endpoint**: `api:{endpoint}:{user_id}` - Different limits per endpoint
 * **Global**: `global:api` - Single limit shared across all requests
+
+### Script caching with EVALSHA
+
+The Python module uses [`EVALSHA`]({{< relref "/commands/evalsha" >}}) for optimal
+performance. `TokenBucket` computes the script's SHA1 digest when you create it,
+loads the script into Redis with `SCRIPT LOAD` on first use, and sends every
+later request as `EVALSHA`. If the script has been evicted from the server's
+cache, it catches the resulting error, falls back to
+[`EVAL`]({{< relref "/commands/eval" >}}), and reloads the script.
+
+```python
+limiter = TokenBucket(capacity=10, refill_rate=1, refill_interval=1.0)
+
+limiter.allow('user:123')  # SCRIPT LOAD, then EVALSHA
+limiter.allow('user:123')  # EVALSHA against the cached script
+```
+
+The [alternative algorithm examples](#alternative-rate-limiting-algorithms) use
+`register_script()` instead, which wraps the same behavior in a `Script` object.
+That object derives the digest from the script text rather than from per-call
+state, so re-registering on each request adds no round trip: the digest is
+unchanged and `EVALSHA` still hits the cached script.
 
 ## Running the demo
 

--- a/content/develop/use-cases/rate-limiter/redis-py/_index.md
+++ b/content/develop/use-cases/rate-limiter/redis-py/_index.md
@@ -237,9 +237,11 @@ their features:
 | [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
 
 The sections below give example implementations of these other algorithms.
-All of them use `redis.call('TIME')` inside the Lua script to derive the
-current timestamp from the Redis server clock. This eliminates clock
-drift when the limiter runs across multiple application servers.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
 
 ### Fixed window counter
 

--- a/content/develop/use-cases/rate-limiter/ruby/_index.md
+++ b/content/develop/use-cases/rate-limiter/ruby/_index.md
@@ -300,6 +300,226 @@ rescue Redis::BaseError => e
 end
 ```
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```ruby
+require "redis"
+
+FIXED_WINDOW_SCRIPT = <<~LUA
+  local key    = KEYS[1]
+  local limit  = tonumber(ARGV[1])
+  local window = tonumber(ARGV[2])
+
+  local count = redis.call('INCR', key)
+  if count == 1 then
+      redis.call('EXPIRE', key, window)
+  end
+
+  local ttl = redis.call('PTTL', key)
+
+  if count > limit then
+      return {0, ttl}
+  end
+  return {1, ttl}
+LUA
+
+# Returns a hash with :allowed and :retry_after_ms keys.
+def fixed_window_allow(redis, key, limit, window_seconds)
+  allowed, ttl = redis.eval(FIXED_WINDOW_SCRIPT,
+                            keys: [key], argv: [limit, window_seconds])
+
+  { allowed: allowed == 1, retry_after_ms: allowed == 1 ? 0 : ttl }
+end
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```ruby
+require "redis"
+require "securerandom"
+
+SLIDING_WINDOW_LOG_SCRIPT = <<~LUA
+  local key    = KEYS[1]
+  local limit  = tonumber(ARGV[1])
+  local window = tonumber(ARGV[2])
+  local member = ARGV[3]
+
+  local t      = redis.call('TIME')
+  local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+  local cutoff = now - window
+
+  redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+  local count = redis.call('ZCARD', key)
+
+  if count < limit then
+      redis.call('ZADD', key, now, member)
+      redis.call('EXPIRE', key, window * 2)
+      return {1, 0}
+  end
+
+  local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+  local retry_after_ms = 0
+  if oldest[2] then
+      retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+  end
+
+  return {0, retry_after_ms}
+LUA
+
+def sliding_window_log_allow(redis, key, limit, window_seconds)
+  allowed, retry_after_ms = redis.eval(SLIDING_WINDOW_LOG_SCRIPT,
+                                       keys: [key],
+                                       argv: [limit, window_seconds, SecureRandom.uuid])
+
+  { allowed: allowed == 1, retry_after_ms: retry_after_ms }
+end
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```ruby
+require "redis"
+
+SLIDING_WINDOW_COUNTER_SCRIPT = <<~LUA
+  local base   = KEYS[1]
+  local limit  = tonumber(ARGV[1])
+  local window = tonumber(ARGV[2])
+
+  local t   = redis.call('TIME')
+  local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+  local window_num = math.floor(now / window)
+  local elapsed     = (now % window) / window
+
+  local curr_key = base .. ':' .. window_num
+  local prev_key = base .. ':' .. (window_num - 1)
+
+  local prev = tonumber(redis.call('GET', prev_key) or 0)
+  local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+  local estimate = prev * (1 - elapsed) + curr
+
+  if estimate >= limit then
+      return {0, 0}
+  end
+
+  local new_count = redis.call('INCR', curr_key)
+  if new_count == 1 then
+      redis.call('EXPIRE', curr_key, window * 2)
+  end
+
+  return {1, 0}
+LUA
+
+def sliding_window_counter_allow(redis, key, limit, window_seconds)
+  allowed, = redis.eval(SLIDING_WINDOW_COUNTER_SCRIPT,
+                        keys: ["{#{key}}"], argv: [limit, window_seconds])
+
+  { allowed: allowed == 1 }
+end
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```ruby
+require "redis"
+
+LEAKY_BUCKET_SCRIPT = <<~LUA
+  local key       = KEYS[1]
+  local capacity  = tonumber(ARGV[1])
+  local leak_rate = tonumber(ARGV[2])
+
+  local t   = redis.call('TIME')
+  local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+  local data      = redis.call('HGETALL', key)
+  local level     = 0
+  local last_leak = now
+
+  if #data > 0 then
+      for i = 1, #data, 2 do
+          if data[i] == 'level' then
+              level = tonumber(data[i+1])
+          elseif data[i] == 'last_leak' then
+              last_leak = tonumber(data[i+1])
+          end
+      end
+  end
+
+  local elapsed = now - last_leak
+  level = math.max(0, level - elapsed * leak_rate)
+
+  if level + 1 > capacity then
+      return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+  end
+
+  level = level + 1
+  local ttl = math.ceil(capacity / leak_rate) + 1
+
+  redis.call('HSET', key, 'level', level, 'last_leak', now)
+  redis.call('EXPIRE', key, ttl)
+
+  return {1, 0}
+LUA
+
+def leaky_bucket_allow(redis, key, capacity, leak_rate)
+  allowed, retry_after_ms = redis.eval(LEAKY_BUCKET_SCRIPT,
+                                       keys: [key], argv: [capacity, leak_rate])
+
+  { allowed: allowed == 1, retry_after_ms: retry_after_ms }
+end
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts

--- a/content/develop/use-cases/rate-limiter/rust/_index.md
+++ b/content/develop/use-cases/rate-limiter/rust/_index.md
@@ -430,6 +430,261 @@ if tokens_acquired == 5 {
 }
 ```
 
+## Alternative rate limiting algorithms
+
+The token bucket algorithm above handles most use cases but Redis supports
+other rate limiter patterns that might fit your requirements better. The table
+below lists four other algorithms alongside token bucket and summarizes
+their features:
+
+| Algorithm | Memory | Accuracy | Burst behavior | Best for |
+|---|---|---|---|---|
+| [Token bucket](#how-it-works) | 1 key (hash) | Exact | Controlled bursts | APIs with bursty traffic |
+| [Fixed window counter](#fixed-window-counter) | 1 key (string) | Approximate | 2x burst at boundaries | Simple API limits |
+| [Sliding window log](#sliding-window-log) | O(n) entries | Exact | No bursts | High-value APIs, audit trails |
+| [Sliding window counter](#sliding-window-counter) | 2 keys (string) | Near-exact | Smoothed boundaries | General-purpose APIs |
+| [Leaky bucket (policing)](#leaky-bucket-policing) | 1 key (hash) | Exact | No bursts | Strict no-burst enforcement |
+
+The sections below give example implementations of these other algorithms.
+The three time-based algorithms call `redis.call('TIME')` inside the Lua
+script to derive the current timestamp from the Redis server clock. This
+eliminates clock drift when the limiter runs across multiple application
+servers. The fixed window counter reads no clock: the key's TTL defines
+the window.
+
+### Fixed window counter
+
+Counts requests within discrete, non-overlapping time intervals.
+Simplest algorithm — one key per window, one `EVAL` round trip.
+
+```rust
+use redis::Script;
+
+const FIXED_WINDOW_SCRIPT: &str = r#"
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local count = redis.call('INCR', key)
+if count == 1 then
+    redis.call('EXPIRE', key, window)
+end
+
+local ttl = redis.call('PTTL', key)
+
+if count > limit then
+    return {0, ttl}
+end
+return {1, ttl}
+"#;
+
+/// Returns `(allowed, retry_after_ms)`. `retry_after_ms` is 0 when allowed.
+fn fixed_window_allow(
+    con: &mut dyn redis::ConnectionLike,
+    key: &str,
+    limit: i64,
+    window_seconds: i64,
+) -> redis::RedisResult<(bool, i64)> {
+    let (allowed, ttl): (i64, i64) = Script::new(FIXED_WINDOW_SCRIPT)
+        .key(key)
+        .arg(limit)
+        .arg(window_seconds)
+        .invoke(con)?;
+
+    Ok((allowed == 1, if allowed == 1 { 0 } else { ttl }))
+}
+```
+
+**Trade-off**: A client can make 2x requests by sending `limit` requests
+at the end of one window and `limit` requests at the start of the next.
+
+### Sliding window log
+
+Records the exact timestamp of every request in a sorted set.
+Provides a true rolling window with no boundary bursts.
+
+```rust
+// Add to Cargo.toml: uuid = { version = "1", features = ["v4"] }
+use redis::Script;
+use uuid::Uuid;
+
+const SLIDING_WINDOW_LOG_SCRIPT: &str = r#"
+local key    = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+local member = ARGV[3]
+
+local t      = redis.call('TIME')
+local now    = tonumber(t[1]) + tonumber(t[2]) / 1e6
+local cutoff = now - window
+
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+local count = redis.call('ZCARD', key)
+
+if count < limit then
+    redis.call('ZADD', key, now, member)
+    redis.call('EXPIRE', key, window * 2)
+    return {1, 0}
+end
+
+local oldest = redis.call('ZRANGE', key, 0, 0, 'WITHSCORES')
+local retry_after_ms = 0
+if oldest[2] then
+    retry_after_ms = math.floor((tonumber(oldest[2]) + window - now) * 1000)
+end
+
+return {0, retry_after_ms}
+"#;
+
+fn sliding_window_log_allow(
+    con: &mut dyn redis::ConnectionLike,
+    key: &str,
+    limit: i64,
+    window_seconds: i64,
+) -> redis::RedisResult<(bool, i64)> {
+    let member = Uuid::new_v4().to_string();
+
+    let (allowed, retry_after_ms): (i64, i64) = Script::new(SLIDING_WINDOW_LOG_SCRIPT)
+        .key(key)
+        .arg(limit)
+        .arg(window_seconds)
+        .arg(member)
+        .invoke(con)?;
+
+    Ok((allowed == 1, retry_after_ms))
+}
+```
+
+**Trade-off**: Memory grows O(n) with request volume. Not ideal for
+high-volume, high-cardinality rate limiting.
+
+### Sliding window counter
+
+Blends two fixed-window counters using a weighted average to approximate
+a true sliding window. Near-exact accuracy with the same low memory
+footprint as a fixed window. The two keys use hash tags so they map
+to the same slot in Redis Cluster.
+
+```rust
+use redis::Script;
+
+const SLIDING_WINDOW_COUNTER_SCRIPT: &str = r#"
+local base   = KEYS[1]
+local limit  = tonumber(ARGV[1])
+local window = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local window_num = math.floor(now / window)
+local elapsed     = (now % window) / window
+
+local curr_key = base .. ':' .. window_num
+local prev_key = base .. ':' .. (window_num - 1)
+
+local prev = tonumber(redis.call('GET', prev_key) or 0)
+local curr = tonumber(redis.call('GET', curr_key) or 0)
+
+local estimate = prev * (1 - elapsed) + curr
+
+if estimate >= limit then
+    return {0, 0}
+end
+
+local new_count = redis.call('INCR', curr_key)
+if new_count == 1 then
+    redis.call('EXPIRE', curr_key, window * 2)
+end
+
+return {1, 0}
+"#;
+
+fn sliding_window_counter_allow(
+    con: &mut dyn redis::ConnectionLike,
+    key: &str,
+    limit: i64,
+    window_seconds: i64,
+) -> redis::RedisResult<bool> {
+    let (allowed, _): (i64, i64) = Script::new(SLIDING_WINDOW_COUNTER_SCRIPT)
+        .key(format!("{{{}}}", key))
+        .arg(limit)
+        .arg(window_seconds)
+        .invoke(con)?;
+
+    Ok(allowed == 1)
+}
+```
+
+**Trade-off**: The weighted estimate may let slightly more or fewer
+requests through than the exact limit. Negligible for most apps.
+
+### Leaky bucket (policing)
+
+A virtual bucket fills with incoming requests and drains at a fixed rate.
+If the bucket is full, requests are rejected immediately. This is the
+policing variant — requests are allowed or denied instantly with no delay.
+
+```rust
+use redis::Script;
+
+const LEAKY_BUCKET_SCRIPT: &str = r#"
+local key       = KEYS[1]
+local capacity  = tonumber(ARGV[1])
+local leak_rate = tonumber(ARGV[2])
+
+local t   = redis.call('TIME')
+local now = tonumber(t[1]) + tonumber(t[2]) / 1e6
+
+local data      = redis.call('HGETALL', key)
+local level     = 0
+local last_leak = now
+
+if #data > 0 then
+    for i = 1, #data, 2 do
+        if data[i] == 'level' then
+            level = tonumber(data[i+1])
+        elseif data[i] == 'last_leak' then
+            last_leak = tonumber(data[i+1])
+        end
+    end
+end
+
+local elapsed = now - last_leak
+level = math.max(0, level - elapsed * leak_rate)
+
+if level + 1 > capacity then
+    return {0, math.floor((level + 1 - capacity) / leak_rate * 1000)}
+end
+
+level = level + 1
+local ttl = math.ceil(capacity / leak_rate) + 1
+
+redis.call('HSET', key, 'level', level, 'last_leak', now)
+redis.call('EXPIRE', key, ttl)
+
+return {1, 0}
+"#;
+
+fn leaky_bucket_allow(
+    con: &mut dyn redis::ConnectionLike,
+    key: &str,
+    capacity: i64,
+    leak_rate: f64,
+) -> redis::RedisResult<(bool, i64)> {
+    let (allowed, retry_after_ms): (i64, i64) = Script::new(LEAKY_BUCKET_SCRIPT)
+        .key(key)
+        .arg(capacity)
+        .arg(leak_rate)
+        .invoke(con)?;
+
+    Ok((allowed == 1, retry_after_ms))
+}
+```
+
+**Trade-off**: Overflow traffic is rejected immediately. Clients must
+handle `429 Too Many Requests` and retry with backoff.
+
 ## Learn more
 
 * [EVAL command]({{< relref "/commands/eval" >}}) - Execute Lua scripts


### PR DESCRIPTION
Follow-up to #3788, which added four extra rate limiting algorithms to the redis-py page only. This ports them to the remaining eight client pages. [DOC-6999](https://redislabs.atlassian.net/browse/DOC-6999)

## What this adds

The `Alternative rate limiting algorithms` section — comparison table plus fixed window counter, sliding window log, sliding window counter, and leaky bucket (policing) — on **dotnet, go, java-jedis, java-lettuce, nodejs, php, ruby, and rust**.

Eight pages, not the six named in #3788: `java` is two separate pages (Jedis and Lettuce), and `ruby` was omitted from that list.

## Approach

The four Lua scripts are the algorithm, so they are reused **byte-for-byte** — only the wrapper around each script is per-language. The sections were generated from a script that extracts the Lua *and* the language-agnostic prose once from the redis-py page, rather than being written out eight times by hand.

Verified after the fact by extracting all 36 script instances (9 pages x 4 scripts) back out of the written files and diffing them against the originals: byte-identical once the host string literal's indentation is stripped.

## Two judgment calls

- **Lettuce is sync only.** That page also carries async and reactive token bucket variants; the new algorithms follow the sync form only, matching the majority of its existing examples.
- **Snippets, not runnable source.** The token bucket on every page is backed by committed demo files (`token_bucket.py`, `TokenBucket.cs`, and so on). These four algorithms are snippets, exactly as redis-py left them. Adding 32 runnable demos would be a much larger job and belongs in its own ticket.

## Placement

The section sits immediately before `## Learn more`, i.e. after `## Customization`. On redis-py those are the same position (it has no Customization section). Mirroring redis-py's literal offset — straight after `## Response headers` — would have split the token bucket material on the other eight, because each page's Customization section refers back to the token bucket limiter.

## One correction to the merged redis-py page

The section intro claimed all four algorithms derive the timestamp from the server clock via `redis.call('TIME')`. Three do; the **fixed window counter reads no clock at all** and leans on the key's TTL. Reworded on all nine pages rather than copied eight more times.

## Verification

- **Compiled** against real libraries: jedis 7.5.3, lettuce-core 7.7.0, StackExchange.Redis 2.9.32, and redis 0.24.1 + uuid (0.24 is the version the Rust page pins).
- **Parsed**: `gofmt -e` (clean, no formatting diff), `node --check`, `ruby -c`, `php -l`.
- **Run against a live server**: the four Lua scripts directly, and the full Ruby wrappers end to end. Limit 3 gave allow/allow/allow/deny with sensible retry-after in every case; the sliding window log's sorted set held exactly 3; the leaky bucket returned ~1s retry at leak rate 1/s. The Ruby run also produced key `{rswc}:178767316`, confirming the hash-tag marshalling yields the Cluster-safe key the prose describes.
- **Hugo build** clean, with all six comparison-table anchors resolving in the rendered HTML on all nine pages.

**Not verified:** the seven non-Ruby wrappers were compiled or parsed, not executed. The Lua they call is proven identical and run-tested, so algorithm behavior is covered; what is untested per language is argument marshalling and return unpacking.

## Also brings redis-py into line with its siblings

The redis-py page was missing two sections that all eight other client pages have: `## Installation` and `### Script caching with EVALSHA`. Both are now added in the sibling position, since this PR is effectively a general pass over the rate limiter use case.

The EVALSHA section's claims were traced with `MONITOR` rather than read off the source. `TokenBucket` sends `SCRIPT LOAD` on the first `allow()` and `EVALSHA` thereafter. The non-obvious part: the four alternative-algorithm snippets call `register_script()` on *every* request, which looks wasteful but is not — redis-py derives the digest from the script text client-side, so a freshly built `Script` object has the same digest and `EVALSHA` still hits the cached script. Three calls through a per-request `register_script()` produced three `EVALSHA` commands and no extra round trip.

Installation is deliberately shorter than the ruby and rust equivalents: naming a minimum redis-py version would have meant inventing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Hugo markdown; no runtime or security-sensitive code paths.
> 
> **Overview**
> Ports the **Alternative rate limiting algorithms** content from the redis-py guide to **dotnet, go, java-jedis, java-lettuce, nodejs, php, ruby, and rust**. Each page gets the same comparison table, shared prose, and four **byte-identical Lua scripts** with per-language `EVAL` wrappers (fixed window, sliding window log, sliding window counter with `{key}` hash tags, leaky bucket policing).
> 
> Sections are inserted **immediately before `## Learn more`** so they stay after customization/error-handling material. Lettuce examples use **sync `RedisCommands` only**, matching how those pages present token bucket.
> 
> On **redis-py**, adds missing **`## Installation`** and **`### Script caching with EVALSHA`** (including how `register_script()` still hits `EVALSHA`), and **corrects the section intro** on all nine pages: only three algorithms use `redis.call('TIME')`; the fixed window counter relies on **key TTL**, not the server clock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec63c7cf4234185a9f10bb997eee151b8ada764c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[DOC-6999]: https://redislabs.atlassian.net/browse/DOC-6999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
