### PR TITLE
DOC-7047: Migrate develop/clients/ioredis to render hooks

### DIFF
--- a/content/develop/clients/ioredis/_index.md
+++ b/content/develop/clients/ioredis/_index.md
@@ -22,14 +22,14 @@ weight: 5
 The sections below explain how to install `ioredis` and connect your application
 to a Redis database.
 
-{{< note >}}Redis actively maintains and supports `ioredis` since it is in widespread use, but
-for new projects, we recommend using our newer Node.js client
-[`node-redis`]({{< relref "/develop/clients/nodejs" >}}). See
-[Migrate from ioredis]({{< relref "/develop/clients/nodejs/migration" >}})
-if you are interested in converting an existing `ioredis` project to `node-redis`.
-{{< /note >}}
+> [!NOTE]
+> Redis actively maintains and supports `ioredis` since it is in widespread use, but
+> for new projects, we recommend using our newer Node.js client
+> [`node-redis`](/content/develop/clients/nodejs/_index.md). See
+> [Migrate from ioredis](/content/develop/clients/nodejs/migration.md)
+> if you are interested in converting an existing `ioredis` project to `node-redis`.
 
-`ioredis` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`ioredis` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 ## Install
 

--- a/content/develop/clients/ioredis/connect.md
+++ b/content/develop/clients/ioredis/connect.md
@@ -68,7 +68,7 @@ const redis = new Redis.Cluster([
 
 ## Connect to your production Redis with TLS
 
-When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
+When you deploy your application, use TLS and follow the [Redis security](/content/operate/oss_and_stack/management/security/_index.md) guidelines.
 
 ```js
 const redis = new Redis({


### PR DESCRIPTION
## Summary
- Part of DOC-7047 (rolling the DOC-6909 render-hook migration out to the rest of the client docs). Converts `content/develop/clients/ioredis` off the `relref` and `note` shortcodes: relref → plain link → canonical `/content/*.md` form, and the one `{{< note >}}` callout → a `> [!NOTE]` blockquote.
- Uses `build/migrate_shortcode_links.py` from #3937 (not merged into this PR — only the resulting content diff is here).

## Test plan
- [x] Before/after Hugo build, href-fingerprint diff (`build/diff_rendered_hrefs.py`) scoped to `develop/clients/ioredis`: 0 differences.
- [x] Full-site href diff: 0 differences outside the two known-nondeterministic families (redisvl/changelog), which were also unaffected.
- [x] No new build warnings.
- [x] `check_shortcode_paths.py --scan` on the converted files: 0 issues.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout formatting with verified equivalent rendered hrefs; no application or build-logic changes in this diff.
> 
> **Overview**
> Continues the DOC-6909 render-hook rollout for **ioredis** client docs by removing Hugo `relref` and `note` shortcodes in favor of plain Markdown.
> 
> In `_index.md`, the `{{< note >}}` callout becomes a `> [!NOTE]` blockquote, and internal links (node-redis, migration guide, Redis install) use canonical `/content/.../*.md` paths instead of `relref`. In `connect.md`, the Redis security link is updated the same way. **`clients-example` shortcodes are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73687c9cad6330720581cd23f1e077d8721d9e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->