### PR TITLE
DOC-7012 Declare futures-util so rust-async cmds_generic compiles

### DIFF
--- a/build/example-test-harness/run.sh
+++ b/build/example-test-harness/run.sh
@@ -386,7 +386,8 @@ run_go() {
 }
 run_rust_sync() { rust_run "$WORK/rust-sync" "$1" 'redis = "1.3"' ; }
 run_rust_async(){ rust_run "$WORK/rust-async" "$1" 'redis = { version = "1.3", features = ["tokio-comp"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }' ; }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+futures-util = "0.3"' ; }
 rust_run() {
   local d="$1" src="$2" deps="$3"; mkdir -p "$d/src"
   if [ ! -f "$d/Cargo.toml" ]; then


### PR DESCRIPTION
[DOC-7012](https://redislabs.atlassian.net/browse/DOC-7012)

## What

`run_rust_async`'s Cargo.toml deps string in the test harness never declared `futures-util`, so `cargo test` failed with `unresolved import futures_util` on `cmds_generic`'s rust-async example — which needs `futures_util::StreamExt` in scope to `.collect().await` an `AsyncIter` (used by its four `scan` steps).

## Correcting the original diagnosis

DOC-6968 characterized this as "async iteration API drift in the pinned redis-rs." That turned out to be wrong: the example's own `use futures_util::StreamExt;` import was already correct, and `redis-rs`'s `AsyncIter` hasn't changed shape. It's a plain missing dependency in the harness's own Cargo.toml template — nothing to do with the pinned redis-rs version.

## Verification

- `build/example-test-harness/run.sh cmds_generic rust-async` → **PASS** (was a compile failure before). Had to delete the cached `work/rust-async/Cargo.toml`/`Cargo.lock` first — `rust_run` only writes `Cargo.toml` if absent, so a deps-string edit in `run.sh` doesn't take effect against a stale cache (the same trap as the Java `pom.xml` caching gotcha).
- Regression-checked every other rust-async set (`cmds_cnxmgmt`, `cmds_hash`, `cmds_list`, `cmds_servermgmt`, `cmds_set`, `cmds_sorted_set`, `cmds_stream`, `cmds_string`, `set_and_get`, `client-specific`): all still pass or SKIP as before, **except** two pre-existing, unrelated failures — confirmed by their actual error text, not assumed:
  - `cmds_stream`'s `xadd2` fails because the ambient local Redis (7.2.7) doesn't support IDMP — the same category of gap as DOC-7011's `HEXPIRE`/`FT.CREATE`/`TS.CREATE`.
  - `client-specific` fails on a missing `JsonAsyncCommands`/`serde_json` (RedisJSON support was never wired into this harness at all) — unrelated to `futures-util`, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-7012]: https://redislabs.atlassian.net/browse/DOC-7012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-harness-only dependency template change; no production or library code paths affected.
> 
> **Overview**
> Fixes **rust-async** example compilation in the test harness by correcting the `run_rust_async` Cargo dependency snippet and declaring **`futures-util = "0.3"`** alongside `redis` (tokio-comp) and `tokio`.
> 
> Examples such as **`cmds_generic`** already import `futures_util::StreamExt` for async `scan` iteration; the failure was an unresolved import because the harness-generated `Cargo.toml` never listed that crate—not a redis-rs API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb167fb4108fddd713105e1ce28fdfe2413fb651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->