### PR TITLE
DOC-7047: Migrate develop/clients/om-clients to render hooks

### DIFF
--- a/content/develop/clients/om-clients/_index.md
+++ b/content/develop/clients/om-clients/_index.md
@@ -25,7 +25,7 @@ Redis OM (pronounced *REDiss OHM*) is a library that provides object mapping for
 
 You can use Redis OM with the following four programming languages:
 
-* [Python]({{< relref "/integrate/redisom-for-python" >}})
-* [C#/.NET]({{< relref "/integrate/redisom-for-net" >}})
-* [Node.js]({{< relref "/integrate/redisom-for-node-js" >}})
-* [Java/Spring]({{< relref "/integrate/redisom-for-java" >}})
+* [Python](/content/integrate/redisom-for-python/_index.md)
+* [C#/.NET](/content/integrate/redisom-for-net/_index.md)
+* [Node.js](/content/integrate/redisom-for-node-js/_index.md)
+* [Java/Spring](/content/integrate/redisom-for-java/_index.md)


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/om-clients/_index.md` per DOC-7047 (rollout of the DOC-6909 render-hook migration) from `relref` shortcodes to canonical `/content/*.md` Markdown links.
- No callout shortcodes (`note`/`warning`/`tip`/`info`/`alert`) were present in this file, so only the link conversion applies.
- Uses the conversion tooling from PR #3937 (`build/migrate_shortcode_links.py`, not yet merged to `main`) to perform the rewrite; that script is not included in this PR — it lands via its own PR.

## Verification
- `git diff` reviewed by hand: all 4 `relref` links converted to plain `/content/integrate/redisom-for-*/_index.md` links, anchors N/A (none used), matching the `redis-py` reference conversion's style exactly.
- No nested block-level shortcodes or custom-title alert forms were present.
- `python3 .claude/hooks/check_shortcode_paths.py --scan content/develop/clients/om-clients/_index.md` reports 0 files with issues, 0 broken file refs, 0 broken relref links.
- Full-site Hugo build verification (href-diff) is being run centrally by the ticket owner before merge — this isolated worktree can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present).

## Test plan
- [ ] Ticket owner runs the centralized full-site Hugo build + href-diff before merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link format change with no runtime, auth, or data impact.
> 
> **Overview**
> **DOC-7047** updates `content/develop/clients/om-clients/_index.md` as part of the render-hook migration (DOC-6909): the four Redis OM language bullets no longer use Hugo `{{< relref "..." >}}` shortcodes.
> 
> Each link now points at the canonical doc path (e.g. `/content/integrate/redisom-for-python/_index.md`), matching the style already used on pages like `redis-py`. No other content or shortcodes in this file were changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d57ad815220e363eb8be48f47f621454d140a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->