### PR TITLE
DOC-7047: Migrate develop/clients/php to render hooks

### DIFF
--- a/content/develop/clients/php/_index.md
+++ b/content/develop/clients/php/_index.md
@@ -24,11 +24,11 @@ weight: 8
 client for Redis. 
 The sections below explain how to install `Predis` and connect your application to a Redis database.
 
-{{< note >}}Although we provide basic documentation for `Predis`, it is a third-party
-client library and is not developed or supported directly by Redis.
-{{< /note >}}
+> [!NOTE]
+> Although we provide basic documentation for `Predis`, it is a third-party
+> client library and is not developed or supported directly by Redis.
 
-`Predis` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`Predis` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 ## Install
 
@@ -52,7 +52,7 @@ Store and retrieve a simple string to test the connection:
 {{< clients-example set="landing" step="set_get_string" lang_filter="PHP" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Store and retrieve a [hash]({{< relref "/develop/data-types/hashes" >}})
+Store and retrieve a [hash](/content/develop/data-types/hashes.md)
 object:
 
 {{< clients-example set="landing" step="set_get_hash" lang_filter="PHP" description="Foundational: Store and retrieve hash data structures using HSET and HGETALL" difficulty="beginner" >}}

--- a/content/develop/clients/php/connect.md
+++ b/content/develop/clients/php/connect.md
@@ -46,7 +46,7 @@ echo $r->get('foo'), PHP_EOL;
 // >>> bar
 ```
 
-Store and retrieve a [hash]({{< relref "/develop/data-types/hashes" >}})
+Store and retrieve a [hash](/content/develop/data-types/hashes.md)
 object:
 
 ```php
@@ -102,7 +102,7 @@ echo $rc->get('foo'), PHP_EOL;
 ## Connect to your production Redis with TLS
 
 When you deploy your application, use TLS and follow the
-[Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}})
+[Redis security](/content/operate/oss_and_stack/management/security/_index.md)
 guidelines.
 
 Use the following commands to generate the client certificate and private key:

--- a/content/develop/clients/php/error-handling.md
+++ b/content/develop/clients/php/error-handling.md
@@ -18,7 +18,7 @@ how Predis error handling works and how to apply common error handling
 patterns.
 
 For an overview of error types and handling strategies, see
-[Error handling]({{< relref "/develop/clients/error-handling" >}}).
+[Error handling](/content/develop/clients/error-handling.md).
 
 ## Exception hierarchy
 
@@ -44,7 +44,7 @@ Predis groups its exceptions under `PredisException`:
 
 The following exceptions are the most commonly encountered in Predis
 applications. See
