### PR TITLE
RS: Document SCAN result inconsistency during shard migration in OSS …

### DIFF
--- a/content/operate/rs/8.0/clusters/configure/sch.md
+++ b/content/operate/rs/8.0/clusters/configure/sch.md
@@ -32,3 +32,7 @@ curl -k -X PUT -H "accept: application/json" \
     -d '{ "client_maint_notifications": true }' \
     https://<host>:<port>/v1/cluster
 ```
+
+## Known limitations
+
+During a rolling upgrade with SCH enabled, when some slot's shards have migrated to a different node but are still reachable from their original node, results of the `SCAN` command might be inconsistent: it might show some of the keys, it might show keys that are not reachable from that node, or it might show no keys. When the slot migration is done, this issue will fix itself.

--- a/content/operate/rs/clusters/configure/sch.md
+++ b/content/operate/rs/clusters/configure/sch.md
@@ -31,3 +31,7 @@ curl -k -X PUT -H "accept: application/json" \
     -d '{ "client_maint_notifications": true }' \
     https://<host>:<port>/v1/cluster
 ```
+
+## Known limitations
+
+During a rolling upgrade with SCH enabled, when some slot's shards have migrated to a different node but are still reachable from their original node, results of the `SCAN` command might be inconsistent: it might show some of the keys, it might show keys that are not reachable from that node, or it might show no keys. When the slot migration is done, this issue will fix itself.

--- a/content/operate/rs/release-notes/rs-8-0-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-0-releases/_index.md
@@ -301,3 +301,7 @@ The following legacy UI features are not yet available in the new Cluster Manage
     Use [`crdb-cli crdb purge-instance`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/purge-instance" >}}) instead.
 
 - Search and export the log.
+
+#### SCAN results can be inconsistent during a rolling upgrade in OSS Cluster API mode
+
+During a rolling upgrade with Smart client handoffs (SCH) enabled, when some slot's shards have migrated to a different node but are still reachable from their original node, results of the `SCAN` command might be inconsistent: it might show some of the keys, it might show keys that are not reachable from that node, or it might show no keys. When the slot migration is done, this issue will fix itself.

--- a/content/operate/rs/release-notes/rs-8-2-releases/_index.md
+++ b/content/operate/rs/release-notes/rs-8-2-releases/_index.md
@@ -189,3 +189,7 @@ The following legacy UI features are not yet available in the new Cluster Manage
     Use [`crdb-cli crdb purge-instance`]({{< relref "/operate/rs/references/cli-utilities/crdb-cli/crdb/purge-instance" >}}) instead.
 
 - Search and export the log.
+
+#### SCAN results can be inconsistent during a rolling upgrade in OSS Cluster API mode
+
+During a rolling upgrade with Smart client handoffs (SCH) enabled, when some slot's shards have migrated to a different node but are still reachable from their original node, results of the `SCAN` command might be inconsistent: it might show some of the keys, it might show keys that are not reachable from that node, or it might show no keys. When the slot migration is done, this issue will fix itself.


### PR DESCRIPTION
…Cluster API mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates with no runtime, API, or configuration behavior changes.
> 
> **Overview**
> Documents a **known limitation** for Redis Software clusters using **Smart client handoffs (SCH)** in **OSS Cluster API** mode: during a **rolling upgrade**, while slot shards have moved but remain reachable from the original node, **`SCAN`** may return partial, incorrect, or empty key sets until migration finishes.
> 
> The same wording is added in four places: **Known limitations** on both Smart client handoffs configure pages (`sch.md` for general and 8.0 paths) and under **Known limitations** in the **8.0.x** and **8.2.x** release note indexes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e56fab60619751516687f7df98b8a3fbd219529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->