### PR TITLE
K8s: remove conflicting info about AA and multi-ns

### DIFF
--- a/content/operate/kubernetes/7.22/architecture/deployment-options.md
+++ b/content/operate/kubernetes/7.22/architecture/deployment-options.md
@@ -18,8 +18,6 @@ Multiple RedisEnterpriseDatabase (REDB) resources can be associated with a singl
 
 The Redis Enterprise cluster (REC) custom resource must reside in the same namespace as the Redis Enterprise operator.
 
-{{<warning>}} Multi-namespace installations don't support Active-Active databases (REEADB). Only databases created with the REDB resource are supported in multi-namespace deployments at this time.{{</warning>}}
-
 ## Single REC and single namespace (one-to-one)
 
 The standard and simplest deployment deploys your Redis Enterprise databases (REDB) in the same namespace as the Redis Enterprise cluster (REC). No additional configuration is required for this, since there is no communication required to cross namespaces. See [Deploy Redis Enterprise for Kubernetes]({{< relref "/operate/kubernetes/7.22/deployment/quick-start" >}}).

--- a/content/operate/kubernetes/8.0.18/architecture/deployment-options.md
+++ b/content/operate/kubernetes/8.0.18/architecture/deployment-options.md
@@ -18,8 +18,6 @@ Multiple RedisEnterpriseDatabase (REDB) resources can be associated with a singl
 
 The Redis Enterprise cluster (REC) custom resource must reside in the same namespace as the Redis Enterprise operator.
 
-{{<warning>}} Multi-namespace installations don't support Active-Active databases (REEADB). Only databases created with the REDB resource are supported in multi-namespace deployments at this time.{{</warning>}}
-
 ## Single REC and single namespace (one-to-one)
 
 The standard and simplest deployment deploys your Redis Enterprise databases (REDB) in the same namespace as the Redis Enterprise cluster (REC). No additional configuration is required for this, since there is no communication required to cross namespaces. See [Deploy Redis Enterprise for Kubernetes]({{< relref "/operate/kubernetes/8.0.18/deployment/quick-start" >}}).

--- a/content/operate/kubernetes/8.0/architecture/deployment-options.md
+++ b/content/operate/kubernetes/8.0/architecture/deployment-options.md
@@ -18,8 +18,6 @@ Multiple RedisEnterpriseDatabase (REDB) resources can be associated with a singl
 
 The Redis Enterprise cluster (REC) custom resource must reside in the same namespace as the Redis Enterprise operator.
 
-{{<warning>}} Multi-namespace installations don't support Active-Active databases (REEADB). Only databases created with the REDB resource are supported in multi-namespace deployments at this time.{{</warning>}}
-
 ## Single REC and single namespace (one-to-one)
 
 The standard and simplest deployment deploys your Redis Enterprise databases (REDB) in the same namespace as the Redis Enterprise cluster (REC). No additional configuration is required for this, since there is no communication required to cross namespaces. See [Deploy Redis Enterprise for Kubernetes]({{< relref "/operate/kubernetes/8.0/deployment/quick-start" >}}).

--- a/content/operate/kubernetes/architecture/deployment-options.md
+++ b/content/operate/kubernetes/architecture/deployment-options.md
@@ -17,8 +17,6 @@ Multiple RedisEnterpriseDatabase (REDB) resources can be associated with a singl
 
 The Redis Enterprise cluster (REC) custom resource must reside in the same namespace as the Redis Enterprise operator.
 
-{{<warning>}} Multi-namespace installations don't support Active-Active databases (REEADB). Only databases created with the REDB resource are supported in multi-namespace deployments at this time.{{</warning>}}
-
 ## Single REC and single namespace (one-to-one)
 
 The standard and simplest deployment deploys your Redis Enterprise databases (REDB) in the same namespace as the Redis Enterprise cluster (REC). No additional configuration is required for this, since there is no communication required to cross namespaces. See [Deploy Redis Enterprise for Kubernetes]({{< relref "/operate/kubernetes/deployment/quick-start" >}}).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits; no product or code behavior changes.
> 
> **Overview**
> Removes the **warning** on **Deployment options** that stated multi-namespace setups do not support Active-Active (REEADB) databases. The same warning was deleted from the versioned pages (`7.22`, `8.0`, `8.0.18`) and the unversioned `content/operate/kubernetes/architecture/deployment-options.md`.
> 
> That text conflicted with **Manage databases in multiple namespaces**, which documents multi-namespace Active-Active support and links to configuration guidance. Dropping it aligns deployment-options with the current multi-namespace docs without changing the rest of the deployment patterns content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ad1c952d1a5a6e0e9ea1d00bcba58fe3c32c95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->