### PR TITLE
DOC-7015 Stop HSCAN/HVALS examples depending on hash field order

### DIFF
--- a/local_examples/cmds_generic/node-redis/cmds-generic.js
+++ b/local_examples/cmds_generic/node-redis/cmds-generic.js
@@ -236,17 +236,17 @@ await client.del(['geokey', 'zkey']);
 const scan4Res1 = await client.hSet('myhash', { a: 1, b: 2 });
 console.log(scan4Res1); // 2
 
+// HSCAN doesn't promise a field order, so pair entries into an object rather than
+// relying on position.
 const scan4Res2 = await client.hScan('myhash', '0');
-console.log(scan4Res2.entries); // [{field: 'a', value: '1'}, {field: 'b', value: '2'}]
+const scan4Pairs = Object.fromEntries(scan4Res2.entries.map((e) => [e.field, e.value]));
+console.log(scan4Pairs); // {a: '1', b: '2'}
 // REMOVE_START
-assert.deepEqual(scan4Res2.entries, [
-  { field: 'a', value: '1' },
-  { field: 'b', value: '2' }
-]);
+assert.deepEqual(scan4Pairs, { a: '1', b: '2' });
 // REMOVE_END
 
 const scan4Res3 = await client.hScan('myhash', '0', { COUNT: 10 });
-const items = scan4Res3.entries.map((item) => item.field)
+const items = scan4Res3.entries.map((item) => item.field).sort()
 console.log(items); // ['a', 'b']
 // REMOVE_START
 assert.deepEqual(items, ['a', 'b'])

--- a/local_examples/cmds_generic/redis-py/cmds_generic.py
+++ b/local_examples/cmds_generic/redis-py/cmds_generic.py
@@ -261,10 +261,10 @@ assert keys == {'a': '1', 'b': '2'}
 # REMOVE_END
 
 cursor, keys = r.hscan("myhash", 0, no_values=True)
-print(keys)
+print(sorted(keys))
 # >>> ['a', 'b']
 # REMOVE_START
-assert keys == ['a', 'b']
+assert sorted(keys) == ['a', 'b']
 # REMOVE_END
 
 # REMOVE_START

--- a/local_examples/cmds_hash/node-redis/cmds-hash.js
+++ b/local_examples/cmds_hash/node-redis/cmds-hash.js
@@ -129,7 +129,8 @@ const res12 = await client.hSet(
   }
 )
 
-const res13 = await client.hVals('myhash')
+// HVALS follows the hash's field order, which Redis does not promise, so sort.
+const res13 = (await client.hVals('myhash')).sort()
 console.log(res13) // [ 'Hello', 'World' ]
 
 // REMOVE_START

--- a/local_examples/cmds_hash/predis/CmdsHashTest.php
+++ b/local_examples/cmds_hash/predis/CmdsHashTest.php
@@ -133,7 +133,9 @@ class CmdsHashTest extends TestCase
         $hValsResult1 = $this->redis->hmset('myhash', ['field1' => 'Hello', 'field2' => 'World']);
         echo "HMSET myhash field1 Hello field2 World: " . ($hValsResult1 ? 'OK' : 'FAIL') . "\n"; // >>> OK
 
+        // HVALS follows the hash's field order, which Redis does not promise, so sort.
         $hValsResult2 = $this->redis->hvals('myhash');
+        sort($hValsResult2);
         echo "HVALS myhash: " . json_encode($hValsResult2) . "\n"; // >>> ["Hello","World"]
         // STEP_END
 

--- a/local_examples/cmds_hash/redis-py/cmds_hash.py
+++ b/local_examples/cmds_hash/redis-py/cmds_hash.py
@@ -110,11 +110,12 @@ r.delete("myhash")
 # STEP_START hvals
 res10 = r.hset("myhash", mapping={"field1": "Hello", "field2": "World"})
 
+# HVALS follows the hash's field order, which Redis does not promise, so sort.
 res11 = r.hvals("myhash")
-print(res11) # >>> [ "Hello", "World" ]
+print(sorted(res11)) # >>> [ "Hello", "World" ]
 
 # REMOVE_START
