### PR TITLE
DOC-7003 retarget dead k8s API anchors to the local reference

### DIFF
--- a/content/operate/kubernetes/re-databases/db-controller.md
+++ b/content/operate/kubernetes/re-databases/db-controller.md
@@ -88,7 +88,7 @@ To modify the database:
     ```
 
 1. Change the specification (only properties in `spec` section) and save the changes.  
-    For more details, see [RedisEnterpriseDatabaseSpec](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_database_api.md#redisenterprisedatabasespec) or [Options for Redis Enterprise databases]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_database_api" >}}). 
+    For more details, see [Options for Redis Enterprise databases]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_database_api" >}}). 
 
 1. Monitor the status to see when the changes take effect:
 

--- a/content/operate/kubernetes/recommendations/node-resources.md
+++ b/content/operate/kubernetes/recommendations/node-resources.md
@@ -42,7 +42,7 @@ For more information about monitoring node conditions, see [Node conditions](htt
 
 Kubernetes uses the `ResourceQuota` object to limit resource consumption per namespace. This lets you limit the number of objects created by a namespace or the amount of compute resources consumed by a namespace. 
 
-The resource settings for Redis Enterprise for Kubernetes are defined in the `operator.yaml` and the [`RedisEnterpriseCluster`](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#redisenterpriseclusterspec) custom resource.
+The resource settings for Redis Enterprise for Kubernetes are defined in the `operator.yaml` and the [`RedisEnterpriseCluster`]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_api#spec" >}}) custom resource.
 
 The following settings are the minimum workloads for the operator to function.
 

--- a/content/operate/kubernetes/security/authentication/ldap.md
+++ b/content/operate/kubernetes/security/authentication/ldap.md
@@ -47,7 +47,7 @@ spec:
       attribute: memberOf
 ```
 
-Refer to the `RedisEnterpriseCluster` [API reference](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#ldapspec) for full details on the available fields.
+Refer to the `RedisEnterpriseCluster` [API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_api#specldap" >}}) for full details on the available fields.
 
 ### Bind credentials
 

--- a/content/operate/kubernetes/security/authentication/sso.md
+++ b/content/operate/kubernetes/security/authentication/sso.md
@@ -361,7 +361,7 @@ spec:
         baseAddress: "https://redis-ui.example.com:443"
 ```
 
-Refer to the `RedisEnterpriseCluster` [API reference](https://github.com/RedisLabs/redis-enterprise-k8s-docs/blob/master/redis_enterprise_cluster_api.md#ssospec) for full details on the available fields.
+Refer to the `RedisEnterpriseCluster` [API reference]({{< relref "/operate/kubernetes/reference/api/redis_enterprise_cluster_api#specsso" >}}) for full details on the available fields.
 
 ## Next steps
 


### PR DESCRIPTION
Third PR for DOC-7003, covering Part A2 — the Kubernetes API anchor retargets.
**Independent of #3863 and #3864**, based directly on `main`, so it can be reviewed and
merged on its own.

## The problem

Upstream restructured `redis_enterprise_cluster_api.md` and
`redis_enterprise_database_api.md` on `master`: each file now contains exactly one
heading, so every Go-type anchor we linked (`#ldapspec`, `#ssospec`,
`#redisenterpriseclusterspec`, `#redisenterprisedatabasespec`) is gone. Four live pages
pointed at them.

Instructive detail from the audit worth keeping in mind for the house rules in a later
PR: our *pinned-SHA* links to these same upstream files still resolve. Pinning survived;
`master` rotted.

## The judgment calls

The ticket flagged this as not a mechanical retarget, and it isn't — the local pages are
organised by **field path** (`### spec.ldap`), not by Go type name, and the string
`LdapSpec` appears nowhere in them. Each link was resolved on what its sentence promises:

| Page | Was | Now | Reasoning |
|:--|:--|:--|:--|
| `security/authentication/ldap.md:50` | `#ldapspec` | `…cluster_api#specldap` | Section opens "Cluster-level LDAP configuration, such as server addresses, protocol, authentication and query settings" — matches the "full details on the available fields" the sentence offers |
| `security/authentication/sso.md:364` | `#ssospec` | `…cluster_api#specsso` | Section opens "Cluster-level SSO configuration for authentication to the Cluster Manager UI" |
| `recommendations/node-resources.md:45` | `#redisenterpriseclusterspec` | `…cluster_api#spec` | Link text is the bare `RedisEnterpriseCluster` identifier, so the whole spec table is the faithful target; narrowing to `#specredisenterprisenoderesources` would make the link say something the sentence doesn't |
| `re-databases/db-controller.md:91` | `#redisenterprisedatabasespec` | *link deleted* | The same line already carried a `relref` to that exact page. Retargeting would have produced the same link twice, so the dead one came out |

Per `content/operate/kubernetes/AGENTS.md`, the `RedisEnterpriseCluster` link text is left
exactly as it is — custom resource identifiers are never reworded.

## These anchors are more stable than the ones they replace

Not by luck. `k8s_apis_sync.yaml` runs a `sed` pass over `crdoc`'s output that strips the
`RedisEnterpriseCluster.` prefix from every heading, which is why the headings read
`### spec.ldap`. **The anchor scheme is ours, not upstream's** — these links now rot only
if we change our own sync workflow, rather than whenever upstream renames a Go type.
Recorded as a `Constraint:` trailer on the commit so a future edit to that `sed` knows what
depends on it.

## Verification

Built the site and checked the rendered ids, not assumed slugs — the ticket specifically
warned not to assume the slug for headings containing dots. The dots are stripped:
`### spec.ldap` renders as `id="specldap"`.

| Check | Result |
|:--|:--|
| `id="spec"`, `id="specldap"`, `id="specsso"` on the built cluster API page | all present |
| `id="spec"` on the built database API page | present |
| Rendered hrefs on all four edited pages | resolve to those exact anchors |
| `href=""` on the four edited pages | zero — no relref silently failed |
| Topical fit of each target section | confirmed by reading the section's lead sentence, not just matching the name |

Only the unversioned current pages are touched. The same dead anchors appear across the
`7.22/`, `7.8.x/` and `8.0/` snapshots; per `AGENTS.md` a current-version change is never
propagated backward into a frozen snapshot, and the ticket scopes archived trees out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fixes with no runtime, security, or configuration behavior changes.
> 
> **Overview**
> **Replaces dead upstream GitHub API anchors** (removed when `redis-enterprise-k8s-docs` restructured headings) with **in-site `relref` links** to the synced Kubernetes API reference pages.
> 
> On **LDAP** and **SSO** auth docs, the `RedisEnterpriseCluster` API reference now points to `#specldap` and `#specsso` on `redis_enterprise_cluster_api`. **Node resources** links `RedisEnterpriseCluster` to `#spec` instead of `#redisenterpriseclusterspec`. **Database controller** drops the redundant GitHub `RedisEnterpriseDatabaseSpec` link because the same line already links to the local database API page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6d85eb9fa8ffecca04ab99d6fcbe727d5e61f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->