### PR TITLE
Add a Copy commands button to the workbench

### DIFF
--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -1035,15 +1035,12 @@
        paste into a redis-cli of their own. The transcript holds replies and
        prompts as well, so copying that would need editing before it ran.
 
-       The session, not the view. "Clear terminal" next to it clears what is
-       printed — a display action, where "Clear keys" is the one that destroys
-       something and asks first — so tying the copy to what happens to be on
-       screen would make tidying up quietly throw work away, and `clear` in
-       redis-cli does not drop its history either. The tooltip says so, because
-       the reader cannot see what they are getting. */
+       What is on screen, no more: a copy that quietly included commands cleared
+       from the transcript surprised the first person to try it, and a button
+       whose result cannot be seen is a button that has to be trusted. Clearing
+       is how the reader says "not that" — see forgetRanCommands. */
     this.copyButton = this.button(COPY_LABEL,
-      'Copy every command run in this session, including any cleared from the '
-      + 'transcript — ready to paste into redis-cli',
+      'Copy the commands in the terminal, ready to paste into redis-cli',
       function () { self.copyCommands(); });
     terminalTools.appendChild(this.copyButton);
     this.terminalToolbar = terminalTools;
@@ -1598,6 +1595,19 @@
      for the label and restore that, leaving the button stuck on it. */
   var COPY_LABEL = 'Copy commands';
 
+  /* An emptied transcript empties what "Copy commands" would hand over, so the
+     two always agree.
+
+     Read off the transcript rather than hooked to the toolbar button: `clear`
+     typed at the prompt is handled inside the widget, which never tells anyone,
+     so a button-only rule would leave the copy full and the screen blank — the
+     surprise this is here to remove. Whatever empties it, this follows. */
+  dock.forgetRanCommands = function () {
+    if (!this.terminalForm) return;
+    var transcript = this.terminalForm.querySelector('pre');
+    if (transcript && transcript.childNodes.length === 0) this.ranCommands = [];
+  };
+
   dock.copyCommands = function () {
     var button = this.copyButton;
     var commands = this.ranCommands;
@@ -1730,6 +1740,7 @@
     if (this.transcriptWatcher) this.transcriptWatcher.disconnect();
     this.transcriptWatcher = new MutationObserver(function () {
       if (self.following) self.scrollTerminal();
+      self.forgetRanCommands();
     });
     this.transcriptWatcher.observe(form,
       { childList: true, subtree: true, characterData: true });

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -51,6 +51,10 @@
      every multi-command probe here is chunked to that. */
   var MAX_BATCH = 20;
 
+  /* How many of the reader's commands to keep for copying. A session that has run
+     more than this is past the point where a paste is the useful thing. */
+  var MAX_RAN_COMMANDS = 200;
+
   /* Batch origin label, for the backend's usage metrics. Introspection is not a
      command the reader chose to run, so it is reported separately from
      'interactive' (typed) and 'tryit' (a snippet the reader asked for) and
@@ -867,6 +871,7 @@
     indexDocs: null,
     /* Page setups already run in this sandbox session, by name. */
     setupRan: {},
+    ranCommands: [],
     selected: null,
     truncated: false,
     /* command batches seen while closed, discovered at first open */
@@ -995,6 +1000,12 @@
          reports only what a reader or a page started — but the guard says which
          batches this is about. */
       if (batch.source !== SOURCE) self.clearIndexFilter();
+      /* A record of what the reader ran, which is what "Copy commands" hands
+         over. Introspection and the widget's own startup are not that. */
+      if (batch.source !== SOURCE && batch.source !== 'internal') {
+        self.ranCommands = self.ranCommands.concat(batch.commands)
+          .slice(-MAX_RAN_COMMANDS);
+      }
       self.observe(batch.commands);
     });
 
@@ -1020,6 +1031,13 @@
        history. Neither reaches into the other. */
     terminalTools.appendChild(this.button('Clear terminal', 'Clear the terminal transcript',
       function () { cli().clear(self.terminalForm); }));
+    /* The way out of the sandbox: what the reader has run here, as lines they can
+       paste into a redis-cli of their own. The transcript holds replies and
+       prompts as well, so copying that would need editing before it ran. */
+    this.copyButton = this.button(COPY_LABEL,
+      'Copy every command run here, ready to paste into redis-cli',
+      function () { self.copyCommands(); });
+    terminalTools.appendChild(this.copyButton);
     this.terminalToolbar = terminalTools;
     this.terminalPane.appendChild(terminalTools);
 
