### PR TITLE
DOC-7047: Migrate develop/clients/patterns to render hooks

### DIFF
--- a/content/develop/clients/patterns/_index.md
+++ b/content/develop/clients/patterns/_index.md
@@ -23,19 +23,19 @@ weight: 100
 
 The following documents describe some novel development patterns you can use with Redis.
 
-[Bulk loading]({{< relref "/develop/clients/patterns/bulk-loading" >}})
+[Bulk loading](/content/develop/clients/patterns/bulk-loading.md)
 
 Writing data in bulk using the Redis protocol
 
-[Distributed Locks with Redis]({{< relref "/develop/clients/patterns/distributed-locks" >}})
+[Distributed Locks with Redis](/content/develop/clients/patterns/distributed-locks.md)
 
 A distributed lock pattern with Redis
 
-[Secondary indexing]({{< relref "/develop/clients/patterns/indexes/index" >}})
+[Secondary indexing](/content/develop/clients/patterns/indexes/index.md)
 
 Building secondary indexes in Redis
 
-[Redis patterns example]({{< relref "/develop/clients/patterns/twitter-clone" >}})
+[Redis patterns example](/content/develop/clients/patterns/twitter-clone.md)
 
 Learn several Redis patterns by building a Twitter clone
 

--- a/content/develop/clients/patterns/bulk-loading.md
+++ b/content/develop/clients/patterns/bulk-loading.md
@@ -74,7 +74,7 @@ from the Redis instance to the standard output.
 ### Generating Redis Protocol
 
 The Redis protocol is extremely simple to generate and parse, and is
-[Documented here]({{< relref "/develop/reference/protocol-spec" >}}). However in order to generate protocol for
+[Documented here](/content/develop/reference/protocol-spec.md). However in order to generate protocol for
 the goal of bulk loading you don't need to understand every detail of the
 protocol, but just that every command is represented in the following way:
 

--- a/content/develop/clients/patterns/distributed-locks.md
+++ b/content/develop/clients/patterns/distributed-locks.md
@@ -114,7 +114,7 @@ The `DELEX` command was introduced in Redis 8.4. On previous Redis versions, thi
     end
 
 This is important in order to avoid removing a lock that was created by another client. For example a client may acquire the lock, get blocked performing some operation for longer than the lock validity time (the time at which the key will expire), and later remove the lock, that was already acquired by some other client.
-Using just [`DEL`]({{< relref "/commands/del" >}}) is not safe as a client may remove another client's lock. With the `DELEX` command or the above script instead every lock is "signed" with a random string, so the lock will be removed only if it is still the one that was set by the client trying to remove it.
+Using just [`DEL`](/content/commands/del.md) is not safe as a client may remove another client's lock. With the `DELEX` command or the above script instead every lock is "signed" with a random string, so the lock will be removed only if it is still the one that was set by the client trying to remove it.
 
 What should this random string be? We assume it’s 20 bytes from `/dev/urandom`, but you can find cheaper ways to make it unique enough for your tasks.
 For example a safe pick is to seed RC4 with `/dev/urandom`, and generate a pseudo random stream from that.
@@ -146,7 +146,7 @@ This paper contains more information about similar systems requiring a bound *cl
 
 ### Retry on Failure
 
-When a client is unable to acquire the lock, it should try again after a random delay in order to try to desynchronize multiple clients trying to acquire the lock for the same resource at the same time (this may result in a split brain condition where nobody wins). Also the faster a client tries to acquire the lock in the majority of Redis instances, the smaller the window for a split brain condition (and the need for a retry), so ideally the client should try to send the [`SET`]({{< relref "/commands/set" >}}) commands to the N instances at the same time using multiplexing.
+When a client is unable to acquire the lock, it should try again after a random delay in order to try to desynchronize multiple clients trying to acquire the lock for the same resource at the same time (this may result in a split brain condition where nobody wins). Also the faster a client tries to acquire the lock in the majority of Redis instances, the smaller the window for a split brain condition (and the need for a retry), so ideally the client should try to send the [`SET`](/content/commands/set.md) commands to the N instances at the same time using multiplexing.
 
 It is worth stressing how important it is for clients that fail to acquire the majority of locks, to release the (partially) acquired locks ASAP, so that there is no need to wait for key expiry in order for the lock to be acquired again (however if a network partition happens and the client is no longer able to communicate with the Redis instances, there is an availability penalty to pay as it waits for key expiration).
 
@@ -174,7 +174,7 @@ The system liveness is based on three main features:
 2. The fact that clients, usually, will cooperate removing the locks when the lock was not acquired, or when the lock was acquired and the work terminated, making it likely that we don’t have to wait for keys to expire to re-acquire the lock.
 3. The fact that when a client needs to retry a lock, it waits a time which is comparably greater than the time needed to acquire the majority of locks, in order to probabilistically make split brain conditions during resource contention unlikely.
 
-However, we pay an availability penalty equal to [`TTL`]({{< relref "/commands/ttl" >}}) time on network partitions, so if there are continuous partitions, we can pay this penalty indefinitely.
+However, we pay an availability penalty equal to [`TTL`](/content/commands/ttl.md) time on network partitions, so if there are continuous partitions, we can pay this penalty indefinitely.
 This happens every time a client acquires a lock and gets partitioned away before being able to remove the lock.
 
 Basically if there are infinite continuous network partitions, the system may become not available for an infinite amount of time.
