### PR TITLE
DEV: PARTITIONS config. parameter missing

### DIFF
--- a/content/develop/ai/search-and-query/administration/configuration.md
+++ b/content/develop/ai/search-and-query/administration/configuration.md
@@ -65,6 +65,7 @@ The version columns indicate availability per Redis Query Engine module version 
 | NOGC                              | [search-no-gc](#search-no-gc)                                     | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | :white_large_square: | <span title="Supported">&#x2705; Supported</span><br /><span><br /></span> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Not supported"><nobr>&#x274c; Free & Fixed</nobr></span> |
 | ON_TIMEOUT                        | [search-on-timeout](#search-on-timeout)                         | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | :white_check_mark:   | <span title="Supported">&#x2705; Supported</span><br /><span><br /></span> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Not supported"><nobr>&#x274c; Free & Fixed</nobr></span> |
 | PARTIAL_INDEXED_DOCS              | [search-partial-indexed-docs](#search-partial-indexed-docs)     | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | :white_large_square: | <span title="Supported">&#x2705; Supported</span><br /><span><br /></span> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Not supported"><nobr>&#x274c; Free & Fixed</nobr></span> |
+| [PARTITIONS](#partitions)         | There is no matching `CONFIG` parameter.                        | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | :white_large_square: | <span title="Supported">&#x2705; Supported</span><br /><span><br /></span> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Not supported"><nobr>&#x274c; Free & Fixed</nobr></span> |
 | RAW_DOCID_ENCODING                | [search-raw-docid-encoding](#search-raw-docid-encoding)         | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | :white_large_square: | | |
 | SEARCH_THREADS                    | [search-threads](#search-threads)                               | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | :white_large_square: | | |
 | SEARCH_IO_THREADS                 | [search-io-threads](#search-io-threads)                         | <span title="Not available">&#x274c;</span> | <span title="Not available">&#x274c;</span> | <span title="Not available">&#x274c;</span> | <span title="Not available">&#x274c;</span> | <span title="Not available">&#x274c;</span> | <span title="Supported">&#x2705;</span> | <span title="Supported">&#x2705;</span> | :white_large_square: | | |
@@ -457,6 +458,19 @@ Type: integer
 Valid values: `0` (false), `1` (true)
 
 Default: `0`
+
+### PARTITIONS
+
+The number of coordinator partitions to use in a clustered deployment (Redis Software,
+Redis Cloud, or Redis Open Source in cluster mode). This parameter is deprecated and
+immutable: any value passed to it is ignored, and the number of partitions is always
+determined automatically.
+
+Type: string
+
+Valid values: `AUTO`
+
+Default: `AUTO`
 
 ### search-raw-docid-encoding
 


### PR DESCRIPTION
Fixes #3880 .

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or configuration behavior impact.
> 
> **Overview**
> Documents the missing **PARTITIONS** Redis Search setting in `configuration.md`, addressing #3880.
> 
> Adds a summary-table row (alphabetically after `PARTIAL_INDEXED_DOCS`) noting there is no Redis 8+ `search-*` `CONFIG` equivalent, with version and Redis Software/Cloud compatibility aligned with similar cluster-only legacy options. Adds a **PARTITIONS** section describing coordinator partition count in clustered deployments, marking the parameter **deprecated and immutable** (values ignored; partitioning is always automatic), with type `string`, valid value `AUTO`, and default `AUTO`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c25efc4af567665876496c2d63dd5255b30850e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->