### PR TITLE
DOC-7013 Add a path-based override rule so RedisVL examples can be staged locally

### DIFF
--- a/build/local_examples.py
+++ b/build/local_examples.py
@@ -99,6 +99,10 @@ def get_client_name_from_language_and_path(language: str, path: str,
       ('using NRedisStack') anywhere in the file content, which matches both the root
       namespace import and any subnamespace imports (e.g. 'using NRedisStack.Search;').
 
+    For Python (.py) files, override based on path substrings:
+    - If 'redisvl' in path -> RedisVL
+    - Otherwise -> Python
+
     Substring checks are case-sensitive and can appear anywhere in the path.
     """
     if language == 'node.js':
@@ -116,6 +120,9 @@ def get_client_name_from_language_and_path(language: str, path: str,
             return 'Rust-Async'
         if 'rust-sync' in path:
             return 'Rust-Sync'
+    if language == 'python':
+        if 'redisvl' in path:
+            return 'RedisVL'
     if language == 'c#':
         variant = 'Async' if 'async' in path else 'Sync'
         client = 'NRedisStack' if is_nredisstack_example(content) else 'SE.Redis'


### PR DESCRIPTION
[DOC-7013](https://redislabs.atlassian.net/browse/DOC-7013)

## What

`LANGUAGE_TO_CLIENT` in `build/local_examples.py` has always carried a `'redisvl': 'RedisVL'` entry, but nothing could ever reach it: `.py` files always resolve to the `'python'` language, and `get_client_name_from_language_and_path` had a path-based override for ioredis (`.js`), the three Lettuce variants (`.java`), and Rust-Sync/Rust-Async (`.rs`) — but none for Python. Every RedisVL fix therefore had to round-trip through `redis-vl-python` upstream, with no way to ship a local override in the meantime.

Adds the same shape of override the other clients already have: a `.py` file whose path contains `redisvl` now resolves to the `RedisVL` client instead of falling through to `Python`.

## Verification

- Created a throwaway file at `local_examples/query_vector/redisvl/query_vector.py` (removed before this commit) and ran `build/local_examples.py`: the log line read `Processing local example: query_vector (python) ... Processed RedisVL example for query_vector`, and the resulting `data/examples.json` entry's `source` field pointed at the local file instead of the upstream `redis-vl-python` doctest.
- Removed the throwaway file and confirmed the mechanism doesn't leave anything behind that would need cleanup — `data/examples.json` is gitignored, so nothing else changed.
- Diffed the full before/after `examples.json` and confirmed no other Python-language entry (i.e. no plain `Python` client anywhere) was affected by adding this branch.

This only wires up the mechanism — no `local_examples/*/redisvl/` directory exists yet. Writing an actual RedisVL local override (e.g. for `query_vector`'s `vector3`/`vector4`, which DOC-6968 declared out of scope partly *because* this gap existed) is separate follow-on work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-7013]: https://redislabs.atlassian.net/browse/DOC-7013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time client labeling in `local_examples.py` only; no runtime or security-sensitive behavior.
> 
> **Overview**
> **Local example staging** now treats Python files like other language-specific overrides: paths containing `redisvl` resolve to the **RedisVL** client in `get_client_name_from_language_and_path`, instead of always falling through to generic **Python**.
> 
> This closes the gap where `LANGUAGE_TO_CLIENT` already mapped `redisvl` → RedisVL but no `.py` path rule could select it, so RedisVL fixes could not be staged locally until upstream `redis-vl-python` updated. No new `local_examples/*/redisvl/` content ships in this PR—only the routing hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89b02b7bdc6152641fa21a3f7fd0ab571278deb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->