### PR TITLE
DOC-7003 document RESP3 streamed types in the protocol spec

### DIFF
--- a/content/develop/reference/protocol-spec.md
+++ b/content/develop/reference/protocol-spec.md
@@ -139,6 +139,9 @@ The following table summarizes the RESP data types that Redis supports:
 | [Sets](#sets) | RESP3 | Aggregate | `~` |
 | [Pushes](#pushes) | RESP3 | Aggregate | `>` |
 
+RESP3 also defines two _streamed_ encodings for payloads whose length isn't known when the transfer begins: [streamed strings](#streamed-strings) and [streamed aggregated data types](#streamed-aggregated-data-types).
+These are alternative encodings of the types in the table rather than types of their own, so the table doesn't list them.
+
 <a name="simple-string-reply"></a>
 
 ### Simple strings
@@ -622,6 +625,63 @@ That means a client won't find push data in the middle of a map reply, for examp
 It also means that pushed data may appear before or after a command's reply, as well as by itself (without calling any command).
 
 Clients should react to pushes by invoking a callback that implements their handling of the pushed data.
+
+### Streamed strings
+A streamed string is a [bulk string](#bulk-strings) whose total length isn't known when the transfer begins.
+Instead of a prefixed length, the sender transfers the payload as a series of chunks.
+
+A streamed string's RESP encoding is as follows:
+
+    $?\r\n;<chunk-1-length>\r\n<chunk-1-data>\r\n...;0\r\n
+
+* A dollar sign (`$`) as the first byte, followed by a question mark (`?`) in place of the length.
+* The CRLF terminator.
+* One or more chunks. Each chunk is a semicolon (`;`), the chunk's length in bytes as an unsigned, base-10 value, the CRLF terminator, the chunk's data, and a final CRLF.
+* A zero-length chunk (`;0\r\n`) to mark the end of the string.
+
+Example:
+
+    $?\r\n
+    ;5\r\n
+    Hello\r\n
+    ;6\r\n
+     world\r\n
+    ;0\r\n
+
+(The raw RESP encoding is split into multiple lines for readability).
+
+The chunks concatenate to the string's value, so the example encodes `Hello world`.
+
+Redis doesn't emit streamed strings, because its RESP3 support excludes streamed types (see [RESP versions](#resp-versions)).
+The [RESP3 specification](https://github.com/redis/redis-specifications/blob/1252427cdbc497f66a7f8550c6b5f2f35367dc92/protocol/RESP3.md#streamed-strings) permits modules to use the encoding, so a client that implements RESP3 in full should be able to parse it.
+
+### Streamed aggregated data types
+[Arrays](#arrays), [sets](#sets), and [maps](#maps) can also be streamed when the number of elements isn't known when the transfer begins.
+A streamed aggregate replaces its number of elements with a question mark (`?`) and marks its end with a dedicated terminator.
+
+A streamed aggregate's RESP encoding is as follows:
+
+    <first-byte>?\r\n<element-1>...<element-n>.\r\n
+
+* The aggregate's usual first byte: an asterisk (`*`) for an array, a tilde (`~`) for a set, or a percent sign (`%`) for a map.
+* A question mark (`?`) in place of the number of elements.
+* The CRLF terminator.
+* An additional RESP type for every element of the aggregate.
+* A period (`.`) followed by the CRLF terminator to mark the end of the aggregate.
+
+Example:
+
+    *?\r\n
+    :1\r\n
+    :2\r\n
+    :3\r\n
+    .\r\n
+
+(The raw RESP encoding is split into multiple lines for readability).
+
+A streamed map's elements are field-value pairs, as in a regular [map](#maps), so a streamed map must contain an even number of elements.
+
+As with [streamed strings](#streamed-strings), Redis doesn't emit streamed aggregates.
 
 ## Client handshake
 New RESP connections should begin the session by calling the [`HELLO`]({{< relref "/commands/hello" >}}) command.

--- a/content/develop/reference/protocol-spec.md
+++ b/content/develop/reference/protocol-spec.md
@@ -636,7 +636,7 @@ A streamed string's RESP encoding is as follows:
 
 * A dollar sign (`$`) as the first byte, followed by a question mark (`?`) in place of the length.
 * The CRLF terminator.
-* One or more chunks. Each chunk is a semicolon (`;`), the chunk's length in bytes as an unsigned, base-10 value, the CRLF terminator, the chunk's data, and a final CRLF.
+* One or more chunks. Each chunk starts with a semicolon (`;`), followed by the chunk's length in bytes as an unsigned, base-10 value, the CRLF terminator, the chunk's data, and a final CRLF.
 * A zero-length chunk (`;0\r\n`) to mark the end of the string.
 
 Example:


### PR DESCRIPTION
First of four PRs for DOC-7003. Adds two sections to the protocol spec page so the
dead RESP3 anchors in `lua-api.md` have somewhere internal to point. The `lua-api.md`
retargets themselves are the next PR in the stack and depend on these anchors.

## Why

`content/develop/programmability/lua-api.md` carries 18 anchored links into
`redis-specifications/protocol/RESP3.md` on `master`. Of its 11 distinct anchors,
7 are dead — the spec never had per-type headings. Nine of those retarget cleanly onto
existing sections of our own protocol spec page, which is build-validated via `relref`.

Two don't: streamed strings and streamed aggregated data types had no equivalent
section here at all. The only trace of them on the page was a single clause in the
[RESP versions](https://redis.io/docs/latest/develop/reference/protocol-spec/#resp-versions)
paragraph. This PR fills that gap.

## What's here

- Two sections at the end of "RESP protocol description", following the existing
  "Verbatim strings" pattern — definition, wire encoding, bullet breakdown, example.
- A two-sentence pointer after the RESP data type table explaining that streamed
  encodings exist and why the table doesn't list them.

60 lines added; nothing removed or reworded.

## Two review points

**The type table deliberately does not gain rows.** It's introduced as "the RESP data
types that Redis supports", and the RESP versions paragraph records that Redis 6.0's
RESP3 support excluded streaming strings and aggregates. Adding rows would assert
support we have no source for and soften a limitation the page already documents. The
sections sit outside the table instead, framed as alternative encodings of existing
types, with support stated only in sourced terms — our own existing statement plus the
spec's permission for modules to use the encoding.

**One thing worth a second opinion.** Whether Redis 7 or 8 emits streamed types is
unverified. Our page scopes the exclusion to Redis 6.0, and the spec only says "there
is no Redis 6 command that uses such extension to the protocol". Neither addresses
current Redis. I have not touched that line or made a fresh claim — but if someone
knows that this changed, the two support sentences and the RESP versions paragraph all
need revisiting together.

## Verification

Anchors checked against the built HTML rather than a predicted slug:

| Check | Result |
|:--|:--|
| `id="streamed-strings"` | present |
| `id="streamed-aggregated-data-types"` | present |
| `id="streamed-aggregate-data-types"` (misspelling, negative control) | absent |
| In-page links introduced (`#bulk-strings`, `#resp-versions`, `#arrays`, `#sets`, `#maps`) | all resolve |
| Hugo warnings for this page | none |

The negative control matters: `aggregate` vs `aggregated` is precisely the spelling that
was dead upstream, so the headings were chosen to slugify to the same anchors the spec
uses. A corrected link now reads identically whether it points here or at the spec.

The spec citation in the new prose is pinned to a commit SHA rather than `master`, per
the house rule this ticket proposes in Part B3 — and because `master` rotting under our
links is the exact failure this ticket exists to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to the protocol reference; no runtime behavior, APIs, or build logic.
> 
> **Overview**
> Adds **documentation for RESP3 streamed encodings** on the protocol spec page so internal links (e.g. from `lua-api.md`) can target stable anchors instead of missing sections.
> 
> After the RESP data type table, a short note explains that **streamed strings** and **streamed aggregated data types** are alternative wire encodings of existing types, not separate table rows—consistent with Redis 6.0’s exclusion of streaming from supported RESP3 features.
> 
> Two new sections at the end of the RESP protocol description follow the same pattern as other types: definition, byte-level encoding, examples, and explicit statements that **Redis does not emit** these encodings while full RESP3 clients should still be able to parse them (with a **commit-pinned** link to the upstream RESP3 spec for module usage).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7138f54cfbc680e134e2a1e3d5068d71f95efde1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->