@@ -187,7 +187,7 @@ However there is another consideration around persistence if we want to target a
 
 Basically to see the problem here, let’s assume we configure Redis without persistence at all. A client acquires the lock in 3 of 5 instances. One of the instances where the client was able to acquire the lock is restarted, at this point there are again 3 instances that we can lock for the same resource, and another client can lock it again, violating the safety property of exclusivity of lock.
 
-If we enable AOF persistence, things will improve quite a bit. For example we can upgrade a server by sending it a [`SHUTDOWN`]({{< relref "/commands/shutdown" >}}) command and restarting it. Because Redis expires are semantically implemented so that time still elapses when the server is off, all our requirements are fine.
+If we enable AOF persistence, things will improve quite a bit. For example we can upgrade a server by sending it a [`SHUTDOWN`](/content/commands/shutdown.md) command and restarting it. Because Redis expires are semantically implemented so that time still elapses when the server is off, all our requirements are fine.
 However everything is fine as long as it is a clean shutdown. What about a power outage? If Redis is configured, as by default, to fsync on disk every second, it is possible that after a restart our key is missing. In theory, if we want to guarantee the lock safety in the face of any kind of instance restart, we need to enable `fsync=always` in the persistence settings. This will affect performance due to the additional sync overhead.
 
 However things are better than they look like at a first glance. Basically,
@@ -197,14 +197,14 @@ set of currently active locks when the instance restarts were all obtained
 by locking instances other than the one which is rejoining the system.
 
 To guarantee this we just need to make an instance, after a crash, unavailable
-for at least a bit more than the max [`TTL`]({{< relref "/commands/ttl" >}}) we use.  This is the time needed
+for at least a bit more than the max [`TTL`](/content/commands/ttl.md) we use.  This is the time needed
 for all the keys about the locks that existed when the instance crashed to
 become invalid and be automatically released.
 
 Using *delayed restarts* it is basically possible to achieve safety even
 without any kind of Redis persistence available, however note that this may
 translate into an availability penalty. For example if a majority of instances
-crash, the system will become globally unavailable for [`TTL`]({{< relref "/commands/ttl" >}}) (here globally means
+crash, the system will become globally unavailable for [`TTL`](/content/commands/ttl.md) (here globally means
 that no resource at all will be lockable during this time).
 
 ### Making the algorithm more reliable: Extending the lock

--- a/content/develop/clients/patterns/indexes/index.md
+++ b/content/develop/clients/patterns/indexes/index.md
@@ -45,12 +45,12 @@ Redis Search provides capabilities to index and query both hash and JSON keys us
 * `VECTOR`
 * `GEOSHAPE`
 
-Once hash or JSON keys have been indexed using the [`FT.CREATE`]({{< relref "commands/ft.create" >}}) command, all keys that use the prefix defined in the index can be queried using the [`FT.SEARCH`]({{< relref "commands/ft.search" >}}) and [`FT.AGGREGATE`]({{< relref "commands/ft.aggregate" >}}) commands.
+Once hash or JSON keys have been indexed using the [`FT.CREATE`](/content/commands/ft.create.md) command, all keys that use the prefix defined in the index can be queried using the [`FT.SEARCH`](/content/commands/ft.search.md) and [`FT.AGGREGATE`](/content/commands/ft.aggregate.md) commands.
 
 For more information on creating hash and JSON indexes, see the following pages.
 
-* [Hash indexes]({{< relref "/develop/ai/search-and-query/indexing/schema-definition" >}})
-* [JSON indexes]({{< relref "/develop/ai/search-and-query/indexing" >}})
+* [Hash indexes](/content/develop/ai/search-and-query/indexing/schema-definition.md)
+* [JSON indexes](/content/develop/ai/search-and-query/indexing/_index.md)
 
 ## Simple numerical indexes with sorted sets
 
@@ -63,8 +63,8 @@ Since the score is a double precision float, indexes you can build with
 vanilla sorted sets are limited to things where the indexing field is a number
 within a given range.
 
-The two commands to build these kind of indexes are [`ZADD`]({{< relref "/commands/zadd" >}}) and
-[`ZRANGE`]({{< relref "/commands/zrange" >}}) with the `BYSCORE` argument to respectively add items and retrieve items within a
+The two commands to build these kind of indexes are [`ZADD`](/content/commands/zadd.md) and
+[`ZRANGE`](/content/commands/zrange.md) with the `BYSCORE` argument to respectively add items and retrieve items within a
 specified range.
 
 For instance, it is possible to index a set of person names by their
@@ -83,18 +83,18 @@ command can be used:
     1) "Manuel"
     2) "Jon"
 
-By using the **WITHSCORES** option of [`ZRANGE`]({{< relref "/commands/zrange" >}}) it is also possible
+By using the **WITHSCORES** option of [`ZRANGE`](/content/commands/zrange.md) it is also possible
 to obtain the scores associated with the returned elements.
 
