### PR TITLE
Scope the A-A module-command upgrade limitation to modules added mid-…

### DIFF
--- a/content/operate/rs/8.0/installing-upgrading/upgrading/upgrade-active-active.md
+++ b/content/operate/rs/8.0/installing-upgrading/upgrading/upgrade-active-active.md
@@ -152,4 +152,6 @@ If your Active-Active database uses modules:
 
 ## Upgrade limitations
 
-- When upgrading an Active-Active database from Redis 7.4 or earlier to version 8.0 or later, you cannot use module commands, such as [Redis Search](https://redis.io/docs/latest/commands/?group=search) and [JSON](https://redis.io/docs/latest/commands/?group=json) commands, until all Active-Active database instances in all participating clusters have been upgraded. These commands are not blocked automatically, and running these commands before finishing the upgrade process can cause syncer crashes.
+- When upgrading an Active-Active database from Redis 7.4 or earlier to version 8.0 or later, if you add a module to the database during the upgrade, you cannot use that module's commands, such as [Redis Search](https://redis.io/docs/latest/commands/?group=search) and [JSON](https://redis.io/docs/latest/commands/?group=json) commands, until all Active-Active database instances in all participating clusters have been upgraded. These commands are not blocked automatically, and running these commands before finishing the upgrade process can cause syncer crashes.
+
+    This limitation applies only when you add modules to a database during the upgrade. If the database already had modules configured before the upgrade, this limitation does not apply.

--- a/content/operate/rs/installing-upgrading/upgrading/upgrade-active-active.md
+++ b/content/operate/rs/installing-upgrading/upgrading/upgrade-active-active.md
@@ -151,4 +151,6 @@ If your Active-Active database uses modules:
 
 ## Upgrade limitations
 
-- When upgrading an Active-Active database from Redis 7.4 or earlier to version 8.0 or later, you cannot use module commands, such as [Redis Search](https://redis.io/docs/latest/commands/?group=search) and [JSON](https://redis.io/docs/latest/commands/?group=json) commands, until all Active-Active database instances in all participating clusters have been upgraded. These commands are not blocked automatically, and running these commands before finishing the upgrade process can cause syncer crashes.
+- When upgrading an Active-Active database from Redis 7.4 or earlier to version 8.0 or later, if you add a module to the database during the upgrade, you cannot use that module's commands, such as [Redis Search](https://redis.io/docs/latest/commands/?group=search) and [JSON](https://redis.io/docs/latest/commands/?group=json) commands, until all Active-Active database instances in all participating clusters have been upgraded. These commands are not blocked automatically, and running these commands before finishing the upgrade process can cause syncer crashes.
+
+    This limitation applies only when you add modules to a database during the upgrade. If the database already had modules configured before the upgrade, this limitation does not apply.

--- a/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/rs-8-0-20-44.md
@@ -206,7 +206,7 @@ Due to module handling changes introduced in Redis Software version 8.0, upgradi
 
 #### Module commands limitation during Active-Active database upgrades to Redis 8.0
 
-When upgrading an Active-Active database to Redis version 8.0, you cannot use module commands until all Active-Active database instances have been upgraded. Currently, these commands are not blocked automatically.
+When upgrading an Active-Active database to Redis version 8.0, if you add a module to the database during the upgrade, you cannot use that module's commands until all Active-Active database instances have been upgraded. Currently, these commands are not blocked automatically. This limitation applies only to modules added during the upgrade; it does not apply if the database already had modules configured before the upgrade.
 
 #### Redis 8.0 database cannot be created with flash
 


### PR DESCRIPTION
…upgrade

The limitation wording implied every Active-Active upgrade to 8.0 blocks module commands. It actually applies only when a module is added to the database during the upgrade; a database that already had modules configured before the upgrade is unaffected. Clarify this on the latest and 8.0 upgrade pages and in the rs-8-0-20-44 release note.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only wording changes with no runtime or configuration impact.
> 
> **Overview**
> **Narrows when Active-Active upgrades to Redis 8.0 block module commands** so the docs match actual behavior: the restriction applies only if you **add** a module while the upgrade is in progress, not for databases that already had modules before upgrading.
> 
> On both **Upgrade an Active-Active database** pages (`upgrade-active-active.md` for current and 8.0 doc trees), the **Upgrade limitations** bullet is rewritten to say you cannot use **that newly added module’s** commands (e.g. Search/JSON) until every instance in every participating cluster is upgraded, with a follow-up note that pre-upgrade modules are **not** subject to this rule. The syncer-crash warning and note that commands are not auto-blocked are unchanged.
> 
> The same scoping is applied in the **rs-8-0-20-44** known limitation *Module commands limitation during Active-Active database upgrades to Redis 8.0*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9051c39be9e3b0b93ed7c92676f14c65c79dc130. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->