-[Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+[Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 | Exception | When it occurs | Recoverable | Recommended action |
@@ -56,7 +56,7 @@ for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 Predis:
 
@@ -64,7 +64,7 @@ Predis:
 
 Catch specific exceptions that represent unrecoverable errors and re-throw them
 (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```php
@@ -81,7 +81,7 @@ try {
 ### Pattern 2: Graceful degradation
 
 Catch connection problems and fall back to an alternative (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```php
@@ -102,7 +102,7 @@ return $database->get($key);
 ### Pattern 3: Retry with backoff
 
 Retry on temporary communication failures (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description):
 
 ```php
@@ -127,7 +127,7 @@ for ($attempt = 0; $attempt < 3; $attempt++) {
 ### Pattern 4: Log and continue
 
 Log non-critical failures and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```php
@@ -165,5 +165,5 @@ for ($attempt = 0; $attempt < 3; $attempt++) {
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Pipelines and transactions]({{< relref "/develop/clients/php/transpipe" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Pipelines and transactions](/content/develop/clients/php/transpipe.md)

--- a/content/develop/clients/php/prob.md
+++ b/content/develop/clients/php/prob.md
@@ -16,7 +16,7 @@ weight: 45
 ---
 
 Redis supports several
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md)
 that let you calculate values approximately rather than exactly.
 The types fall into two basic categories:
 
@@ -32,7 +32,7 @@ counting the number of distinct IP addresses that access a website in one day.
 
 Assuming that you already have code that supplies you with each IP
 address as a string, you could record the addresses in Redis using
-a [set]({{< relref "/develop/data-types/sets" >}}):
+a [set](/content/develop/data-types/sets.md):
 
 ```php
 $r->sadd('ip_tracker', $newIpAddress);
@@ -68,11 +68,11 @@ time than the equivalent precise calculations.
 Redis supports the following approximate set operations:
 
 -   [Membership](#set-membership): The
-    [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-    [Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+    [Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+    [Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
     data types let you track whether or not a given item is a member of a set.
 -   [Cardinality](#set-cardinality): The
-    [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+    [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
     data type gives you an approximate value for the number of items in a set, also
     known as the *cardinality* of the set.
 
@@ -80,8 +80,8 @@ The sections below describe these operations in more detail.
 
 ### Set membership
 
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 objects provide a set membership operation that lets you track whether or not a
 particular item has been added to a set. These two types provide different
 trade-offs for memory usage and speed, so you can select the best one for your
@@ -90,7 +90,7 @@ absence of items in the set. If an item is reported as absent, then it is defini
 absent, but if it is reported as present, then there is a small chance it may really be
 absent.
 
-Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+Instead of storing strings directly, like a [set](/content/develop/data-types/sets.md),
 a Bloom filter records the presence or absence of the
 [hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
 This gives a very compact representation of the
@@ -112,13 +112,13 @@ Which of these two data types you choose depends on your use case.
 Bloom filters are generally faster than Cuckoo filters when adding new items,
 and also have better memory usage. Cuckoo filters are generally faster
 at checking membership and also support the delete operation. See the
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 reference pages for more information and comparison between the two types.
 
 ### Set cardinality
 
-A [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+A [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 object calculates the cardinality of a set. As you add
 items, the HyperLogLog tracks the number of distinct set members but
 doesn't let you retrieve them or query which items have been added.
@@ -142,20 +142,20 @@ Redis supports several approximate statistical calculations
 on numeric data sets:
 
 -   [Frequency](#frequency): The
-    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
     data type lets you find the approximate frequency of a labeled item in a data stream.
 -   [Quantiles](#quantiles): The
-    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
     data type estimates the quantile of a query value in a data stream.
 -   [Ranking](#ranking): The
-    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    [Top-K](/content/develop/data-types/probabilistic/top-k.md) data type
     estimates the ranking of labeled items by frequency in a data stream.
 
 The sections below describe these operations in more detail.
 
 ### Frequency
 
-A [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+A [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
 (CMS) object keeps count of a set of related items represented by
 string labels. The count is approximate, but you can specify
 how close you want to keep the count to the true value (as a fraction)
@@ -169,7 +169,7 @@ a Count-min sketch object, add data to it, and then query it.
 {{< /clients-example >}}
 
 The advantage of using a CMS over keeping an exact count with a
-[sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
+[sorted set](/content/develop/data-types/sorted-sets.md)
 is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
@@ -184,7 +184,7 @@ the value of height below which 75% of all people's heights lie.
 [Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
 to quantiles, except that the fraction is expressed as a percentage.
 
-A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+A [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 object can estimate quantiles from a set of values added to it
 without having to store each value in the set explicitly. This can
 save a lot of memory when you have a large number of samples.
@@ -202,12 +202,12 @@ data set.
 
 A t-digest object also supports several other related commands, such
 as querying by rank. See the
-[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+[t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 reference for more information.
 
 ### Ranking
 
-A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+A [Top-K](/content/develop/data-types/probabilistic/top-k.md)
 object estimates the rankings of different labeled items in a data
 stream according to frequency. For example, you could use this to
 track the top ten most frequently-accessed pages on a website, or the

--- a/content/develop/clients/php/queryjson.md
+++ b/content/develop/clients/php/queryjson.md
@@ -24,26 +24,26 @@ weight: 20
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
-{{< note >}}From [v3.0.0](https://github.com/predis/predis/releases/tag/v3.0.0) onwards,
-`Predis` uses query dialect 2 by default.
-Redis Search methods such as [`ftSearch()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v3.0.0](https://github.com/predis/predis/releases/tag/v3.0.0) onwards,
+> `Predis` uses query dialect 2 by default.
+> Redis Search methods such as [`ftSearch()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[`Predis`]({{< relref "/develop/clients/php" >}}) client library if you
+[`Predis`](/content/develop/clients/php/_index.md) client library if you
 haven't already done so.
 
 Add the following dependencies:
@@ -62,17 +62,17 @@ Create some test data to add to your database:
 
 Connect to your Redis database. The code below shows the most
 basic connection but see
-[Connect to the server]({{< relref "/develop/clients/php/connect" >}})
+[Connect to the server](/content/develop/clients/php/connect.md)
 to learn more about the available connection options.
 
 {{< clients-example set="php_home_json" step="connect" description="Foundational: Connect to a Redis server and establish a client connection" difficulty="beginner" >}}
 {{< /clients-example >}}
 
 Create an
-[index]({{< relref "/develop/ai/search-and-query/indexing" >}}).
+[index](/content/develop/ai/search-and-query/indexing/_index.md).
 In this example, only JSON documents with the key prefix `user:` are indexed.
 For more information, see
-[Query syntax]({{< relref "/develop/ai/search-and-query/query/" >}}).
+[Query syntax](/content/develop/ai/search-and-query/query/_index.md).
 
 {{< clients-example set="php_home_json" step="make_index" description="Foundational: Create a search index for JSON documents with field schema and prefix filtering" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -80,7 +80,7 @@ For more information, see
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them:
 
@@ -90,7 +90,7 @@ objects automatically as you add them:
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -103,7 +103,7 @@ Specify query options to return only the `city` field:
 {{< /clients-example >}}
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< clients-example set="php_home_json" step="query3" description="Aggregation: Use aggregation queries to group and count results from indexed documents" difficulty="advanced" >}}
@@ -124,8 +124,8 @@ the `idx:users` index used for JSON documents in the previous examples.
 {{< clients-example set="php_home_json" step="make_hash_index" description="Foundational: Create a search index for hash documents with HASH type specification" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-You use [`hmset()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`jsonset()`]({{< relref "/commands/json.set" >}}).
+You use [`hmset()`](/content/commands/hset.md) to add the hash
+documents instead of [`jsonset()`](/content/commands/json.set.md).
 Supply the fields as an array directly, without using
 [`json_encode()`](https://www.php.net/manual/en/function.json-encode.php).
 
@@ -142,5 +142,5 @@ result array rather than in a JSON string with `$` as its key:
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/php/transpipe.md
+++ b/content/develop/clients/php/transpipe.md
@@ -22,11 +22,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -63,7 +63,7 @@ several clients may modify at the same time. The basic idea is to watch for
 changes to any keys that you use in a transaction while you are preparing the
 update. If the watched keys do change, you must restart the update using the
 latest value from Redis. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The example below reads a string that represents a `PATH` variable for a

--- a/content/develop/clients/php/vecsearch.md
+++ b/content/develop/clients/php/vecsearch.md
@@ -24,14 +24,14 @@ topics:
 weight: 30
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}}) 
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md) 
 reference page for more information).
 Among other things, vector fields can store *text embeddings*, which are AI-generated vector
 representations of the semantic information in pieces of text. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings indicates how similar they are semantically. By comparing the
 similarity of an embedding generated from some query text with embeddings stored in hash
 or JSON fields, Redis can retrieve documents that closely match the query in terms
