### PR TITLE
Document Flex best practices and limitations

### DIFF
--- a/content/operate/rc/databases/create-database/create-flex-database.md
+++ b/content/operate/rc/databases/create-database/create-flex-database.md
@@ -32,6 +32,24 @@ Flex is **not** a durable data store. It is designed for performance, elasticity
 
 For workloads that require durability and recovery across restarts or failures, use Redis Cloud's [Data persistence]({{< relref "/operate/rc/databases/configuration/data-persistence" >}}) features.
 
+## Best practices and limitations
+
+### RAM percentage
+
+On Redis Cloud Essentials, the RAM percentage for Flex plans is fixed at 10% and can't be changed. On Redis Cloud Pro, you can select a RAM percentage between 10% and 50% when you create your database. See [Choosing the right RAM ratio](https://support.redislabs.com/hc/en-us/articles/36437338181522-Redis-Flex-V2-Choosing-the-Right-RAM-Ratio-and-Troubleshooting-Performance) for guidance on selecting a RAM percentage.
+
+### Key and value sizes
+
+Similar to best practices for in-memory Redis, we recommend storing relatively small keys and values in Flex. If possible, avoid large objects (>10 KB).
+
+Depending on your application's traffic pattern, using large objects might decrease performance, since the entire value is moved from RAM to Flash storage and vice versa.
+
+Flex databases cannot store keys or values larger than 4 GB in Flash storage. Keys or values larger than 4 GB are stored in RAM only, and warnings appear in the Redis logs similar to:
+
+```
+# WARNING: key too big for disk driver, size: 4703717276, key: subactinfo:htable
+```
+
 ## Create a Flex database 
 
 ### Redis Cloud Essentials

--- a/content/operate/rc/databases/create-database/create-flex-database.md
+++ b/content/operate/rc/databases/create-database/create-flex-database.md
@@ -44,7 +44,7 @@ Similar to best practices for in-memory Redis, we recommend storing relatively s
 
 Depending on your application's traffic pattern, using large objects might decrease performance, since the entire value is moved from RAM to Flash storage and vice versa.
 
-Flex databases cannot store keys or values larger than 4 GB in Flash storage. Keys or values larger than 4 GB are stored in RAM only, and warnings appear in the Redis logs similar to:
+Flex databases cannot store keys or values larger than 4 GB in Flash storage. Keys or values larger than 4 GB are stored in RAM only, and will generate warnings like the following in the Redis logs:
 
 ```
 # WARNING: key too big for disk driver, size: 4703717276, key: subactinfo:htable


### PR DESCRIPTION
Add key/value size guidance and the 4 GB Flash storage limit (larger values fall back to RAM-only with a log warning), plus clarify that the Essentials RAM percentage is fixed at 10% versus Pro's configurable 10-50% range.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or configuration behavior changes.
> 
> **Overview**
> Adds a **Best practices and limitations** section to the Redis Cloud Flex database creation guide, before the existing create steps.
> 
> It documents **RAM percentage** rules: Essentials Flex is fixed at 10% (not configurable), while Pro allows 10–50% at creation, with a link to support guidance on choosing a ratio.
> 
> It adds **key and value size** guidance: prefer small objects (avoid >10 KB) because tiering moves whole values between RAM and Flash; Flash cannot hold keys/values over **4 GB** (those stay RAM-only and log a `key too big for disk driver` warning), including an example log line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5b43f8c6b694c588c177d9f7366cd4767c2e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->