### PR TITLE
AGENTS.md: fix relref build-failure claim, add .md-extension rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,8 +55,9 @@ around a literal, rewrite the sentence.
 ## Site mechanics
 
 - **Cross-references use the relref shortcode**, not markdown paths:
-  `{{< relref "/operate/rs/clusters/new-cluster-setup" >}}`. A broken relref fails the
-  build. Link text is descriptive — never "click here" or a bare URL.
+  `{{< relref "/operate/rs/clusters/new-cluster-setup" >}}`. The path never ends in
+  `.md`. A broken relref warns at build time and must still be fixed — it resolves to
+  the wrong page or a 404. Link text is descriptive — never "click here" or a bare URL.
 - **Preserve shortcodes, frontmatter, and code fences verbatim.** Do not reformat them.
 - **Frontmatter**: copy the shape from a sibling page in the same directory rather than
   composing one. `title` and `linkTitle` are effectively universal; `description`,


### PR DESCRIPTION
## Summary
- Corrects `AGENTS.md`'s claim that a broken relref fails the build — it only warns, per David's earlier finding in #3826 (never pushed before that PR merged).
- Adds a new rule: relref paths never carry a `.md` extension.

## Test plan
- [ ] Docs review (infra-only change, no SME gate needed — same as #3826)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to contributor conventions; no runtime, security, or product behavior impact.
> 
> **Overview**
> Updates **Site mechanics** guidance for Hugo `relref` cross-references in `AGENTS.md`.
> 
> **Broken relrefs** are described accurately: they **warn at build time** rather than failing the build, while still requiring a fix because they can land on the wrong page or a 404.
> 
> A new rule states that **relref paths must not end in `.md`**, with the example path unchanged. The bullet is also reformatted from a nested continuation line into a single block under the cross-reference item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72414eb6ab42b17fd687665945dc99c89068b53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->