### PR TITLE
RC: Doc 6624 clarify number of connections

### DIFF
--- a/content/operate/rc/subscriptions/_index.md
+++ b/content/operate/rc/subscriptions/_index.md
@@ -27,7 +27,7 @@ Here's a quick comparison of each plan:
 | Feature | Redis Cloud Essentials (free) | Redis Cloud Essentials (paid) | Essentials with Redis Flex | Redis Cloud Pro |
 |:---:|:---:|:---:|:---:|:---:|
 | Memory size | 30 MB | 250 MB-12 GB | 1 GB-100GB | 50 TB |
-| Concurrent connections | 30 | 256-10000 | 1024-10000 | Unlimited |
+| Concurrent connections | 30 | 256-10000 | 1024-10000 | No fixed database-level limit.<br/>Actual capacity depends on infrastructure, database configuration, and workload characteristics.<br/>Additional connections may be limited when infrastructure capacity is reached to preserve service stability. |
 | Security | Role-based auth<br/>Password protection<br/>Encryption in transit | Role-based auth<br/>Password protection<br/>TLS auth<br/>Encryption in transit | Role-based auth<br/>Password protection<br/>TLS auth<br/>Encryption in transit | Role-based auth<br/>Password protection<br/>TLS auth<br/>Encryption in transit<br/>Encryption at rest<br/>Private Connectivity |
 | REST API | No | Yes | Yes | Yes |
 | Selected additional features<br/> <br/> <br/> |  | Replication<br/>Auto-failover<br /> | Replication<br/>Auto-failover<br /> | Dedicated accounts<br>Redis Flex<br/>Active/Active<br/> |

--- a/content/operate/rc/subscriptions/_index.md
+++ b/content/operate/rc/subscriptions/_index.md
@@ -58,7 +58,7 @@ See [Create a Redis Flex database]({{< relref "/operate/rc/databases/create-data
 - [View and upgrade Essentials or Flex plan]({{< relref "/operate/rc/subscriptions/view-essentials-subscription" >}})
 
 ### Redis Cloud Pro
-Redis Cloud Pro supports more databases, larger databases, greater throughput, and unlimited connections compared to Redis Cloud Essentials. Hosted in dedicated VPCs, they feature high-availability in a single or multi-AZ, Active-Active, clustering, data persistence, and configurable backups.  Pricing is "pay as you go" to support any dataset size or throughput. [Redis Flex]({{< relref "/operate/rc/databases/create-database/create-flex-database" >}}) is also available on Redis Cloud Pro.
+Redis Cloud Pro supports more databases, larger databases, greater throughput, and no fixed database-level connection limit compared to Redis Cloud Essentials. Hosted in dedicated VPCs, they feature high-availability in a single or multi-AZ, Active-Active, clustering, data persistence, and configurable backups.  Pricing is "pay as you go" to support any dataset size or throughput. [Redis Flex]({{< relref "/operate/rc/databases/create-database/create-flex-database" >}}) is also available on Redis Cloud Pro.
 
 Redis Cloud Pro annual plans support the same features as Redis Cloud Pro but at significant savings. Annual plans also provide Premium support. The underlying commitment applies to all workloads across multiple providers and regions.
 


### PR DESCRIPTION
clarification for No. of connections Redis Cloud Pro 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification on the subscriptions page; no product or code behavior changes.
> 
> **Overview**
> Updates **Redis Cloud Pro** connection wording on the subscriptions overview so it no longer claims **“Unlimited”** concurrent connections.
> 
> The plan comparison table now states there is **no fixed database-level limit**, and that real capacity depends on infrastructure, database configuration, and workload, with possible throttling when capacity is reached for stability. The **Redis Cloud Pro** section intro is aligned to **“no fixed database-level connection limit”** instead of **“unlimited connections.”**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5874542d488e8e3119c78fd005a45fdc3e53c88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->