-The [`ZCOUNT`]({{< relref "/commands/zcount" >}}) command can be used in order to retrieve the number of elements
+The [`ZCOUNT`](/content/commands/zcount.md) command can be used in order to retrieve the number of elements
 within a given range, without actually fetching the elements, which is also
 useful, especially given the fact the operation is executed in logarithmic
 time regardless of the size of the range.
 
-Ranges can be inclusive or exclusive, please refer to the [`ZRANGE`]({{< relref "/commands/zrange" >}})
+Ranges can be inclusive or exclusive, please refer to the [`ZRANGE`](/content/commands/zrange.md)
 command documentation for more information.
 
-**Note**: Using the [`ZRANGE`]({{< relref "/commands/zrange" >}}) with the `BYSCORE` and `REV` arguments, it is possible to query a range in
+**Note**: Using the [`ZRANGE`](/content/commands/zrange.md) with the `BYSCORE` and `REV` arguments, it is possible to query a range in
 reversed order, which is often useful when data is indexed in a given
 direction (ascending or descending) but we want to retrieve information
 the other way around.
@@ -121,8 +121,8 @@ could do:
     ZADD user.age.index 33 3
 
 This time the value associated with the score in the sorted set is the
-ID of the object. So once I query the index with [`ZRANGE`]({{< relref "/commands/zrange" >}}) with the `BYSCORE` argument, I'll
-also have to retrieve the information I need with [`HGETALL`]({{< relref "/commands/hgetall" >}}) or similar
+ID of the object. So once I query the index with [`ZRANGE`](/content/commands/zrange.md) with the `BYSCORE` argument, I'll
+also have to retrieve the information I need with [`HGETALL`](/content/commands/hgetall.md) or similar
 commands. The obvious advantage is that objects can change without touching
 the index, as long as we don't change the indexed field.
 
@@ -138,7 +138,7 @@ make sense to use the birth date as index instead of the age itself,
 but there are other cases where we simply want some field to change from
 time to time, and the index to reflect this change.
 
-The [`ZADD`]({{< relref "/commands/zadd" >}}) command makes updating simple indexes a very trivial operation
+The [`ZADD`](/content/commands/zadd.md) command makes updating simple indexes a very trivial operation
 since re-adding back an element with a different score and the same value
 will simply update the score and move the element at the right position,
 so if the user `antirez` turned 39 years old, in order to update the
@@ -148,7 +148,7 @@ to execute the following two commands:
     HSET user:1 age 39
     ZADD user.age.index 39 1
 
-The operation may be wrapped in a [`MULTI`]({{< relref "/commands/multi" >}})/[`EXEC`]({{< relref "/commands/exec" >}}) transaction in order to
+The operation may be wrapped in a [`MULTI`](/content/commands/multi.md)/[`EXEC`](/content/commands/exec.md) transaction in order to
 make sure both fields are updated or none.
 
 ### Turn multi-dimensional data into linear data
@@ -160,7 +160,7 @@ is not always true. If you can efficiently represent something
 multi-dimensional in a linear way, they it is often possible to use a simple
 sorted set for indexing.
 
-For example the [Redis geo indexing API]({{< relref "/commands/geoadd" >}}) uses a sorted
+For example the [Redis geo indexing API](/content/commands/geoadd.md) uses a sorted
 set to index places by latitude and longitude using a technique called
 [Geo hash](https://en.wikipedia.org/wiki/Geohash). The sorted set score
 represents alternating bits of longitude and latitude, so that we map the
@@ -183,11 +183,11 @@ index.
 
 ## Time series indexes
 
-When you create a new time series using the [`TS.CREATE`]({{< relref "commands/ts.create" >}}) command, you can associate one or more `LABELS` with it. Each label is a name-value pair, where the both name and value are text. Labels serve as a secondary index that allows you to execute queries on groups of time series keys using various time series commands.
+When you create a new time series using the [`TS.CREATE`](/content/commands/ts.create.md) command, you can associate one or more `LABELS` with it. Each label is a name-value pair, where the both name and value are text. Labels serve as a secondary index that allows you to execute queries on groups of time series keys using various time series commands.
 
-See the [time series quickstart guide]({{< relref "/develop/data-types/timeseries#create-a-time-series" >}}) for an example of creating a time series with a label.
+See the [time series quickstart guide](/content/develop/data-types/timeseries/_index.md#create-a-time-series) for an example of creating a time series with a label.
 
-The [`TS.MGET`]({{< relref "commands/ts.mget" >}}), [`TS.MRANGE`]({{< relref "commands/ts.mrange" >}}), and [`TS.MREVRANGE`]({{< relref "commands/ts.mrevrange" >}}) commands operate on multiple time series based on specified labels or using a label-related filter expression. The [`TS.QUERYINDEX`]({{< relref "commands/ts.queryindex" >}}) command returns all time series keys matching a given label-related filter expression.
+The [`TS.MGET`](/content/commands/ts.mget.md), [`TS.MRANGE`](/content/commands/ts.mrange.md), and [`TS.MREVRANGE`](/content/commands/ts.mrevrange.md) commands operate on multiple time series based on specified labels or using a label-related filter expression. The [`TS.QUERYINDEX`](/content/commands/ts.queryindex.md) command returns all time series keys matching a given label-related filter expression.
 
 ## Lexicographical indexes
 
@@ -202,7 +202,7 @@ the second is checked and so forth. If the common prefix of two strings is
 the same then the longer string is considered the greater of the two,
 so "foobar" is greater than "foo".
 
-There are commands such as [`ZRANGE`]({{< relref "/commands/zrange" >}}) and [`ZLEXCOUNT`]({{< relref "/commands/zlexcount" >}}) that
+There are commands such as [`ZRANGE`](/content/commands/zrange.md) and [`ZLEXCOUNT`](/content/commands/zlexcount.md) that
 are able to query and count ranges in a lexicographically fashion, assuming
 they are used with sorted sets where all the elements have the same score.
 
@@ -230,7 +230,7 @@ are ordered lexicographically.
     3) "baaa"
     4) "bbbb"
 