-assert res11 == [ "Hello", "World" ]
+assert sorted(res11) == [ "Hello", "World" ]
 r.delete("myhash")
 # REMOVE_END
 # STEP_END

--- a/local_examples/cmds_hash/ruby/cmds_hash.rb
+++ b/local_examples/cmds_hash/ruby/cmds_hash.rb
@@ -107,7 +107,8 @@ r.del('myhash')
 # STEP_START hvals
 r.hset('myhash', { 'field1' => 'Hello', 'field2' => 'World' })
 
-res15 = r.hvals('myhash')
+# HVALS follows the hash's field order, which Redis does not promise, so sort.
+res15 = r.hvals('myhash').sort
 puts res15.inspect # >>> ["Hello", "World"]
 # STEP_END
 

--- a/local_examples/ruby/dt_hash.rb
+++ b/local_examples/ruby/dt_hash.rb
@@ -30,7 +30,7 @@ puts res3 # >>> 4972
 
 res4 = r.hgetall('bike:1')
 puts res4.inspect
-# >>> {"model"=>"Deimos", "brand"=>"Ergonom", "type"=>"Enduro bikes", "price"=>"4972"}
+# >>> {"model" => "Deimos", "brand" => "Ergonom", "type" => "Enduro bikes", "price" => "4972"}
 # STEP_END
 
 # REMOVE_START

