### PR TITLE
RS: SSE-C

### DIFF
--- a/content/operate/rs/databases/import-export/export-data.md
+++ b/content/operate/rs/databases/import-export/export-data.md
@@ -200,7 +200,7 @@ To encrypt data exported to S3 or an S3-compatible location with a customer-prov
 ```
 
 - `sse_customer_key` must be a base64-encoded string that decodes to exactly 32 bytes (AES-256).
-- SSE-C encryption is only available for S3 and S3-compatible storage locations, and only for this one export request. You can't add `encryption` to a database's persisted [backup_location]({{<relref "/operate/rs/references/rest-api/objects/bdb/backup_location">}}) configuration, so SSE-C isn't available for [scheduled backups]({{<relref "/operate/rs/databases/import-export/schedule-backups.md">}}).
+- SSE-C encryption is only available for S3 and S3-compatible storage locations, and only for this one export request. You can't add `encryption` to a database's persisted [backup_location]({{<relref "/operate/rs/references/rest-api/objects/bdb/backup_location">}}) configuration, so SSE-C isn't available for [scheduled backups]({{<relref "/operate/rs/databases/import-export/schedule-backups">}}).
 
 ### Google Cloud Storage
 

--- a/content/operate/rs/databases/import-export/export-data.md
+++ b/content/operate/rs/databases/import-export/export-data.md
@@ -180,6 +180,28 @@ To connect to an S3-compatible storage location:
 
     Replace `<filepath>` with the location of the S3 CA certificate `ca.pem`.
 
+#### Encrypt an export with a customer-provided key (SSE-C)
+
+To encrypt data exported to S3 or an S3-compatible location with a customer-provided key ([SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html)), add an `encryption` object to `export_location` in an [export database request]({{<relref "/operate/rs/references/rest-api/requests/bdbs/actions/export">}}):
+
+```json
+{
+    "export_location": {
+        "type": "s3",
+        "bucket_name": "backups",
+        "access_key_id": "XXXXXXXXXXXXX",
+        "secret_access_key": "XXXXXXXXXXXXXXXX",
+        "encryption": {
+            "type": "sse-c",
+            "sse_customer_key": "<base64-encoded 32-byte key>"
+        }
+    }
+}
+```
+
+- `sse_customer_key` must be a base64-encoded string that decodes to exactly 32 bytes (AES-256).
+- SSE-C encryption is only available for S3 and S3-compatible storage locations, and only for this one export request. You can't add `encryption` to a database's persisted [backup_location]({{<relref "/operate/rs/references/rest-api/objects/bdb/backup_location">}}) configuration, so SSE-C isn't available for [scheduled backups]({{<relref "/operate/rs/databases/import-export/schedule-backups.md">}}).
+
 ### Google Cloud Storage
 
 To export to a [Google Cloud](https://developers.google.com/console/) storage bucket:

--- a/content/operate/rs/databases/import-export/import-data.md
+++ b/content/operate/rs/databases/import-export/import-data.md
@@ -270,6 +270,32 @@ POST /v1/bdbs/<database-id>/actions/import
 }
 ```
 