-Now we can use [`ZRANGE`]({{< relref "/commands/zrange" >}}) with the `BYLEX` argument in order to perform range queries.
+Now we can use [`ZRANGE`](/content/commands/zrange.md) with the `BYLEX` argument in order to perform range queries.
 
     ZRANGE myindex [a (b BYLEX
     1) "aaaa"
@@ -266,7 +266,7 @@ we'll just do:
     ZADD myindex 0 banana
 
 And so forth for each search query ever encountered. Then when we want to
-complete the user input, we execute a range query using [`ZRANGE`]({{< relref "/commands/zrange" >}}) with the `BYLEX` argument.
+complete the user input, we execute a range query using [`ZRANGE`](/content/commands/zrange.md) with the `BYLEX` argument.
 Imagine the user is typing "bit" inside the search form, and we want to
 offer possible search keywords starting for "bit". We send Redis a command
 like that:
@@ -310,7 +310,7 @@ commands:
     ZADD myindex 0 banana:2
 
 Note that because it is possible that there are concurrent updates, the
-above three commands should be send via a [Lua script]({{< relref "/commands/eval" >}})
+above three commands should be send via a [Lua script](/content/commands/eval.md)
 instead, so that the Lua script will atomically get the old count and
 re-add the item with incremented score.
 
@@ -493,7 +493,7 @@ So for example, when we index we also add to a hash:
 This is not always needed, but simplifies the operations of updating
 the index. In order to remove the old information we indexed for the object
 ID 90, regardless of the *current* fields values of the object, we just
-have to retrieve the hash value by object ID and [`ZREM`]({{< relref "/commands/zrem" >}}) it in the sorted
+have to retrieve the hash value by object ID and [`ZREM`](/content/commands/zrem.md) it in the sorted
 set view.
 
 ## Represent and query graphs using a hexastore
@@ -735,20 +735,20 @@ in order to build other kind of indexes. They are very commonly used but
 maybe we don't always realize they are actually a form of indexing.
 
 For instance I can index object IDs into a Set data type in order to use
-the *get random elements* operation via [`SRANDMEMBER`]({{< relref "/commands/srandmember" >}}) in order to retrieve
+the *get random elements* operation via [`SRANDMEMBER`](/content/commands/srandmember.md) in order to retrieve
 a set of random objects. Sets can also be used to check for existence when
 all I need is to test if a given item exists or not or has a single boolean
 property or not.
 
 Similarly lists can be used in order to index items into a fixed order.
 I can add all my items into a Redis list and rotate the list with
-[`RPOPLPUSH`]({{< relref "/commands/rpoplpush" >}}) using the same key name as source and destination. This is useful
+[`RPOPLPUSH`](/content/commands/rpoplpush.md) using the same key name as source and destination. This is useful
 when I want to process a given set of items again and again forever in the
 same order. Think of an RSS feed system that needs to refresh the local copy
 periodically.
 
 Another popular index often used with Redis is a **capped list**, where items
-are added with [`LPUSH`]({{< relref "/commands/lpush" >}}) and trimmed with [`LTRIM`]({{< relref "/commands/ltrim" >}}), in order to create a view
+are added with [`LPUSH`](/content/commands/lpush.md) and trimmed with [`LTRIM`](/content/commands/ltrim.md), in order to create a view
 with just the latest N items encountered, in the same order they were
 seen.
 
@@ -761,5 +761,5 @@ bugs, network partitions or other events.
 Different strategies could be used. If the index data is outside Redis
 *read repair* can be a solution, where data is fixed in a lazy way when
 it is requested. When we index data which is stored in Redis itself
-the [`SCAN`]({{< relref "/commands/scan" >}}) family of commands can be used in order to verify, update or
+the [`SCAN`](/content/commands/scan.md) family of commands can be used in order to verify, update or
 rebuild the index from scratch, incrementally.

--- a/content/develop/clients/patterns/twitter-clone.md
+++ b/content/develop/clients/patterns/twitter-clone.md
@@ -37,7 +37,7 @@ implementation for the sake of following the article better).
 
 What is a key-value store?
 ---
