### PR TITLE
DOC-7014 Standardize dt_*.rb output comments to # >>> value

### DIFF
--- a/local_examples/ruby/dt_hash.rb
+++ b/local_examples/ruby/dt_hash.rb
@@ -20,17 +20,17 @@ res1 = r.hset('bike:1', {
   'type' => 'Enduro bikes',
   'price' => 4972
 })
-puts res1 # 4
+puts res1 # >>> 4
 
 res2 = r.hget('bike:1', 'model')
-puts res2 # Deimos
+puts res2 # >>> Deimos
 
 res3 = r.hget('bike:1', 'price')
-puts res3 # 4972
+puts res3 # >>> 4972
 
 res4 = r.hgetall('bike:1')
 puts res4.inspect
-# {"model"=>"Deimos", "brand"=>"Ergonom", "type"=>"Enduro bikes", "price"=>"4972"}
+# >>> {"model"=>"Deimos", "brand"=>"Ergonom", "type"=>"Enduro bikes", "price"=>"4972"}
 # STEP_END
 
 # REMOVE_START
@@ -56,7 +56,7 @@ r.hset('bike:1', {
 })
 
 res5 = r.hmget('bike:1', 'model', 'price', 'no-such-field')
-puts res5.inspect # ["Deimos", "4972", nil]
+puts res5.inspect # >>> ["Deimos", "4972", nil]
 # STEP_END
 
 # REMOVE_START
@@ -74,10 +74,10 @@ r.hset('bike:1', {
 })
 
 res6 = r.hincrby('bike:1', 'price', 100)
-puts res6 # 5072
+puts res6 # >>> 5072
 
 res7 = r.hincrby('bike:1', 'price', -100)
-puts res7 # 4972
+puts res7 # >>> 4972
 # STEP_END
 
 # REMOVE_START
@@ -87,25 +87,25 @@ assert_equal(4972, res7)
 
 # STEP_START incrby_get_mget
 res8 = r.hincrby('bike:1:stats', 'rides', 1)
-puts res8 # 1
+puts res8 # >>> 1
 
 res9 = r.hincrby('bike:1:stats', 'rides', 1)
-puts res9 # 2
+puts res9 # >>> 2
 
 res10 = r.hincrby('bike:1:stats', 'rides', 1)
-puts res10 # 3
+puts res10 # >>> 3
 
 res11 = r.hincrby('bike:1:stats', 'crashes', 1)
-puts res11 # 1
+puts res11 # >>> 1
 
 res12 = r.hincrby('bike:1:stats', 'owners', 1)
-puts res12 # 1
+puts res12 # >>> 1
 
 res13 = r.hget('bike:1:stats', 'rides')
-puts res13 # 3
+puts res13 # >>> 3
 
 res14 = r.hmget('bike:1:stats', 'owners', 'crashes')
-puts res14.inspect # ["1", "1"]
+puts res14.inspect # >>> ["1", "1"]
 # STEP_END
 
 # REMOVE_START

--- a/local_examples/ruby/dt_hyperloglog.rb
+++ b/local_examples/ruby/dt_hyperloglog.rb
@@ -15,19 +15,19 @@ r.del('bikes', 'commuter_bikes', 'all_bikes')
 
 # STEP_START pfadd
 res1 = r.pfadd('bikes', ['Hyperion', 'Deimos', 'Phoebe', 'Quaoar'])
-puts res1 # true
+puts res1 # >>> true
 
 res2 = r.pfcount('bikes')
-puts res2 # 4
+puts res2 # >>> 4
 
 res3 = r.pfadd('commuter_bikes', ['Salacia', 'Mimas', 'Quaoar'])
-puts res3 # true
+puts res3 # >>> true
 
 res4 = r.pfmerge('all_bikes', 'bikes', 'commuter_bikes')
-puts res4 # true
+puts res4 # >>> true
 
 res5 = r.pfcount('all_bikes')
-puts res5 # 6
+puts res5 # >>> 6
 # STEP_END
 
 # REMOVE_START

--- a/local_examples/ruby/dt_list.rb
+++ b/local_examples/ruby/dt_list.rb
@@ -15,16 +15,16 @@ r.del('bikes:repairs', 'bikes:finished', 'new_bikes')
 
 # STEP_START queue
 res1 = r.lpush('bikes:repairs', 'bike:1')
-puts res1 # 1
+puts res1 # >>> 1
 
 res2 = r.lpush('bikes:repairs', 'bike:2')
-puts res2 # 2
+puts res2 # >>> 2
 
 res3 = r.rpop('bikes:repairs')
-puts res3 # bike:1
+puts res3 # >>> bike:1
 
 res4 = r.rpop('bikes:repairs')
-puts res4 # bike:2
+puts res4 # >>> bike:2
 # STEP_END
 
 # REMOVE_START
@@ -36,16 +36,16 @@ assert_equal('bike:2', res4)
 
 # STEP_START stack
 res5 = r.lpush('bikes:repairs', 'bike:1')
-puts res5 # 1
+puts res5 # >>> 1
 
 res6 = r.lpush('bikes:repairs', 'bike:2')
-puts res6 # 2
+puts res6 # >>> 2
 
 res7 = r.lpop('bikes:repairs')
-puts res7 # bike:2
+puts res7 # >>> bike:2
 
 res8 = r.lpop('bikes:repairs')
-puts res8 # bike:1
+puts res8 # >>> bike:1
 # STEP_END
 
 # REMOVE_START
