### PR TITLE
DOC-7003 fix dead and brittle links in the develop docs

### DIFF
--- a/content/develop/ai/search-and-query/administration/configuration.md
+++ b/content/develop/ai/search-and-query/administration/configuration.md
@@ -564,7 +564,7 @@ UPGRADE_INDEX idx PREFIX 1 tt LANGUAGE french LANGUAGE_FIELD MyLang SCORE 0.5 SC
 Available in Redis Query Engine 2.4.8 and later.
 
 The maximum memory resize (in bytes) for vector indexes.
-The maximum memory resize (in bytes) for vector indexes. This value will override default memory limits if you need to allow for a large [`BLOCK_SIZE`]({{< relref "/develop/ai/search-and-query/vectors/#creation-attributes-per-algorithm" >}}).
+The maximum memory resize (in bytes) for vector indexes. This value will override default memory limits if you need to allow for a large [`BLOCK_SIZE`]({{< relref "/develop/ai/search-and-query/vectors#create-a-vector-index" >}}).
 
 Type: integer
 

--- a/content/develop/programmability/_index.md
+++ b/content/develop/programmability/_index.md
@@ -25,7 +25,7 @@ Redis provides a programming interface that lets you execute custom scripts on t
 
 ## Background
 
-Redis is, by [definition](https://github.com/redis/redis/blob/unstable/MANIFESTO#L7), a _"domain-specific language for abstract data types"_.
+Redis is, by [definition](https://github.com/redis/redis/blob/3eaa2cdc44a9b0742f0695f44911b92547995836/MANIFESTO#L7), a _"domain-specific language for abstract data types"_.
 The language that Redis speaks consists of its [commands]({{< relref "/commands" >}}).
 Most the commands specialize at manipulating core [data types]({{< relref "/develop/data-types" >}}) in different ways.
 In many cases, these commands provide all the functionality that a developer requires for managing application data in Redis.

--- a/content/develop/programmability/lua-api.md
+++ b/content/develop/programmability/lua-api.md
@@ -633,29 +633,29 @@ An executing script may call the [`redis.setresp`](#redis.setresp) function duri
 
 Once Redis' replies are in RESP3 protocol, all of the [RESP2 to Lua conversion](#resp2-to-lua-type-conversion) rules apply, with the following additions:
 
-* [RESP3 map reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#map-type) -> Lua table with a single _map_ field containing a Lua table representing the fields and values of the map.
-* [RESP set reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#set-reply) -> Lua table with a single _set_ field containing a Lua table representing the elements of the set as fields, each with the Lua Boolean value of `true`.
-* [RESP3 null](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#null-reply) -> Lua `nil`.
-* [RESP3 true reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#boolean-reply) -> Lua true boolean value.
-* [RESP3 false reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#boolean-reply) -> Lua false boolean value.
-* [RESP3 double reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#double-type) -> Lua table with a single _double_ field containing a Lua number representing the double value.
-* [RESP3 big number reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#big-number-type) -> Lua table with a single _big_number_ field containing a Lua string representing the big number value.
-* [Redis verbatim string reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#verbatim-string-type) -> Lua table with a single _verbatim_string_ field containing a Lua table with two fields, _string_ and _format_, representing the verbatim string and its format, respectively.
+* [RESP3 map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}) -> Lua table with a single _map_ field containing a Lua table representing the fields and values of the map.
+* [RESP set reply]({{< relref "/develop/reference/protocol-spec#sets" >}}) -> Lua table with a single _set_ field containing a Lua table representing the elements of the set as fields, each with the Lua Boolean value of `true`.
+* [RESP3 null]({{< relref "/develop/reference/protocol-spec#nulls" >}}) -> Lua `nil`.
+* [RESP3 true reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}) -> Lua true boolean value.
+* [RESP3 false reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}) -> Lua false boolean value.
+* [RESP3 double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}}) -> Lua table with a single _double_ field containing a Lua number representing the double value.
+* [RESP3 big number reply]({{< relref "/develop/reference/protocol-spec#big-numbers" >}}) -> Lua table with a single _big_number_ field containing a Lua string representing the big number value.
+* [Redis verbatim string reply]({{< relref "/develop/reference/protocol-spec#verbatim-strings" >}}) -> Lua table with a single _verbatim_string_ field containing a Lua table with two fields, _string_ and _format_, representing the verbatim string and its format, respectively.
 
 **Note:**
-the RESP3 [big number](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#big-number-type) and [verbatim strings](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#verbatim-string-type) replies are only supported as of Redis v7.0 and greater. 
-Also, presently, RESP3's [attributes](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#attribute-type), [streamed strings](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#streamed-strings) and [streamed aggregate data types](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#streamed-aggregate-data-types) are not supported by the Redis Lua API.
+the RESP3 [big number]({{< relref "/develop/reference/protocol-spec#big-numbers" >}}) and [verbatim strings]({{< relref "/develop/reference/protocol-spec#verbatim-strings" >}}) replies are only supported as of Redis v7.0 and greater. 
+Also, presently, RESP3's [attributes]({{< relref "/develop/reference/protocol-spec#attributes" >}}), [streamed strings]({{< relref "/develop/reference/protocol-spec#streamed-strings" >}}) and [streamed aggregated data types]({{< relref "/develop/reference/protocol-spec#streamed-aggregated-data-types" >}}) are not supported by the Redis Lua API.
 
 ### Lua to RESP3 type conversion
 
 Regardless of the script's choice of protocol version set for replies with the [`redis.setresp()` function] when it calls `redis.call()` or `redis.pcall()`, the user may opt-in to using RESP3 (with the `HELLO 3` command) for the connection.
 Although the default protocol for incoming client connections is RESP2, the script should honor the user's preference and return adequately-typed RESP3 replies, so the following rules apply on top of those specified in the [Lua to RESP2 type conversion](#lua-to-resp2-type-conversion) section when that is the case.
 
-* Lua Boolean -> [RESP3 Boolean reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#boolean-reply) (note that this is a change compared to the RESP2, in which returning a Boolean Lua `true` returned the number 1 to the Redis client, and returning a `false` used to return a `null`.
-* Lua table with a single _map_ field set to an associative Lua table -> [RESP3 map reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#map-type).
-* Lua table with a single _set_ field set to an associative Lua table -> [RESP3 set reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#set-type). Values can be set to anything and are discarded anyway.
-* Lua table with a single _double_ field to an associative Lua table -> [RESP3 double reply](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#double-type).
-* Lua nil -> [RESP3 null](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md#null-reply).
+* Lua Boolean -> [RESP3 Boolean reply]({{< relref "/develop/reference/protocol-spec#booleans" >}}) (note that this is a change compared to the RESP2, in which returning a Boolean Lua `true` returned the number 1 to the Redis client, and returning a `false` used to return a `null`.
+* Lua table with a single _map_ field set to an associative Lua table -> [RESP3 map reply]({{< relref "/develop/reference/protocol-spec#maps" >}}).
+* Lua table with a single _set_ field set to an associative Lua table -> [RESP3 set reply]({{< relref "/develop/reference/protocol-spec#sets" >}}). Values can be set to anything and are discarded anyway.
+* Lua table with a single _double_ field to an associative Lua table -> [RESP3 double reply]({{< relref "/develop/reference/protocol-spec#doubles" >}}).
+* Lua nil -> [RESP3 null]({{< relref "/develop/reference/protocol-spec#nulls" >}}).
 
 However, if the connection is set use the RESP2 protocol, and even if the script replies with RESP3-typed responses, Redis will automatically perform a RESP3 to RESP2 conversion of the reply as is the case for regular commands.
 That means, for example, that returning the RESP3 map type to a RESP2 connection will result in the reply being converted to a flat RESP2 array that consists of alternating field names and their values, rather than a RESP3 map.

--- a/content/develop/whats-new/7-2.md
+++ b/content/develop/whats-new/7-2.md
@@ -28,7 +28,7 @@ JSON now includes two new commands for improved data handling:
 ## Improvements
 
 ### Existing data structures
-Significant performance improvements have been made across Redis data types. Sorted sets, commonly used for gaming leaderboards, now see performance improvements ranging from [30% to 100%](https://redis.io/blog/introducing-redis-7-2/#:~:text=We%20made%20Redis%20more%20powerful%20for%20developers).
+Significant performance improvements have been made across Redis data types. Sorted sets, commonly used for gaming leaderboards, now see performance improvements ranging from [30% to 100%](https://redis.io/blog/introducing-redis-7-2/).
 
 Additionally, Redis stream consumer tracking has been enhanced to provide better visibility into consumer activity, and blocked stream commands now return a distinct error when the target key no longer exists.
 
@@ -50,7 +50,7 @@ Redis 7.2 introduces several backward-incompatible changes. Lua scripts no longe
 Expired keys are now deleted from Redis Search replica indexes, ensuring that queries return an empty array rather than `nil` when the data no longer exists.
 
 ### Other changes
-Redis Stack 7.2 no longer includes Graph capabilities. For more details, refer to the [RedisGraph End-of-Life Announcement](https://redis.io/blog/redisgraph-eol/#:~:text=After%20January%2031%2C%202025%2C%20RedisGraph,subscriptions%20until%20January%2031%2C%202024.).
+Redis Stack 7.2 no longer includes Graph capabilities. For more details, refer to the [RedisGraph End-of-Life Announcement](https://redis.io/blog/redisgraph-eol/).
 
 ## Component versions
 The Redis version 7.2 includes the following components:

--- a/content/integrate/railway-redis/_index.md
+++ b/content/integrate/railway-redis/_index.md
@@ -34,7 +34,7 @@ Since the deployed container is pulled from the [redis](https://hub.docker.com/_
 
 ## Connecting to your Railway Redis Service
 
-It is possible to connect to Redis externally by using the [TCP Proxy](https://docs.railway.com/deploy/exposing-your-app#tcp-proxying?utm_medium=integration&utm_source=docs&utm_campaign=redis) which is enabled by default.
+It is possible to connect to Redis externally by using the [TCP Proxy](https://docs.railway.com/deploy/exposing-your-app?utm_medium=integration&utm_source=docs&utm_campaign=redis#tcp-proxying) which is enabled by default.
 
 ## Backup and Monitoring
 

--- a/content/operate/rs/security/encryption/tls/ciphers.md
+++ b/content/operate/rs/security/encryption/tls/ciphers.md
@@ -65,7 +65,7 @@ To configure cipher suites using the Cluster Manager UI:
 
 ### Control plane cipher suites {#control-plane-ciphers-tls-1-2}
 
-As of Redis Software version 6.0.12, control plane cipher suites can use the BoringSSL library format for TLS connections to the Cluster Manager UI. See the BoringSSL documentation for a full list of available [BoringSSL configurations](https://github.com/google/boringssl/blob/master/ssl/test/runner/cipher_suites.go#L99-L131).
+As of Redis Software version 6.0.12, control plane cipher suites can use the BoringSSL library format for TLS connections to the Cluster Manager UI. See the BoringSSL documentation for a full list of available [BoringSSL configurations](https://github.com/google/boringssl/blob/887d517832ccd678abf4216531786ca675928629/ssl/test/runner/cipher_suites.go#L99-L130).
 
 #### Configure TLS 1.2 control plane cipher suites
 


### PR DESCRIPTION
Second of four PRs for DOC-7003, covering Part A1, A3 and A4 — the `develop/` link
fixes. **Stacked on #3863**, which supplies the two streamed-type anchors this PR
links to. Base is set to that branch; review or merge it first.

## What changed

| Fix | File |
|:--|:--|
| A1 — 18 anchored RESP3 links retargeted to `relref` | `develop/programmability/lua-api.md` |
| A3 — `BLOCK_SIZE` link repointed | `develop/ai/search-and-query/administration/configuration.md` |
| A4 — query string moved before the fragment | `integrate/railway-redis/_index.md` |
| A4 — MANIFESTO line anchor pinned to a SHA | `develop/programmability/_index.md` |
| A4 — boringssl line range pinned and corrected | `operate/rs/security/encryption/tls/ciphers.md` |
| A4 — two scroll-to-text fragments dropped | `develop/whats-new/7-2.md` |

21 lines changed across 6 files. Of `lua-api.md`'s 11 distinct anchors, 7 were dead
because the spec never had per-type headings; all 18 links now go through `relref`, so
the build validates the target page. The prose read "streamed aggregate data types",
and that missing "d" is exactly what made the anchor dead, so the link text was
corrected too.

## One finding in the ticket is a false positive

**The Wikipedia LDAP bind link is not broken, and this PR does not touch it.** The audit
reported that its unescaped closing paren truncates the markdown link. The rendered HTML
disagrees:

```
href="https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol#Bind_(authenticate)"
```

Full href, anchor intact, no stray text after the link. CommonMark permits balanced
parentheses inside a link destination and goldmark implements that, so the detector's
regex stopping at the first paren is the bug. The target anchor `Bind_(authenticate)`
also still exists on Wikipedia, so the link is healthy end to end. Worth folding back
into `ANCHOR_AUDIT_FINDINGS.md` as a third detector bug alongside the two the audit
already documents.

## Line numbers had to be verified the hard way

WebFetch could not settle either line anchor — it placed the MANIFESTO phrase on line 8
and hedged on the boringssl range with "approximately". Fetching both files at pinned
SHAs and counting lines directly gave the real answers:

- **MANIFESTO** — `#L7` was correct all along. Pinned to `3eaa2cdc`, so it stays correct.
- **boringssl** — `var cipherSuites` opens at line 99 and the list closes at line **130**;
  the link said `#L99-L131`, one blank line past the end. Pinned to `887d5178` and
  tightened to `#L99-L130`.

## Verification

Built the site and checked every retarget against rendered anchors, not predicted slugs:

- All 10 distinct anchors `lua-api.md` now targets are present as real ids on the built
  protocol spec page.
- `#create-a-vector-index` present on the built vectors page.
- Zero `href=""` on the rendered `lua-api.md` — no relref silently failed to resolve.
- The 18 new hrefs reconcile exactly against the per-anchor counts.

## Two things to flag

**A3 is a retarget under protest.** `BLOCK_SIZE` is no longer documented anywhere on the
vectors page — the only trace is `DEFAULT_BLOCK_SIZE` inside a `TRAINING_THRESHOLD` table
cell. `#create-a-vector-index` is the closest honest target, but the real gap is editorial
and outlives this link fix.

**Two more dead relref anchors exist on the protocol spec page, left alone as out of
scope.** `eval-intro.md:122` uses `#resp-arrays` and the generated `content/commands/ft.aliaslist.md:78`
uses `#array`; both should be `#arrays`. Not in Part A, and the second is regenerated
upstream so a local fix would revert. They make good test fixtures for the offline checker
in PR 3.

Also unverified: the railway `#tcp-proxying` anchor. This PR fixes the URL's structure —
the query string was after the fragment, so `?utm_medium=…` was being parsed as part of the
anchor — which is correct regardless. Whether that anchor exists rests on one weak negative
fetch, so I have not claimed it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and anchor updates with no changes to application code, configuration defaults, or security-sensitive runtime behavior.
> 
> **Overview**
> This PR repairs **broken or fragile documentation links** across six files as part of DOC-7003 (develop link fixes), with no product or API behavior changes.
> 
> The largest edit is in **`lua-api.md`**: **18 external RESP3 GitHub spec URLs** are replaced with **`relref` links** to **`protocol-spec`** anchors (`#maps`, `#sets`, `#nulls`, `#booleans`, and related types). Unsupported Lua API types are linked to **`#attributes`**, **`#streamed-strings`**, and **`#streamed-aggregated-data-types`**, and the prose is corrected from “streamed aggregate” to **“streamed aggregated”** to match the real heading.
> 
> **`configuration.md`** repoints the **`BLOCK_SIZE`** mention from a dead vectors anchor to **`#create-a-vector-index`**. **`programmability/_index.md`** pins the Redis **MANIFESTO** GitHub link to a **commit SHA** instead of **`unstable`**. **`ciphers.md`** pins the BoringSSL cipher list link to a SHA and tightens the line range to **L99–L130**.
> 
> **`railway-redis/_index.md`** moves UTM query parameters **before** the **`#tcp-proxying`** fragment so tracking params are not treated as part of the anchor. **`whats-new/7-2.md`** drops brittle **scroll-to-text** fragments from two **redis.io** blog URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd0c878961587cfe07ba1edaf46bf09d21aa686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->