### PR TITLE
Document Redis-managed repo backup storage type

### DIFF
--- a/content/operate/rc/databases/back-up-data.md
+++ b/content/operate/rc/databases/back-up-data.md
@@ -51,7 +51,7 @@ When you enable **Remote backup**, additional options appear.  The options vary 
 | **Interval** | Defines the frequency of automatic backups.  Paid Redis Cloud Essentials databases are backed up every 24 hours.  Redis Cloud Pro databases can be set to 24, 12, 6, 4, 2, or 1 hour backup intervals. |
 | **Set backup time** | When checked, this lets you set the hour of the **Backup time**. (_Redis Cloud Pro only_) |
 | **Backup time** | Defines the hour automatic backups are made.  Note that actual backup times will vary up in order to minimize customer access disruptions.  (_Redis Cloud Pro only_)<br/> Times are expressed in [Coordinated Universal Time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) (UTC).|
-| **Storage type** | Defines the provider of the storage location, which can be: `AWS S3`, `Google Cloud Storage`, `Azure Blob Storage`, or `FTP` (FTPS). |
+| **Storage type** | Defines the provider of the storage location, which can be: `AWS S3`, `Google Cloud Storage`, `Azure Blob Storage`, `FTP` (FTPS), or `Redis-managed repo`. `Redis-managed repo` is only available for databases created through the [Heroku]({{< relref "/operate/rc/cloud-integrations/heroku" >}}) or [Vercel]({{< relref "/operate/rc/cloud-integrations/vercel" >}}) integrations. |
 | **Backup destination** | Defines a URI representing the backup storage location. |
 
 ## Back up and export data on demand


### PR DESCRIPTION
Add the missing Redis-managed repo option to the Storage type setting, available only for databases created through the Heroku or Vercel integrations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a backup settings table; no product or runtime behavior.
> 
> **Overview**
> Updates the **Storage type** row in the remote backup settings table on `back-up-data.md` so the documented options match the console.
> 
> The **Storage type** description now includes **`Redis-managed repo`** alongside the existing cloud and FTP options, with a note that **`Redis-managed repo`** is only available for databases created via the **Heroku** and **Vercel** integrations (linked to the existing integration docs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d173f72b9d1ecf6f63020368b73874c11b78c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->