### PR TITLE
DOC-7010 Add the xadd2 idempotent-XADD step for Ruby and ioredis

### DIFF
--- a/local_examples/cmds_stream/ioredis/cmds-stream.js
+++ b/local_examples/cmds_stream/ioredis/cmds-stream.js
@@ -36,6 +36,32 @@ assert.deepEqual(res4[1][1], ['field1', 'value1', 'field2', 'value2', 'field3', 
 await redis.del('mystream');
 // REMOVE_END
 
+// STEP_START xadd2
+const res5 = await redis.call('XADD', 'mystream', 'IDMP', 'producer1', 'msg1', '*', 'field', 'value');
+console.log(res5); // >>> 1726055713867-0
+
+// Attempting to add the same message again with IDMP returns the original entry ID
+const res6 = await redis.call('XADD', 'mystream', 'IDMP', 'producer1', 'msg1', '*', 'field', 'different_value');
+console.log(res6); // >>> 1726055713867-0 (same ID as res5, message was deduplicated)
+
+const res7 = await redis.call('XADD', 'mystream', 'IDMPAUTO', 'producer2', '*', 'field', 'value');
+console.log(res7); // >>> 1726055713867-1
+
+// Auto-generated idempotent ID prevents duplicates for same producer+content
+const res8 = await redis.call('XADD', 'mystream', 'IDMPAUTO', 'producer2', '*', 'field', 'value');
+console.log(res8); // >>> 1726055713867-1 (same ID as res7, duplicate detected)
+
+// Configure idempotent message processing settings
+const res9 = await redis.call('XCFGSET', 'mystream', 'IDMP-DURATION', 300, 'IDMP-MAXSIZE', 1000);
+console.log(res9); // >>> OK
+// STEP_END
+
+// REMOVE_START
+assert.equal(res5, res6);
+assert.equal(res7, res8);
+await redis.del('mystream');
+// REMOVE_END
+
 // HIDE_START
 redis.disconnect();
 // HIDE_END

--- a/local_examples/cmds_stream/ruby/cmds_stream.rb
+++ b/local_examples/cmds_stream/ruby/cmds_stream.rb
@@ -38,5 +38,31 @@ assert_equal(2, res4.length)
 assert_equal({ 'name' => 'Sara', 'surname' => 'OConnor' }, res4[0][1])
 assert_equal({ 'field1' => 'value1', 'field2' => 'value2', 'field3' => 'value3' }, res4[1][1])
 r.del('mystream')
+# REMOVE_END
+
+# STEP_START xadd2
+res5 = r.call('XADD', 'mystream', 'IDMP', 'producer1', 'msg1', '*', 'field', 'value')
+puts res5 # >>> 1726055713867-0
+
+# Attempting to add the same message again with IDMP returns the original entry ID
+res6 = r.call('XADD', 'mystream', 'IDMP', 'producer1', 'msg1', '*', 'field', 'different_value')
+puts res6 # >>> 1726055713867-0 (same ID as res5, message was deduplicated)
+
+res7 = r.call('XADD', 'mystream', 'IDMPAUTO', 'producer2', '*', 'field', 'value')
+puts res7 # >>> 1726055713867-1
+
+# Auto-generated idempotent ID prevents duplicates for same producer+content
+res8 = r.call('XADD', 'mystream', 'IDMPAUTO', 'producer2', '*', 'field', 'value')
+puts res8 # >>> 1726055713867-1 (same ID as res7, duplicate detected)
+
+# Configure idempotent message processing settings
+res9 = r.call('XCFGSET', 'mystream', 'IDMP-DURATION', 300, 'IDMP-MAXSIZE', 1000)
+puts res9 # >>> OK
+# STEP_END
+
+# REMOVE_START
+assert_equal(res5, res6)
+assert_equal(res7, res8)
+r.del('mystream')
 r.close
 # REMOVE_END


### PR DESCRIPTION
Note: this reduces the number of recently-introduced warnings about missing TCEs. There are still a few more that will be addressed separately -  I haven't forgotten about them!

[DOC-7010](https://redislabs.atlassian.net/browse/DOC-7010)

## What

Adds the `xadd2` step (IDMP/IDMPAUTO dedup, `XCFGSET`) to the Ruby and ioredis `cmds_stream` examples — the last real coverage gap DOC-6968 left open after #3812. `commands/xadd.md` now renders full client tabs on `xadd2` (Ruby and ioredis were previously omitted).

## Implementation note

Neither client's pinned version has typed support for this Redis 8.6+ feature yet: redis-rb 6.0.0's `xadd` has no `idmp`/`idmpauto` keyword, and ioredis 5.11.1's bundled command table doesn't know `xcfgset` at all. Both steps use the raw `.call(...)` escape hatch for the whole `XADD`/`XCFGSET` invocation, matching the same pattern already used elsewhere for commands newer than a client's typed API.

## Verification

- Ran both example files directly against Redis 8.8.0 (Docker) — confirmed dedup (`res5 == res6`, `res7 == res8`) and `XCFGSET` returns `OK`.
- Full `build/example-test-harness/run.sh cmds_stream` sweep: all runnable clients PASS (Ruby, ioredis included).
- Rebuilt the site (`hugo`) and confirmed via the rendered `commands/xadd/index.html`: the `xadd2` tab group now lists all 12 client tabs (previously omitted Ruby/ioredis), the Hugo build warning for this pane is gone, and the client-specific code panes contain the actual `r.call(...)` / `redis.call(...)` source (not a legacy whole-file dump).
- The Redis 7.2.7 used ambiently for other local dev work was restored after testing — it's untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-7010]: https://redislabs.atlassian.net/browse/DOC-7010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only example and test-harness changes with no production runtime impact.
> 
> **Overview**
> Adds the **`xadd2`** documentation step to the Ruby and **ioredis** `cmds_stream` examples so `commands/xadd` can show the same idempotent-stream coverage as the other clients.
> 
> Each new step demonstrates **`XADD`** with **`IDMP`** and **`IDMPAUTO`** (duplicate publishes return the original entry ID) and **`XCFGSET`** for **`IDMP-DURATION`** / **`IDMP-MAXSIZE`**, using **`r.call`** / **`redis.call`** because pinned client libraries lack typed support for Redis 8.6+ flags. Hidden assertions check dedup (`res5 == res6`, `res7 == res8`) and cleanup, matching the existing example harness pattern after **`xadd1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b3ada6e030f8e06dd206c175e6349f18a53815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->