@@ -44,14 +44,14 @@ The code is first demonstrated for hash documents with a
 separate section to explain the
 [differences with JSON documents](#differences-with-json-documents).
 
-{{< note >}}From [v3.0.0](https://github.com/predis/predis/releases/tag/v3.0.0) onwards,
-`Predis` uses query dialect 2 by default.
-Redis Search methods such as [`ftSearch()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v3.0.0](https://github.com/predis/predis/releases/tag/v3.0.0) onwards,
+> `Predis` uses query dialect 2 by default.
+> Redis Search methods such as [`ftSearch()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
@@ -101,7 +101,7 @@ $extractor = pipeline('embeddings', 'Xenova/all-MiniLM-L6-v2');
 
 Connect to Redis and delete any index previously created with the
 name `vector_idx`. (The
-[`ftdropindex()`]({{< relref "/commands/ft.dropindex" >}})
+[`ftdropindex()`](/content/commands/ft.dropindex.md)
 call throws an exception if the index doesn't already exist, which is
 why you need the `try...catch` block.)
 
@@ -118,16 +118,16 @@ try {
 
 Next, create the index.
 The schema in the example below includes three fields: the text content to index, a
-[tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+[tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
 field to represent the "genre" of the text, and the embedding vector generated from
 the original text content. The `embedding` field specifies
-[HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}}) 
+[HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index) 
 indexing, the
-[L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
-The `CreateArguments` parameter to [`ftcreate()`]({{< relref "/commands/ft.create" >}})
+The `CreateArguments` parameter to [`ftcreate()`](/content/commands/ft.create.md)
 specifies hash objects for storage and a prefix `doc:` that identifies the hash objects
 to index.
 
@@ -156,7 +156,7 @@ $client->ftcreate("vector_idx", $schema,
 ## Add data
 
 You can now supply the data objects, which will be indexed automatically
-when you add them with [`hmset()`]({{< relref "/commands/hset" >}}), as long as
+when you add them with [`hmset()`](/content/commands/hset.md), as long as
 you use the `doc:` prefix specified in the index definition.
 
 Use the `$extractor()` function as shown below to create the embedding that
@@ -173,7 +173,7 @@ vector array as a binary string. The built-in
 [`pack()`](https://www.php.net/manual/en/function.pack.php) function is a convenient
 way to do this in PHP, using the `g*` format specifier to denote a packed
 array of `float` values. Note that if you are using
-[JSON]({{< relref "/develop/data-types/json" >}})
+[JSON](/content/develop/data-types/json/_index.md)
 objects to store your documents instead of hashes, then you should store
 the `float` array directly without first converting it to a binary
 string (see [Differences with JSON documents](#differences-with-json-documents)
@@ -218,10 +218,10 @@ sorted to rank them in order of ascending distance.
 
 The code below creates the query embedding using the `$extractor()` function, as with
 the indexing, and passes it as a parameter when the query executes (see
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about using query parameters with embeddings).
 The query is a
-[K nearest neighbors (KNN)]({{< relref "/develop/ai/search-and-query/vectors#knn-vector-search" >}})
+[K nearest neighbors (KNN)](/content/develop/ai/search-and-query/vectors/_index.md#knn-vector-search)
 search that sorts the results in order of vector distance from the query vector.
 
 The results are returned as an array with the number of results in the
@@ -290,7 +290,7 @@ is the result judged to be most similar in meaning to the query text
 
 Indexing JSON documents is similar to hash indexing, but there are some
 important differences. JSON allows much richer data modeling with nested fields, so
-you must supply a [path]({{< relref "/develop/data-types/json/path" >}}) in the schema
+you must supply a [path](/content/develop/data-types/json/path.md) in the schema
 to identify each field you want to index. However, you can declare a short alias for each
 of these paths to avoid typing it in full for
 every query. Also, you must specify `JSON` with the `on()` option when you create the index.
@@ -321,8 +321,8 @@ $client->ftcreate("vector_json_idx", $jsonSchema,
 );
 ```
 
-Use [`jsonset()`]({{< relref "/commands/json.set" >}}) to add the data
-instead of [`hmset()`]({{< relref "/commands/hset" >}}). The arrays
+Use [`jsonset()`](/content/commands/json.set.md) to add the data
+instead of [`hmset()`](/content/commands/hset.md). The arrays
 that specify the fields have roughly the same structure as the ones used for
 `hmset()` but you should use the standard library function
 [`json_encode()`](https://www.php.net/manual/en/function.json-encode.php)
@@ -417,6 +417,6 @@ Field: vector_distance, Value: 44.6189727783
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about the indexing options, distance metrics, and query format
 for vectors.

--- a/content/develop/clients/php/vecsets.md
+++ b/content/develop/clients/php/vecsets.md
@@ -21,18 +21,18 @@ topics:
 - vectors
 ---
 
-A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+A Redis [vector set](/content/develop/data-types/vector-sets/_index.md) lets
 you store a set of unique keys, each with its own associated vector.
 You can then retrieve keys from the set according to the similarity between
 their stored vectors and a query vector that you specify.
 
 You can use vector sets to store any type of numeric vector but they are
 particularly optimized to work with text embedding vectors (see
-[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+[Redis for AI](/content/develop/ai/_index.md) to learn more about text
 embeddings). The example below shows how to use the
 [TransformersPHP](https://transformers.codewithkyrian.com/) library to
 generate text embeddings and then store and retrieve them using a vector set
-with [`Predis`]({{< relref "/develop/clients/php" >}}).
+with [`Predis`](/content/develop/clients/php/_index.md).
 
 ## Initialize
 
@@ -68,9 +68,9 @@ The next step is to connect to Redis and add the data to a new vector set.
 
 The code below iterates through the array, uses the embedding pipeline to
 generate a `float` vector from each description, and then adds the result to a
-vector set called `famousPeople` with [`vadd()`]({{< relref "/commands/vadd" >}}).
+vector set called `famousPeople` with [`vadd()`](/content/commands/vadd.md).
 It then stores the `born` and `died` values as element attributes using
-[`vsetattr()`]({{< relref "/commands/vsetattr" >}}), so you can use the metadata
+[`vsetattr()`](/content/commands/vsetattr.md), so you can use the metadata
 later during queries.
 
 {{< clients-example set="home_vecsets" step="add_data" lang_filter="PHP" description="Foundational: Add embedding vectors to a vector set and attach metadata attributes for later filtering" difficulty="beginner" >}}
@@ -80,7 +80,7 @@ later during queries.
 
 You can now query the data in the set. The basic approach is to generate
 another embedding vector from the query text and pass it to
-[`vsim()`]({{< relref "/commands/vsim" >}}), which returns elements ranked in
+[`vsim()`](/content/commands/vsim.md), which returns elements ranked in
 order of similarity to that query vector.
 
 Start with a simple query for "actors":
@@ -123,7 +123,7 @@ followed by the mathematicians:
 ```
 
 You can also use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 with `vsim()` to restrict the search further. For example, repeat the
 "science" query, but this time limit the results to people who died before the
 year 2000:
@@ -133,16 +133,16 @@ year 2000:
 
 ## More information
 
-See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+See the [vector sets](/content/develop/data-types/vector-sets/_index.md)
 docs for more information and code examples. See the
-[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+[Redis for AI](/content/develop/ai/_index.md) section for more details
 about text embeddings and other AI techniques you can use with Redis.
 
 You may also be interested in
-[vector search]({{< relref "/develop/clients/php/vecsearch" >}}).
+[vector search](/content/develop/clients/php/vecsearch.md).
 This is a feature of
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 that lets you retrieve
-[JSON]({{< relref "/develop/data-types/json" >}}) and
-[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+[JSON](/content/develop/data-types/json/_index.md) and
+[hash](/content/develop/data-types/hashes.md) documents based on
 vector data stored in their fields.


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/php/` (8 files: `_index.md`, `connect.md`, `error-handling.md`, `prob.md`, `queryjson.md`, `transpipe.md`, `vecsearch.md`, `vecsets.md`) per DOC-7047, continuing the DOC-6909 render-hook rollout.
- `{{< relref ... >}}` shortcode links (84 occurrences) rewritten to plain Markdown links in the canonical `/content/<path>.md` / `/content/<path>/_index.md` form, anchors preserved.
- 3 `{{< note >}}...{{< /note >}}` callouts (no nesting, no custom titles, no warning/tip/info/alert usage in this directory) converted to `> [!NOTE]`-style blockquotes.
- Uses the migration tooling from PR #3937 (`build/migrate_shortcode_links.py`, not merged into this PR — pulled in as an untracked helper via `git show`, run, then removed before committing).

## Test plan
- [x] `python3 .claude/hooks/check_shortcode_paths.py --scan content/develop/clients/php/*.md` reports 0 files with issues (0 broken relrefs, 0 broken file refs).
- [x] Manually reviewed the full diff: no remaining `{{< relref` or `{{< note/warning/tip/info/alert }}` shortcodes, no nested block-level shortcodes mangled inside a blockquote, blockquote formatting matches the `redis-py` reference conversion.
- [ ] Full-site Hugo build verification (rendered-href diff) is being run centrally by the ticket owner before merge — this isolated worktree can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present here).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout rewrites with no application or build-config changes; main risk is broken cross-links if canonical `/content/...` paths are wrong.
> 
> **Overview**
> Continues the DOC-6909 render-hook rollout for **DOC-7047** by updating all eight pages under `content/develop/clients/php/`.
> 
> **`{{< relref ... >}}` links (84)** are replaced with plain Markdown URLs in the canonical `/content/<path>.md` or `/content/<path>/_index.md` form, including fragment anchors. **Three `{{< note >}}` callouts** become GitHub-style `> [!NOTE]` blockquotes (Predis third-party disclaimer on the landing page, plus Predis v3 query dialect notes in `queryjson.md` and `vecsearch.md`).
> 
> Prose and **`{{< clients-example >}}`** snippets are unchanged; this is a linking and callout-format migration only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb77cecd07b83502042c5d603fca27064cabf32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->