-The essence of a key-value store is the ability to store some data, called a _value_, inside a key. The value can be retrieved later only if we know the specific key it was stored in. There is no direct way to search for a key by value. In some sense, it is like a very large hash/dictionary, but it is persistent, i.e. when your application ends, the data doesn't go away. So, for example, I can use the command [`SET`]({{< relref "/commands/set" >}}) to store the value *bar* in the key *foo*:
+The essence of a key-value store is the ability to store some data, called a _value_, inside a key. The value can be retrieved later only if we know the specific key it was stored in. There is no direct way to search for a key by value. In some sense, it is like a very large hash/dictionary, but it is persistent, i.e. when your application ends, the data doesn't go away. So, for example, I can use the command [`SET`](/content/commands/set.md) to store the value *bar* in the key *foo*:
 
     SET foo bar
 
@@ -45,7 +45,7 @@ Redis stores data permanently, so if I later ask "_What is the value stored in k
 
     GET foo => bar
 
-Other common operations provided by key-value stores are [`DEL`]({{< relref "/commands/del" >}}), to delete a given key and its associated value, SET-if-not-exists (called [`SETNX`]({{< relref "/commands/setnx" >}}) on Redis), to assign a value to a key only if the key does not already exist, and [`INCR`]({{< relref "/commands/incr" >}}), to atomically increment a number stored in a given key:
+Other common operations provided by key-value stores are [`DEL`](/content/commands/del.md), to delete a given key and its associated value, SET-if-not-exists (called [`SETNX`](/content/commands/setnx.md) on Redis), to assign a value to a key only if the key does not already exist, and [`INCR`](/content/commands/incr.md), to atomically increment a number stored in a given key:
 
     SET foo 10
     INCR foo => 11