@@ -57,7 +57,7 @@ assert_equal('bike:1', res8)
 
 # STEP_START llen
 res9 = r.llen('bikes:repairs')
-puts res9 # 0
+puts res9 # >>> 0
 # STEP_END
 
 # REMOVE_START
@@ -66,19 +66,19 @@ assert_equal(0, res9)
 
 # STEP_START lmove_lrange
 res10 = r.lpush('bikes:repairs', 'bike:1')
-puts res10 # 1
+puts res10 # >>> 1
 
 res11 = r.lpush('bikes:repairs', 'bike:2')
-puts res11 # 2
+puts res11 # >>> 2
 
 res12 = r.lmove('bikes:repairs', 'bikes:finished', 'LEFT', 'LEFT')
-puts res12 # bike:2
+puts res12 # >>> bike:2
 
 res13 = r.lrange('bikes:repairs', 0, -1)
-puts res13.inspect # ["bike:1"]
+puts res13.inspect # >>> ["bike:1"]
 
 res14 = r.lrange('bikes:finished', 0, -1)
-puts res14.inspect # ["bike:2"]
+puts res14.inspect # >>> ["bike:2"]
 # STEP_END
 
 # REMOVE_START
@@ -93,13 +93,13 @@ assert_equal(['bike:2'], res14)
 r.del('bikes:repairs')
 
 res15 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
-puts res15 # 5
+puts res15 # >>> 5
 
 res16 = r.ltrim('bikes:repairs', 0, 2)
-puts res16 # OK
+puts res16 # >>> OK
 
 res17 = r.lrange('bikes:repairs', 0, -1)
-puts res17.inspect # ["bike:1", "bike:2", "bike:3"]
+puts res17.inspect # >>> ["bike:1", "bike:2", "bike:3"]
 # STEP_END
 
 # REMOVE_START
@@ -112,16 +112,16 @@ assert_equal(['bike:1', 'bike:2', 'bike:3'], res17)
 r.del('bikes:repairs')
 
 res18 = r.rpush('bikes:repairs', 'bike:1')
-puts res18 # 1
+puts res18 # >>> 1
 
 res19 = r.rpush('bikes:repairs', 'bike:2')
-puts res19 # 2
+puts res19 # >>> 2
 
 res20 = r.lpush('bikes:repairs', 'bike:important_bike')
-puts res20 # 3
+puts res20 # >>> 3
 
 res21 = r.lrange('bikes:repairs', 0, -1)
-puts res21.inspect # ["bike:important_bike", "bike:1", "bike:2"]
+puts res21.inspect # >>> ["bike:important_bike", "bike:1", "bike:2"]
 # STEP_END
 
 # REMOVE_START
@@ -135,14 +135,14 @@ assert_equal(['bike:important_bike', 'bike:1', 'bike:2'], res21)
 r.del('bikes:repairs')
 
 res22 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3'])
-puts res22 # 3
+puts res22 # >>> 3
 
 res23 = r.lpush('bikes:repairs', ['bike:important_bike', 'bike:very_important_bike'])
-puts res23 # 5
+puts res23 # >>> 5
 
 res24 = r.lrange('bikes:repairs', 0, -1)
 puts res24.inspect
-# ["bike:very_important_bike", "bike:important_bike", "bike:1", "bike:2", "bike:3"]
+# >>> ["bike:very_important_bike", "bike:important_bike", "bike:1", "bike:2", "bike:3"]
 # STEP_END
 
 # REMOVE_START
