### PR TITLE
MOD-17977 Document Phase-2 deterministic PII exclusions for Cloud

### DIFF
--- a/content/develop/ai/context-engine/agent-memory/developer-guide.md
+++ b/content/develop/ai/context-engine/agent-memory/developer-guide.md
@@ -120,13 +120,18 @@ See [memory configuration]({{< relref "/operate/iris/agent-memory/create-service
 
 ### Exclude sensitive data from automatic extraction
 
-Semantic exclusions guide Redis Agent Memory away from storing specified information in long-term memory during automatic extraction. Define an exclusion prompt in the service configuration using plain-language categories such as passwords, access tokens, recovery codes, payment card information, or booking confirmation codes.
+Sensitive-data exclusions keep specified information out of long-term memory when Redis Agent Memory creates or updates memories through automatic extraction — built-in extraction, a custom memory type's extraction strategy, or the session summary view.
 
-Exclusions apply to automatic extraction from session events. They do not apply when an application creates long-term memories directly.
+* **Semantic exclusions** guide the extraction model with a plain-language prompt, using categories such as passwords, access tokens, recovery codes, payment card information, or booking confirmation codes. They are advisory: they steer the model, but don't guarantee that sensitive content is excluded.
+* **Built-in and custom detectors** deterministically scan each candidate memory's text, string-valued attribute fields, and topics, and redact or drop the memory according to the detector's configured action.
+
+None of these mechanisms apply when an application creates or updates long-term memories directly through the API or an SDK — direct writes bypass automatic extraction entirely, so nothing scans them.
 
 {{< warning >}}
-Semantic exclusions are advisory and do not guarantee exclusion. Sensitive session content still reaches the extraction model provider. Use appropriate controls before sending sensitive information to Redis Agent Memory or the model provider.
+Semantic exclusions are advisory and do not guarantee exclusion — sensitive session content still reaches the extraction model provider. Built-in and custom detectors are deterministic, but only for memories created through automatic extraction; long-term memories created or updated directly through the API or an SDK are never scanned by any exclusion mechanism. Use appropriate controls before sending sensitive information to Redis Agent Memory, the model provider, or a direct long-term-memory write.
 {{< /warning >}}
+
+Changing your exclusion configuration only affects memories created or updated afterward. Existing long-term memories are not re-evaluated, and there is no way to remove only the memories that match your exclusions.
 
 See [sensitive-data exclusions]({{< relref "/operate/iris/agent-memory/create-service#sensitive-data-exclusions" >}}) to configure the feature in Redis Cloud.
 

--- a/content/operate/iris/agent-memory/create-service.md
+++ b/content/operate/iris/agent-memory/create-service.md
@@ -157,7 +157,7 @@ Each custom memory type can have an **extraction strategy** that controls how th
 
 ### Sensitive-data exclusions {#sensitive-data-exclusions}
 
-The **Sensitive-data exclusions** section lets you define information that should not be kept in long-term memory.
+The **Sensitive-data exclusions** section lets you define information that should not be kept in long-term memory, using three independent mechanisms: a semantic exclusion prompt, built-in detectors, and custom detectors.
 
 {{< note >}}
 Sensitive-data exclusions are an early-stage feature, enabled for selected accounts. If you want to try them, contact your Redis representative or [contact sales](https://redis.io/contact/).
@@ -178,11 +178,71 @@ For example, a prompt might tell the pipeline never to keep passwords, access to
 
 Where useful context remains, the extraction model prefers a generalized memory that omits the excluded details rather than dropping the memory entirely. For example, "The user's card ending 4242 was declined" can become "The user had a payment failure".
 
-Semantic exclusions are applied when long-term memories are created from a session. Session memory is unaffected: events and their summaries are kept as sent.
+{{<warning>}}
+Semantic exclusions are **advisory**. They steer the extraction model, but they do not guarantee that sensitive content is excluded, and sensitive session content still reaches the extraction model provider. Do not rely on semantic exclusions as your only control for regulated or highly sensitive data.
+{{</warning>}}
+
+#### Built-in detectors {#built-in-detectors}
+
+Built-in detectors match common categories of personal data, such as email addresses or credit card numbers, using Redis-maintained detection logic. Unlike semantic exclusions, a built-in detector's action always applies to a match — it does not depend on model judgment. They are disabled by default.
+
+| Setting name          |Description|
+|:----------------------|:----------|
+| **Built-in detectors** | Whether built-in detectors are applied when memories are extracted. Disabled by default. |
+| **Detector** | One or more detectors selected from the [detector catalog](#detector-catalog). |
+| **Action** | What happens when the detector matches. See [Redact or drop matches](#redact-or-drop-matches). Default: **Redact**. |
+
+#### Custom detectors {#custom-detectors}
+
+Custom detectors let you match patterns specific to your application, such as an internal account-number format, using regular expressions. They are disabled by default.
+
+| Setting name          |Description|
+|:----------------------|:----------|
+| **Custom detectors** | Whether custom detectors are applied when memories are extracted. Disabled by default. |
+| **Name** | A unique name for the detector. Must start with a letter and contain only letters, numbers, hyphens, or underscores (1–64 characters). Cannot match the name of a built-in detector. |
+| **Pattern** | A regular expression that matches the content you want to exclude. |
+| **Action** | What happens when the detector matches. See [Redact or drop matches](#redact-or-drop-matches). Default: **Redact**. |
+
+You can define up to **32 custom detectors** per service.
+
+{{< note >}}
+Custom detector patterns use [RE2](https://github.com/google/re2/wiki/Syntax) syntax and cannot use lookahead, lookbehind, or backreferences. Many PII regex patterns published online rely on lookahead and need to be rewritten to work here. A pattern can be up to 512 characters, must compile, and must match at least one character — a pattern that can match an empty string (such as `\b` or `a*` on its own) is rejected because it would match everywhere in the text and exclude every memory.
+{{< /note >}}
+
+#### Redact or drop matches {#redact-or-drop-matches}
+
+Each built-in and custom detector has an action that controls what happens when it matches:
+
+- **Redact** (default): Replace the matched text with a placeholder and keep the rest of the memory.
+- **Drop**: Discard the memory entirely.
+
+If more than one detector matches the same memory and their actions disagree, **drop** takes precedence.
+
+#### Detector catalog {#detector-catalog}
+
+Detector ids are lowercase, hyphen-separated identifiers (`^[a-z0-9]+(-[a-z0-9]+)*$`), with a jurisdiction prefix when the detector is specific to one jurisdiction (for example, `us-ssn`). Rely on a detector's id — not a specific catalog version — to stay stable across releases: if a detector is ever renamed or retired, a service that already selected it keeps working.
+
+Each detector is tuned to avoid false positives, since a false match silently discards a real memory. Every entry below states what it deliberately does not catch.
+
+| Id | Matches | Known limitation |
+|:---|:---|:---|
+| `email` | Email addresses. | Doesn't match addresses with non-ASCII (internationalized) characters. |
+| `credit-card` | Card numbers for Visa, Mastercard, American Express, Discover, JCB, Diners Club, and UnionPay, confirmed with a checksum. Digits can be separated by spaces or hyphens. | Doesn't match Maestro cards. |
+| `us-ssn` | US Social Security numbers. | Matched on their own only in the standard `123-45-6789` format. Other formats are matched only when nearby text mentions "SSN" or "social security". |
+| `phone` | Phone numbers for the US, Canada, the UK, Germany, Israel, India, and Brazil. | Doesn't cover other countries. A plain run of digits with no formatting is matched only when nearby text mentions a phone number. |
+| `ip-address` | IPv4 and IPv6 addresses. | Doesn't match CIDR network ranges or loopback addresses. |
+
+#### Where exclusions apply {#where-exclusions-apply}
+
+Semantic exclusions and detectors (built-in and custom) apply only to memories that Redis Agent Memory creates or updates through automatic extraction — built-in extraction, a custom memory type's extraction strategy, or the session summary view. Detectors scan a candidate memory's text, its string-valued attribute fields, and its topics.
 
 {{<warning>}}
-Semantic exclusions are **advisory**. They steer the extraction model, but they do not guarantee that sensitive content is excluded. Sensitive session content still reaches the extraction model provider, and they are not applied to long-term memories your application creates directly through the API or an SDK. Do not rely on semantic exclusions as your only control for regulated or highly sensitive data.
+Long-term memories your application creates or updates directly through the API or an SDK bypass this pipeline entirely. Semantic exclusions and detectors are never applied to them, so they are not deterministically filtered.
 {{</warning>}}
+
+Session memory, including automatic summarization, is never evaluated by any exclusion mechanism — it's session-scoped and expires with the short-term TTL.
+
+Changing your exclusion configuration only affects memories created or updated afterward. Existing long-term memories are not re-evaluated. If a detector configured to drop matches an update to an existing memory, the entire update is discarded and the previous version of the memory remains stored. The only way to remove memories stored before you configured exclusions is to [flush the service]({{< relref "/operate/iris/agent-memory/view-service#flush-memory-entries" >}}), which erases all of the service's stored memory data.
 
 ### Create service
 

--- a/content/operate/iris/agent-memory/view-service.md
+++ b/content/operate/iris/agent-memory/view-service.md
@@ -111,13 +111,15 @@ Sensitive-data exclusions are an early-stage feature, enabled for selected accou
 |:----------------------|:----------|
 | **Semantic exclusions** | Whether semantic exclusions are applied when memories are extracted. _(Editable)_ |
 | **Exclusion prompt** | The plain-language description of what should never be kept in long-term memory. Required when semantic exclusions are enabled. _(Editable)_ |
+| **Built-in detectors** | Whether [built-in detectors]({{< relref "/operate/iris/agent-memory/create-service#built-in-detectors" >}}) are applied when memories are extracted. _(Editable)_ |
+| **Custom detectors** | Whether [custom detectors]({{< relref "/operate/iris/agent-memory/create-service#custom-detectors" >}}) are applied when memories are extracted. _(Editable)_ |
 
-Turning semantic exclusions off keeps the exclusion prompt you saved, so you can turn them back on later without retyping it.
+Turning off a semantic, built-in, or custom exclusion group keeps its saved settings, so you can turn it back on later without reconfiguring it.
 
-Changing exclusions affects memories extracted after you save. Memories already in long-term memory are not re-evaluated, and there is no way to remove only the memories that match your exclusions. The only way to clear memories stored before you configured exclusions is to [flush the service](#flush-memory-entries), which permanently erases all of the service's stored memory data.
+Changing exclusions affects memories created or updated after you save. Memories already in long-term memory are not re-evaluated, and there is no way to remove only the memories that match your exclusions. If a detector configured to drop matches an update to an existing memory, the update is discarded and the previous version of the memory remains stored. The only way to clear memories stored before you configured exclusions is to [flush the service](#flush-memory-entries), which permanently erases all of the service's stored memory data.
 
 {{<warning>}}
-Semantic exclusions are **advisory**. They steer the extraction model, but they do not guarantee that sensitive content is excluded. Do not rely on semantic exclusions as your only control for regulated or highly sensitive data.
+Semantic exclusions are **advisory** and do not guarantee that sensitive content is excluded. Built-in and custom detectors are deterministic, but — like semantic exclusions — they only apply to memories created through automatic extraction. Long-term memories your application creates or updates directly through the API or an SDK are never scanned by any exclusion mechanism. See [Where exclusions apply]({{< relref "/operate/iris/agent-memory/create-service#where-exclusions-apply" >}}) for details.
 {{</warning>}}
 
 ### Actions


### PR DESCRIPTION
Ticket: [MOD-17977](https://redislabs.atlassian.net/browse/MOD-17977) (epic: [MOD-17268](https://redislabs.atlassian.net/browse/MOD-17268))

Extends the Phase 1 semantic-exclusions docs ([MOD-17269](https://redislabs.atlassian.net/browse/MOD-17269), PR #3760) with the Phase-2 deterministic mechanisms: built-in detectors, custom regex detectors, and the customer-facing detector catalog.

## What this adds

- **`create-service.md`** — **Built-in detectors** and **Custom detectors** subsections (selection/authoring, redact-vs-drop action), a **Redact or drop matches** subsection (drop wins on conflict), a customer-facing **Detector catalog** table (id, what it matches, known limitation — sourced from the TDD's Appendix F and `catalog.go`), and a **Where exclusions apply** section.
- **`view-service.md`** — extends the read/edit settings table and warning with the two new detector groups.
- **`developer-guide.md`** — updates the developer-facing "Exclude sensitive data from automatic extraction" section with the same three-mechanism framing.

## Scope and guarantees — the part that must not be soft

- Deterministic enforcement (built-in + custom detectors) applies only to memories created or updated through automatic extraction (built-in extraction, custom-type extraction, session summary view).
- Direct/manual long-term-memory writes through the API or an SDK bypass this pipeline entirely and are **not** deterministically filtered — called out explicitly since it's the gap most likely to be mistaken for a bug.
- Detectors scan a candidate's `text`, string-valued `attributes`, and `topics`.
- A `drop` on an update can leave a stale memory in long-term storage — documented as accepted behavior, not a defect.
- Session summarization (session-scoped/TTL'd) stays out of scope.

## Detector catalog

Five detectors ship: `email`, `credit-card`, `us-ssn`, `phone`, `ip-address`. Each entry states its known limitation as documentation, consistent with the catalog's precision-over-recall design (a false positive silently discards a real memory). Id convention (`^[a-z0-9]+(-[a-z0-9]+)*$`, jurisdiction-prefixed) is documented as the compatibility surface, not the catalog version.

Custom detector limits (max 32 per service, 512-char patterns, RE2 syntax with no lookahead/lookbehind/backreferences) are called out with a note, since RE2's lack of lookahead is likely the most common support question — most published PII regex patterns use lookahead.

## Out of scope

- On-prem chart/guide documentation for the detector fields ([MOD-17976](https://redislabs.atlassian.net/browse/MOD-17976)) — ships with the on-prem surface itself.
- The engineering-repo documentation criteria (`docs/dataplane-metrics.md`, `docs/tdd/sensitive-data-exclusions.md`) live in the `iris` repo, not this one. Verified both are already up to date on `iris`'s `main` (the exclusions metrics and TDD open questions are filled in as part of the MOD-17152/MOD-17154/MOD-17156 implementation), so no action was needed there.
- No new screenshots: the Phase-2 Cloud UI ([MOD-17155](https://redislabs.atlassian.net/browse/MOD-17155)) is still in review and not yet merged, so the new subsections describe settings without images, consistent with how they're modeled in the underlying config (`LongTermMemoryExclusionsConfig`).

## Verification

`.claude/hooks/check_shortcode_paths.py --scan` on the three changed files reports 0 broken file refs, 0 broken relref links. All new in-page anchors (`#built-in-detectors`, `#custom-detectors`, `#redact-or-drop-matches`, `#detector-catalog`, `#where-exclusions-apply`) have matching explicit heading ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOD-17977]: https://redislabs.atlassian.net/browse/MOD-17977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-17268]: https://redislabs.atlassian.net/browse/MOD-17268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-17269]: https://redislabs.atlassian.net/browse/MOD-17269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MOD-17976]: https://redislabs.atlassian.net/browse/MOD-17976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Agent Memory guides; no runtime or application code is modified.
> 
> **Overview**
> Extends Redis Agent Memory **sensitive-data exclusions** docs beyond Phase 1 semantic prompts to cover **built-in detectors**, **custom RE2 regex detectors**, and a customer-facing **detector catalog** (`email`, `credit-card`, `us-ssn`, `phone`, `ip-address`), plus **redact vs drop** behavior (drop wins on conflict).
> 
> **`create-service.md`** adds the bulk of the new material: configuration tables, RE2/limits (32 custom detectors, 512-char patterns), **where exclusions apply** (automatic extraction only; scans `text`, string attributes, and `topics`), and explicit gaps—direct API/SDK long-term writes and session memory are never scanned; config changes are forward-only; a drop on update leaves the previous memory version.
> 
> **`view-service.md`** and **`developer-guide.md`** align with the same three-mechanism model, updated warnings, and view/edit settings for the detector toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e076ad7400b7307d6eddffbf457215b86982b0e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->