@@ -55,7 +55,7 @@ Other common operations provided by key-value stores are [`DEL`]({{< relref "/co
 Atomic operations
 ---
 
-There is something special about [`INCR`]({{< relref "/commands/incr" >}}). You may wonder why Redis provides such an operation if we can do it ourselves with a bit of code? After all, it is as simple as:
+There is something special about [`INCR`](/content/commands/incr.md). You may wonder why Redis provides such an operation if we can do it ourselves with a bit of code? After all, it is as simple as:
 
     x = GET foo
     x = x + 1
@@ -83,7 +83,7 @@ In this section we will see which Redis features we need to build our Twitter cl
     LPUSH mylist b (now mylist holds 'b','a')
     LPUSH mylist c (now mylist holds 'c','b','a')
 
-[`LPUSH`]({{< relref "/commands/lpush" >}}) means _Left Push_, that is, add an element to the left (or to the head) of the list stored in _mylist_. If the key _mylist_ does not exist it is automatically created as an empty list before the PUSH operation. As you can imagine, there is also an [`RPUSH`]({{< relref "/commands/rpush" >}}) operation that adds the element to the right of the list (on the tail). This is very useful for our Twitter clone. User updates can be added to a list stored in `username:updates`, for instance.
+[`LPUSH`](/content/commands/lpush.md) means _Left Push_, that is, add an element to the left (or to the head) of the list stored in _mylist_. If the key _mylist_ does not exist it is automatically created as an empty list before the PUSH operation. As you can imagine, there is also an [`RPUSH`](/content/commands/rpush.md) operation that adds the element to the right of the list (on the tail). This is very useful for our Twitter clone. User updates can be added to a list stored in `username:updates`, for instance.
 
 There are operations to get data from Lists, of course. For instance, LRANGE returns a range from the list, or the whole list.
 
@@ -103,7 +103,7 @@ Sorted Sets, which are kind of a more capable version of Sets, it is better
 to start introducing Sets first (which are a very useful data structure
 per se), and later Sorted Sets.
 
-There are more data types than just Lists. Redis also supports Sets, which are unsorted collections of elements. It is possible to add, remove, and test for existence of members, and perform the intersection between different Sets. Of course it is possible to get the elements of a Set. Some examples will make it more clear. Keep in mind that [`SADD`]({{< relref "/commands/sadd" >}}) is the _add to set_ operation, [`SREM`]({{< relref "/commands/srem" >}}) is the _remove from set_ operation, [`SISMEMBER`]({{< relref "/commands/sismember" >}}) is the _test if member_ operation, and [`SINTER`]({{< relref "/commands/sinter" >}}) is the _perform intersection_ operation. Other operations are [`SCARD`]({{< relref "/commands/scard" >}}) to get the cardinality (the number of elements) of a Set, and [`SMEMBERS`]({{< relref "/commands/smembers" >}}) to return all the members of a Set.
+There are more data types than just Lists. Redis also supports Sets, which are unsorted collections of elements. It is possible to add, remove, and test for existence of members, and perform the intersection between different Sets. Of course it is possible to get the elements of a Set. Some examples will make it more clear. Keep in mind that [`SADD`](/content/commands/sadd.md) is the _add to set_ operation, [`SREM`](/content/commands/srem.md) is the _remove from set_ operation, [`SISMEMBER`](/content/commands/sismember.md) is the _test if member_ operation, and [`SINTER`](/content/commands/sinter.md) is the _perform intersection_ operation. Other operations are [`SCARD`](/content/commands/scard.md) to get the cardinality (the number of elements) of a Set, and [`SMEMBERS`](/content/commands/smembers.md) to return all the members of a Set.
 
     SADD myset a
     SADD myset b
@@ -112,14 +112,14 @@ There are more data types than just Lists. Redis also supports Sets, which are u
     SCARD myset => 4
     SMEMBERS myset => bar,a,foo,b
 
-Note that [`SMEMBERS`]({{< relref "/commands/smembers" >}}) does not return the elements in the same order we added them since Sets are *unsorted* collections of elements. When you want to store in order it is better to use Lists instead. Some more operations against Sets:
+Note that [`SMEMBERS`](/content/commands/smembers.md) does not return the elements in the same order we added them since Sets are *unsorted* collections of elements. When you want to store in order it is better to use Lists instead. Some more operations against Sets:
 
     SADD mynewset b
     SADD mynewset foo
     SADD mynewset hello
     SINTER myset mynewset => foo,b
 
-[`SINTER`]({{< relref "/commands/sinter" >}}) can return the intersection between Sets but it is not limited to two Sets. You may ask for the intersection of 4,5, or 10000 Sets. Finally let's check how [`SISMEMBER`]({{< relref "/commands/sismember" >}}) works:
+[`SINTER`](/content/commands/sinter.md) can return the intersection between Sets but it is not limited to two Sets. You may ask for the intersection of 4,5, or 10000 Sets. Finally let's check how [`SISMEMBER`](/content/commands/sismember.md) works:
 
     SISMEMBER myset foo => 1
     SISMEMBER myset notamember => 0
@@ -144,17 +144,17 @@ of Sorted Sets usage:
     ZADD zset 12.55 c
     ZRANGE zset 0 -1 => b,a,c
 
-In the above example we added a few elements with [`ZADD`]({{< relref "/commands/zadd" >}}), and later retrieved
-the elements with [`ZRANGE`]({{< relref "/commands/zrange" >}}). As you can see the elements are returned in order
+In the above example we added a few elements with [`ZADD`](/content/commands/zadd.md), and later retrieved
+the elements with [`ZRANGE`](/content/commands/zrange.md). As you can see the elements are returned in order
 according to their score. In order to check if a given element exists, and
-also to retrieve its score if it exists, we use the [`ZSCORE`]({{< relref "/commands/zscore" >}}) command:
+also to retrieve its score if it exists, we use the [`ZSCORE`](/content/commands/zscore.md) command:
 
     ZSCORE zset a => 10
     ZSCORE zset non_existing_element => NULL
 
 Sorted Sets are a very powerful data structure, you can query elements by
 score range, lexicographically, in reverse order, and so forth.
-To know more [please check the Sorted Set sections in the official Redis commands documentation]({{< relref "/commands/#sorted_set" >}}).
+To know more [please check the Sorted Set sections in the official Redis commands documentation](/commands/#sorted_set).
 
 The Hash data type
 ---
@@ -167,9 +167,9 @@ collection of fields associated with values:
     HMSET myuser name Salvatore surname Sanfilippo country Italy
     HGET myuser surname => Sanfilippo
 
-[`HMSET`]({{< relref "/commands/hmset" >}}) can be used to set fields in the hash, that can be retrieved with
-[`HGET`]({{< relref "/commands/hget" >}}) later. It is possible to check if a field exists with [`HEXISTS`]({{< relref "/commands/hexists" >}}), or
-to increment a hash field with [`HINCRBY`]({{< relref "/commands/hincrby" >}}) and so forth.
+[`HMSET`](/content/commands/hmset.md) can be used to set fields in the hash, that can be retrieved with
+[`HGET`](/content/commands/hget.md) later. It is possible to check if a field exists with [`HEXISTS`](/content/commands/hexists.md), or
+to increment a hash field with [`HINCRBY`](/content/commands/hincrby.md) and so forth.
 
 Hashes are the ideal data structure to represent *objects*. For example we
 use Hashes in order to represent Users and Updates in our Twitter clone.
@@ -189,7 +189,7 @@ Data layout
 
 When working with a relational database, a database schema must be designed so that we'd know the tables, indexes, and so on that the database will contain. We don't have tables in Redis, so what do we need to design? We need to identify what keys are needed to represent our objects and what kind of values these keys need to hold.
 
-Let's start with Users. We need to represent users, of course, with their username, userid, password, the set of users following a given user, the set of users a given user follows, and so on. The first question is, how should we identify a user? Like in a relational DB, a good solution is to identify different users with different numbers, so we can associate a unique ID with every user. Every other reference to this user will be done by id. Creating unique IDs is very simple to do by using our atomic [`INCR`]({{< relref "/commands/incr" >}}) operation. When we create a new user we can do something like this, assuming the user is called "antirez":
+Let's start with Users. We need to represent users, of course, with their username, userid, password, the set of users following a given user, the set of users a given user follows, and so on. The first question is, how should we identify a user? Like in a relational DB, a good solution is to identify different users with different numbers, so we can associate a unique ID with every user. Every other reference to this user will be done by id. Creating unique IDs is very simple to do by using our atomic [`INCR`](/content/commands/incr.md) operation. When we create a new user we can do something like this, assuming the user is called "antirez":
 
     INCR next_user_id => 1000
     HMSET user:1000 username antirez password p1pp0
@@ -225,7 +225,7 @@ We can add new followers with:
 
     ZADD followers:1000 1401267618 1234 => Add user 1234 with time 1401267618
 
-Another important thing we need is a place where we can add the updates to display in the user's home page. We'll need to access this data in chronological order later, from the most recent update to the oldest, so the perfect kind of data structure for this is a List. Basically every new update will be [`LPUSH`]({{< relref "/commands/lpush" >}})ed in the user updates key, and thanks to [`LRANGE`]({{< relref "/commands/lrange" >}}), we can implement pagination and so on. Note that we use the words _updates_ and _posts_ interchangeably, since updates are actually "little posts" in some way.
+Another important thing we need is a place where we can add the updates to display in the user's home page. We'll need to access this data in chronological order later, from the most recent update to the oldest, so the perfect kind of data structure for this is a List. Basically every new update will be [`LPUSH`](/content/commands/lpush.md)ed in the user updates key, and thanks to [`LRANGE`](/content/commands/lrange.md), we can implement pagination and so on. Note that we use the words _updates_ and _posts_ interchangeably, since updates are actually "little posts" in some way.
 
     posts:1000 => a List of post ids - every new post is LPUSHed here.
 
@@ -378,22 +378,22 @@ After we create a post and we obtain the post ID, we need to LPUSH the ID in the
 
     header("Location: index.php");
 
-The core of the function is the `foreach` loop. We use [`ZRANGE`]({{< relref "/commands/zrange" >}}) to get all the followers of the current user, then the loop will [`LPUSH`]({{< relref "/commands/lpush" >}}) the push the post in every follower timeline List.
+The core of the function is the `foreach` loop. We use [`ZRANGE`](/content/commands/zrange.md) to get all the followers of the current user, then the loop will [`LPUSH`](/content/commands/lpush.md) the push the post in every follower timeline List.
 
-Note that we also maintain a global timeline for all the posts, so that in the Retwis home page we can show everybody's updates easily. This requires just doing an [`LPUSH`]({{< relref "/commands/lpush" >}}) to the `timeline` List. Let's face it, aren't you starting to think it was a bit strange to have to sort things added in chronological order using `ORDER BY` with SQL? I think so.
+Note that we also maintain a global timeline for all the posts, so that in the Retwis home page we can show everybody's updates easily. This requires just doing an [`LPUSH`](/content/commands/lpush.md) to the `timeline` List. Let's face it, aren't you starting to think it was a bit strange to have to sort things added in chronological order using `ORDER BY` with SQL? I think so.
 
 There is an interesting thing to notice in the code above: we used a new
-command called [`LTRIM`]({{< relref "/commands/ltrim" >}}) after we perform the [`LPUSH`]({{< relref "/commands/lpush" >}}) operation in the global
+command called [`LTRIM`](/content/commands/ltrim.md) after we perform the [`LPUSH`](/content/commands/lpush.md) operation in the global
 timeline. This is used in order to trim the list to just 1000 elements. The
 global timeline is actually only used in order to show a few posts in the
 home page, there is no need to have the full history of all the posts.
 
-Basically [`LTRIM`]({{< relref "/commands/ltrim" >}}) + [`LPUSH`]({{< relref "/commands/lpush" >}}) is a way to create a *capped collection* in Redis.
+Basically [`LTRIM`](/content/commands/ltrim.md) + [`LPUSH`](/content/commands/lpush.md) is a way to create a *capped collection* in Redis.
 
 Paginating updates
 ---
 
-Now it should be pretty clear how we can use [`LRANGE`]({{< relref "/commands/lrange" >}}) in order to get ranges of posts, and render these posts on the screen. The code is simple:
+Now it should be pretty clear how we can use [`LRANGE`](/content/commands/lrange.md) in order to get ranges of posts, and render these posts on the screen. The code is simple:
 
     function showPost($id) {
         $r = redisLink();
@@ -424,7 +424,7 @@ Now it should be pretty clear how we can use [`LRANGE`]({{< relref "/commands/lr
 
 `showPost` will simply convert and print a Post in HTML while `showUserPosts` gets a range of posts and then passes them to `showPosts`.
 
-*Note: [`LRANGE`]({{< relref "/commands/lrange" >}}) is not very efficient if the list of posts start to be very
+*Note: [`LRANGE`](/content/commands/lrange.md) is not very efficient if the list of posts start to be very
 big, and we want to access elements which are in the middle of the list, since Redis Lists are backed by linked lists. If a system is designed for
 deep pagination of million of items, it is better to resort to Sorted Sets
 instead.*
@@ -432,12 +432,12 @@ instead.*
 Following users
 ---
 
-It is not hard, but we did not yet check how we create following / follower relationships. If user ID 1000 (antirez) wants to follow user ID 5000 (pippo), we need to create both a following and a follower relationship. We just need to [`ZADD`]({{< relref "/commands/zadd" >}}) calls:
+It is not hard, but we did not yet check how we create following / follower relationships. If user ID 1000 (antirez) wants to follow user ID 5000 (pippo), we need to create both a following and a follower relationship. We just need to [`ZADD`](/content/commands/zadd.md) calls:
 
         ZADD following:1000 5000
         ZADD followers:5000 1000
 
-Note the same pattern again and again. In theory with a relational database, the list of following and followers would be contained in a single table with fields like `following_id` and `follower_id`. You can extract the followers or following of every user using an SQL query. With a key-value DB things are a bit different since we need to set both the `1000 is following 5000` and `5000 is followed by 1000` relations. This is the price to pay, but on the other hand accessing the data is simpler and extremely fast. Having these things as separate sets allows us to do interesting stuff. For example, using [`ZINTERSTORE`]({{< relref "/commands/zinterstore" >}}) we can have the intersection of `following` of two different users, so we may add a feature to our Twitter clone so that it is able to tell you very quickly when you visit somebody else's profile, "you and Alice have 34 followers in common", and things like that.
+Note the same pattern again and again. In theory with a relational database, the list of following and followers would be contained in a single table with fields like `following_id` and `follower_id`. You can extract the followers or following of every user using an SQL query. With a key-value DB things are a bit different since we need to set both the `1000 is following 5000` and `5000 is followed by 1000` relations. This is the price to pay, but on the other hand accessing the data is simpler and extremely fast. Having these things as separate sets allows us to do interesting stuff. For example, using [`ZINTERSTORE`](/content/commands/zinterstore.md) we can have the intersection of `following` of two different users, so we may add a feature to our Twitter clone so that it is able to tell you very quickly when you visit somebody else's profile, "you and Alice have 34 followers in common", and things like that.
 
 You can find the code that sets or removes a following / follower relation in the `follow.php` file.
 
@@ -454,7 +454,7 @@ simple: you may use client-side sharding, or something like a sharding proxy
 like Twemproxy, or the upcoming Redis Cluster.
 
 To know more about those topics please read
-[our documentation about sharding]({{< relref "/operate/oss_and_stack/management/scaling" >}}). However, the point here
+[our documentation about sharding](/content/operate/oss_and_stack/management/scaling.md). However, the point here
 to stress is that in a key-value store, if you design with care, the data set
 is split among **many independent small keys**. To distribute those keys
 to multiple nodes is more straightforward and predictable compared to using

--- a/content/develop/clients/patterns/twitter-clone.md
+++ b/content/develop/clients/patterns/twitter-clone.md
@@ -154,7 +154,7 @@ also to retrieve its score if it exists, we use the [`ZSCORE`](/content/commands
 
 Sorted Sets are a very powerful data structure, you can query elements by
 score range, lexicographically, in reverse order, and so forth.
-To know more [please check the Sorted Set sections in the official Redis commands documentation](/commands/#sorted_set).
+To know more [please check the Sorted Set sections in the official Redis commands documentation](/commands/?group=sorted-set).
 
 The Hash data type
 ---


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/patterns/` (`_index.md`, `bulk-loading.md`, `distributed-locks.md`, `twitter-clone.md`) per DOC-7047, following the DOC-6909 render-hook pattern proven on `develop/clients/redis-py` and already applied to om-clients, hiredis, rust, and ruby (#3940-#3943).
- All `{{< relref ... >}}` shortcode links rewritten to plain Markdown links resolved to their canonical `/content/<path>.md[#anchor]` form (49 links). No callout shortcodes (`note`/`warning`/`tip`/`info`/`alert`) exist in this section, so no blockquote conversion was needed.
- Uses the migration tooling from PR #3937 (not merged into this PR — the script was pulled via `git show` as an untracked helper and deleted before committing).

## Test plan
- [x] Confirmed no `{{< relref` or callout shortcodes remain in the converted files.
- [x] Confirmed no custom-title alert form (`{{< alert title="X" >}}`) was present.
- [x] Spot-checked rewritten links resolve to real content files (e.g. `content/commands/del.md`, `content/develop/reference/protocol-spec.md`, `content/operate/oss_and_stack/management/scaling.md`, `content/develop/clients/patterns/indexes/index.md`).
- [x] One relref (`/commands/#sorted_set`) has no corresponding `_index.md`/`index.md` under `content/commands/`, so the tool correctly left it as a plain link rather than rewriting it — expected behavior, not a defect.
- [x] `.claude/hooks/check_shortcode_paths.py --scan` reports 0 files with issues.
- [ ] Full-site Hugo build verification (href-diff vs main) is being run centrally by the ticket owner before merge — isolated worktrees here can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link format changes with no runtime or application logic affected; main risk is a broken internal link if a canonical path is wrong.
> 
> **Overview**
> Migrates **`content/develop/clients/patterns/`** (section index plus `bulk-loading`, `distributed-locks`, `indexes/index`, and `twitter-clone`) to the render-hook link style used elsewhere (DOC-7047 / DOC-6909).
> 
> Every **`{{< relref ... >}}`** internal link is replaced with plain Markdown URLs in canonical **`/content/<path>.md`** form (including anchors where applicable). Command references, cross-docs (protocol spec, sharding, Redis Search indexing), and the patterns hub nav all follow that pattern.
> 
> One edge case: **`/commands/#sorted_set`** becomes **`/commands/?group=sorted-set`** because there is no single content file for that fragment. No callout shortcodes were present, so prose is otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63f390880de1b79d5aaf0fce1d3762711629217f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->