@@ -161,19 +161,19 @@ assert_equal([
 r.del('bikes:repairs')
 
 res25 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3'])
-puts res25 # 3
+puts res25 # >>> 3
 
 res26 = r.rpop('bikes:repairs')
-puts res26 # bike:3
+puts res26 # >>> bike:3
 
 res27 = r.lpop('bikes:repairs')
-puts res27 # bike:1
+puts res27 # >>> bike:1
 
 res28 = r.rpop('bikes:repairs')
-puts res28 # bike:2
+puts res28 # >>> bike:2
 
 res29 = r.rpop('bikes:repairs')
-puts res29.inspect # nil
+puts res29.inspect # >>> nil
 # STEP_END
 
 # REMOVE_START
@@ -188,13 +188,13 @@ assert_equal(nil, res29)
 r.del('bikes:repairs')
 
 res30 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
-puts res30 # 5
+puts res30 # >>> 5
 
 res31 = r.ltrim('bikes:repairs', 0, 2)
-puts res31 # OK
+puts res31 # >>> OK
 
 res32 = r.lrange('bikes:repairs', 0, -1)
-puts res32.inspect # ["bike:1", "bike:2", "bike:3"]
+puts res32.inspect # >>> ["bike:1", "bike:2", "bike:3"]
 # STEP_END
 
 # REMOVE_START
@@ -207,13 +207,13 @@ assert_equal(['bike:1', 'bike:2', 'bike:3'], res32)
 r.del('bikes:repairs')
 
 res33 = r.rpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
-puts res33 # 5
+puts res33 # >>> 5
 
 res34 = r.ltrim('bikes:repairs', -3, -1)
-puts res34 # OK
+puts res34 # >>> OK
 
 res35 = r.lrange('bikes:repairs', 0, -1)
-puts res35.inspect # ["bike:3", "bike:4", "bike:5"]
+puts res35.inspect # >>> ["bike:3", "bike:4", "bike:5"]
 # STEP_END
 
 # REMOVE_START
@@ -226,16 +226,16 @@ assert_equal(['bike:3', 'bike:4', 'bike:5'], res35)
 r.del('bikes:repairs')
 
 res36 = r.rpush('bikes:repairs', ['bike:1', 'bike:2'])
-puts res36 # 2
+puts res36 # >>> 2
 
 res37 = r.brpop('bikes:repairs', timeout: 1)
-puts res37.inspect # ["bikes:repairs", "bike:2"]
+puts res37.inspect # >>> ["bikes:repairs", "bike:2"]
 
 res38 = r.brpop('bikes:repairs', timeout: 1)
-puts res38.inspect # ["bikes:repairs", "bike:1"]
+puts res38.inspect # >>> ["bikes:repairs", "bike:1"]
 
 res39 = r.brpop('bikes:repairs', timeout: 1)
-puts res39.inspect # nil
+puts res39.inspect # >>> nil
 # STEP_END
 
 # REMOVE_START
@@ -248,10 +248,10 @@ r.del('bikes:repairs', 'new_bikes')
 
 # STEP_START rule_1
 res40 = r.del('new_bikes')
-puts res40 # 0
+puts res40 # >>> 0
 
 res41 = r.lpush('new_bikes', ['bike:1', 'bike:2', 'bike:3'])
-puts res41 # 3
+puts res41 # >>> 3
 # STEP_END
 
 # REMOVE_START
@@ -263,17 +263,17 @@ assert_equal(3, res41)
 r.del('new_bikes')
 
 res42 = r.set('new_bikes', 'bike:1')
-puts res42 # OK
+puts res42 # >>> OK
 
 res43 = r.type('new_bikes')
-puts res43 # string
+puts res43 # >>> string
 
 wrong_type_error = nil
 begin
   r.lpush('new_bikes', ['bike:2', 'bike:3'])
 rescue Redis::CommandError => e
   wrong_type_error = e
-  puts e.message # WRONGTYPE Operation against a key holding the wrong kind of value
+  puts e.message # >>> WRONGTYPE Operation against a key holding the wrong kind of value
 end
 # STEP_END
 
@@ -288,22 +288,22 @@ r.del('new_bikes')
 r.del('bikes:repairs')
 
 res44 = r.lpush('bikes:repairs', ['bike:1', 'bike:2', 'bike:3'])
-puts res44 # 3
+puts res44 # >>> 3
 
 res45 = r.exists('bikes:repairs')
-puts res45 # 1
+puts res45 # >>> 1
 
 res46 = r.lpop('bikes:repairs')
-puts res46 # bike:3
+puts res46 # >>> bike:3
 
 res47 = r.lpop('bikes:repairs')
-puts res47 # bike:2
+puts res47 # >>> bike:2
 
 res48 = r.lpop('bikes:repairs')
-puts res48 # bike:1
+puts res48 # >>> bike:1
 
 res49 = r.exists('bikes:repairs')
-puts res49 # 0
+puts res49 # >>> 0
 # STEP_END
 
 # REMOVE_START
@@ -319,13 +319,13 @@ assert_equal(0, res49)
 r.del('bikes:repairs')
 
 res50 = r.del('bikes:repairs')
-puts res50 # 0
+puts res50 # >>> 0
 
 res51 = r.llen('bikes:repairs')
-puts res51 # 0
+puts res51 # >>> 0
 
 res52 = r.lpop('bikes:repairs')
-puts res52.inspect # nil
+puts res52.inspect # >>> nil
 # STEP_END
 
 # REMOVE_START

--- a/local_examples/ruby/dt_sets.rb
+++ b/local_examples/ruby/dt_sets.rb
@@ -19,16 +19,16 @@ r.del('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
 
 # STEP_START sadd
 res1 = r.sadd('bikes:racing:france', ['bike:1'])
-puts res1 # 1
+puts res1 # >>> 1
 
 res2 = r.sadd('bikes:racing:france', ['bike:1'])
-puts res2 # 0
+puts res2 # >>> 0
 
 res3 = r.sadd('bikes:racing:france', ['bike:2', 'bike:3'])
-puts res3 # 2
+puts res3 # >>> 2
 
 res4 = r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
-puts res4 # 2
+puts res4 # >>> 2
 # STEP_END
 
 # REMOVE_START
@@ -45,10 +45,10 @@ r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
 r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
 # HIDE_END
 res5 = r.sismember('bikes:racing:usa', 'bike:1')
-puts res5 # true
+puts res5 # >>> true
 
 res6 = r.sismember('bikes:racing:usa', 'bike:2')
-puts res6 # false
+puts res6 # >>> false
 # STEP_END
 
 # REMOVE_START
@@ -63,7 +63,7 @@ r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
 r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
 # HIDE_END
 res7 = r.sinter('bikes:racing:france', 'bikes:racing:usa')
-puts res7.inspect # ["bike:1"]
+puts res7.inspect # >>> ["bike:1"]
 # STEP_END
 
 # REMOVE_START
@@ -76,7 +76,7 @@ r.del('bikes:racing:france')
 r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
 # HIDE_END
 res8 = r.scard('bikes:racing:france')
-puts res8 # 3
+puts res8 # >>> 3
 # STEP_END
 
 # REMOVE_START
@@ -87,10 +87,10 @@ assert_equal(3, res8)
 r.del('bikes:racing:france')
 
 res9 = r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
-puts res9 # 3
+puts res9 # >>> 3
 
 res10 = r.smembers('bikes:racing:france')
-puts res10.sort.inspect # ["bike:1", "bike:2", "bike:3"]
+puts res10.sort.inspect # >>> ["bike:1", "bike:2", "bike:3"]
 # STEP_END
 
 # REMOVE_START
@@ -104,10 +104,10 @@ r.del('bikes:racing:france')
 r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
 
 res11 = r.sismember('bikes:racing:france', 'bike:1')
-puts res11 # true
+puts res11 # >>> true
 
 res12 = r.smismember('bikes:racing:france', 'bike:2', 'bike:3', 'bike:4')
-puts res12.inspect # [true, true, false]
+puts res12.inspect # >>> [true, true, false]
 # STEP_END
 
 # REMOVE_START
@@ -120,7 +120,7 @@ r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3'])
 r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
 
 res13 = r.sdiff('bikes:racing:france', 'bikes:racing:usa')
-puts res13.sort.inspect # ["bike:2", "bike:3"]
+puts res13.sort.inspect # >>> ["bike:2", "bike:3"]
 # STEP_END
 
 # REMOVE_START
@@ -135,19 +135,19 @@ r.sadd('bikes:racing:usa', ['bike:1', 'bike:4'])
 r.sadd('bikes:racing:italy', ['bike:1', 'bike:2', 'bike:3', 'bike:4'])
 
 res14 = r.sinter('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
-puts res14.inspect # ["bike:1"]
+puts res14.inspect # >>> ["bike:1"]
 
 res15 = r.sunion('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
-puts res15.sort.inspect # ["bike:1", "bike:2", "bike:3", "bike:4"]
+puts res15.sort.inspect # >>> ["bike:1", "bike:2", "bike:3", "bike:4"]
 
 res16 = r.sdiff('bikes:racing:france', 'bikes:racing:usa', 'bikes:racing:italy')
-puts res16.inspect # []
+puts res16.inspect # >>> []
 
 res17 = r.sdiff('bikes:racing:france', 'bikes:racing:usa')
-puts res17.sort.inspect # ["bike:2", "bike:3"]
+puts res17.sort.inspect # >>> ["bike:2", "bike:3"]
 
 res18 = r.sdiff('bikes:racing:usa', 'bikes:racing:france')
-puts res18.inspect # ["bike:4"]
+puts res18.inspect # >>> ["bike:4"]
 # STEP_END
 
 # REMOVE_START
@@ -164,16 +164,16 @@ r.del('bikes:racing:france')
 r.sadd('bikes:racing:france', ['bike:1', 'bike:2', 'bike:3', 'bike:4', 'bike:5'])
 
 res19 = r.srem('bikes:racing:france', ['bike:1'])
-puts res19 # 1
+puts res19 # >>> 1
 
 res20 = r.spop('bikes:racing:france')
-puts res20 # bike:3, for example
+puts res20 # >>> bike:3, for example
 
 res21 = r.smembers('bikes:racing:france')
-puts res21.sort.inspect # Remaining members, in no particular order
+puts res21.sort.inspect # >>> Remaining members, in no particular order
 
 res22 = r.srandmember('bikes:racing:france')
-puts res22 # bike:4, for example
+puts res22 # >>> bike:4, for example
 # STEP_END
 
 # REMOVE_START

--- a/local_examples/ruby/dt_sorted_sets.rb
+++ b/local_examples/ruby/dt_sorted_sets.rb
@@ -15,10 +15,10 @@ r.del('racer_scores')
 
 # STEP_START zadd
 res1 = r.zadd('racer_scores', [[10, 'Norem']])
-puts res1 # 1
+puts res1 # >>> 1
 
 res2 = r.zadd('racer_scores', [[12, 'Castilla']])
-puts res2 # 1
+puts res2 # >>> 1
 
 res3 = r.zadd('racer_scores', [
   [8, 'Sam-Bodden'],
@@ -27,7 +27,7 @@ res3 = r.zadd('racer_scores', [
   [14, 'Prickett'],
   [12, 'Castilla']
 ])
-puts res3 # 4
+puts res3 # >>> 4
 # STEP_END
 
 # REMOVE_START
@@ -39,10 +39,10 @@ assert_equal(6, r.zcard('racer_scores'))
 
 # STEP_START zrange
 res4 = r.zrange('racer_scores', 0, -1)
-puts res4.inspect # ["Ford", "Sam-Bodden", "Norem", "Royce", "Castilla", "Prickett"]
+puts res4.inspect # >>> ["Ford", "Sam-Bodden", "Norem", "Royce", "Castilla", "Prickett"]
 
 res5 = r.zrevrange('racer_scores', 0, -1)
-puts res5.inspect # ["Prickett", "Castilla", "Royce", "Norem", "Sam-Bodden", "Ford"]
+puts res5.inspect # >>> ["Prickett", "Castilla", "Royce", "Norem", "Sam-Bodden", "Ford"]
 # STEP_END
 
 # REMOVE_START
@@ -53,7 +53,7 @@ assert_equal(['Prickett', 'Castilla', 'Royce', 'Norem', 'Sam-Bodden', 'Ford'], r
 # STEP_START zrange_withscores
 res6 = r.zrange('racer_scores', 0, -1, with_scores: true)
 puts res6.inspect
-# [["Ford", 6.0], ["Sam-Bodden", 8.0], ["Norem", 10.0], ["Royce", 10.0],
+# >>> [["Ford", 6.0], ["Sam-Bodden", 8.0], ["Norem", 10.0], ["Royce", 10.0],
 #  ["Castilla", 12.0], ["Prickett", 14.0]]
 # STEP_END
 
@@ -70,7 +70,7 @@ assert_equal([
 
 # STEP_START zrangebyscore
 res7 = r.zrangebyscore('racer_scores', '-inf', 10)
-puts res7.inspect # ["Ford", "Sam-Bodden", "Norem", "Royce"]
+puts res7.inspect # >>> ["Ford", "Sam-Bodden", "Norem", "Royce"]
 # STEP_END
 
 # REMOVE_START
@@ -79,13 +79,13 @@ assert_equal(['Ford', 'Sam-Bodden', 'Norem', 'Royce'], res7)
 
 # STEP_START zremrangebyscore
 res8 = r.zrem('racer_scores', ['Castilla'])
-puts res8 # 1
+puts res8 # >>> 1
 
 res9 = r.zremrangebyscore('racer_scores', '-inf', 9)
-puts res9 # 2
+puts res9 # >>> 2
 
 res10 = r.zrange('racer_scores', 0, -1)
-puts res10.inspect # ["Norem", "Royce", "Prickett"]
+puts res10.inspect # >>> ["Norem", "Royce", "Prickett"]
 # STEP_END
 
 # REMOVE_START
@@ -100,10 +100,10 @@ r.del('racer_scores')
 r.zadd('racer_scores', [[10, 'Norem'], [10, 'Royce'], [14, 'Prickett']])
 
 res11 = r.zrank('racer_scores', 'Norem')
-puts res11 # 0
+puts res11 # >>> 0
 
 res12 = r.zrevrank('racer_scores', 'Norem')
-puts res12 # 2
+puts res12 # >>> 2
 # STEP_END
 
 # REMOVE_START
@@ -120,13 +120,13 @@ res13 = r.zadd('racer_scores', [
   [0, 'Prickett'],
   [0, 'Castilla']
 ])
-puts res13 # 3
+puts res13 # >>> 3
 
 res14 = r.zrange('racer_scores', 0, -1)
-puts res14.inspect # ["Castilla", "Ford", "Norem", "Prickett", "Royce", "Sam-Bodden"]
+puts res14.inspect # >>> ["Castilla", "Ford", "Norem", "Prickett", "Royce", "Sam-Bodden"]
 
 res15 = r.zrangebylex('racer_scores', '[A', '[L')
-puts res15.inspect # ["Castilla", "Ford"]
+puts res15.inspect # >>> ["Castilla", "Ford"]
 # STEP_END
 
 # REMOVE_START
@@ -137,19 +137,19 @@ assert_equal(['Castilla', 'Ford'], res15)
 
 # STEP_START leaderboard
 res16 = r.zadd('racer_scores', [[100, 'Wood']])
-puts res16 # 1
+puts res16 # >>> 1
 
 res17 = r.zadd('racer_scores', [[100, 'Henshaw']])
-puts res17 # 1
+puts res17 # >>> 1
 
 res18 = r.zadd('racer_scores', [[150, 'Henshaw']])
-puts res18 # 0
+puts res18 # >>> 0
 
 res19 = r.zincrby('racer_scores', 50, 'Wood')
-puts res19 # 150.0
+puts res19 # >>> 150.0
 
 res20 = r.zincrby('racer_scores', 50, 'Henshaw')
-puts res20 # 200.0
+puts res20 # >>> 200.0
 # STEP_END
 
 # REMOVE_START

--- a/local_examples/ruby/dt_stream.rb
+++ b/local_examples/ruby/dt_stream.rb
@@ -16,7 +16,7 @@ res1 = r.xadd('race:france', {
   'position' => 1,
   'location_id' => 1
 })
-puts res1 # 1692632086370-0, for example
+puts res1 # >>> 1692632086370-0, for example
 
 res2 = r.xadd('race:france', {
   'rider' => 'Norem',
@@ -24,7 +24,7 @@ res2 = r.xadd('race:france', {
   'position' => 3,
   'location_id' => 1
 })
-puts res2 # 1692632094485-0, for example
+puts res2 # >>> 1692632094485-0, for example
 
 res3 = r.xadd('race:france', {
   'rider' => 'Prickett',
@@ -32,7 +32,7 @@ res3 = r.xadd('race:france', {
   'position' => 2,
   'location_id' => 1
 })
-puts res3 # 1692632102976-0, for example
+puts res3 # >>> 1692632102976-0, for example
 # STEP_END
 
 # REMOVE_START
@@ -70,7 +70,7 @@ r.xadd('race:france', {
 # HIDE_END
 res4 = r.xrange('race:france', '1692632086370-0', '+', count: 2)
 puts res4.inspect
-# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
 #  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]
 # STEP_END
 
@@ -86,7 +86,7 @@ r.del('race:france')
 r.xadd('race:france', {'rider' => 'Castilla'}, id: '1692632086370-0')
 # HIDE_END
 res5 = r.xread(['race:france'], ['$'], count: 100, block: 300)
-puts res5.inspect # {}
+puts res5.inspect # >>> {}
 # STEP_END
 
 # REMOVE_START
@@ -100,7 +100,7 @@ res6 = r.xadd('race:france', {
   'position' => 1,
   'location_id' => 2
 })
-puts res6 # 1692632147973-0, for example
+puts res6 # >>> 1692632147973-0, for example
 # STEP_END
 
 # REMOVE_START
@@ -116,7 +116,7 @@ r.xadd('race:france', {'rider' => 'Prickett'}, id: '1692632102976-0')
 r.xadd('race:france', {'rider' => 'Castilla'}, id: '1692632147973-0')
 # HIDE_END
 res7 = r.xlen('race:france')
-puts res7 # 4
+puts res7 # >>> 4
 # STEP_END
 
 # REMOVE_START
@@ -128,10 +128,10 @@ raise 'Expected four stream entries' unless res7 == 4
 r.del('race:usa')
 # HIDE_END
 res8 = r.xadd('race:usa', {'racer' => 'Castilla'}, id: '0-1')
-puts res8 # 0-1
+puts res8 # >>> 0-1
 
 res9 = r.xadd('race:usa', {'racer' => 'Norem'}, id: '0-2')
-puts res9 # 0-2
+puts res9 # >>> 0-2
 # STEP_END
 
 # REMOVE_START
@@ -144,7 +144,7 @@ begin
   r.xadd('race:usa', {'racer' => 'Prickett'}, id: '0-1')
 rescue Redis::CommandError => e
   puts e.message
-  # ERR The ID specified in XADD is equal or smaller than the target stream top item
+  # >>> ERR The ID specified in XADD is equal or smaller than the target stream top item
 end
 # STEP_END
 
@@ -164,7 +164,7 @@ r.xadd('race:usa', {'racer' => 'Castilla'}, id: '0-1')
 r.xadd('race:usa', {'racer' => 'Norem'}, id: '0-2')
 # HIDE_END
 res10 = r.xadd('race:usa', {'racer' => 'Prickett'}, id: '0-*')
-puts res10 # 0-3
+puts res10 # >>> 0-3
 # STEP_END
 
 # REMOVE_START
@@ -181,7 +181,7 @@ r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '
 # HIDE_END
 res11 = r.xrange('race:france', '-', '+')
 puts res11.inspect
-# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
 #  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}],
 #  ["1692632102976-0", {"rider"=>"Prickett", "speed"=>"29.7", "position"=>"2", "location_id"=>"1"}],
 #  ["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
@@ -199,7 +199,7 @@ r.xadd('race:france', {'rider' => 'Norem', 'speed' => '28.8', 'position' => '3',
 # HIDE_END
 res12 = r.xrange('race:france', '1692632086369', '1692632086371')
 puts res12.inspect
-# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}]]
+# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}]]
 # STEP_END
 
 # REMOVE_START
@@ -217,7 +217,7 @@ r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '
 # HIDE_END
 res13 = r.xrange('race:france', '-', '+', count: 2)
 puts res13.inspect
-# [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
 #  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]
 # STEP_END
 
@@ -235,7 +235,7 @@ r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '
 # HIDE_END
 res14 = r.xrange('race:france', '(1692632094485-0', '+', count: 2)
 puts res14.inspect
-# [["1692632102976-0", {"rider"=>"Prickett", "speed"=>"29.7", "position"=>"2", "location_id"=>"1"}],
+# >>> [["1692632102976-0", {"rider"=>"Prickett", "speed"=>"29.7", "position"=>"2", "location_id"=>"1"}],
 #  ["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
 # STEP_END
 
@@ -245,7 +245,7 @@ raise 'Expected second page of two entries' unless res14.map(&:first) == ['16926
 
 # STEP_START xrange_empty
 res15 = r.xrange('race:france', '(1692632147973-0', '+', count: 2)
-puts res15.inspect # []
+puts res15.inspect # >>> []
 # STEP_END
 
 # REMOVE_START
@@ -255,7 +255,7 @@ raise 'Expected no more entries' unless res15.empty?
 # STEP_START xrevrange
 res16 = r.xrevrange('race:france', '+', '-', count: 1)
 puts res16.inspect
-# [["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
+# >>> [["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
 # STEP_END
 
 # REMOVE_START
@@ -265,7 +265,7 @@ raise 'Expected newest entry' unless res16.length == 1 && res16[0][0] == '169263
 # STEP_START xread
 res17 = r.xread(['race:france'], ['0'], count: 2)
 puts res17.inspect
-# {"race:france"=>[["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
+# >>> {"race:france"=>[["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
 #                  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]}
 # STEP_END
 
@@ -279,7 +279,7 @@ r.del('race:france')
 r.xadd('race:france', {'rider' => 'Castilla'}, id: '1692632086370-0')
 # HIDE_END
 res18 = r.xgroup(:create, 'race:france', 'france_riders', '$')
-puts res18 # OK
+puts res18 # >>> OK
 # STEP_END
 
 # REMOVE_START
@@ -291,7 +291,7 @@ raise 'Expected OK' unless res18 == 'OK'
 r.del('race:italy')
 # HIDE_END
 res19 = r.xgroup(:create, 'race:italy', 'italy_riders', '$', mkstream: true)
-puts res19 # OK
+puts res19 # >>> OK
 # STEP_END
 
 # REMOVE_START
@@ -311,7 +311,7 @@ r.xadd('race:italy', {'rider' => 'Norem'}, id: '1692632678249-0')
 
 res20 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['>'], count: 1)
 puts res20.inspect
-# {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
+# >>> {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -321,7 +321,7 @@ raise 'Expected Alice to receive Castilla' unless res20['race:italy'][0][0] == '
 # STEP_START xgroup_read_id
 res21 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['0'], count: 1)
 puts res21.inspect
-# {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
+# >>> {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -330,11 +330,11 @@ raise 'Expected pending Castilla message' unless res21['race:italy'][0][0] == '1
 
 # STEP_START xack
 res22 = r.xack('race:italy', 'italy_riders', '1692632639151-0')
-puts res22 # 1
+puts res22 # >>> 1
 
 res23 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['0'])
 puts res23.inspect
-# {"race:italy"=>[]}
+# >>> {"race:italy"=>[]}
 # STEP_END
 
 # REMOVE_START
@@ -345,7 +345,7 @@ raise 'Expected no pending messages for Alice' unless res23['race:italy'].empty?
 # STEP_START xgroup_read_bob
 res24 = r.xreadgroup('italy_riders', 'Bob', ['race:italy'], ['>'], count: 2)
 puts res24.inspect
-# {"race:italy"=>[["1692632647899-0", {"rider"=>"Royce"}],
+# >>> {"race:italy"=>[["1692632647899-0", {"rider"=>"Royce"}],
 #                 ["1692632662819-0", {"rider"=>"Sam-Bodden"}]]}
 # STEP_END
 
@@ -356,7 +356,7 @@ raise 'Expected Bob to receive two messages' unless res24['race:italy'].map(&:fi
 # STEP_START xpending
 res25 = r.xpending('race:italy', 'italy_riders')
 puts res25.inspect
-# {"size"=>2, "min_entry_id"=>"1692632647899-0", "max_entry_id"=>"1692632662819-0", "consumers"=>{"Bob"=>"2"}}
+# >>> {"size"=>2, "min_entry_id"=>"1692632647899-0", "max_entry_id"=>"1692632662819-0", "consumers"=>{"Bob"=>"2"}}
 # STEP_END
 
 # REMOVE_START
@@ -377,7 +377,7 @@ raise 'Expected Bob ownership' unless res26.all? { |entry| entry['consumer'] == 
 # STEP_START xrange_pending
 res27 = r.xrange('race:italy', '1692632647899-0', '1692632647899-0')
 puts res27.inspect
-# [["1692632647899-0", {"rider"=>"Royce"}]]
+# >>> [["1692632647899-0", {"rider"=>"Royce"}]]
 # STEP_END
 
 # REMOVE_START
@@ -387,7 +387,7 @@ raise 'Expected Royce pending entry' unless res27[0][1]['rider'] == 'Royce'
 # STEP_START xclaim
 res28 = r.xclaim('race:italy', 'italy_riders', 'Alice', 0, '1692632647899-0')
 puts res28.inspect
-# [["1692632647899-0", {"rider"=>"Royce"}]]
+# >>> [["1692632647899-0", {"rider"=>"Royce"}]]
 # STEP_END
 
 # REMOVE_START
@@ -397,7 +397,7 @@ raise 'Expected Alice to claim Royce' unless res28[0][0] == '1692632647899-0'
 # STEP_START xautoclaim
 res29 = r.xautoclaim('race:italy', 'italy_riders', 'Alice', 0, '0-0', count: 1)
 puts res29.inspect
-# {"next"=>"1692632662819-0", "entries"=>[["1692632647899-0", {"rider"=>"Royce"}]]}
+# >>> {"next"=>"1692632662819-0", "entries"=>[["1692632647899-0", {"rider"=>"Royce"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -407,7 +407,7 @@ raise 'Expected autoclaim result' unless res29['entries'].length == 1
 # STEP_START xautoclaim_cursor
 res30 = r.xautoclaim('race:italy', 'italy_riders', 'Lora', 0, res29['next'], count: 1)
 puts res30.inspect
-# {"next"=>"0-0", "entries"=>[["1692632662819-0", {"rider"=>"Sam-Bodden"}]]}
+# >>> {"next"=>"0-0", "entries"=>[["1692632662819-0", {"rider"=>"Sam-Bodden"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -458,11 +458,11 @@ r.xadd('race:italy', {'rider' => 'Wood'}, id: '1692633198206-0', maxlen: 2)
 r.xadd('race:italy', {'rider' => 'Henshaw'}, id: '1692633208557-0', maxlen: 2)
 
 res34 = r.xlen('race:italy')
-puts res34 # 2
+puts res34 # >>> 2
 
 res35 = r.xrange('race:italy', '-', '+')
 puts res35.inspect
-# [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
+# >>> [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
 # STEP_END
 
 # REMOVE_START
@@ -472,7 +472,7 @@ raise 'Expected Wood and Henshaw' unless res35.map { |entry| entry[1]['rider'] }
 
 # STEP_START xtrim
 res36 = r.xtrim('race:italy', 10, approximate: false)
-puts res36 # 0
+puts res36 # >>> 0
 # STEP_END
 
 # REMOVE_START
@@ -487,7 +487,7 @@ r.del('mystream')
 end
 # HIDE_END
 res37 = r.xtrim('mystream', 10, approximate: true)
-puts res37 # 0
+puts res37 # >>> 0
 # STEP_END
 
 # REMOVE_START
@@ -502,14 +502,14 @@ r.xadd('race:italy', {'rider' => 'Henshaw'}, id: '1692633208557-0')
 # HIDE_END
 res38 = r.xrange('race:italy', '-', '+', count: 2)
 puts res38.inspect
-# [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
+# >>> [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
 
 res39 = r.xdel('race:italy', '1692633208557-0')
-puts res39 # 1
+puts res39 # >>> 1
 
 res40 = r.xrange('race:italy', '-', '+', count: 2)
 puts res40.inspect
-# [["1692633198206-0", {"rider"=>"Wood"}]]
+# >>> [["1692633198206-0", {"rider"=>"Wood"}]]
 # STEP_END
 
 # REMOVE_START

--- a/local_examples/ruby/dt_string.rb
+++ b/local_examples/ruby/dt_string.rb
@@ -7,10 +7,10 @@ r = Redis.new
 
 # STEP_START set_get
 res1 = r.set('bike:1', 'Deimos')
-puts res1 # OK
+puts res1 # >>> OK
 
 res2 = r.get('bike:1')
-puts res2 # Deimos
+puts res2 # >>> Deimos
 # STEP_END
 
 # REMOVE_START
@@ -23,12 +23,12 @@ raise "Expected 'Deimos'" unless res2 == 'Deimos'
 r.set('bike:1', 'Deimos')
 
 res3 = r.set('bike:1', 'bike', nx: true)
-puts res3 # false
+puts res3 # >>> false
 
-puts r.get('bike:1') # Deimos
+puts r.get('bike:1') # >>> Deimos
 
 res4 = r.set('bike:1', 'bike', xx: true)
-puts res4 # true
+puts res4 # >>> true
 # STEP_END
 
 # REMOVE_START
@@ -39,10 +39,10 @@ raise "Expected 'bike'" unless r.get('bike:1') == 'bike'
 
 # STEP_START mset
 res5 = r.mset('bike:1', 'Deimos', 'bike:2', 'Ares', 'bike:3', 'Vanth')
-puts res5 # OK
+puts res5 # >>> OK
 
 res6 = r.mget('bike:1', 'bike:2', 'bike:3')
-puts res6.inspect # ["Deimos", "Ares", "Vanth"]
+puts res6.inspect # >>> ["Deimos", "Ares", "Vanth"]
 # STEP_END
 
 # REMOVE_START
@@ -54,10 +54,10 @@ raise 'Expected all bike names' unless res6 == ['Deimos', 'Ares', 'Vanth']
 r.set('total_crashes', 0)
 
 res7 = r.incr('total_crashes')
-puts res7 # 1
+puts res7 # >>> 1
 
 res8 = r.incrby('total_crashes', 10)
-puts res8 # 11
+puts res8 # >>> 11
 # STEP_END
 
 # REMOVE_START


### PR DESCRIPTION
[DOC-7014](https://redislabs.atlassian.net/browse/DOC-7014)

## What

All seven Ruby data-type tutorial files under `local_examples/ruby/` used plain `# value` output comments where every other client file in their sets uses `# >>> value`. `dt_hash.rb` was internally mixed — DOC-6967 added two `>>> `-prefixed steps (`hexpire`, `hpexpire`) while the rest of the file kept the older plain style.

Converted every comment that documents a printed/inspected return value across `dt_hash.rb`, `dt_hyperloglog.rb`, `dt_list.rb`, `dt_sets.rb`, `dt_sorted_sets.rb`, `dt_stream.rb` and `dt_string.rb`. Left untouched:
- Narrative comments (`# Recreate the ... so this example runs on its own.`)
- Caveats already correctly excluded by DOC-6967 (`# (your actual value may vary)`)
- Multi-line output blocks' continuation lines — only the first line of a multi-line value gets `>>> `, matching the convention already used elsewhere (e.g. ioredis's `cmds_stream` example)

Text is otherwise byte-identical; this is a marker change, not a rewrite.

## Verification

- `ss_tutorial`, `set_tutorial`, `hash_tutorial`, `sets_tutorial` → **PASS** via `build/example-test-harness/run.sh ... ruby` (against Redis 8.8.0 in Docker — `hash_tutorial` needs `HEXPIRE`, which the ambient local Redis 7.2.7 lacks).
- `hll_tutorial`, `list_tutorial`, `stream_tutorial` aren't wired into the harness's `src_path` mapping, so ran them directly (`ruby -I <redis-rb-6.0.0> <file>`) — all exit 0, no raised assertion, and printed values match the new `>>> ` comments exactly.
- Local Redis was restored to its original 7.2.7 state afterward.

## Found but not fixed (out of scope for this ticket)

`dt_hash.rb:33` and 26 lines in `dt_stream.rb` document `Hash#inspect` output as `"key"=>"value"` (no spaces), but Ruby 4.0 / redis-rb 6.0.0 actually prints `"key" => "value"` (spaces around the hash rocket) — confirmed by running both files live. This is pre-existing and unrelated to comment *style*; flagging rather than fixing it here, since this ticket is about the `>>> ` marker, not content accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only documentation formatting in example scripts; no runtime, API, or build logic changes.
> 
> **Overview**
> Aligns Ruby data-type tutorial examples with the cross-client convention where documented `puts` / `inspect` results use **`# >>>`** instead of plain **`# value`**.
> 
> The change is comment-only across **`dt_hash.rb`**, **`dt_hyperloglog.rb`**, **`dt_list.rb`**, **`dt_sets.rb`**, **`dt_sorted_sets.rb`**, **`dt_stream.rb`**, and **`dt_string.rb`**. Inline output comments and the first line of multi-line expected-output blocks now prefix with `>>> `; continuation lines of multi-line values stay unprefixed. Narrative setup comments and existing caveat lines (e.g. TTL “may vary”) are unchanged. **`dt_hash.rb`** steps that already used `>>>` (`hexpire` / `hpexpire`) were left as-is; the rest of that file was brought in line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43499f9dedd86f10902ac987b4095fde71c36874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[DOC-7014]: https://redislabs.atlassian.net/browse/DOC-7014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