### PR TITLE
RC: Note RDI pipeline CIDR requirement for target database allow lists

### DIFF
--- a/content/operate/rc/security/cidr-whitelist.md
+++ b/content/operate/rc/security/cidr-whitelist.md
@@ -48,6 +48,10 @@ To define the CIDR allow list for a database:
 The database CIDR allow list applies to both the public endpoint and the private endpoint. If you use connectivity options such as [VPC Peering]({{< relref "/operate/rc/security/vpc-peering" >}}) and [Transit Gateway]({{< relref "/operate/rc/security/aws-transit-gateway" >}}) to connect to your database via the private endpoint, you must also add those IPs to your database's CIDR allow list.
 {{< /note >}}
 
+{{< note >}}
+If the target database has a CIDR allow list, you must add the Redis Data Integration (RDI) pipeline's CIDR to the target database's CIDR allow list. Otherwise, the RDI pipeline can't access the database. The RDI pipeline's CIDR is displayed in the [**Workspace details**]({{< relref "/operate/rc/rdi/create-workspace" >}}) modal.
+{{< /note >}}
+
 ## Continue learning with Redis University
 
 {{< university-links >}}

--- a/content/operate/rc/security/cidr-whitelist.md
+++ b/content/operate/rc/security/cidr-whitelist.md
@@ -48,6 +48,7 @@ To define the CIDR allow list for a database:
 The database CIDR allow list applies to both the public endpoint and the private endpoint. If you use connectivity options such as [VPC Peering]({{< relref "/operate/rc/security/vpc-peering" >}}) and [Transit Gateway]({{< relref "/operate/rc/security/aws-transit-gateway" >}}) to connect to your database via the private endpoint, you must also add those IPs to your database's CIDR allow list.
 {{< /note >}}
 
+&nbsp;
 {{< note >}}
 If the target database has a CIDR allow list, you must add the Redis Data Integration (RDI) pipeline's CIDR to the target database's CIDR allow list. Otherwise, the RDI pipeline can't access the database. The RDI pipeline's CIDR is displayed in the [**Workspace details**]({{< relref "/operate/rc/rdi/create-workspace" >}}) modal.
 {{< /note >}}


### PR DESCRIPTION
Explain that when a target database has a CIDR allow list, the RDI pipeline's CIDR must be added to it or the pipeline can't reach the database, and link to where that CIDR is shown in Workspace details.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Redis Cloud CIDR allow list guidance; no runtime or security logic changes.
> 
> **Overview**
> Adds a **CIDR allow list** doc note for Redis Data Integration: when the **target database** uses an allow list, operators must include the **RDI pipeline's CIDR** on that list so the pipeline can connect.
> 
> The note states that failure to add it blocks pipeline access and points readers to the [**Workspace details**]({{< relref "/operate/rc/rdi/create-workspace" >}}) modal for the pipeline CIDR value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4978c350f401e24889397c08ee4b0d65d47ed11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->