### PR TITLE
DOC-7045: Fix dead academic-source link and the link checker that missed it

### DIFF
--- a/.github/workflows/link_check.yaml
+++ b/.github/workflows/link_check.yaml
@@ -66,7 +66,12 @@ jobs:
 
       - name: Check links
         id: lychee
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
+        # Must postdate lychee-action#330 (auto-detect lychee bin in a subfolder,
+        # 2026-04-24): the previously pinned SHA predated that fix, so its
+        # installer assumed the v0.24.2 release tarball extracts flat. It doesn't,
+        # so every run since this workflow was added crashed before checking a
+        # single link. See DOC-7045.
+        uses: lycheeverse/lychee-action@649b0e4890508ea3e11ea6b3ee35ce899a25afd5
         with:
           # Pin the lychee binary: the action's own default lags, and the
           # host_concurrency / host_request_interval keys in .lychee.toml need >= 0.24.

--- a/content/develop/data-types/probabilistic/count-min-sketch.md
+++ b/content/develop/data-types/probabilistic/count-min-sketch.md
@@ -121,7 +121,7 @@ Adding, updating and querying for elements in a CMS has a time complexity O(1).
 
 
 ## Academic sources
-- [An Improved Data Stream Summary: The Count-Min Sketch and its Applications](http://dimacs.rutgers.edu/~graham/pubs/papers/cm-full.pdf)
+- [An Improved Data Stream Summary: The Count-Min Sketch and its Applications](https://doi.org/10.1016/j.jalgor.2003.12.001)
 
 ## References
 - [Count-Min Sketch: The Art and Science of Estimating Stuff](https://redis.com/blog/count-min-sketch-the-art-and-science-of-estimating-stuff/)


### PR DESCRIPTION
## Summary
- Replace the dead `dimacs.rutgers.edu` PDF link in the Count-Min Sketch page's Academic sources section with the paper's DOI (`https://doi.org/10.1016/j.jalgor.2003.12.001`), which resolves.
- Re-pin `lycheeverse/lychee-action` to a commit that postdates its fix for the v0.24.2 tarball's subfolder layout. The previously pinned SHA predated that fix, so the "Check links" step crashed in its own installer on every scheduled run since the workflow was added — before checking a single URL — and because the crash happened before the "flag broken links" step, no tracking issue was ever opened either. That's why the dead PDF link went unreported; it wasn't a PDF-specific gap in the checker's link validation.

## Test plan
- [ ] After merge, manually trigger the `link_check` workflow (`gh workflow run link_check.yaml`) and confirm the "Check links" step completes instead of failing in the lychee-action installer.
- [x] Confirmed the new DOI link resolves (302 → publisher article page) and the old link 404s.
- [x] Confirmed the re-pinned SHA's `action.yml` contains the subfolder-detection fix.

Fixes DOC-7045.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation URL swap and a third-party GitHub Action SHA bump; no application, auth, or data-handling changes.
> 
> **Overview**
> **Fixes DOC-7045** by addressing both the broken citation and the CI step that never reported it.
> 
> The Count-Min Sketch **Academic sources** entry now points at the paper’s **DOI** (`https://doi.org/10.1016/j.jalgor.2003.12.001`) instead of a **404** `dimacs.rutgers.edu` PDF URL.
> 
> The **`link_check`** workflow re-pins **`lycheeverse/lychee-action`** to a commit after the installer fix for **v0.24.2** tarballs that extract into a subfolder. The old pin assumed a flat layout, so **Check links** failed during install on every run and never validated URLs or opened tracking issues—explaining why the dead PDF went unnoticed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ced929ca288fba0aca8acf7e22a822a81f6403e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->