### PR TITLE
DOC-7047: Migrate develop/clients/ruby to render hooks

### DIFF
--- a/content/develop/clients/ruby/_index.md
+++ b/content/develop/clients/ruby/_index.md
@@ -23,7 +23,7 @@ weight: 11
 The sections below explain how to install `redis-rb` and connect your application
 to a Redis database.
 
-`redis-rb` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`redis-rb` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 ## Install
 

--- a/content/develop/clients/ruby/error-handling.md
+++ b/content/develop/clients/ruby/error-handling.md
@@ -17,7 +17,7 @@ command failures explicitly. This page explains how error handling works in
 `redis-rb` and how to apply common error handling patterns.
 
 For an overview of error types and handling strategies, see
-[Error handling]({{< relref "/develop/clients/error-handling" >}}).
+[Error handling](/content/develop/clients/error-handling.md).
 
 ## Exception hierarchy
 
@@ -48,7 +48,7 @@ For an overview of error types and handling strategies, see
 
 The following exceptions are the most commonly encountered in `redis-rb`
 applications. See
-[Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+[Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 | Exception | When it occurs | Recoverable | Recommended action |
@@ -60,7 +60,7 @@ for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 `redis-rb`:
 
@@ -68,7 +68,7 @@ describes four main patterns. The sections below show how to implement them in
 
 Catch specific exceptions that represent unrecoverable errors and re-raise them
 (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```ruby
@@ -83,7 +83,7 @@ end
 ### Pattern 2: Graceful degradation
 
 Catch connection failures and fall back to an alternative (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```ruby
@@ -100,7 +100,7 @@ database.get(key)
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors such as timeouts (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description):
 
 ```ruby
@@ -121,7 +121,7 @@ end
 ### Pattern 4: Log and continue
 
 Log non-critical failures and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```ruby
@@ -152,5 +152,5 @@ retry_transaction if result.nil?
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Pipelines and transactions]({{< relref "/develop/clients/ruby/transpipe" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Pipelines and transactions](/content/develop/clients/ruby/transpipe.md)

--- a/content/develop/clients/ruby/queryjson.md
+++ b/content/develop/clients/ruby/queryjson.md
@@ -23,28 +23,28 @@ weight: 2
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
-{{< note >}}The redis-rb Query Engine requires redis-rb v6.0.0 or later.
-{{< /note >}}
+> [!NOTE]
+> The redis-rb Query Engine requires redis-rb v6.0.0 or later.
 
-{{< note >}}`redis-rb` uses query dialect 2 by default.
-Redis Search methods such as [`search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> `redis-rb` uses query dialect 2 by default.
+> Redis Search methods such as [`search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[`redis-rb`]({{< relref "/develop/clients/ruby" >}}) client library if you
+[`redis-rb`](/content/develop/clients/ruby/_index.md) client library if you
 haven't already done so.
 
 Require the `redis` gem. The Query Engine classes live under the
@@ -65,7 +65,7 @@ Create some test data to add to the database:
 
 Connect to your Redis database. The code below shows the most
 basic connection but see the
-[`redis-rb` guide]({{< relref "/develop/clients/ruby" >}})
+[`redis-rb` guide](/content/develop/clients/ruby/_index.md)
 to learn more about the available connection options.
 
 {{< clients-example set="ruby_home_json" step="connect" description="Foundational: Establish a connection to a Redis server for query operations" difficulty="beginner" >}}
@@ -76,11 +76,11 @@ Delete any existing index called `idx:users` and any keys that start with `user:
 {{< clients-example set="ruby_home_json" step="cleanup_json" description="Foundational: Clean up existing indexes and data before creating new indexes" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax]({{< relref "/develop/ai/search-and-query/query/" >}}).
+Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax](/content/develop/ai/search-and-query/query/_index.md).
 
 Build the schema with the field type helpers (`text_field`, `tag_field`,
 `numeric_field`) inside a `Search::Schema.build` block. Each field's first
-argument is the [JSON path]({{< relref "/develop/data-types/json/path" >}}) to
+argument is the [JSON path](/content/develop/data-types/json/path.md) to
 the value, and the `as:` option gives the field an alias you can refer to in
 queries.
 
@@ -90,7 +90,7 @@ queries.
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them:
 
@@ -100,7 +100,7 @@ objects automatically as you add them:
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -118,7 +118,7 @@ the `city` field:
 {{< /clients-example >}}
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< clients-example set="ruby_home_json" step="query3" description="Aggregation query: Group and count results by field values to analyze data patterns" difficulty="intermediate" >}}
@@ -147,8 +147,8 @@ Now create the new index:
 {{< clients-example set="ruby_home_json" step="make_hash_index" description="Foundational: Create a search index for hash documents with field definitions and key prefix filtering" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-Use [`hset()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`json_set()`]({{< relref "/commands/json.set" >}}).
+Use [`hset()`](/content/commands/hset.md) to add the hash
+documents instead of [`json_set()`](/content/commands/json.set.md).
 
 {{< clients-example set="ruby_home_json" step="add_hash_data" description="Foundational: Store hash documents in Redis with automatic indexing based on key prefix" difficulty="beginner" >}}
 {{< /clients-example >}}
@@ -162,5 +162,5 @@ the name of the hash index is different). The results are returned as
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/ruby/queryjson.md
+++ b/content/develop/clients/ruby/queryjson.md
@@ -32,6 +32,8 @@ documents.
 > [!NOTE]
 > The redis-rb Query Engine requires redis-rb v6.0.0 or later.
 
+&nbsp;
+
 > [!NOTE]
 > `redis-rb` uses query dialect 2 by default.
 > Redis Search methods such as [`search()`](/content/commands/ft.search.md)

--- a/content/develop/clients/ruby/transpipe.md
+++ b/content/develop/clients/ruby/transpipe.md
@@ -21,11 +21,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -52,7 +52,7 @@ several clients may modify at the same time. The basic idea is to watch for
 changes to any keys that you use in a transaction while you are preparing the
 update. If the watched keys do change, the transaction returns `nil` and you
 must retry using the latest value from Redis. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The example below watches a key, reads its current value, and then updates it

--- a/content/develop/clients/ruby/vecsearch.md
+++ b/content/develop/clients/ruby/vecsearch.md
@@ -24,14 +24,14 @@ topics:
 weight: 3
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md)
 reference page for more information).
 Among other things, vector fields can store *text embeddings*, which are AI-generated vector
 representations of the semantic information in pieces of text. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings indicates how similar they are semantically. By comparing the
 similarity of an embedding generated from some query text with embeddings stored in hash
 or JSON fields, Redis can retrieve documents that closely match the query in terms
@@ -47,20 +47,20 @@ The code is first demonstrated for hash documents with a
 separate section to explain the
 [differences with JSON documents](#differences-with-json-documents).
 
-{{< note >}}The redis-rb Query Engine requires redis-rb v6.0.0 or later.
-{{< /note >}}
+> [!NOTE]
+> The redis-rb Query Engine requires redis-rb v6.0.0 or later.
 
-{{< note >}}`redis-rb` uses query dialect 2 by default.
-Redis Search methods such as [`search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> `redis-rb` uses query dialect 2 by default.
+> Redis Search methods such as [`search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Install [`redis-rb`]({{< relref "/develop/clients/ruby" >}}) if you
+Install [`redis-rb`](/content/develop/clients/ruby/_index.md) if you
 have not already done so. Also, install `informers` with the
 following command:
 
@@ -123,12 +123,12 @@ Next, delete any index previously created with the name `vector_idx`
 which is why you need the `begin`/`rescue` block) and create the index.
 The schema in the example below specifies hash objects for storage and includes
 three fields: the text content to index, a
-[tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+[tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
 field to represent the "genre" of the text, and the embedding vector generated from
 the original text content. The `embedding` field specifies
-[HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}})
+[HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index)
 indexing, the
-[L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 vector distance metric, `FLOAT32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
@@ -138,7 +138,7 @@ and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 ## Add data
 
 You can now supply the data objects, which will be indexed automatically
-when you add them with [`hset()`]({{< relref "/commands/hset" >}}), as long as
+when you add them with [`hset()`](/content/commands/hset.md), as long as
 you use the `doc:` prefix specified in the index definition.
 
 Call the pipeline with `pooling: 'mean'` and `normalize: true` to create the
@@ -158,7 +158,7 @@ results in order of this numeric similarity value.
 
 The code below creates the query embedding, packs it with the `to_bytes` helper,
 and passes it as a query parameter (see
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about using query parameters with embeddings).
 
 {{< clients-example set="ruby_home_query_vec" step="query" lang_filter="Ruby" description="Vector similarity search: Find semantically similar documents by comparing query embeddings with indexed vectors using L2 distance" difficulty="intermediate" >}}
@@ -191,7 +191,7 @@ than `doc:0`.
 
 Indexing JSON documents is similar to hash indexing, but there are some
 important differences. JSON allows much richer data modelling with nested fields, so
-you must supply a [path]({{< relref "/develop/data-types/json/path" >}}) in the schema
+you must supply a [path](/content/develop/data-types/json/path.md) in the schema
 to identify each field you want to index. However, you can declare a short alias for each
 of these paths (using the `as:` keyword argument) to avoid typing it in full for
 every query. Also, you must specify `Search::IndexType::JSON` when you create the index.
@@ -202,8 +202,8 @@ the one created previously for hashes:
 {{< clients-example set="ruby_home_query_vec" step="json_index" lang_filter="Ruby" description="Foundational: Create a vector search index for JSON documents with JSON paths and field aliases" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-Use [`json_set()`]({{< relref "/commands/json.set" >}}) to add the data
-instead of [`hset()`]({{< relref "/commands/hset" >}}).
+Use [`json_set()`](/content/commands/json.set.md) to add the data
+instead of [`hset()`](/content/commands/hset.md).
 
 An important difference with JSON indexing is that the vectors are
 specified using arrays instead of binary strings. Pass the `Array<Float>`
@@ -236,6 +236,6 @@ query is the same as for hash:
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about the indexing options, distance metrics, and query format
 for vectors.

--- a/content/develop/clients/ruby/vecsearch.md
+++ b/content/develop/clients/ruby/vecsearch.md
@@ -50,6 +50,8 @@ separate section to explain the
 > [!NOTE]
 > The redis-rb Query Engine requires redis-rb v6.0.0 or later.
 
+&nbsp;
+
 > [!NOTE]
 > `redis-rb` uses query dialect 2 by default.
 > Redis Search methods such as [`search()`](/content/commands/ft.search.md)


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/ruby/` (`_index.md`, `error-handling.md`, `queryjson.md`, `transpipe.md`, `vecsearch.md`) to the DOC-6909 render-hook forms, continuing the DOC-7047 section-by-section rollout (redis-py was the proof section).
- `{{< relref >}}` links -> plain Markdown links -> canonical `/content/*.md` (or `/content/*/_index.md`) form, resolved by `layouts/_default/_markup/render-link.html`. Anchors preserved.
- The 4 `{{< note >}}` callouts (2 in `queryjson.md`, 2 in `vecsearch.md`) -> `> [!NOTE]`-style blockquotes, resolved by `layouts/_default/_markup/render-blockquote.html`. No custom titles, no nesting.
- Uses the migration tooling from PR #3937 (`build/migrate_shortcode_links.py`, not yet merged) as a local, untracked helper — not included in this PR's diff.

## Test plan
- [x] Verified no `{{< relref` or `{{< note/warning/tip/info/alert` shortcodes remain in the directory.
- [x] Manually reviewed every diff hunk: no nested shortcodes inside converted blockquotes, no custom-title alert forms, blockquote `>` prefixing correct on every line.
- [x] Spot-checked link rewrites, including a bare-relative relref (`transpipe.md`) and anchored links (`vecsearch.md`), all resolving to the correct canonical path.
- [x] `python3 .claude/hooks/check_shortcode_paths.py --scan content/develop/clients/ruby/*.md` reports 0 files with issues.
- [ ] Full-site Hugo build verification (href-diff) — being run centrally by the ticket owner before merge, since this isolated worktree can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout syntax migration with no runtime or application code changes.
> 
> **Overview**
> Migrates **`content/develop/clients/ruby/`** (five pages) to the DOC-6909 render-hook markdown forms: Hugo **`{{< relref >}}`** internal links become plain links in canonical **`/content/...`** form (with **`_index.md`** where needed), and **`{{< note >}}`** callouts in **`queryjson.md`** and **`vecsearch.md`** become **`> [!NOTE]`** blockquotes (with a spacer between the two notes on those pages).
> 
> **`clients-example`** and **`jupyter-example`** shortcodes are unchanged. Scope is link and callout syntax only—no Ruby API or tutorial content edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b879822faec5fe2385356491fac0aa248cc461ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->