### PR TITLE
DOC-7011 Stub SkipIfRedisFactAttribute so nredisstack cmds_generic compiles

### DIFF
--- a/build/example-test-harness/dotnet/stubs.cs
+++ b/build/example-test-harness/dotnet/stubs.cs
@@ -26,6 +26,16 @@ namespace NRedisStack.Tests
 
     // The examples annotate the test method [SkippableFact]; make it a plain Fact.
     public class SkippableFactAttribute : FactAttribute { }
+
+    // Some examples annotate with [SkipIfRedisFact(Comparison.LessThan, "7.0.0")] to skip
+    // on old servers. The harness always runs against a recent Redis, so make it a plain
+    // Fact too rather than reproducing NRedisStack's real version-detection logic.
+    public enum Comparison { LessThan, GreaterThanOrEqual }
+
+    public class SkipIfRedisFactAttribute : FactAttribute
+    {
+        public SkipIfRedisFactAttribute(Comparison comparison, string targetVersion) { }
+    }
 }
 
 // Satisfy [Collection("DocsTests")] + constructor injection of EndpointsFixture.


### PR DESCRIPTION
[DOC-7011](https://redislabs.atlassian.net/browse/DOC-7011)

## What

The portable C# test harness (`build/example-test-harness/dotnet/stubs.cs`) stands in for NRedisStack's own test fixtures so a doc example can compile and run under plain xunit. It stubbed `AbstractNRedisStackTest` and `[SkippableFact]`, but not `[SkipIfRedisFact(...)]` — which `cmds_generic`'s NRedisStack example uses to skip on old servers. That left nredisstack failing `cmds_generic` with `CS0246: SkipIfRedisFactAttribute could not be found`.

Added a minimal `Comparison` enum and a no-op `SkipIfRedisFactAttribute`, following the same philosophy as the existing `SkippableFact` stub: the harness always runs against a recent Redis, so there's no need to reproduce NRedisStack's real version-detection logic — just satisfy the one constructor overload the doc example actually calls.

## A wrinkle worth flagging

Checked a local NRedisStack clone for the "real" implementation to model the stub on, and found the attribute has moved twice upstream: an older `SkipIfRedisAttribute`, then today's `master` has a much larger `SkipIfRedisFactAttribute` built on custom xunit v3 discoverers. Neither is worth mirroring — the stub stays deliberately minimal.

## Verification

- `build/example-test-harness/run.sh cmds_generic nredisstack` → **PASS** (was a compile failure before).
- `cmds_string nredisstack` (also uses the shared stub file, not this attribute) → **PASS**, confirming the stub file itself is still intact.
- Regression-checked every other set sharing this stub (`cmds_hash`, `cmds_stream`, `geoindex`, `search_quickstart`, `time_series_tutorial`): all still **FAIL**, but for unrelated reasons visible in their error messages — the ambient local Redis (7.2.7, no modules) doesn't have `HEXPIRE`, `FT.CREATE`, or `TS.CREATE`. Not a regression from this change, and out of scope for this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-7011]: https://redislabs.atlassian.net/browse/DOC-7011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect example-test-harness stubs for documentation builds; no runtime product or security paths.
> 
> **Overview**
> The portable C# doc example harness in `stubs.cs` now defines a minimal **`Comparison`** enum and **`SkipIfRedisFactAttribute`** (constructor overload matching the docs), both inheriting from plain xunit **`Fact`** behavior like the existing **`SkippableFact`** stub.
> 
> This fixes **`cmds_generic`** NRedisStack examples that annotate tests with `[SkipIfRedisFact(Comparison.LessThan, "7.0.0")]`, which previously failed to compile with **`CS0246`**. Version-based skipping is intentionally not implemented because the harness assumes a recent Redis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3a22864b6eb865bd7f640abc1f542eaf50f0f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->