### PR TITLE
RC: Fix prometheus.yml indentation and note Infinity plugin requirement

### DIFF
--- a/content/integrate/prometheus-with-redis-cloud/_index.md
+++ b/content/integrate/prometheus-with-redis-cloud/_index.md
@@ -85,14 +85,14 @@ To get started with custom monitoring with Prometheus on Docker:
 
     scrape_configs:
         # scrape Prometheus itself
-        - job_name: prometheus
+      - job_name: prometheus
         scrape_interval: 10s
         scrape_timeout: 5s
         static_configs:
           - targets: ["localhost:9090"]
 
         # scrape Redis Cloud
-        - job_name: redis-cloud
+      - job_name: redis-cloud
         scrape_interval: 30s
         scrape_timeout: 30s
         metrics_path: /  # For v2, use /v2
@@ -184,6 +184,10 @@ Redis publishes preconfigured dashboards for Redis Cloud and Grafana:
 * The [subscription status dashboard](https://grafana.com/grafana/dashboards/18406-subscription-status-dashboard/) provides an overview of your Redis Cloud subscriptions.
 * The [database status dashboard](https://grafana.com/grafana/dashboards/18407-database-status-dashboard/) displays specific database metrics, including latency, memory usage, ops/second, and key count.
 * The [Active-Active dashboard](https://github.com/redis-field-engineering/redis-enterprise-observability/blob/main/grafana/dashboards/grafana_v9-11/cloud/basic/redis-cloud-active-active-dashboard_v9-11.json) displays metrics specific to [Active-Active databases]({{< relref "/operate/rc/databases/active-active" >}}).
+
+{{< note >}}
+The database status dashboard requires the Infinity data source plugin. Install it from **Connections > Add new connection**, search for **Infinity**, and add it as a data source before importing the dashboard.
+{{< /note >}}
 
 These dashboards are open source. For additional dashboard options, or to file an issue, see the [Redis Enterprise observability Github repository](https://github.com/redis-field-engineering/redis-enterprise-observability/tree/main/grafana).
 


### PR DESCRIPTION
The scrape_configs job_name entries were indented to align with field names instead of the list marker, which is invalid YAML and prevents the Prometheus container from starting. Also note that the database status Grafana dashboard requires installing the Infinity data source plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to an integration how-to; no runtime, auth, or application code is affected.
> 
> **Overview**
> Updates the **Prometheus & Grafana with Redis Cloud** integration guide so the sample `prometheus.yml` uses valid YAML for `scrape_configs`: the `prometheus` and `redis-cloud` jobs are list items under `scrape_configs` instead of being indented like sibling keys, which would block the Prometheus container from starting when users copy the file.
> 
> Adds a short **note** in the Grafana dashboards section that the database status dashboard needs the **Infinity** data source plugin, with steps to add it via **Connections > Add new connection** before import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d023cdc71c37730ccb5038e6ad0a08c2a6448a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->