### PR TITLE
Clarify Multi-AZ requires a region with at least three availability z…

### DIFF
--- a/content/operate/rc/databases/configuration/high-availability.md
+++ b/content/operate/rc/databases/configuration/high-availability.md
@@ -73,6 +73,10 @@ For all other AWS clusters, select an availability zone ID from the **Zone IDs**
 
 {{<image filename="images/rc/availability-zones-aws-hosted-no-multi-az.png" width="80%" alt="For hosted AWS clusters, select availability zone IDs from the Zone IDs list." >}}
 
+{{< note >}}
+Multi-AZ requires a region with at least three availability zones. Regions with fewer than three availability zones don't support Multi-AZ deployments.
+{{< /note >}}
+
 If **Multi-AZ** is enabled, you must select three availability zones from the list.
 
 {{<image filename="images/rc/availability-zones-multi-az.png" width="80%" alt="Select Manual selection to select three availability zones when Multi-AZ is enabled." >}}


### PR DESCRIPTION
…ones

The requirement was only implied by "select three availability zones," not stated as a prerequisite. Add an explicit note so regions with fewer than three AZs are clearly called out as unsupported for Multi-AZ deployments.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification with no runtime or configuration behavior changes.
> 
> **Overview**
> Adds a **note** in the **Availability zones** section of `high-availability.md`, directly before the Multi-AZ zone-selection steps.
> 
> The note states that **Multi-AZ needs a region with at least three availability zones**, and that regions with fewer than three AZs **cannot** use Multi-AZ—making the prerequisite explicit instead of relying only on “select three availability zones.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88321bbae518dcc624984ac101f9178a7ef11a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->