### PR TITLE
Fix broken Imperva Sonar onboarding link in audit events docs

### DIFF
--- a/content/operate/rs/7.22/security/audit-events.md
+++ b/content/operate/rs/7.22/security/audit-events.md
@@ -25,7 +25,7 @@ Example external listeners include:
 
 - [`ncat`](https://nmap.org/ncat/): useful for debugging but not suitable for production environments.
 
-- Imperva Sonar: a third-party service available for purchase separately from Redis Enterprise Software. See [Redis Onboarding Steps](https://docs.imperva.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Onboarding-Steps_48368215.html) for more information.
+- Imperva Sonar: a third-party service available for purchase separately from Redis Enterprise Software. See [Redis Onboarding Steps](https://docs-cybersec.thalesgroup.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Enterprise-Software-Onboarding-Steps_48368215.html) for more information.
 
 For development and testing environments, notifications can be saved to a local file; however, this is neither supported nor intended for production environments.
 

--- a/content/operate/rs/7.8/security/audit-events.md
+++ b/content/operate/rs/7.8/security/audit-events.md
@@ -25,7 +25,7 @@ Example external listeners include:
 
 - [`ncat`](https://nmap.org/ncat/): useful for debugging but not suitable for production environments.
 
-- Imperva Sonar: a third-party service available for purchase separately from Redis Enterprise Software. See [Redis Onboarding Steps](https://docs.imperva.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Onboarding-Steps_48368215.html) for more information.
+- Imperva Sonar: a third-party service available for purchase separately from Redis Enterprise Software. See [Redis Onboarding Steps](https://docs-cybersec.thalesgroup.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Enterprise-Software-Onboarding-Steps_48368215.html) for more information.
 
 For development and testing environments, notifications can be saved to a local file; however, this is neither supported nor intended for production environments.
 

--- a/content/operate/rs/8.0/security/audit-events.md
+++ b/content/operate/rs/8.0/security/audit-events.md
@@ -25,7 +25,7 @@ Example external listeners include:
 
 - [`ncat`](https://nmap.org/ncat/): useful for debugging but not suitable for production environments.
 
-- Imperva Sonar: a third-party service available for purchase separately from Redis Software. See [Redis Onboarding Steps](https://docs.imperva.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Onboarding-Steps_48368215.html) for more information.
+- Imperva Sonar: a third-party service available for purchase separately from Redis Software. See [Redis Onboarding Steps](https://docs-cybersec.thalesgroup.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Enterprise-Software-Onboarding-Steps_48368215.html) for more information.
 
 For development and testing environments, notifications can be saved to a local file; however, this is neither supported nor intended for production environments.
 

--- a/content/operate/rs/security/audit-events.md
+++ b/content/operate/rs/security/audit-events.md
@@ -27,7 +27,7 @@ Example external listeners include:
 
 - [`ncat`](https://nmap.org/ncat/): useful for debugging but not suitable for production environments.
 
-- Imperva Sonar: a third-party service available for purchase separately from Redis Software. See [Redis Onboarding Steps](https://docs.imperva.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Onboarding-Steps_48368215.html) for more information.
+- Imperva Sonar: a third-party service available for purchase separately from Redis Software. See [Redis Onboarding Steps](https://docs-cybersec.thalesgroup.com/bundle/onboarding-databases-to-sonar-reference-guide/page/Redis-Enterprise-Software-Onboarding-Steps_48368215.html) for more information.
 
 - IBM Guardium
 


### PR DESCRIPTION
The "Redis Onboarding Steps" link pointed at the retired docs.imperva.com host and old page slug. Update it to the current Thales docs-cybersec URL across the latest page and the 7.22, 7.8, and 8.0 snapshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL updates with no product or security behavior changes.
> 
> **Overview**
> Updates the **Redis Onboarding Steps** link for Imperva Sonar in Redis Software audit-events documentation. The href now points to Thales Cybersecurity docs (`docs-cybersec.thalesgroup.com`) instead of the retired `docs.imperva.com` host, and the page slug is updated to `Redis-Enterprise-Software-Onboarding-Steps_48368215.html`.
> 
> The same link fix is applied in four doc variants: the current `content/operate/rs/security/audit-events.md` and versioned snapshots **7.8**, **7.22**, and **8.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5ad95d0e65b82c650dbbb0932a01e9895e0fa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->