--- a/local_examples/ruby/dt_stream.rb
+++ b/local_examples/ruby/dt_stream.rb
@@ -70,8 +70,8 @@ r.xadd('race:france', {
 # HIDE_END
 res4 = r.xrange('race:france', '1692632086370-0', '+', count: 2)
 puts res4.inspect
-# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
-#  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]
+# >>> [["1692632086370-0", {"rider" => "Castilla", "speed" => "30.2", "position" => "1", "location_id" => "1"}],
+#  ["1692632094485-0", {"rider" => "Norem", "speed" => "28.8", "position" => "3", "location_id" => "1"}]]
 # STEP_END
 
 # REMOVE_START
@@ -181,10 +181,10 @@ r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '
 # HIDE_END
 res11 = r.xrange('race:france', '-', '+')
 puts res11.inspect
-# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
-#  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}],
-#  ["1692632102976-0", {"rider"=>"Prickett", "speed"=>"29.7", "position"=>"2", "location_id"=>"1"}],
-#  ["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
+# >>> [["1692632086370-0", {"rider" => "Castilla", "speed" => "30.2", "position" => "1", "location_id" => "1"}],
+#  ["1692632094485-0", {"rider" => "Norem", "speed" => "28.8", "position" => "3", "location_id" => "1"}],
+#  ["1692632102976-0", {"rider" => "Prickett", "speed" => "29.7", "position" => "2", "location_id" => "1"}],
+#  ["1692632147973-0", {"rider" => "Castilla", "speed" => "29.9", "position" => "1", "location_id" => "2"}]]
 # STEP_END
 
 # REMOVE_START
@@ -199,7 +199,7 @@ r.xadd('race:france', {'rider' => 'Norem', 'speed' => '28.8', 'position' => '3',
 # HIDE_END
 res12 = r.xrange('race:france', '1692632086369', '1692632086371')
 puts res12.inspect
-# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}]]
+# >>> [["1692632086370-0", {"rider" => "Castilla", "speed" => "30.2", "position" => "1", "location_id" => "1"}]]
 # STEP_END
 
 # REMOVE_START
@@ -217,8 +217,8 @@ r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '
 # HIDE_END
 res13 = r.xrange('race:france', '-', '+', count: 2)
 puts res13.inspect
-# >>> [["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
-#  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]
+# >>> [["1692632086370-0", {"rider" => "Castilla", "speed" => "30.2", "position" => "1", "location_id" => "1"}],
+#  ["1692632094485-0", {"rider" => "Norem", "speed" => "28.8", "position" => "3", "location_id" => "1"}]]
 # STEP_END
 
 # REMOVE_START
@@ -235,8 +235,8 @@ r.xadd('race:france', {'rider' => 'Castilla', 'speed' => '29.9', 'position' => '
 # HIDE_END
 res14 = r.xrange('race:france', '(1692632094485-0', '+', count: 2)
 puts res14.inspect
-# >>> [["1692632102976-0", {"rider"=>"Prickett", "speed"=>"29.7", "position"=>"2", "location_id"=>"1"}],
-#  ["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
+# >>> [["1692632102976-0", {"rider" => "Prickett", "speed" => "29.7", "position" => "2", "location_id" => "1"}],
+#  ["1692632147973-0", {"rider" => "Castilla", "speed" => "29.9", "position" => "1", "location_id" => "2"}]]
 # STEP_END
 
 # REMOVE_START
@@ -255,7 +255,7 @@ raise 'Expected no more entries' unless res15.empty?
 # STEP_START xrevrange
 res16 = r.xrevrange('race:france', '+', '-', count: 1)
 puts res16.inspect
-# >>> [["1692632147973-0", {"rider"=>"Castilla", "speed"=>"29.9", "position"=>"1", "location_id"=>"2"}]]
+# >>> [["1692632147973-0", {"rider" => "Castilla", "speed" => "29.9", "position" => "1", "location_id" => "2"}]]
 # STEP_END
 
 # REMOVE_START
@@ -265,8 +265,8 @@ raise 'Expected newest entry' unless res16.length == 1 && res16[0][0] == '169263
 # STEP_START xread
 res17 = r.xread(['race:france'], ['0'], count: 2)
 puts res17.inspect
-# >>> {"race:france"=>[["1692632086370-0", {"rider"=>"Castilla", "speed"=>"30.2", "position"=>"1", "location_id"=>"1"}],
-#                  ["1692632094485-0", {"rider"=>"Norem", "speed"=>"28.8", "position"=>"3", "location_id"=>"1"}]]}
+# >>> {"race:france"=>[["1692632086370-0", {"rider" => "Castilla", "speed" => "30.2", "position" => "1", "location_id" => "1"}],
+#                  ["1692632094485-0", {"rider" => "Norem", "speed" => "28.8", "position" => "3", "location_id" => "1"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -311,7 +311,7 @@ r.xadd('race:italy', {'rider' => 'Norem'}, id: '1692632678249-0')
 
 res20 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['>'], count: 1)
 puts res20.inspect
-# >>> {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
+# >>> {"race:italy"=>[["1692632639151-0", {"rider" => "Castilla"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -321,7 +321,7 @@ raise 'Expected Alice to receive Castilla' unless res20['race:italy'][0][0] == '
 # STEP_START xgroup_read_id
 res21 = r.xreadgroup('italy_riders', 'Alice', ['race:italy'], ['0'], count: 1)
 puts res21.inspect
-# >>> {"race:italy"=>[["1692632639151-0", {"rider"=>"Castilla"}]]}
+# >>> {"race:italy"=>[["1692632639151-0", {"rider" => "Castilla"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -345,8 +345,8 @@ raise 'Expected no pending messages for Alice' unless res23['race:italy'].empty?
 # STEP_START xgroup_read_bob
 res24 = r.xreadgroup('italy_riders', 'Bob', ['race:italy'], ['>'], count: 2)
 puts res24.inspect
-# >>> {"race:italy"=>[["1692632647899-0", {"rider"=>"Royce"}],
-#                 ["1692632662819-0", {"rider"=>"Sam-Bodden"}]]}
+# >>> {"race:italy"=>[["1692632647899-0", {"rider" => "Royce"}],
+#                 ["1692632662819-0", {"rider" => "Sam-Bodden"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -356,7 +356,7 @@ raise 'Expected Bob to receive two messages' unless res24['race:italy'].map(&:fi
 # STEP_START xpending
 res25 = r.xpending('race:italy', 'italy_riders')
 puts res25.inspect
-# >>> {"size"=>2, "min_entry_id"=>"1692632647899-0", "max_entry_id"=>"1692632662819-0", "consumers"=>{"Bob"=>"2"}}
+# >>> {"size"=>2, "min_entry_id" => "1692632647899-0", "max_entry_id" => "1692632662819-0", "consumers"=>{"Bob" => "2"}}
 # STEP_END
 
 # REMOVE_START
@@ -377,7 +377,7 @@ raise 'Expected Bob ownership' unless res26.all? { |entry| entry['consumer'] == 
 # STEP_START xrange_pending
 res27 = r.xrange('race:italy', '1692632647899-0', '1692632647899-0')
 puts res27.inspect
-# >>> [["1692632647899-0", {"rider"=>"Royce"}]]
+# >>> [["1692632647899-0", {"rider" => "Royce"}]]
 # STEP_END
 
 # REMOVE_START
@@ -387,7 +387,7 @@ raise 'Expected Royce pending entry' unless res27[0][1]['rider'] == 'Royce'
 # STEP_START xclaim
 res28 = r.xclaim('race:italy', 'italy_riders', 'Alice', 0, '1692632647899-0')
 puts res28.inspect
-# >>> [["1692632647899-0", {"rider"=>"Royce"}]]
+# >>> [["1692632647899-0", {"rider" => "Royce"}]]
 # STEP_END
 
 # REMOVE_START
@@ -397,7 +397,7 @@ raise 'Expected Alice to claim Royce' unless res28[0][0] == '1692632647899-0'
 # STEP_START xautoclaim
 res29 = r.xautoclaim('race:italy', 'italy_riders', 'Alice', 0, '0-0', count: 1)
 puts res29.inspect
-# >>> {"next"=>"1692632662819-0", "entries"=>[["1692632647899-0", {"rider"=>"Royce"}]]}
+# >>> {"next" => "1692632662819-0", "entries"=>[["1692632647899-0", {"rider" => "Royce"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -407,7 +407,7 @@ raise 'Expected autoclaim result' unless res29['entries'].length == 1
 # STEP_START xautoclaim_cursor
 res30 = r.xautoclaim('race:italy', 'italy_riders', 'Lora', 0, res29['next'], count: 1)
 puts res30.inspect
-# >>> {"next"=>"0-0", "entries"=>[["1692632662819-0", {"rider"=>"Sam-Bodden"}]]}
+# >>> {"next" => "0-0", "entries"=>[["1692632662819-0", {"rider" => "Sam-Bodden"}]]}
 # STEP_END
 
 # REMOVE_START
@@ -462,7 +462,7 @@ puts res34 # >>> 2
 
 res35 = r.xrange('race:italy', '-', '+')
 puts res35.inspect
-# >>> [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
+# >>> [["1692633198206-0", {"rider" => "Wood"}], ["1692633208557-0", {"rider" => "Henshaw"}]]
 # STEP_END
 
 # REMOVE_START
@@ -502,14 +502,14 @@ r.xadd('race:italy', {'rider' => 'Henshaw'}, id: '1692633208557-0')
 # HIDE_END
 res38 = r.xrange('race:italy', '-', '+', count: 2)
 puts res38.inspect
-# >>> [["1692633198206-0", {"rider"=>"Wood"}], ["1692633208557-0", {"rider"=>"Henshaw"}]]
+# >>> [["1692633198206-0", {"rider" => "Wood"}], ["1692633208557-0", {"rider" => "Henshaw"}]]
 
 res39 = r.xdel('race:italy', '1692633208557-0')
 puts res39 # >>> 1
 
 res40 = r.xrange('race:italy', '-', '+', count: 2)
 puts res40.inspect
-# >>> [["1692633198206-0", {"rider"=>"Wood"}]]
+# >>> [["1692633198206-0", {"rider" => "Wood"}]]
 # STEP_END
 
 # REMOVE_START


### PR DESCRIPTION
[DOC-7015](https://redislabs.atlassian.net/browse/DOC-7015)

## What

Redis doesn't guarantee hash field order under hashtable encoding. Forced `hash-max-listpack-entries` to `0` and confirmed (5 trials each, both encodings) six still-fragile assertions across the five clients this ticket named:

- **redis-py**: `cmds_generic` scan4's HSCAN NOVALUES list, `cmds_hash`'s HVALS
- **node-redis**: `cmds_generic` scan4's HSCAN entries and NOVALUES list, `cmds_hash`'s HVALS
- **predis**: `cmds_hash`'s HVALS
- **ruby**: `cmds_hash`'s HVALS

Fixed each by sorting (field-name lists and HVALS values) or pairing HSCAN's structured entries into an object (node-redis's scan4), matching the established ioredis/Go pattern from DOC-6968. **lettuce-reactive needed no changes** — its scan4 and HVALS were already sorted; DOC-6968's list of five affected clients had that one stale.

## Folded in from DOC-7014

`dt_hash.rb` and `dt_stream.rb` documented Ruby `Hash#inspect` output as `"key"=>"value"` (no spaces), but Ruby 4.0 prints `"key" => "value"`. Fixed all 27 lines, verified against a live run.

⚠️ This branch predates DOC-7014's merge, so these exact lines will conflict with DOC-7014's `>>> ` prefix change when both land — trivial to resolve (apply both edits), but flagging so it's not a surprise.

## Two unrelated bugs found, not fixed here

1. **`cmds_generic`'s scan2 step is inherently flaky.** It asserts the last of five sequential SCAN calls returns exactly 18 matches. That split isn't guaranteed — reproduced `0,0,0,0,19` and `1,0,0,1,17` splits across repeated fresh Redis 8.8 instances, never landing on DOC-6968's originally observed `0,0,0,1,18`. This blocks every full-script run of `cmds_generic` for redis-py, lettuce-reactive and predis (an uncaught exception halts the script before scan4 ever runs) — node-redis is accidentally immune because its equivalent check uses `console.assert`, which doesn't throw. Verifying this ticket's actual scan4/HVALS targets required isolated snippets that skip scan1-3 entirely.
2. **Maven's surefire runs stale compiled classes.** `work/lettuce-reactive/target/test-classes/` still had a `HashExample.class` from an unrelated, earlier build; `run_maven_java`'s cleanup only removes stale `.java` sources, not compiled classes, so surefire ran it alongside the current test and produced a spurious, unrelated failure. Removing the stale `.class` file fixed it for this session — the harness doesn't clean `target/` between runs, so it will recur.

Both are captured as `Gaps` trailers on the commit for follow-up tickets.

## Verification

- Each fix isolated and run 5 times under forced hashtable encoding (`hash-max-listpack-entries=0`) against a fresh Redis 8.8 container — all pass.
- Re-verified under default (listpack) encoding — all pass.
- Ran the full modified files through `build/example-test-harness/run.sh` under both encodings (`cmds_hash` for all 4 fixed clients, `hash_tutorial`/`stream_tutorial` for ruby) — all PASS.
- Local Redis restored to its original 7.2.7 state afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOC-7015]: https://redislabs.atlassian.net/browse/DOC-7015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to local example scripts and expected-output comments; no application or library runtime behavior is modified.
> 
> **Overview**
> Makes Redis client **documentation examples** deterministic where Redis does not guarantee hash field order, and updates Ruby sample output for **Ruby 4.0** `Hash#inspect` formatting.
> 
> **HSCAN / HVALS (DOC-7015):** In `cmds_generic` **scan4**, node-redis now builds an object from HSCAN entries instead of asserting entry order, and both node-redis and redis-py **sort** field-name lists for NOVALUES-style checks. **HVALS** steps in node-redis, redis-py, predis, and ruby **sort** returned values (with brief comments) before print/assert, matching the existing ioredis/Go approach.
> 
> **Ruby inspect (folded from DOC-7014):** Comment-only fixes in `dt_hash.rb` and `dt_stream.rb` change documented `inspect` strings from `"key"=>"value"` to `"key" => "value"` so examples match Ruby 4.0 output; runtime assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7012a20001336481a3e012652d914eac1ead30cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->