### PR TITLE
RC:Document GCP custom routes behavior for VPC peering

### DIFF
--- a/content/operate/rc/security/vpc-peering.md
+++ b/content/operate/rc/security/vpc-peering.md
@@ -124,6 +124,10 @@ To set up VPC peering:
 
     {{<image filename="images/rc/subscription-connectivity-vpc-peering-gcp.png" width="350px" alt="View VPC peering list." >}}
 
+{{< note >}}
+Redis Cloud enables **Import custom routes** by default on its side of the peering connection. If you want Redis Cloud to import custom routes from your application VPC (for example, to reach Redis Cloud from other networks connected to your application VPC), you must also enable **Export custom routes** on your application VPC. Otherwise, custom routes from your application VPC aren't imported and you may experience connectivity issues.
+{{< /note >}}
+
 ### Approve VPC peering request {#approve-gcp-vpc-peering}
 
 To approve the VPC peering request between Redis Cloud and Google Cloud, use the [`gcloud` CLI](https://cloud.google.com/sdk/gcloud) to run the **Google cloud command** that you copied before you initiated VPC peering.


### PR DESCRIPTION
Explain that Redis Cloud enables Import custom routes by default, but customers must enable Export custom routes on their application VPC for those routes to actually be imported. Addresses connectivity issues reported by customers using the application VPC as a jump station to Redis.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security impact.
> 
> **Overview**
> Adds a **note** in the Google Cloud VPC peering section of `vpc-peering.md`, placed after initiating peering and before approving the request.
> 
> The note states that Redis Cloud turns on **Import custom routes** on its side by default, and that customers must enable **Export custom routes** on their application VPC if they need those routes imported (for example when reaching Redis Cloud via other networks behind the app VPC). Without export on the customer side, custom routes are not imported and connectivity can fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57133bc49ad06fc0746e2a1c3d1638ef50355e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->