### PR TITLE
DOC-7047: Migrate develop/clients/rust to render hooks

### DIFF
--- a/content/develop/clients/rust/_index.md
+++ b/content/develop/clients/rust/_index.md
@@ -22,11 +22,11 @@ weight: 9
 [`redis-rs`](https://github.com/redis-rs/redis-rs) is the [Rust](https://www.rust-lang.org/) client for Redis.
 The sections below explain how to install `redis-rs` and connect your application to a Redis database.
 
-{{< note >}}Although we provide basic documentation for `redis-rs`, it is a third-party
-client library and is not developed or supported directly by Redis.
-{{< /note >}}
+> [!NOTE]
+> Although we provide basic documentation for `redis-rs`, it is a third-party
+> client library and is not developed or supported directly by Redis.
 
-`redis-rs` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`redis-rs` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 ## Install
 
@@ -66,12 +66,12 @@ The following example shows the simplest way to connect to a Redis server:
 {{< /clients-example >}}
 
 After connecting, you can test the connection by  storing and retrieving
-a simple [string]({{< relref "/develop/data-types/strings" >}}):
+a simple [string](/content/develop/data-types/strings/_index.md):
 
 {{< clients-example set="landing" step="set_get_string" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-You can also easily store and retrieve a [hash]({{< relref "/develop/data-types/hashes" >}}):
+You can also easily store and retrieve a [hash](/content/develop/data-types/hashes.md):
 
 {{< clients-example set="landing" step="set_get_hash" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Store and retrieve hash data structures using HSET and HGETALL" difficulty="beginner" >}}
 {{< /clients-example >}}

--- a/content/develop/clients/rust/error-handling.md
+++ b/content/develop/clients/rust/error-handling.md
@@ -15,7 +15,7 @@ redis-rs uses **Result types** following Rust's idiomatic error handling pattern
 but it is essential in production code.
 This page explains how error handling works in redis-rs and how to apply
 some common error handling patterns. For an overview of error types and handling
-strategies, see [Error handling]({{< relref "/develop/clients/error-handling" >}}).
+strategies, see [Error handling](/content/develop/clients/error-handling.md).
 
 ## Error handling in Rust
 
@@ -48,19 +48,19 @@ redis-rs provides a `RedisError` type with various error kinds. Common error kin
 | `ErrorKind::Server` | Redis server error response | ⚠️ | Check specific server error; some are retryable |
 | `ErrorKind::Parse` | Failed to parse server response | ❌ | Report as a bug |
 
-See [Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+See [Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 redis-rs:
 
 ### Pattern 1: Fail fast
 
 Return the error immediately if it represents an unrecoverable situation (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```rust
@@ -76,7 +76,7 @@ fn get_value(con: &mut redis::Connection, key: &str) -> RedisResult<String> {
 ### Pattern 2: Graceful degradation
 
 Check for specific errors and fall back to an alternative (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```rust
@@ -104,7 +104,7 @@ fn get_with_fallback(
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors such as timeouts (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description):
 
 ```rust
@@ -140,7 +140,7 @@ fn get_with_retry(
 ### Pattern 4: Log and continue
 
 Log non-critical errors and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```rust
@@ -186,6 +186,6 @@ async fn get_with_fallback_async(
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
 - [redis-rs documentation](https://docs.rs/redis/latest/redis/)
 

--- a/content/develop/clients/rust/json.md
+++ b/content/develop/clients/rust/json.md
@@ -23,8 +23,8 @@ weight: 30
 ---
 
 This example shows how to work with a
-[JSON]({{< relref "/develop/data-types/json" >}})
-document from Rust using [`redis-rs`]({{< relref "/develop/clients/rust" >}}).
+[JSON](/content/develop/data-types/json/_index.md)
+document from Rust using [`redis-rs`](/content/develop/clients/rust/_index.md).
 It uses one `bike:1` document to demonstrate a simple workflow:
 create the document, read nested fields, update part of the document,
 and append data to an array.
@@ -69,7 +69,7 @@ JSON paths work with more realistic data than a flat object.
 ## Connect to Redis
 
 Connect to your Redis server in the usual way.
-See [Connect to the server]({{< relref "/develop/clients/rust" >}})
+See [Connect to the server](/content/develop/clients/rust/_index.md)
 for more connection options.
 
 {{< clients-example set="rust_home_json" step="connect" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Create a Redis client and open a sync or async connection from Rust" difficulty="beginner" >}}
@@ -77,8 +77,8 @@ for more connection options.
 
 ## Store and retrieve the document
 
-Use [`JSON.SET`]({{< relref "/commands/json.set" >}}) to store the whole document at the root path `$`.
-You can then retrieve the document again with [`JSON.GET`]({{< relref "/commands/json.get" >}}).
+Use [`JSON.SET`](/content/commands/json.set.md) to store the whole document at the root path `$`.
+You can then retrieve the document again with [`JSON.GET`](/content/commands/json.get.md).
 
 {{< clients-example set="rust_home_json" step="set_get_doc" lang_filter="Rust-Sync,Rust-Async" description="Foundational: Store a complete JSON document with JSON.SET and fetch it again with JSON.GET" difficulty="beginner" >}}
 {{< /clients-example >}}
@@ -95,7 +95,7 @@ This is useful when your application only needs a small subset of the data.
 
 You can update individual fields without replacing the whole document.
 The example below changes the stock count and then applies a price change with
-[`JSON.NUMINCRBY`]({{< relref "/commands/json.numincrby" >}}).
+[`JSON.NUMINCRBY`](/content/commands/json.numincrby.md).
 
 {{< clients-example set="rust_home_json" step="update_fields" lang_filter="Rust-Sync,Rust-Async" description="Update nested values: Modify individual fields in place with JSON.SET and JSON.NUMINCRBY" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -112,6 +112,6 @@ This example adds another color to the bike and then retrieves the updated array
 
 See the following pages to learn more:
 
-- [JSON data type]({{< relref "/develop/data-types/json" >}})
-- [JSON path syntax]({{< relref "/develop/data-types/json/path" >}})
+- [JSON data type](/content/develop/data-types/json/_index.md)
+- [JSON path syntax](/content/develop/data-types/json/path.md)
 - [`redis-rs` documentation](https://docs.rs/redis/latest/redis/)

--- a/content/develop/clients/rust/prob.md
+++ b/content/develop/clients/rust/prob.md
@@ -16,28 +16,27 @@ weight: 45
 ---
 
 Redis supports several
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md)
 that let you calculate values approximately rather than exactly.
 The `redis-rs` high-level command traits include support for
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md)
 set membership and
-[HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+[HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 cardinality estimation.
 
-{{< note >}}
-This page covers Bloom filters and HyperLogLog because `redis-rs` provides
-dedicated high-level methods for them. Other probabilistic data types,
-such as Cuckoo filters, Count-min sketch, t-digest, and Top-K, can still be
-called with low-level Redis commands, but they don't currently have dedicated
-high-level `redis-rs` methods.
-{{< /note >}}
+> [!NOTE]
+> This page covers Bloom filters and HyperLogLog because `redis-rs` provides
+> dedicated high-level methods for them. Other probabilistic data types,
+> such as Cuckoo filters, Count-min sketch, t-digest, and Top-K, can still be
+> called with low-level Redis commands, but they don't currently have dedicated
+> high-level `redis-rs` methods.
 
 ## Set membership
 
-A [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}})
+A [Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md)
 lets you track whether or not a particular item has been added to a set.
 Instead of storing the items themselves, like a
-[set]({{< relref "/develop/data-types/sets" >}}), a Bloom filter records the
+[set](/content/develop/data-types/sets.md), a Bloom filter records the
 presence or absence of the
 [hash value](https://en.wikipedia.org/wiki/Hash_function) of each item. This
 gives a very compact representation of the set's membership with a fixed memory
@@ -75,6 +74,6 @@ can count up to 2^64 items with less than 1% standard error using a maximum
 
 See the following pages to learn more:
 
-- [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+- [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 - [`redis-rs` command trait](https://docs.rs/redis/latest/redis/trait.Commands.html)
 - [`redis-rs` async command trait](https://docs.rs/redis/latest/redis/trait.AsyncCommands.html)

--- a/content/develop/clients/rust/transpipe.md
+++ b/content/develop/clients/rust/transpipe.md
@@ -21,11 +21,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -59,7 +59,7 @@ to different keys. The basic idea is to watch for changes to any
 keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The example below shows how to use the `transaction()` function to


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/rust/` (`_index.md`, `error-handling.md`, `json.md`, `prob.md`, `transpipe.md`; `amr.md` had nothing to convert) per DOC-7047, continuing the DOC-6909 render-hook rollout (redis-py was the proof section).
- 28 `{{< relref >}}` shortcode links -> plain Markdown links in canonical `/content/<path>.md[#anchor]` form (resolved by `layouts/_default/_markup/render-link.html`).
- 2 `{{< note >}}` callouts -> `> [!NOTE]` blockquotes (resolved by `layouts/_default/_markup/render-blockquote.html`). No nested shortcodes or custom titles were present.
- Uses the conversion tooling from PR #3937 (not merged into this PR) — `build/migrate_shortcode_links.py` was pulled locally via `git show`, run, then deleted before committing; it is not part of this diff.

## Test plan
- [x] Confirmed no `{{< relref` or `{{< note/warning/tip/info/alert` shortcodes remain in the directory.
- [x] Confirmed no nested block-level shortcode was mangled inside a converted blockquote.
- [x] Confirmed no custom-title alert form was present to lose.
- [x] Verified blockquote formatting (`> [!NOTE]` header, `>` prefix per line) for both callouts.
- [x] Spot-checked rewritten links, including a bare-relative relref (no leading slash) in `transpipe.md`, resolving correctly with anchors preserved.
- [x] Ran `python3 .claude/hooks/check_shortcode_paths.py --scan content/develop/clients/rust/*.md` (main's version) -> 0 files with issues.
- [ ] Full-site Hugo build verification (href-diff) is being run centrally by the ticket owner before merge — this isolated worktree can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout format changes with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Continues the DOC-6909 render-hook rollout for **`content/develop/clients/rust/`** (`_index.md`, `error-handling.md`, `json.md`, `prob.md`, `transpipe.md`): Hugo **`{{< relref >}}`** links are replaced with plain Markdown URLs in canonical **`/content/...md`** form (including anchors), and **`{{< note >}}`** callouts become **`> [!NOTE]`** blockquotes so **`render-link.html`** and **`render-blockquote.html`** resolve them at build time.
> 
> **`clients-example`** shortcodes and page structure are unchanged; this is a markup migration only, with no redis-rs API or example content edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65d4b5d17ec722cc11c54b912ce9c7a54d1f92e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->