### PR TITLE
Fix the Back to top link on Chrome

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -61,7 +61,8 @@
         {{ partial "mathjax.html" }}
     {{ end }}
   </head>
-  <body class="antialiased tracking-[-0.01em] bg-white w-full">
+  <body class="antialiased tracking-[-0.01em] bg-white w-full relative">
+    <span id="page-top" class="absolute top-0"></span>
     {{ partial "ai-metadata-body.html" . }}
 
     {{ if hugo.IsProduction -}}

--- a/layouts/partials/feedback.html
+++ b/layouts/partials/feedback.html
@@ -18,7 +18,7 @@
         {{ end }}
       </div>
     </div>  
-    <a href="#" class="font-mono no-underline">
+    <a href="#page-top" class="font-mono no-underline">
       Back to top ↑
     </a>
   </div>


### PR DESCRIPTION
The footer link used a bare href="#". On production the Qualified chat widget restyles the page so <body>, not <html>, is the scroll container, and Chrome's empty-fragment navigation only scrolls the (frozen) html viewport, so the link did nothing. Firefox scrolls the body scroller, which is why it only broke on Chrome. Pointing the link at a real element at the top of <body> scrolls correctly in both browsers because navigating to an element scrolls whichever ancestor is scrollable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small layout and anchor-link change with no impact on auth, data, or APIs.
> 
> **Overview**
> Fixes the footer **Back to top** link in the page feedback block when Chrome does not scroll after a bare `href="#"`.
> 
> The base layout now adds a **`#page-top`** anchor at the start of `<body>` (`relative` on `<body>` plus an absolutely positioned marker). The feedback partial’s link targets **`#page-top`** instead of `#`, so fragment navigation scrolls the element that is actually scrolling (notably when third-party widgets make `<body>` the scroll container).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e86ccaf3dc08a711f173bb6c47245cf19b4d4bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->