### PR TITLE
Keep the workbench off /develop/

### DIFF
--- a/layouts/develop/list.html
+++ b/layouts/develop/list.html
@@ -1,6 +1,15 @@
 {{ define "head" }}
   {{ partial "cli-assets.html" . }}
   <script src='{{ relURL "js/codetabs.js" }}' defer></script>
+  {{- /* No workbench on /develop/ itself. The Redis CLI shown there is a picture
+         of one — a block of commands with their output, to show what Redis looks
+         like — and a docked console along the bottom of the page is a console the
+         page never asked for. Only this page: the children under /develop/ use
+         the same layout and are ordinary docs pages, examples and all. See
+         pageBarsCli in js/redis-workbench.js. */ -}}
+  {{- if strings.HasSuffix .RelPermalink "/develop/" }}
+  <script>window.REDIS_WORKBENCH_NEVER = true;</script>
+  {{- end }}
 {{ end }}
 
 {{ define "main" }}

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2569,17 +2569,34 @@
     return window.REDIS_WORKBENCH_ALWAYS === true;
   }
 
+  /* And some pages say no. /develop/ is a landing page whose Redis CLI is a
+     picture of one — a block of commands and their output, there to show what
+     Redis looks like rather than to be run — and the dock's own bar along the
+     bottom of it adds a console the page never asked for. The template says so,
+     for the same reason as above: Hugo knows which page this is and the browser
+     only knows a path that changes per environment. See layouts/develop/list.html.
+
+     Declining outright, not just staying closed: nothing mounts, so there is no
+     bar, no session and no keyspace probing from here. A "Try it" added to such a
+     page later still works — RedisWorkbench.open() reports that it cannot run,
+     and the caller opens redis.io/cli as it did before the dock existed. */
+  function pageBarsCli() {
+    return window.REDIS_WORKBENCH_NEVER === true;
+  }
+
   /* Does this page have anything for a terminal to run? The CLI blocks and their
      "Try it" buttons, and not the notebook's — a client page's Try it carries
      .thebe-tryit and opens a cell in the notebook pane, which has nothing to do
      with the sandbox terminal. */
   function pageHasCli() {
+    if (pageBarsCli()) return false;
     if (pageWantsCli()) return true;
     return !!document.querySelector(
       'form.redis-cli, .redis-cli-static, .tryit-button:not(.thebe-tryit)');
   }
 
   function pageHasRedis() {
+    if (pageBarsCli()) return false;
     if (pageWantsCli()) return true;
     /* `.thebe-container` is in here for the notebook pane: a client page can have
        runnable cells and no CLI terminal at all. */
@@ -2625,7 +2642,11 @@
            on is fetched from the /cli backend, so a click in the moment before it
            lands used to be answered by opening redis.io/cli in another tab —
            the reader's first click being the one that leaves the page. Wait for
-           it instead, and only fall back if it never arrives. */
+           it instead, and only fall back if it never arrives.
+
+           A page that bars the dock is the exception: no waiting, because no
+           amount of it will produce one. */
+        if (pageBarsCli()) return false;
         if (window.REDIS_CLI_LOADING) {
           waitForWidget(options);
           return true;


### PR DESCRIPTION
This change hides the workbench on the /develop/ landing page