### PR TITLE
Move module-args warning next to the command it describes

### DIFF
--- a/content/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module.md
+++ b/content/operate/oss_and_stack/stack-with-enterprise/install/upgrade-module.md
@@ -67,10 +67,6 @@ To upgrade a module enabled for a database:
         rladmin upgrade db < database-name | database-ID > latest_with_modules
         ```
 
-    {{<warning>}}
-The upgrade process does not validate the module upgrade arguments, and incorrect arguments can cause unexpected downtime. Test module upgrade commands in a test environment before you upgrade modules in production. 
-    {{</warning>}}
-
     - Use `keep_redis_version` to upgrade the modules without upgrading the database to the latest Redis version.
     
         `keep_redis_version` is deprecated as of Redis Software version 7.8.2. To upgrade modules without upgrading the Redis database version, set `redis_version` to the current Redis database version instead.
@@ -80,6 +76,10 @@ The upgrade process does not validate the module upgrade arguments, and incorrec
         ```sh
         and module module_name <module_name> version <new_module_version_number> module_args "<module arguments>"
         ```
+
+        {{<warning>}}
+The upgrade process does not validate the module upgrade arguments, and incorrect arguments can cause unexpected downtime. Test module upgrade commands in a test environment before you upgrade modules in production.
+        {{</warning>}}
 
         For the module arguments, use one of the following:
 


### PR DESCRIPTION
The warning about unvalidated module upgrade arguments sat directly after the plain `rladmin upgrade db ... latest_with_modules` command, making it read as a caution about that command (customer-reported confusion). It actually concerns the module arguments in the `and module ... module_args` syntax. Move it beside that command block; warning text unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only reordering with no behavioral or security impact.
> 
> **Overview**
> Relocates the existing **warning** about unvalidated `module_args` so it sits immediately after the `and module ... module_args` example instead of after the `latest_with_modules` `rladmin upgrade db` snippet.
> 
> **Warning copy is unchanged**—only placement changes so readers associate the caution with per-module argument syntax, not the generic upgrade command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 922d3fa62e9f00d377bb06cc1d2baebc09eb5116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->