### PR TITLE
Added Beekeeper Studio to third-party client tools section

### DIFF
--- a/content/develop/tools/_index.md
+++ b/content/develop/tools/_index.md
@@ -62,3 +62,18 @@ The tools above are maintained by Redis. The tools below are maintained by their
 * Server, client, and slow command views built from `INFO`, `CLIENT LIST`, and `SLOWLOG GET`.
 
 It connects to a single standalone node over an unencrypted connection: Cluster, Sentinel, and TLS are not supported. Commands carry the privileges of the user you connect as, so read-only access has to come from a Redis ACL rather than from the tool.
+
+### Beekeeper Studio
+
+[Beekeeper Studio](https://www.beekeeperstudio.io) Beekeeper Studio is a free, open-source database manager that supports a range of databases like Redis, MongoDB, PostgreSQL, MySQL and more.
+Beekeeper Studio is a desktop app, and is available for Linux, macOS, and Windows with full feature parity across all operating systems. 
+
+Redis support includes
+
+* A command console with autocomplete, history, saved commands, and multi-tab editing, plus an AI assistant that can turn natural-language questions into Redis commands.
+* A spreadsheet-style key browser for browsing, filtering, and editing values, including JSON documents via the ReJSON module.
+* One-click export of query results to CSV, Excel, or JSON.
+
+It connects to a Redis server directly or over an SSH tunnel, with TLS/SSL supported, and authenticates with either a password or a username and password against Redis 6+ ACLs.
+
+[Download for free on their website](https://beekeeperstudio.io/get)


### PR DESCRIPTION
Adds Beekeeper Studio to the "Third-party tools" section of the Client
tools page, alongside the existing LibreDB Studio entry.

Beekeeper Studio added Redis support in v5.4 (command console, key
browser, ReJSON support) and isn't currently listed among the
community-maintained clients on this page.

I'm affiliated with Beekeeper Studio and an operations manager. If you have any questions, please let me know.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition to the client tools index; no product code or runtime behavior changes.
> 
> **Overview**
> Adds a **Beekeeper Studio** subsection under **Third-party tools** on the Client tools page (`content/develop/tools/_index.md`), placed after LibreDB Studio.
> 
> The new copy describes it as a cross-platform desktop client for Redis and other databases, and documents Redis-specific capabilities (command console with AI assist, spreadsheet-style key browser including ReJSON, export to CSV/Excel/JSON) plus connection options (direct or SSH tunnel, TLS/SSL, password or Redis 6+ ACL auth). It ends with a link to download from beekeeperstudio.io.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66099fc85a10dbcc76e068faef611259ffaa8f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->