### PR TITLE
DOC-7047: Migrate shared develop/clients top-level files to render hooks

### DIFF
--- a/content/develop/clients/_index.md
+++ b/content/develop/clients/_index.md
@@ -27,35 +27,35 @@ for nine main languages:
 
 | Language | Client name | Docs | Supported |
 | :-- | :-- | :-- | :-- |
-| [Python](https://www.python.org/) | [`redis-py`](https://github.com/redis/redis-py) |[`redis-py` guide]({{< relref "/develop/clients/redis-py" >}}) | Yes |
-| [Python](https://www.python.org/) | [`RedisVL`](https://github.com/redis/redis-vl-python) |[RedisVL guide]({{< relref "/develop/ai/redisvl" >}}) | Yes 
-| [C#/.NET](https://learn.microsoft.com/en-us/dotnet/csharp/) | [`StackExchange.Redis`](https://github.com/StackExchange/StackExchange.Redis) |[`StackExchange.Redis` guide]({{< relref "/develop/clients/dotnet" >}}) | Yes |
-| [C#/.NET](https://learn.microsoft.com/en-us/dotnet/csharp/) | [`NRedisStack`](https://github.com/redis/NRedisStack) |[`NRedisStack` guide]({{< relref "/develop/clients/dotnet/nredisstack" >}}) | Yes |
-| [JavaScript](https://nodejs.org/en) | [`node-redis`](https://github.com/redis/node-redis) | [`node-redis` guide]({{< relref "/develop/clients/nodejs" >}}) | Yes |
-| [JavaScript](https://nodejs.org/en) | [`ioredis`](https://github.com/redis/ioredis) | [`ioredis` guide]({{< relref "/develop/clients/ioredis" >}}) | Yes |
-| [Java](https://www.java.com/en/) | [`Jedis`](https://github.com/redis/jedis) | [`Jedis` guide]({{< relref "/develop/clients/jedis" >}}) |  Yes |
-| [Java](https://www.java.com/en/) | [`Lettuce`](https://github.com/redis/lettuce) | [`Lettuce` guide]({{< relref "/develop/clients/lettuce" >}}) | Yes |
-| [Go](https://go.dev/) | [`go-redis`](https://github.com/redis/go-redis) | [`go-redis` guide]({{< relref "/develop/clients/go" >}}) | Yes |
-| [PHP](https://www.php.net/)| [`Predis`](https://github.com/predis/predis) | [`Predis` guide]({{< relref "/develop/clients/php" >}}) | Best effort [*](#best-effort) |
-| [C](https://en.wikipedia.org/wiki/C_(programming_language)) | [`hiredis`](https://github.com/redis/hiredis) | [`hiredis` guide]({{< relref "/develop/clients/hiredis" >}}) | Yes |
-| [Rust](https://www.rust-lang.org/) | [`redis-rs`](https://github.com/redis-rs/redis-rs) | [`redis-rs` guide]({{< relref "/develop/clients/rust" >}}) | Best effort [*](#best-effort) |
-| [Ruby](https://www.ruby-lang.org/en/) | [`redis-rb`](https://github.com/redis/redis-rb) | [`redis-rb` guide]({{< relref "/develop/clients/ruby" >}}) | Yes |
+| [Python](https://www.python.org/) | [`redis-py`](https://github.com/redis/redis-py) |[`redis-py` guide](/content/develop/clients/redis-py/_index.md) | Yes |
+| [Python](https://www.python.org/) | [`RedisVL`](https://github.com/redis/redis-vl-python) |[RedisVL guide](/content/develop/ai/redisvl/_index.md) | Yes 
+| [C#/.NET](https://learn.microsoft.com/en-us/dotnet/csharp/) | [`StackExchange.Redis`](https://github.com/StackExchange/StackExchange.Redis) |[`StackExchange.Redis` guide](/content/develop/clients/dotnet/_index.md) | Yes |
+| [C#/.NET](https://learn.microsoft.com/en-us/dotnet/csharp/) | [`NRedisStack`](https://github.com/redis/NRedisStack) |[`NRedisStack` guide](/content/develop/clients/dotnet/nredisstack/_index.md) | Yes |
+| [JavaScript](https://nodejs.org/en) | [`node-redis`](https://github.com/redis/node-redis) | [`node-redis` guide](/content/develop/clients/nodejs/_index.md) | Yes |
+| [JavaScript](https://nodejs.org/en) | [`ioredis`](https://github.com/redis/ioredis) | [`ioredis` guide](/content/develop/clients/ioredis/_index.md) | Yes |
+| [Java](https://www.java.com/en/) | [`Jedis`](https://github.com/redis/jedis) | [`Jedis` guide](/content/develop/clients/jedis/_index.md) |  Yes |
+| [Java](https://www.java.com/en/) | [`Lettuce`](https://github.com/redis/lettuce) | [`Lettuce` guide](/content/develop/clients/lettuce/_index.md) | Yes |
+| [Go](https://go.dev/) | [`go-redis`](https://github.com/redis/go-redis) | [`go-redis` guide](/content/develop/clients/go/_index.md) | Yes |
+| [PHP](https://www.php.net/)| [`Predis`](https://github.com/predis/predis) | [`Predis` guide](/content/develop/clients/php/_index.md) | Best effort [*](#best-effort) |
+| [C](https://en.wikipedia.org/wiki/C_(programming_language)) | [`hiredis`](https://github.com/redis/hiredis) | [`hiredis` guide](/content/develop/clients/hiredis/_index.md) | Yes |
+| [Rust](https://www.rust-lang.org/) | [`redis-rs`](https://github.com/redis-rs/redis-rs) | [`redis-rs` guide](/content/develop/clients/rust/_index.md) | Best effort [*](#best-effort) |
+| [Ruby](https://www.ruby-lang.org/en/) | [`redis-rb`](https://github.com/redis/redis-rb) | [`redis-rb` guide](/content/develop/clients/ruby/_index.md) | Yes |
 
-{{< note >}}*<a name="best-effort"></a>
-Redis does not provide official support for third-party client libraries.
-However, we contribute new features, offer guidance, and collaborate with the community
-on a best-effort basis to help ensure these libraries remain reliable and up-to-date.
-{{< /note >}}
+> [!NOTE]
+> *<a name="best-effort"></a>
+> Redis does not provide official support for third-party client libraries.
+> However, we contribute new features, offer guidance, and collaborate with the community
+> on a best-effort basis to help ensure these libraries remain reliable and up-to-date.
 
-See [Client library support and versioning policy]({{< relref "/develop/clients/version-support" >}})
+See [Client library support and versioning policy](/content/develop/clients/version-support.md)
 for details about how Redis maintains, versions, and tests the official client libraries.
 
 We also provide several higher-level
-[object mapping (OM)]({{< relref "/develop/clients/om-clients" >}})
-libraries for [Python]({{< relref "/integrate/redisom-for-python" >}}),
-[C#/.NET]({{< relref "/integrate/redisom-for-net" >}}),
-[Node.js]({{< relref "/integrate/redisom-for-node-js" >}}), and
-[Java/Spring]({{< relref "/integrate/redisom-for-java" >}}).
+[object mapping (OM)](/content/develop/clients/om-clients/_index.md)
+libraries for [Python](/content/integrate/redisom-for-python/_index.md),
+[C#/.NET](/content/integrate/redisom-for-net/_index.md),
+[Node.js](/content/integrate/redisom-for-node-js/_index.md), and
+[Java/Spring](/content/integrate/redisom-for-java/_index.md).
 
 ## Community-supported clients
 
@@ -74,10 +74,10 @@ develop or contribute to these libraries directly.
 
 You will need access to a Redis server to use these libraries.
 You can experiment with a local installation of Redis Open Source
-(see [Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/install-stack/" >}})) or with a free trial of [Redis Cloud]({{< relref "/operate/rc" >}}).
+(see [Install Redis Open Source](/content/operate/oss_and_stack/install/install-stack/_index.md)) or with a free trial of [Redis Cloud](/content/operate/rc/_index.md).
 To interact with a Redis server without writing code, use the
-[Redis CLI]({{< relref "/develop/tools/cli" >}}) and
-[Redis Insight]({{< relref "/develop/tools/insight" >}}) tools.
+[Redis CLI](/content/develop/tools/cli.md) and
+[Redis Insight](/content/develop/tools/insight/_index.md) tools.
 
 ## Choose a client library for your language
 
@@ -102,7 +102,7 @@ between the options for each language.
     lacks some of the newer features and performance optimizations of `node-redis`.
     Note that there is a migration guide available if you are interested in converting
     your `ioredis` project to `node-redis`
-    (see [Migrate from ioredis]({{< relref "/develop/clients/nodejs/migration" >}})).
+    (see [Migrate from ioredis](/content/develop/clients/nodejs/migration.md)).
 -   [RedisOM for Node.js](https://github.com/redis/redis-om-node) is an object mapping library that
     provides a high-level API for working with Redis data structures.
 
@@ -123,9 +123,9 @@ between the options for each language.
 -   [`NRedisStack`](https://github.com/redis/NRedisStack) builds upon
     `StackExchange.Redis` with
     support for an extended set of data types and features, such as
-    [JSON]({{< relref "/develop/data-types/json" >}}),
-    [Redis search]({{< relref "/develop/ai/search-and-query" >}}), and
-    [Time series]({{< relref "/develop/data-types/timeseries" >}}).
+    [JSON](/content/develop/data-types/json/_index.md),
+    [Redis search](/content/develop/ai/search-and-query/_index.md), and
+    [Time series](/content/develop/data-types/timeseries/_index.md).
 -   [RedisOM for .NET](https://github.com/redis/redis-om-dotnet) is an object mapping library that
     provides a high-level API for working with Redis data structures.
 
@@ -134,7 +134,7 @@ between the options for each language.
 -   [`Predis`](https://github.com/predis/predis) is the recommended PHP client library for
     most use cases. It has "best effort" support from the Redis team (it's a third-party library
     but the Redis team contributes to it and helps with issues) and has good coverage in the
-    [Redis documentation]({{< relref "/develop/clients/php" >}}). However, it is implemented in
+    [Redis documentation](/content/develop/clients/php/_index.md). However, it is implemented in
     PHP, which limits its performance compared to [phpredis](https://github.com/phpredis/phpredis),
     which is implemented in C.
 -   [phpredis](https://github.com/phpredis/phpredis) is a popular and well-maintained PHP client

--- a/content/develop/clients/client-side-caching.md
+++ b/content/develop/clients/client-side-caching.md
@@ -63,9 +63,9 @@ approach called *tracking*.
 
 When client-side caching is enabled, the Redis server remembers or *tracks* the set of keys
 that each client connection has previously read. This includes cases where the client
-reads data directly, as with the [`GET`]({{< relref "/commands/get" >}})
+reads data directly, as with the [`GET`](/content/commands/get.md)
 command, and also where the server calculates values from the stored data,
-as with [`STRLEN`]({{< relref "/commands/strlen" >}}). When any client
+as with [`STRLEN`](/content/commands/strlen.md). When any client
 writes new data to a tracked key, the server sends an invalidation message
 to all clients that have accessed that key previously. This message warns
 the clients that their cached copies of the data are no longer valid and the clients
@@ -73,11 +73,11 @@ will evict the stale data in response. Next time a client reads from
 the same key, it will access the database directly and refresh its cache
 with the updated data.
 
-{{< note >}}If any connection from a client gets disconnected (including
-one from a connection pool), then the client will flush all keys from the
-client-side cache. Caching then resumes for subsequent reads from the
-connections that are still active.
-{{< /note >}}
+> [!NOTE]
+> If any connection from a client gets disconnected (including
+> one from a connection pool), then the client will flush all keys from the
+> client-side cache. Caching then resumes for subsequent reads from the
+> connections that are still active.
 
 The sequence diagram below shows how two clients might interact as they
 access and update the same key:
@@ -90,33 +90,33 @@ The following client libraries support CSC from the stated version onwards:
 
 | Client | Version |
 | :-- | :-- |
-| [`redis-py`]({{< relref "/develop/clients/redis-py/connect#connect-using-client-side-caching" >}}) | v5.1.0 |
-| [`Jedis`]({{< relref "/develop/clients/jedis/connect#connect-using-client-side-caching" >}}) | v5.2.0 |
-| [`node-redis`]({{< relref "/develop/clients/nodejs/connect#connect-using-client-side-caching" >}}) | v5.1.0 |
-| [`go-redis`]({{< relref "/develop/clients/go/connect#connect-using-client-side-caching" >}}) | v9.22.0 |
+| [`redis-py`](/content/develop/clients/redis-py/connect.md#connect-using-client-side-caching) | v5.1.0 |
+| [`Jedis`](/content/develop/clients/jedis/connect.md#connect-using-client-side-caching) | v5.2.0 |
+| [`node-redis`](/content/develop/clients/nodejs/connect.md#connect-using-client-side-caching) | v5.1.0 |
+| [`go-redis`](/content/develop/clients/go/connect.md#connect-using-client-side-caching) | v9.22.0 |
 
-Note that some other clients support the [`CLIENT TRACKING`]({{< relref "/commands/client-tracking" >}}) command to configure CSC on the server, but this does not mean they support the
+Note that some other clients support the [`CLIENT TRACKING`](/content/commands/client-tracking.md) command to configure CSC on the server, but this does not mean they support the
 features required for CSC themselves.
 
 ## Which commands can cache data?
 
 All read-only commands (with the `@read`
-[ACL category]({{< relref "/operate/oss_and_stack/management/security/acl" >}}))
+[ACL category](/content/operate/oss_and_stack/management/security/acl.md))
 will use cached data, except for the following:
 
 -   Any commands for the
-    [probabilistic]({{< relref "/develop/data-types/probabilistic" >}}) and
-    [time series]({{< relref "/develop/data-types/timeseries" >}}) data types.
+    [probabilistic](/content/develop/data-types/probabilistic/_index.md) and
+    [time series](/content/develop/data-types/timeseries/_index.md) data types.
     These types are designed to be updated frequently, which means that caching
     has little or no benefit.
--   Non-deterministic commands such as [`HRANDFIELD`]({{< relref "/commands/hrandfield" >}}),
-    [`HSCAN`]({{< relref "/commands/hscan" >}}),
-    and [`ZRANDMEMBER`]({{< relref "/commands/zrandmember" >}}). By design, these commands
+-   Non-deterministic commands such as [`HRANDFIELD`](/content/commands/hrandfield.md),
+    [`HSCAN`](/content/commands/hscan.md),
+    and [`ZRANDMEMBER`](/content/commands/zrandmember.md). By design, these commands
     give different results each time they are called.
 -   Redis Search commands (with the `FT.*` prefix), such as
-    [`FT.SEARCH`]({{< relref "commands/ft.search" >}}).
+    [`FT.SEARCH`](/content/commands/ft.search.md).
 
-You can use the [`MONITOR`]({{< relref "/commands/monitor" >}}) command to
+You can use the [`MONITOR`](/content/commands/monitor.md) command to
 check the server's behavior when you are using client-side caching. Because `MONITOR` only
 reports activity from the server, you should find the first cacheable
 access to a key causes a response from the server. However, subsequent
@@ -130,35 +130,35 @@ gets cached after it is used for the first time. Subsets of that data
 or values calculated from it are retrieved from the server as usual and
 then cached separately. For example:
 
--   The whole string retrieved by [`GET`]({{< relref "/commands/get" >}})
+-   The whole string retrieved by [`GET`](/content/commands/get.md)
     is added to the cache. Parts of the same string retrieved by
-    [`SUBSTR`]({{< relref "/commands/substr" >}}) are calculated on the
+    [`SUBSTR`](/content/commands/substr.md) are calculated on the
     server the first time and then cached separately from the original
     string.
--   Using [`GETBIT`]({{< relref "/commands/getbit" >}}) or
-    [`BITFIELD`]({{< relref "/commands/bitfield" >}}) on a string
+-   Using [`GETBIT`](/content/commands/getbit.md) or
+    [`BITFIELD`](/content/commands/bitfield.md) on a string
     caches the returned values separately from the original string.
 -   For composite data types accessed by keys
-    ([hash]({{< relref "/develop/data-types/hashes" >}}),
-    [JSON]({{< relref "/develop/data-types/json" >}}),
-    [set]({{< relref "/develop/data-types/sets" >}}), and
-    [sorted set]({{< relref "/develop/data-types/sorted-sets" >}})),
+    ([hash](/content/develop/data-types/hashes.md),
+    [JSON](/content/develop/data-types/json/_index.md),
+    [set](/content/develop/data-types/sets.md), and
+    [sorted set](/content/develop/data-types/sorted-sets.md)),
     the whole object is cached separately from the individual fields.
     So the results of `JSON.GET mykey $` and `JSON.GET mykey $.myfield` create
     separate entries in the cache.
--   Ranges from [lists]({{< relref "/develop/data-types/lists" >}}),
-    [streams]({{< relref "/develop/data-types/streams" >}}),
-    and [sorted sets]({{< relref "/develop/data-types/sorted-sets" >}})
+-   Ranges from [lists](/content/develop/data-types/lists.md),
+    [streams](/content/develop/data-types/streams/_index.md),
+    and [sorted sets](/content/develop/data-types/sorted-sets.md)
     are cached separately from the object they form a part of. Likewise,
-    subsets returned by [`SINTER`]({{< relref "/commands/sinter" >}}) and
-    [`SDIFF`]({{< relref "/commands/sdiff" >}}) create separate cache entries.
--   For multi-key read commands such as [`MGET`]({{< relref "/commands/mget" >}}),
+    subsets returned by [`SINTER`](/content/commands/sinter.md) and
+    [`SDIFF`](/content/commands/sdiff.md) create separate cache entries.
+-   For multi-key read commands such as [`MGET`](/content/commands/mget.md),
     the ordering of the keys is significant. For example `MGET name:1 name:2` is
     cached separately from `MGET name:2 name:1` because the server returns the
     values in the order you specify.
 -   Boolean or numeric values calculated from data types (for example 
-    [`SISMEMBER`]({{< relref "/commands/sismember" >}})) and
-    [`LLEN`]({{< relref "/commands/llen" >}}) are cached separately from the
+    [`SISMEMBER`](/content/commands/sismember.md)) and
+    [`LLEN`](/content/commands/llen.md) are cached separately from the
     object they refer to.
 
 ## Usage recommendations
@@ -187,7 +187,7 @@ limitations:
     can calculate an estimate for this number by dividing the 
     maximum desired size of the
     cache in memory by the average size of the items you want to store
-    (use the [`MEMORY USAGE`]({{< relref "/commands/memory-usage" >}})
+    (use the [`MEMORY USAGE`](/content/commands/memory-usage.md)
     command to get the memory footprint of a key). For example, if you had
     10MB (or 10485760 bytes) available for the cache, and the average
     size of an item was 80 bytes, you could fit approximately
@@ -200,5 +200,5 @@ limitations:
     The Redis server implements extra features for client-side caching that are not used by
     the main Redis clients, but may be useful for custom clients and other
     advanced applications. See
-    [Client-side caching reference]({{< relref "/develop/reference/client-side-caching" >}})
+    [Client-side caching reference](/content/develop/reference/client-side-caching.md)
     for a full technical guide to all the options available for client-side caching.

--- a/content/develop/clients/error-handling.md
+++ b/content/develop/clients/error-handling.md
@@ -69,8 +69,8 @@ Command errors occur when Redis receives an invalid or malformed command. These 
 -   Typo in command name
 -   Wrong number of arguments
 -   Invalid argument types (for example, supplying a
-    [string]({{< relref "/develop/data-types/strings" >}}) key to a
-    [list]({{< relref "/develop/data-types/lists" >}}) command))
+    [string](/content/develop/data-types/strings/_index.md) key to a
+    [list](/content/develop/data-types/lists.md) command))
 -   Using a command that doesn't exist in your Redis version
 
 **Examples:**
@@ -282,7 +282,7 @@ occur and monitor the logs for patterns. This can help you identify
 which errors are most common and whether your retry and fallback
 strategies are effective. Note that some Redis client
 libraries have built-in instrumentation that can provide this
-information for you (see [Observability]({{< relref "/develop/clients/observability" >}})
+information for you (see [Observability](/content/develop/clients/observability.md)
 for a full description).
 
 ### What to log
@@ -388,11 +388,11 @@ result = r.get(key)  # Might timeout waiting for connection
 
 For detailed information about exceptions in your client library, see:
 
-- [redis-py error handling]({{< relref "/develop/clients/redis-py/error-handling" >}})
-- [Node.js error handling]({{< relref "/develop/clients/nodejs/error-handling" >}})
-- [Java (Jedis) error handling]({{< relref "/develop/clients/jedis/error-handling" >}})
-- [Java (Lettuce) error handling]({{< relref "/develop/clients/lettuce/error-handling" >}})
-- [Go (go-redis) error handling]({{< relref "/develop/clients/go/error-handling" >}})
-- [.NET (StackExchange.Redis) error handling]({{< relref "/develop/clients/dotnet/error-handling" >}})
-- [PHP (Predis) error handling]({{< relref "/develop/clients/php/error-handling" >}})
-- [Ruby (redis-rb) error handling]({{< relref "/develop/clients/ruby/error-handling" >}})
+- [redis-py error handling](/content/develop/clients/redis-py/error-handling.md)
+- [Node.js error handling](/content/develop/clients/nodejs/error-handling.md)
+- [Java (Jedis) error handling](/content/develop/clients/jedis/error-handling.md)
+- [Java (Lettuce) error handling](/content/develop/clients/lettuce/error-handling.md)
+- [Go (go-redis) error handling](/content/develop/clients/go/error-handling.md)
+- [.NET (StackExchange.Redis) error handling](/content/develop/clients/dotnet/error-handling.md)
+- [PHP (Predis) error handling](/content/develop/clients/php/error-handling.md)
+- [Ruby (redis-rb) error handling](/content/develop/clients/ruby/error-handling.md)

--- a/content/develop/clients/failover.md
+++ b/content/develop/clients/failover.md
@@ -38,14 +38,14 @@ along with their release state and available features.
 
 | Client | Basic failover | Pub/sub failover | OSS Cluster failover | Failback |
 | :-- | :-- | :-- | :-- | :-- |
-| [Jedis]({{< relref "/develop/clients/jedis/failover" >}}) | Yes | No | No | Yes |
-| [redis-py]({{< relref "/develop/clients/redis-py/failover" >}}) | Yes  (Preview) | Yes | Yes | Yes |
-| [Lettuce]({{< relref "/develop/clients/lettuce/failover" >}}) | Yes (Preview) | Yes | No | Yes |
-| [StackExchange.Redis]({{< relref "/develop/clients/dotnet/failover" >}}) | Yes | Yes | Yes | Yes |
+| [Jedis](/content/develop/clients/jedis/failover.md) | Yes | No | No | Yes |
+| [redis-py](/content/develop/clients/redis-py/failover.md) | Yes  (Preview) | Yes | Yes | Yes |
+| [Lettuce](/content/develop/clients/lettuce/failover.md) | Yes (Preview) | Yes | No | Yes |
+| [StackExchange.Redis](/content/develop/clients/dotnet/failover.md) | Yes | Yes | Yes | Yes |
 
 ## Concepts
 
-You may have several [Active-Active databases]({{< relref "/operate/rs/databases/active-active" >}})
+You may have several [Active-Active databases](/content/operate/rs/databases/active-active/_index.md)
 or independent Redis servers that are all suitable to serve your app.
 Typically, you would prefer to use some database endpoints over others for a particular
 instance of your app (perhaps the ones that are closest geographically to the app server
@@ -106,10 +106,10 @@ Clients periodically run a "health check" on each server to see if it has recove
 Several health check strategies are implemented in all clients:
 
 -   **Ping**: This is the default strategy, which just sends a
-    [`PING`]({{< relref "/commands/ping" >}}) command and ensures that it gives the
+    [`PING`](/content/commands/ping.md) command and ensures that it gives the
     expected response.
 -   **Lag aware** (Redis Software only): This strategy uses the
-    [REST API]({{< relref "/operate/rs/references/rest-api" >}}) to check the
+    [REST API](/content/operate/rs/references/rest-api/_index.md) to check the
     synchronization lag between a specific database and the others in the Active-Active
     setup. If the lag is within a specified tolerance, the server is considered healthy.
 -   **Custom**: You can implement your own health check strategy to use information

--- a/content/develop/clients/observability.md
+++ b/content/develop/clients/observability.md
@@ -32,9 +32,9 @@ observability framework to let you gather performance metrics
 for your application. This can help you optimize performance and pinpoint problems
 quickly. Currently, the following clients support OTel:
 
-- [redis-py]({{< relref "/develop/clients/redis-py/observability" >}})
-- [go-redis]({{< relref "/develop/clients/go/observability" >}})
-- [node-redis]({{< relref "/develop/clients/nodejs/observability" >}})
+- [redis-py](/content/develop/clients/redis-py/observability.md)
+- [go-redis](/content/develop/clients/go/observability.md)
+- [node-redis](/content/develop/clients/nodejs/observability.md)
 
 
 <!--
@@ -154,11 +154,11 @@ metric groups:
 - [`connection-advanced`](#group-connection-advanced): more detailed metrics about Redis connections.
 - [`command`](#group-command): metrics about Redis commands executed by the client.
 - [`client-side-caching`](#group-client-side-caching): metrics about
-  [client-side caching]({{< relref "/develop/clients/client-side-caching" >}}) operations.
+  [client-side caching](/content/develop/clients/client-side-caching.md) operations.
 - [`streaming`](#group-streaming): metrics about
-  [stream]({{< relref "/develop/data-types/streams" >}}) operations.
+  [stream](/content/develop/data-types/streams/_index.md) operations.
 - [`pubsub`](#group-pubsub): metrics about
-  [pub/sub]({{< relref "/develop/pubsub" >}}) operations.
+  [pub/sub](/content/develop/pubsub/_index.md) operations.
 
 When you configure the client to activate OTel, you can select which metric groups
 you are interested in. By default, only the `resiliency` and `connection-basic` groups are enabled.

--- a/content/develop/clients/pools-and-muxing.md
+++ b/content/develop/clients/pools-and-muxing.md
@@ -27,13 +27,13 @@ code by making as few separate connections as possible.
 Managing connections in your own code can be tricky, so the Redis
 client libraries give you some help. The two basic approaches to
 connection management are called *connection pooling* and *multiplexing*.
-The [`redis-py`]({{< relref "/develop/clients/redis-py" >}}),
-[`jedis`]({{< relref "/develop/clients/jedis" >}}), and
-[`go-redis`]({{< relref "/develop/clients/go" >}}) clients support
+The [`redis-py`](/content/develop/clients/redis-py/_index.md),
+[`jedis`](/content/develop/clients/jedis/_index.md), and
+[`go-redis`](/content/develop/clients/go/_index.md) clients support
 connection pooling, while
-[`StackExchange.Redis`]({{< relref "/develop/clients/dotnet" >}})
+[`StackExchange.Redis`](/content/develop/clients/dotnet/_index.md)
 supports multiplexing.
-[`Lettuce`]({{< relref "/develop/clients/lettuce" >}})
+[`Lettuce`](/content/develop/clients/lettuce/_index.md)
 supports both approaches.
 
 ## Connection pooling
@@ -71,11 +71,11 @@ used to identify where to send the response data from your commands.
 
 Note that it is not a problem if the multiplexer receives several commands close
 together in time. When this happens, the multiplexer can often combine the commands into a
-[pipeline]({{< relref "/develop/using-commands/pipelining" >}}), which
+[pipeline](/content/develop/using-commands/pipelining.md), which
 improves efficiency.
 
 Multiplexing offers high efficiency but works transparently without requiring
 any special code to enable it in your app. The main disadvantage of multiplexing compared to
 connection pooling is that it can't support the blocking "pop" commands (such as
-[`BLPOP`]({{< relref "/commands/blpop" >}})) since these would stall the
+[`BLPOP`](/content/commands/blpop.md)) since these would stall the
 connection for all callers.

--- a/content/develop/clients/redis-vl.md
+++ b/content/develop/clients/redis-vl.md
@@ -18,4 +18,4 @@ title: Redis vector library guide (Python)
 weight: 2
 ---
 
-See the [RedisVL Guide]({{< relref "/develop/ai/redisvl" >}}) for more information.
+See the [RedisVL Guide](/content/develop/ai/redisvl/_index.md) for more information.

--- a/content/develop/clients/sch.md
+++ b/content/develop/clients/sch.md
@@ -47,36 +47,36 @@ client avoid disruptions in service during the maintenance period:
     see no disruption in service. These transparent reconnections to new endpoints
     are known as *pre-handoffs*.
 
-{{< note >}}SCH does not work with blocking connections.
-These include connections used for blocking operations like
-[`BLPOP`]({{< relref "/commands/blpop" >}}) and also
-[pub/sub]({{< relref "/develop/pubsub" >}}) subscriptions.
-All non-blocking operations are safe to use with SCH.
-{{< /note >}}
+> [!NOTE]
+> SCH does not work with blocking connections.
+> These include connections used for blocking operations like
+> [`BLPOP`](/content/commands/blpop.md) and also
+> [pub/sub](/content/develop/pubsub/_index.md) subscriptions.
+> All non-blocking operations are safe to use with SCH.
 
 ## SCH support in Redis client libraries
 
 SCH is enabled automatically on the client side during connection
-if you select the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
+if you select the [RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
 protocol, which is a requirement for SCH. However, you can
 configure some parameters, such as the timeouts to use
 during maintenance.
 
 The table below lists the Redis client libraries that support SCH,
 and the versions that added support for basic connections and
-[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
+[OSS Cluster API](/content/operate/rs/databases/configure/oss-cluster-api.md) connections.
 
 | Client | Basic connection | OSS Cluster API | Client-side geographic failover |
 | :-- | :-- | :-- | :-- |
-| [redis-py]({{< relref "/develop/clients/redis-py/connect#connect-using-smart-client-handoffs-sch" >}}) | v7.0.0 | v7.2.0 | Disabled |
-| [node-redis]({{< relref "/develop/clients/nodejs/connect#connect-using-smart-client-handoffs-sch" >}}) | v5.9.0 | v5.11.0 | Disabled |
-| [Lettuce]({{< relref "/develop/clients/lettuce/connect#connect-using-smart-client-handoffs-sch" >}}) | v7.0.0 | - | Disabled |
-| [go-redis]({{< relref "/develop/clients/go/connect#connect-using-smart-client-handoffs-sch" >}}) | v9.16.0 | v9.18.0 | Disabled |
+| [redis-py](/content/develop/clients/redis-py/connect.md#connect-using-smart-client-handoffs-sch) | v7.0.0 | v7.2.0 | Disabled |
+| [node-redis](/content/develop/clients/nodejs/connect.md#connect-using-smart-client-handoffs-sch) | v5.9.0 | v5.11.0 | Disabled |
+| [Lettuce](/content/develop/clients/lettuce/connect.md#connect-using-smart-client-handoffs-sch) | v7.0.0 | - | Disabled |
+| [go-redis](/content/develop/clients/go/connect.md#connect-using-smart-client-handoffs-sch) | v9.16.0 | v9.18.0 | Disabled |
 
-{{< note >}}SCH is currently disabled when a client is configured for
-[Client-side geographic failover]({{< relref "/develop/clients/failover" >}}).
-Integration of the two features is planned for a future release.
-{{< /note >}}
+> [!NOTE]
+> SCH is currently disabled when a client is configured for
+> [Client-side geographic failover](/content/develop/clients/failover.md).
+> Integration of the two features is planned for a future release.
 
 ## SCH support in Redis server products
 
@@ -85,8 +85,8 @@ Integration of the two features is planned for a future release.
 SCH is fully supported and enabled by default on Redis Cloud, except when you
 are using one of the following options:
 
-- [AWS PrivateLink]({{< relref "/operate/rc/security/aws-privatelink" >}})
-- [Google Cloud Private Service Connect]({{< relref "/operate/rc/security/private-service-connect" >}})
+- [AWS PrivateLink](/content/operate/rc/security/aws-privatelink.md)
+- [Google Cloud Private Service Connect](/content/operate/rc/security/private-service-connect.md)
 
 These services don't currently allow for pre-handoffs, but you still get the
 benefit of relaxed timeouts during database version upgrades. All other
@@ -95,7 +95,7 @@ configurations have full support for both relaxed timeouts and pre-handoffs.
 ### Redis Software
 
 You must enable SCH explicitly on self-managed Redis Software servers by using the
-[v1/cluster]({{< relref "/operate/rs/references/rest-api/requests/cluster" >}})
+[v1/cluster](/content/operate/rs/references/rest-api/requests/cluster/_index.md)
 REST API request to set the `client_maint_notifications` option to `true`.
 The example below shows how to do this using the
 [`curl`](https://curl.se/) command line utility:
@@ -119,8 +119,8 @@ the specific upgrade method you use, as detailed in the table below.
 
 ### Redis Enterprise for Kubernetes
 
-SCH is not currently supported for [Kubernetes]({{< relref "/operate/kubernetes" >}}) clusters.
+SCH is not currently supported for [Kubernetes](/content/operate/kubernetes/_index.md) clusters.
 
 ### Redis Open Source
 
-SCH is not currently supported for [Redis Open Source]({{< relref "/operate/oss_and_stack" >}}).
+SCH is not currently supported for [Redis Open Source](/content/operate/oss_and_stack/_index.md).

--- a/content/develop/clients/version-support.md
+++ b/content/develop/clients/version-support.md
@@ -24,7 +24,7 @@ rules for those clients.
 
 The policy is based on the non-EOL Redis Server **major.minor** versions
 currently available in Redis Cloud, as listed in
-[Supported database versions]({{< relref "/operate/rc/databases/version-management#supported-database-versions" >}}).
+[Supported database versions](/content/operate/rc/databases/version-management/_index.md#supported-database-versions).
 
 ## Versioning
 
@@ -50,7 +50,7 @@ for future patch and maintenance releases (for example, `5.2.x`).
 
 Each new client `major`, `minor`, and `patch` release is tested against a
 compatibility matrix of the
-[non-EOL Redis API versions]({{< relref "/operate/rc/databases/version-management#supported-database-versions" >}})
+[non-EOL Redis API versions](/content/operate/rc/databases/version-management/_index.md#supported-database-versions)
 currently available. For example, if the supported API versions are 6.2, 7.2,
 and 7.4, then each client release is tested against all three. The release notes
 for each client report the compatibility matrix used for testing.


### PR DESCRIPTION
## Summary
- Converts the section per DOC-7047 (the DOC-6909 render-hook rollout): the 9 shared top-level files directly under `content/develop/clients/` (`_index.md`, `client-side-caching.md`, `error-handling.md`, `failover.md`, `observability.md`, `pools-and-muxing.md`, `redis-vl.md`, `sch.md`, `version-support.md`).
- `{{< relref >}}` shortcode links -> plain Markdown links -> canonical `/content/<path>.md[#anchor]` form, resolved by `layouts/_default/_markup/render-link.html`.
- 4 `{{< note >}}` callouts (in `_index.md`, `client-side-caching.md`, `sch.md`) -> `> [!NOTE]`-style Markdown blockquotes, resolved by `layouts/_default/_markup/render-blockquote.html`.
- 109 relref links converted; all now resolve to real content files or were left untouched where they don't (expected/no-op).
- Uses the conversion tooling from PR #3937 (not yet merged, so not included in this PR) — the script was pulled in as an untracked helper, used to convert, then deleted before committing.
- This unit does **not** touch any per-client subdirectory (dotnet, go, jedis, etc.) — only the 9 shared files directly under `develop/clients/`.

## Test plan
- [x] Reviewed the full diff file-by-file: no remaining `{{< relref` or callout shortcodes, no nested shortcodes mangled, no custom-title alert forms (none were present).
- [x] `python3 .claude/hooks/check_shortcode_paths.py --scan content/develop/clients/*.md` -> `0 with issues`.
- [x] Spot-checked rewritten links resolve to real content files with anchors preserved (e.g. `#connect-using-smart-client-handoffs-sch`).
- [ ] Full-site Hugo build verification (rendered-href diff) is being run centrally by the ticket owner across all DOC-7047 units before merge — isolated worktrees here can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout syntax migration with no application or runtime behavior changes; main risk is broken internal links if a path or anchor is wrong until full Hugo build verification.
> 
> **Overview**
> Updates **nine** shared pages under `content/develop/clients/` (`_index.md`, client-side caching, error handling, failover, observability, pools/multiplexing, redis-vl stub, SCH, version support) as part of the DOC-7047 render-hook rollout.
> 
> **Internal links:** Roughly **109** `{{< relref >}}` shortcodes are replaced with plain Markdown links in canonical `/content/.../*.md` form (including anchors such as `#connect-using-client-side-caching`). Hugo’s `render-link.html` hook resolves these at build time instead of `relref`.
> 
> **Callouts:** Four `{{< note >}}` shortcodes in `_index.md`, `client-side-caching.md`, and `sch.md` become GitHub-style `> [!NOTE]` blockquotes, handled by `render-blockquote.html`.
> 
> Prose, tables, images, and other shortcodes (e.g. `{{< image >}}`, `{{< embed-md >}}`) are unchanged. Per-client subdirectories are **not** touched in this unit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fccb80086be73c08c12038a6db9a00072f740488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->