### PR TITLE
K8s: add RED-192548 to release notes

### DIFF
--- a/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026.md
+++ b/content/operate/kubernetes/release-notes/8-2-0-releases/8-2-0-12-july2026.md
@@ -40,6 +40,7 @@ Redis Software for Kubernetes 8.2.0-12 is a feature release that supports [Redis
 - Security fixes <!--RED-201725-->
 - Fixed an REDB reapply error after recovery <!--RED-200719-->
 - Fixed a memory usage increase in the bootstrapper container <!--RED-200754-->
+- Fixed client authentication being turned off and client certificates being cleared when you patched a field other than a certificate field, such as `evictionPolicy`, in the `spec.globalConfigurations` of a REAADB. The operator now preserves the mutual TLS (mTLS) settings on the underlying Active-Active database. REDB resources were not affected <!--RED-192548-->
 
 ## API changes
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change to release notes; no runtime or operator behavior is modified in this PR.
> 
> **Overview**
> Adds a **Resolved issues** entry for Redis Software for Kubernetes **8.2.0-12** covering **RED-192548**.
> 
> The note explains that patching non-certificate fields (e.g. `evictionPolicy`) under `spec.globalConfigurations` on a **REAADB** used to disable client authentication and clear client certificates; the operator fix preserves mTLS on the underlying Active-Active database, with **REDB** unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aad967ed214b7da74b0f4a548db08613338cf28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->