### PR TITLE
Update may-2026.md

### DIFF
--- a/content/operate/rc/changelog/may-2026.md
+++ b/content/operate/rc/changelog/may-2026.md
@@ -30,7 +30,7 @@ Redis 8.6 is now available for [Redis Cloud Essentials databases]({{< relref "/o
 
 ### Dynamic endpoints
 
-Redis Cloud is gradually rolling out dynamic endpoints for all databases. You will be able to view both legacy static endpoints and dynamic endpoints when the feature is available for your account. Static endpoints will still work at this time, but they may be deprecated in the future.
+Redis Cloud is gradually rolling out dynamic endpoints. During the rollout, some databases will display both a dynamic endpoint and a legacy static endpoint, while some newly created databases will display only a dynamic endpoint. Previously assigned static endpoints will continue to work for now but may be deprecated in the future.
 
 {{< embed-md "rc-endpoint-description.md" >}}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording change in a changelog entry; no product code or configuration changes.
> 
> **Overview**
> Updates the **Dynamic endpoints** section in the May 2026 Redis Cloud changelog to describe rollout behavior more precisely.
> 
> The text no longer says endpoints roll out to *all* databases and that customers will see both endpoint types once the feature is on their account. It now states that during rollout some databases show both dynamic and legacy static endpoints, while **newly created** databases may show **only** a dynamic endpoint, and that existing static endpoints still work for now but may be deprecated later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1fa1f5c5cddc7e60b2d8dbffa9a363e54b5ef34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->