### PR TITLE
docs: remove duplicated words in client and command docs

### DIFF
--- a/content/commands/bf.reserve.md
+++ b/content/commands/bf.reserve.md
@@ -62,7 +62,7 @@ The required number of bits per item, given the desired `error_rate` and the opt
 
 <details open><summary><code>key</code></summary>
 
-is key name for the the Bloom filter to be created.
+is key name for the Bloom filter to be created.
 </details>
 
 <details open><summary><code>error_rate</code></summary>

--- a/content/commands/cf.reserve.md
+++ b/content/commands/cf.reserve.md
@@ -65,7 +65,7 @@ The filter can grow up to 32 times.
 
 <details open><summary><code>key</code></summary>
 
-is key name for the the cuckoo filter to be created.
+is key name for the cuckoo filter to be created.
 </details>
 
 <details open><summary><code>capacity</code></summary>

--- a/content/develop/clients/dotnet/nredisstack/prob.md
+++ b/content/develop/clients/dotnet/nredisstack/prob.md
@@ -176,7 +176,7 @@ sketch commands.
 
 The advantage of using a CMS over keeping an exact count with a
 [sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
-is that that a CMS has very low and fixed memory usage, even for
+is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
 other similar statistics.

--- a/content/develop/clients/dotnet/transpipe.md
+++ b/content/develop/clients/dotnet/transpipe.md
@@ -55,7 +55,7 @@ tasks complete after the transaction executes.
 
 Redis supports *optimistic locking* to avoid inconsistent updates
 to different keys. The basic idea is to watch for changes to any
-keys that you use in a transaction while you are are processing the
+keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
 [Transactions]({{< relref "develop/using-commands/transactions" >}})

--- a/content/develop/clients/go/prob.md
+++ b/content/develop/clients/go/prob.md
@@ -169,7 +169,7 @@ a Count-min sketch object, add data to it, and then query it.
 
 The advantage of using a CMS over keeping an exact count with a
 [sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
-is that that a CMS has very low and fixed memory usage, even for
+is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
 other similar statistics.

--- a/content/develop/clients/go/transpipe.md
+++ b/content/develop/clients/go/transpipe.md
@@ -78,7 +78,7 @@ to `Pipelined()`, described above:
 
 Redis supports *optimistic locking* to avoid inconsistent updates
 to different keys. The basic idea is to watch for changes to any
-keys that you use in a transaction while you are are processing the
+keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
 [Transactions]({{< relref "develop/using-commands/transactions" >}})

--- a/content/develop/clients/hiredis/handle-replies.md
+++ b/content/develop/clients/hiredis/handle-replies.md
@@ -226,7 +226,7 @@ reply = NULL;
 Arrays (reply type `REDIS_REPLY_ARRAY`) and maps (reply type `REDIS_REPLY_MAP`)
 are returned by commands that retrieve several values at the
 same time. For both types, the number of elements in the reply is contained in
-`reply->elements` and the pointer to the array itself is is `reply->element`.
+`reply->elements` and the pointer to the array itself is `reply->element`.
 Each item in the array is of type `redisReply`. The array elements
 are typically simple types rather than arrays or maps.
 

--- a/content/develop/clients/jedis/prob.md
+++ b/content/develop/clients/jedis/prob.md
@@ -170,7 +170,7 @@ a Count-min sketch object, add data to it, and then query it.
 
 The advantage of using a CMS over keeping an exact count with a
 [sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
-is that that a CMS has very low and fixed memory usage, even for
+is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
 other similar statistics.

--- a/content/develop/clients/jedis/transpipe.md
+++ b/content/develop/clients/jedis/transpipe.md
@@ -65,7 +65,7 @@ an example that uses the results list).
 
 Redis supports *optimistic locking* to avoid inconsistent updates
 to different keys. The basic idea is to watch for changes to any
-keys that you use in a transaction while you are are processing the
+keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
 [Transactions]({{< relref "develop/using-commands/transactions" >}})

--- a/content/develop/clients/lettuce/produsage.md
+++ b/content/develop/clients/lettuce/produsage.md
@@ -356,7 +356,7 @@ The example below shows a filter that retries all commands except for
 [`DECR`]({{< relref "/commands/decr" >}})
 (this command is not [idempotent](https://en.wikipedia.org/wiki/Idempotence) and
 so you might need to avoid executing it more than once). Note that
-replay filters are only available in in Lettuce v6.6 and above.
+replay filters are only available in Lettuce v6.6 and above.
 
 ```java
 Predicate<RedisCommand<?, ?, ?> > filter =

--- a/content/develop/clients/nodejs/prob.md
+++ b/content/develop/clients/nodejs/prob.md
@@ -255,7 +255,7 @@ console.log(res19);  // >>> [400, 200, 350, 100]
 
 The advantage of using a CMS over keeping an exact count with a
 [sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
-is that that a CMS has very low and fixed memory usage, even for
+is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
 other similar statistics.

--- a/content/develop/clients/nodejs/transpipe.md
+++ b/content/develop/clients/nodejs/transpipe.md
@@ -109,7 +109,7 @@ console.log(res3); // >>> 3
 
 Redis supports *optimistic locking* to avoid inconsistent updates
 to different keys. The basic idea is to watch for changes to any
-keys that you use in a transaction while you are are processing the
+keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
 [Transactions]({{< relref "develop/using-commands/transactions" >}})

--- a/content/develop/clients/php/prob.md
+++ b/content/develop/clients/php/prob.md
@@ -170,7 +170,7 @@ a Count-min sketch object, add data to it, and then query it.
 
 The advantage of using a CMS over keeping an exact count with a
 [sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
-is that that a CMS has very low and fixed memory usage, even for
+is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
 other similar statistics.

--- a/content/develop/clients/redis-py/prob.md
+++ b/content/develop/clients/redis-py/prob.md
@@ -174,7 +174,7 @@ sketch commands.
 
 The advantage of using a CMS over keeping an exact count with a
 [sorted set](/content/develop/data-types/sorted-sets.md)
-is that that a CMS has very low and fixed memory usage, even for
+is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
 other similar statistics.

--- a/content/develop/clients/rust/amr.md
+++ b/content/develop/clients/rust/amr.md
@@ -161,7 +161,7 @@ fn example() -> RedisResult<()> {
 
 The examples above use the default `RetryConfig` when starting the provider.
 However, the `RetryConfig` class provides configuration methods that let you customise
-the way the the provider retries token requests:
+the way the provider retries token requests:
 
 ```rust
 use redis::{EntraIdCredentialsProvider, RetryConfig, RedisResult};

--- a/content/develop/reference/eviction/index.md
+++ b/content/develop/reference/eviction/index.md
@@ -316,7 +316,7 @@ This distinction makes LRM particularly useful in scenarios where:
 
 To configure LRM eviction, the following policies are available:
 
-* `volatile-lrm` Evict using LRM among the keys with an an associated expiration (TTL).
+* `volatile-lrm` Evict using LRM among the keys with an associated expiration (TTL).
 * `allkeys-lrm` Evict any key using LRM.
 
 Like LRU, LRM uses an approximation algorithm that samples a small number of keys at random and evicts the ones with the longest time since last modification. The same `maxmemory-samples` configuration directive that affects LRU performance also applies to LRM.


### PR DESCRIPTION
## Summary

Remove duplicated words in Redis client documentation and command reference pages.

| File | Fix |
|------|-----|
| content/commands/bf.reserve.md | "the the" → "the" |
| content/commands/cf.reserve.md | "the the" → "the" |
| content/develop/reference/eviction/index.md | "an an" → "an" |
| content/develop/clients/hiredis/handle-replies.md | "is is" → "is" |
| content/develop/clients/lettuce/produsage.md | "in in" → "in" |
| content/develop/clients/rust/amr.md | "the the" → "the" |
| content/develop/clients/dotnet/transpipe.md | "are are" → "are" |
| content/develop/clients/go/transpipe.md | "are are" → "are" |
| content/develop/clients/jedis/transpipe.md | "are are" → "are" |
| content/develop/clients/nodejs/transpipe.md | "are are" → "are" |
| content/develop/clients/dotnet/nredisstack/prob.md | "that that" → "that" |
| content/develop/clients/go/prob.md | "that that" → "that" |
| content/develop/clients/jedis/prob.md | "that that" → "that" |
| content/develop/clients/nodejs/prob.md | "that that" → "that" |
| content/develop/clients/php/prob.md | "that that" → "that" |
| content/develop/clients/redis-py/prob.md | "that that" → "that" |

## Test plan

- [x] Verified each duplicated word was present before editing
- [x] Residual scan clean in changed develop/ and commands/ paths
- [ ] CI checks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only typo fixes with no runtime, API, or configuration behavior changes.
> 
> **Overview**
> This PR is a **copy-editing pass** across Redis command reference and client documentation. It removes accidental **doubled words** (for example `the the`, `that that`, `are are`, `is is`, `in in`, `an an`) without changing meaning, structure, or examples.
> 
> Touches **BF.RESERVE** and **CF.RESERVE** `key` argument text, the **volatile-lrm** bullet on the eviction reference page, **hiredis** array/map reply wording, **Lettuce** replay-filter availability note, **rust** AMR `RetryConfig` prose, shared **optimistic locking** sentences in several **pipelines/transactions** guides, and the repeated **Count-min sketch vs sorted set** sentence in multiple **probabilistic data types** client pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e116e5753c3ea9387e3510f963d53f17c8a4ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->