+#### Import from a source encrypted with a customer-provided key (SSE-C)
+
+To import from an S3 or S3-compatible source encrypted with a customer-provided key ([SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html)), add an `encryption` object to the source in `dataset_import_sources`:
+
+```json
+{
+  "dataset_import_sources": [
+    {
+      "type": "s3",
+      "bucket_name": "backups",
+      "subdir": "test-db",
+      "filename": "<filename>.rdb",
+      "access_key_id": "XXXXXXXXXXXXX",
+      "secret_access_key": "XXXXXXXXXXXXXXXX",
+      "encryption": {
+        "type": "sse-c",
+        "sse_customer_key": "<base64-encoded 32-byte key>"
+      }
+    }
+  ]
+}
+```
+
+- `sse_customer_key` must be a base64-encoded string that decodes to exactly 32 bytes (AES-256).
+- SSE-C encryption is only available for S3 and S3-compatible storage locations, and only for this one import request. You can't add `encryption` to a database's persisted [dataset_import_sources]({{<relref "/operate/rs/references/rest-api/objects/bdb/dataset_import_sources">}}) configuration.
+
 ### Google Cloud Storage
 
 Before you import data from a [Google Cloud](https://developers.google.com/console/) storage bucket, make sure you have:

--- a/content/operate/rs/databases/import-export/schedule-backups.md
+++ b/content/operate/rs/databases/import-export/schedule-backups.md
@@ -229,6 +229,10 @@ To connect to an S3-compatible storage location:
 
     Replace `<filepath>` with the location of the S3 CA certificate `ca.pem`.
 
+{{< note >}}
+Customer-provided encryption keys (SSE-C) aren't supported for scheduled backups. SSE-C is only available for on-demand [export]({{< relref "/operate/rs/databases/import-export/export-data.md" >}}) and [import]({{< relref "/operate/rs/databases/import-export/import-data.md" >}}) requests.
+{{< /note >}}
+
 ### Google Cloud Storage
 
 For [Google Cloud](https://developers.google.com/console/) subscriptions, store your backups in a Google Cloud Storage bucket:

--- a/content/operate/rs/databases/import-export/schedule-backups.md
+++ b/content/operate/rs/databases/import-export/schedule-backups.md
@@ -230,7 +230,7 @@ To connect to an S3-compatible storage location:
     Replace `<filepath>` with the location of the S3 CA certificate `ca.pem`.
 
 {{< note >}}
-Customer-provided encryption keys (SSE-C) aren't supported for scheduled backups. SSE-C is only available for on-demand [export]({{< relref "/operate/rs/databases/import-export/export-data.md" >}}) and [import]({{< relref "/operate/rs/databases/import-export/import-data.md" >}}) requests.
+Customer-provided encryption keys (SSE-C) aren't supported for scheduled backups. SSE-C is only available for on-demand [export]({{< relref "/operate/rs/databases/import-export/export-data" >}}) and [import]({{< relref "/operate/rs/databases/import-export/import-data" >}}) requests.
 {{< /note >}}
 
 ### Google Cloud Storage

--- a/content/operate/rs/references/rest-api/objects/bdb/backup_location.md
+++ b/content/operate/rs/references/rest-api/objects/bdb/backup_location.md
@@ -57,6 +57,7 @@ Any additional required parameters may differ based on the backup/export locatio
 |----------|------|-------------|
 | access_key_id | string | The AWS Access Key ID with access to the bucket |
 | bucket_name | string | S3 bucket name |
+| encryption | object | Customer-provided encryption key (SSE-C) configuration. Valid only in `export_location` for [export requests]({{<relref "/operate/rs/references/rest-api/requests/bdbs/actions/export">}}) — the request fails if you include it in a database's persisted `backup_location`. See [Customer-provided encryption keys (SSE-C)](#sse-c) below. (optional) |
 | region_name | string | Amazon S3 region name (optional) |
 | secret_access_key | string | The AWS Secret Access Key that matches the Access Key ID |
 | subdir | string | Path to the backup directory in the S3 bucket (optional) |
@@ -80,6 +81,15 @@ To connect to an S3-compatible storage location:
     ```
 
     Replace `<filepath>` with the location of the S3 CA certificate `ca.pem`.
+
+#### Customer-provided encryption keys (SSE-C) {#sse-c}
+
+| Key name | Type | Description |
+|----------|------|-------------|
+| type | string | Must be `"sse-c"`. |
+| sse_customer_key | string | Base64-encoded encryption key that decodes to exactly 32 bytes (AES-256). |
+
+SSE-C is request-scoped: it's accepted only when passed directly to an [export]({{<relref "/operate/rs/references/rest-api/requests/bdbs/actions/export">}}) or [import]({{<relref "/operate/rs/references/rest-api/requests/bdbs/actions/import">}}) action, never as part of a database's persisted `backup_location` configuration.
 
 ### Google Cloud Storage
 

--- a/content/operate/rs/references/rest-api/objects/bdb/dataset_import_sources.md
+++ b/content/operate/rs/references/rest-api/objects/bdb/dataset_import_sources.md
@@ -61,6 +61,7 @@ Any additional required parameters may differ based on the import location type.
 |----------|------|-------------|
 | access_key_id | string | The AWS Access Key ID with access to the bucket |
 | bucket_name | string | S3 bucket name |
+| encryption | object | Customer-provided encryption key (SSE-C) configuration for a source encrypted with a customer key. Valid only when passed directly to the [import action]({{<relref "/operate/rs/references/rest-api/requests/bdbs/actions/import">}}) — the request fails if you include it in a database's persisted `dataset_import_sources`. See [Customer-provided encryption keys (SSE-C)](#sse-c) below. (optional) |
 | filename | string | RDB filename, including the file extension. |
 | region_name | string | Amazon S3 region name (optional) |
 | secret_access_key | string | The AWS Secret Access that matches the Access Key ID |
@@ -85,6 +86,15 @@ To connect to an S3-compatible storage location:
     ```
 
     Replace `<filepath>` with the location of the S3 CA certificate `ca.pem`.
+
+#### Customer-provided encryption keys (SSE-C) {#sse-c}
+
+| Key name | Type | Description |
+|----------|------|-------------|
+| type | string | Must be `"sse-c"`. |
+| sse_customer_key | string | Base64-encoded encryption key that decodes to exactly 32 bytes (AES-256). |
+
+SSE-C is request-scoped: it's accepted only when passed directly to an [import]({{<relref "/operate/rs/references/rest-api/requests/bdbs/actions/import">}}) action, never as part of a database's persisted `dataset_import_sources` configuration.
 
 ### Google Cloud Storage
 

--- a/content/operate/rs/references/rest-api/requests/bdbs/actions/export.md
+++ b/content/operate/rs/references/rest-api/requests/bdbs/actions/export.md
@@ -75,6 +75,25 @@ The request body should contain a JSON object with the following export paramete
 
 The above request initiates an export operation to the specified location.
 
+##### Example JSON body with a customer-provided encryption key (SSE-C)
+
+```json
+{
+    "export_location": {
+        "type": "s3",
+        "bucket_name": "backups",
+        "access_key_id": "XXXXXXXXXXXXX",
+        "secret_access_key": "XXXXXXXXXXXXXXXX",
+        "encryption": {
+            "type": "sse-c",
+            "sse_customer_key": "<base64-encoded 32-byte key>"
+        }
+    }
+}
+```
+
+`encryption` is available only for S3 and S3-compatible `export_location` values. See [backup_location/export_location]({{< relref "/operate/rs/references/rest-api/objects/bdb/backup_location" >}}) for the field details.
+
 ### Response {#post-response}
 
 Returns a status code.

--- a/content/operate/rs/references/rest-api/requests/bdbs/actions/import.md
+++ b/content/operate/rs/references/rest-api/requests/bdbs/actions/import.md
@@ -165,6 +165,29 @@ Azure Blob Storage example:
 }
 ```
 
+Customer-provided encryption key (SSE-C) example:
+
+```json
+{
+  "dataset_import_sources": [
+    {
+      "type": "s3",
+      "bucket_name": "backups",
+      "subdir": "test-db",
+      "filename": "<filename>.rdb",
+      "access_key_id": "XXXXXXXXXXXXX",
+      "secret_access_key": "XXXXXXXXXXXXXXXX",
+      "encryption": {
+        "type": "sse-c",
+        "sse_customer_key": "<base64-encoded 32-byte key>"
+      }
+    }
+  ]
+}
+```
+
+`encryption` is available only for S3 and S3-compatible sources. See [dataset_import_sources]({{< relref "/operate/rs/references/rest-api/objects/bdb/dataset_import_sources" >}}) for the field details.
+
 ### Response {#post-response}
 
 Returns a status code.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime or API behavior changes in this diff.
> 
> **Overview**
> Documents **customer-provided S3 encryption (SSE-C)** for Redis Software on-demand database **import** and **export** via the REST API.
> 
> Adds how-to sections in the import/export guides, optional `encryption` (`type: "sse-c"`, `sse_customer_key`) on S3 `export_location` and `dataset_import_sources`, matching REST API examples, and object reference tables. **SSE-C is request-scoped only** (export/import actions); it cannot be stored on `backup_location` or `dataset_import_sources`, and **scheduled backups** explicitly do not support it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc22d9c4e6f9cef1b3f4ac44d2d30d43b72d88ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->