@@ -1563,6 +1581,41 @@
      so a command typed at the wrong moment cannot land in front of it. FLUSHDB
      mints a fresh session on this backend and is intercepted before Redis, so the
      ACL's -flushdb never applies. */
+  /* Hand the session's commands to the clipboard, one per line. Said on the
+     button itself rather than in the status line: the reader is looking at what
+     they just clicked.
+
+     The label is the constant, never the button's current text: read live, a
+     second click landing inside the 1.6s window would take "12 commands copied"
+     for the label and restore that, leaving the button stuck on it. */
+  var COPY_LABEL = 'Copy commands';
+
+  dock.copyCommands = function () {
+    var button = this.copyButton;
+    var commands = this.ranCommands;
+
+    function say(message) {
+      if (!button) return;
+      button.textContent = message;
+      button.disabled = true;
+      window.setTimeout(function () {
+        button.textContent = COPY_LABEL;
+        button.disabled = false;
+      }, 1600);
+    }
+
+    if (!commands.length) return say('Nothing run yet');
+    var text = commands.join('\n') + '\n';
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      return say('Cannot copy here');
+    }
+    navigator.clipboard.writeText(text).then(function () {
+      say(plural(commands.length, 'command') + ' copied');
+    }, function () {
+      say('Cannot copy here');
+    });
+  };
+
   /* "Clear keys" is the one control here that destroys something, and what it
      destroys took a snippet to make: a reader who hits it by accident has to go
      back up the page and find the "Try it" that filled the sandbox. So it asks

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -1033,9 +1033,17 @@
       function () { cli().clear(self.terminalForm); }));
     /* The way out of the sandbox: what the reader has run here, as lines they can
        paste into a redis-cli of their own. The transcript holds replies and
-       prompts as well, so copying that would need editing before it ran. */
+       prompts as well, so copying that would need editing before it ran.
+
+       The session, not the view. "Clear terminal" next to it clears what is
+       printed — a display action, where "Clear keys" is the one that destroys
+       something and asks first — so tying the copy to what happens to be on
+       screen would make tidying up quietly throw work away, and `clear` in
+       redis-cli does not drop its history either. The tooltip says so, because
+       the reader cannot see what they are getting. */
     this.copyButton = this.button(COPY_LABEL,
-      'Copy every command run here, ready to paste into redis-cli',
+      'Copy every command run in this session, including any cleared from the '
+      + 'transcript — ready to paste into redis-cli',
       function () { self.copyCommands(); });
     terminalTools.appendChild(this.copyButton);
     this.terminalToolbar = terminalTools;


### PR DESCRIPTION
The sandbox is a place to try things, not to keep them: a reader who has followed a page's examples has a keyspace they built and no way to take the work with them. Copying the transcript does not do it — it holds the prompts and the replies too, so it needs editing before it will run.

So the toolbar hands over the commands themselves, one per line, ready to paste into a redis-cli. Both what the reader typed and what a "Try it" ran, in the order they ran, capped at the last 200: a session longer than that is past the point where a paste is the useful thing.

Not the dock's own keyspace probing. COMMAND GETKEYS, TYPE, TTL and FT._LIST are how the key browser knows what to show, and nobody wants them in their paste — they run under the 'workbench' source, which is also how the backend keeps them out of a page's metrics.

The button says what happened on itself rather than in the status line — "2 commands copied", "Nothing run yet", "Cannot copy here" where the browser has no clipboard API — because that is where the reader is looking. The label it restores is a constant, not the text it read when clicked: read live, a second click inside the 1.6s window would take "2 commands copied" for the label and leave the button stuck on it.

Verified against a live sandbox: two typed commands and a Try it snippet come back as six lines with no probes among them, the empty case is reported, and a double click settles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only workbench UX using the Clipboard API; no server, auth, or data-model changes.
> 
> **Overview**
> Readers can export what they ran in the sandbox as **redis-cli–ready lines** (one command per line), instead of copying the transcript with prompts and replies.
> 
> The workbench records commands from **interactive** and **Try it** batches in `ranCommands` (last **200**), and skips **`workbench`** introspection and **`internal`** startup traffic. A new **Copy commands** button on the terminal toolbar writes that list via the Clipboard API and shows short feedback on the button itself (“2 commands copied”, “Nothing run yet”, “Cannot copy here”).
> 
> **Clear terminal** stays aligned with copy: when the transcript `<pre>` is emptied (toolbar clear or `clear` at the prompt), `forgetRanCommands` clears the stored list via the existing transcript `MutationObserver`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aef1277286fe277ccf82959a37065740421dfcaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->