### PR TITLE
Note the 25,000 ops/sec clustering threshold alongside 25 GB

### DIFF
--- a/content/operate/rc/databases/configuration/clustering.md
+++ b/content/operate/rc/databases/configuration/clustering.md
@@ -6,7 +6,8 @@ categories:
 - operate
 - rc
 description: Redis Cloud uses clustering to manage very large databases (25 GB and
-  larger).  Here, you'll learn how to manage clustering and how to use hashing policies
+  larger) or high-throughput databases (25,000 ops/sec and higher).  Here, you'll
+  learn how to manage clustering and how to use hashing policies
   to control how data is managed.
 linkTitle: Clustering
 weight: $weight
@@ -21,7 +22,7 @@ For very large databases, Redis Cloud distributes database data to different clo
 
 - The operations performed against the database are CPU intensive enough to degrade performance.
 
-    Clustering distributes operational load, whether to instances on the same server or across multiple servers.
+    Multiple shards should be used when throughput grows to 25,000 ops/sec. Clustering distributes operational load, whether to instances on the same server or across multiple servers.
 
 This distribution is called _clustering_ because it manages the way data is distributed throughout the cluster of nodes that support the database.
 


### PR DESCRIPTION
The page stated the data-size trigger for clustering (25 GB) but left the throughput trigger without a concrete number. Add the 25,000 ops/sec threshold to the throughput bullet, paralleling the size bullet, and mention it in the page description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or security impact.
> 
> **Overview**
> **Documents the throughput trigger for Redis Cloud clustering** so it matches the existing size guidance (25 GB).
> 
> The page **description** now mentions high-throughput databases (**25,000 ops/sec and higher**) in addition to very large databases. The CPU/throughput example bullet adds an explicit rule: use multiple shards when throughput reaches **25,000 ops/sec**, while keeping the explanation that clustering spreads operational load across instances.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88a779cedee20a20398cd43da2ca2923b855041d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->