### PR TITLE
DOC-7047: Migrate develop/clients/lettuce to render hooks

### DIFF
--- a/content/develop/clients/lettuce/_index.md
+++ b/content/develop/clients/lettuce/_index.md
@@ -23,12 +23,12 @@ weight: 6
 [Lettuce](https://github.com/redis/lettuce/tree/main/src/main) is an advanced Java client for Redis
 that supports synchronous, asynchronous, and reactive connections.
 If you only need synchronous connections then you may find the other Java client
-[Jedis]({{< relref "/develop/clients/jedis" >}}) easier to use.
+[Jedis](/content/develop/clients/jedis/_index.md) easier to use.
 
 The sections below explain how to install `Lettuce` and connect your application
 to a Redis database.
 
-`Lettuce` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`Lettuce` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 ## Install
 

--- a/content/develop/clients/lettuce/amr.md
+++ b/content/develop/clients/lettuce/amr.md
@@ -30,7 +30,7 @@ in the Microsoft docs to learn how to configure Azure to use Entra ID authentica
 
 ## Install
 
-Install [`Lettuce`]({{< relref "/develop/clients/lettuce" >}}) first,
+Install [`Lettuce`](/content/develop/clients/lettuce/_index.md) first,
 if you have not already done so.
 
 If you are using Maven, add
@@ -166,14 +166,14 @@ enable automatic re-authentication.
 The connection uses
 [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security),
 which is recommended and enabled by default for managed identities. See
-[TLS connection]({{< relref "/develop/clients/lettuce/connect#tls-connection" >}}) for more information.
+[TLS connection](/content/develop/clients/lettuce/connect.md#tls-connection) for more information.
 
-{{< note >}} The `Lettuce` client library doesn't manage the lifecycle of
-the `TokenBasedRedisCredentialsProvider` instance for you. You can reuse the
-same instance for as many clients and connections as you want. When you have
-finished using the credentials provider, call its `close()` method, as shown
-at the end of the example.
-{{< /note >}}
+> [!NOTE]
+> The `Lettuce` client library doesn't manage the lifecycle of
+> the `TokenBasedRedisCredentialsProvider` instance for you. You can reuse the
+> same instance for as many clients and connections as you want. When you have
+> finished using the credentials provider, call its `close()` method, as shown
+> at the end of the example.
 
 ```java
 // Entra ID credentials provider for Service Principal Identity with Client Secret.

--- a/content/develop/clients/lettuce/connect.md
+++ b/content/develop/clients/lettuce/connect.md
@@ -175,7 +175,7 @@ clusterClient.shutdown();
 
 ### TLS connection
 
-When you deploy your application, use TLS and follow the [Redis security guidelines]({{< relref "/operate/oss_and_stack/management/security/" >}}).
+When you deploy your application, use TLS and follow the [Redis security guidelines](/content/operate/oss_and_stack/management/security/_index.md).
 
 ```java
 RedisURI redisUri = RedisURI.Builder.redis("localhost")
@@ -196,7 +196,7 @@ For connection pooling, Lettuce leverages `RedisClient` or `RedisClusterClient`,
 A typical approach with Lettuce is to create a single `RedisClient` instance and reuse it to establish connections to your Redis server(s).
 These connections are multiplexed; that is, multiple commands can be run concurrently over a single or a small set of connections, making explicit pooling less practical.
 See
-[Connection pools and multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}})
+[Connection pools and multiplexing](/content/develop/clients/pools-and-muxing.md)
 for more information.
 
 Lettuce provides pool config to be used with Lettuce asynchronous connection methods.
@@ -261,18 +261,18 @@ In this setup, `LettuceConnectionFactory` is a custom class you would need to im
 Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH.
 
-{{< note >}}Support for SCH in Lettuce requires v7.0.0 or later.
-{{< /note >}}
+> [!NOTE]
+> Support for SCH in Lettuce requires v7.0.0 or later.
 
 By default, `Lettuce` always attempts to connect via SCH but falls back to
 a non-SCH connection if the server doesn't support it. However, you can configure SCH
 explicitly by creating a `MaintNotificationsConfig` object and/or a `TimeoutOptions`
 object and passing them to the `ClientOptions` builder as shown in the example below.
 Note that SCH also requires the
-[RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
+[RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
 protocol. Lettuce uses this by default, but make sure you don't set
 `protocolVersion(ProtocolVersion.RESP2)` in the `ClientOptions` builder.
 
@@ -348,10 +348,10 @@ that is relevant to SCH:
 | `relaxedTimeoutsDuringMaintenance(Duration duration)` | Set the *command* timeout to use while the server is performing maintenance (this doesn't change the connection timeout). The default is 10 seconds. Note that relaxed timeouts are only available for the asynchronous and reactive APIs. |
 |
 
-{{< note >}} Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
-either [AWS PrivateLink]({{< relref "/operate/rc/security/aws-privatelink" >}}) or
-[Google Cloud Private Service Connect]({{< relref "/operate/rc/security/private-service-connect" >}})
-(see [Smart client handoffs]({{< relref "/develop/clients/sch#redis-cloud" >}}) for more information).
-To use relaxed timeouts with these services, you should set `endpointType(EndpointType.NONE)`
-when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.
-{{< /note >}}
+> [!NOTE]
+> Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
+> either [AWS PrivateLink](/content/operate/rc/security/aws-privatelink.md) or
+> [Google Cloud Private Service Connect](/content/operate/rc/security/private-service-connect.md)
+> (see [Smart client handoffs](/content/develop/clients/sch.md#redis-cloud) for more information).
+> To use relaxed timeouts with these services, you should set `endpointType(EndpointType.NONE)`
+> when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.

--- a/content/develop/clients/lettuce/error-handling.md
+++ b/content/develop/clients/lettuce/error-handling.md
@@ -18,8 +18,8 @@ the exceptions that matter for your workload. This page explains how Lettuce's
 error handling works and how to apply common error handling patterns.
 
 For an overview of error types and handling strategies, see
-[Error handling]({{< relref "/develop/clients/error-handling" >}}).
-See also [Production usage]({{< relref "/develop/clients/lettuce/produsage" >}})
+[Error handling](/content/develop/clients/error-handling.md).
+See also [Production usage](/content/develop/clients/lettuce/produsage.md)
 for more information on connection management, timeouts, and other aspects of
 app reliability.
 
@@ -47,7 +47,7 @@ Lettuce organizes its exceptions under `RedisException`, which extends
 
 The following exceptions are the most commonly encountered in Lettuce
 applications. See
-[Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+[Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 | Exception | When it occurs | Recoverable | Recommended action |
@@ -59,7 +59,7 @@ for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 Lettuce:
 
@@ -67,7 +67,7 @@ Lettuce:
 
 Catch specific exceptions that represent unrecoverable errors and re-throw them
 (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```java
@@ -82,7 +82,7 @@ try {
 ### Pattern 2: Graceful degradation
 
 Catch temporary connectivity failures and fall back to an alternative (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```java
@@ -101,7 +101,7 @@ return database.get(key);
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors such as timeouts or disconnections (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description):
 
 ```java
@@ -131,7 +131,7 @@ throw new IllegalStateException("unreachable");
 ### Pattern 4: Log and continue
 
 Log non-critical cache failures and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```java
@@ -167,5 +167,5 @@ async.get(key).whenComplete((value, error) -> {
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Production usage]({{< relref "/develop/clients/lettuce/produsage" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Production usage](/content/develop/clients/lettuce/produsage.md)

--- a/content/develop/clients/lettuce/failover.md
+++ b/content/develop/clients/lettuce/failover.md
@@ -28,7 +28,7 @@ bannerText: This feature is currently in preview and may be subject to change.
 Lettuce supports [Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. This page explains
 how to configure Lettuce for failover. For an overview of the concepts,
-see the main [Client-side geographic failover]({{< relref "/develop/clients/failover" >}}) page.
+see the main [Client-side geographic failover](/content/develop/clients/failover.md) page.
 
 ## Connection configuration
 
@@ -48,7 +48,7 @@ import io.lettuce.core.failover.api.StatefulRedisMultiDbConnection;
 ```
 
 Supply the weighted endpoints using a `List` of `DatabaseConfig` objects
-(see [Selecting a failover target]({{< relref "/develop/clients/failover#selecting-a-failover-target" >}})
+(see [Selecting a failover target](/content/develop/clients/failover.md#selecting-a-failover-target)
 for a full description of how the weighted list is used).
 Use the `weight` option in the builder to order the endpoints, with the highest
 weight being tried first.
@@ -155,7 +155,7 @@ are described in the sections below.
 ### Circuit breaker configuration
 
 The `CircuitBreakerConfig` builder lets you pass several options to configure
-the circuit breaker, as shown in the example below (see [Detecting connection problems]({{< relref "/develop/clients/failover#detecting-connection-problems" >}}) for more information on how the
+the circuit breaker, as shown in the example below (see [Detecting connection problems](/content/develop/clients/failover.md#detecting-connection-problems) for more information on how the
 circuit breaker works):
 
 ```java
@@ -238,7 +238,7 @@ client.getResources().eventBus().get()
 ## Health check configuration
 
 Each health check consists of one or more separate "probes", each of which is a simple
-test (such as a [`PING`]({{< relref "/commands/ping" >}}) command) to determine if the database is available. The results of the separate probes are combined
+test (such as a [`PING`](/content/commands/ping.md) command) to determine if the database is available. The results of the separate probes are combined
 using a configurable policy to determine if the database is healthy.
 
 There are several strategies available for health checks that you can deploy using the
@@ -262,7 +262,7 @@ The sections below explain the available strategies in more detail.
 ### `PingStrategy` (default)
 
 The default strategy, `PingStrategy`, periodically sends a Redis
-[`PING`]({{< relref "/commands/ping" >}}) command
+[`PING`](/content/commands/ping.md) command
 and checks that it gives the expected response. Any unexpected response
 or exception indicates an unhealthy server. Although `PingStrategy` is
 very simple, it is a good basic approach for most Redis deployments.
@@ -292,12 +292,12 @@ DatabaseConfig db = DatabaseConfig.builder(redisUri)
 ### `LagAwareStrategy`
 
 `LagAwareStrategy` is designed specifically for
-Redis Software [Active-Active]({{< relref "/operate/rs/databases/active-active" >}})
+Redis Software [Active-Active](/content/operate/rs/databases/active-active/_index.md)
 deployments. It uses the Redis Software REST API to check database availability
 and can also optionally check replication lag.
 
 `LagAwareStrategy` determines the health of the server using the
-[REST API]({{< relref "/operate/rs/references/rest-api" >}}). The example
+[REST API](/content/operate/rs/references/rest-api/_index.md). The example
 below shows how to configure and use `LagAwareStrategy`. Note that
 `LagAwareStrategy` requires the following dependencies (although they are
 added automatically with Lettuce):
@@ -439,7 +439,7 @@ exposes a REST API, you might consider creating a REST endpoint to call
 
 ## Pub/Sub and re-subscription
 
-`MultiDbClient` supports [Pub/Sub]({{< relref "/develop/pubsub" >}})
+`MultiDbClient` supports [Pub/Sub](/content/develop/pubsub/_index.md)
 messaging with automatic re-subscription to channels during failover.
 This means you don't have to detect failovers and re-subscribe manually:
 
@@ -488,17 +488,17 @@ StatefulRedisMultiDbPubSubConnection<String, String> publisher =
 publisher.sync().publish("news", "Hello World");
 ```
 
-{{< note >}}The only addition over a standard Lettuce Pub/Sub connection is that
-you obtain the connection with `connectPubSub()` on the `MultiDbClient`. The
-subscription and publishing API is otherwise identical, but the active
-subscriptions and registered listeners are automatically migrated to the new
-database when a failover occurs.
-
-Message loss can still occur if the failover events happen in the reverse order,
-with the publisher failing over to the new database before the subscriber.
-Messages published during this window may not reach a subscriber that is still
-connected to the previous database.
-{{< /note >}}
+> [!NOTE]
+> The only addition over a standard Lettuce Pub/Sub connection is that
+> you obtain the connection with `connectPubSub()` on the `MultiDbClient`. The
+> subscription and publishing API is otherwise identical, but the active
+> subscriptions and registered listeners are automatically migrated to the new
+> database when a failover occurs.
+>
+> Message loss can still occur if the failover events happen in the reverse order,
+> with the publisher failing over to the new database before the subscriber.
+> Messages published during this window may not reach a subscriber that is still
+> connected to the previous database.
 
 ## Behavior when all endpoints are unhealthy
 

--- a/content/develop/clients/lettuce/produsage.md
+++ b/content/develop/clients/lettuce/produsage.md
@@ -163,7 +163,7 @@ public LettuceClientConfigurationBuilderCustomizer lettuceClientConfigurationBui
 
 The Redis Cluster configuration is dynamic and can change at runtime. 
 New nodes may be added, and the primary node for a specific slot can shift.
-Lettuce automatically handles [MOVED]({{< relref "/operate/oss_and_stack/reference/cluster-spec#moved-redirection" >}}) and [ASK]({{< relref "/operate/oss_and_stack/reference/cluster-spec#ask-redirection" >}}) redirects, but to enhance your application's resilience, you should enable adaptive topology refreshing:
+Lettuce automatically handles [MOVED](/content/operate/oss_and_stack/reference/cluster-spec.md#moved-redirection) and [ASK](/content/operate/oss_and_stack/reference/cluster-spec.md#ask-redirection) redirects, but to enhance your application's resilience, you should enable adaptive topology refreshing:
 
 ```java
 RedisURI redisURI = RedisURI.Builder
@@ -261,7 +261,7 @@ well, re-run the warm-up when the topology changes (for example, from a
 
 ### Warming up connections in Spring Data Redis
 
-With [Spring Data Redis]({{< relref "/integrate/spring-framework-cache" >}}), run the warm-up once at startup, before the instance is
+With [Spring Data Redis](/content/integrate/spring-framework-cache/_index.md), run the warm-up once at startup, before the instance is
 marked ready. Obtain the shared native cluster connection from the
 `LettuceConnectionFactory` and warm it with the same `upstream()` call:
 
@@ -291,11 +291,12 @@ class RedisClusterWarmUp {
 }
 ```
 
-{{< note >}}The `LettuceConnectionFactory` `eagerInitialization` option is not
-sufficient on its own. It establishes the cluster topology and a single
-connection at startup, but the remaining per-node connections are still opened
-lazily on first use. Use the warm-up shown above to open connections to all
-nodes.{{< /note >}}
+> [!NOTE]
+> The `LettuceConnectionFactory` `eagerInitialization` option is not
+> sufficient on its own. It establishes the cluster topology and a single
+> connection at startup, but the remaining per-node connections are still opened
+> lazily on first use. Use the warm-up shown above to open connections to all
+> nodes.
 
 
 ## DNS cache and Redis
@@ -353,7 +354,7 @@ client.setOptions(ClientOptions.builder()
 If you need finer control over which commands you want to execute in which mode, you can
 configure a *replay filter* to choose the commands that should retry after a disconnection.
 The example below shows a filter that retries all commands except for
-[`DECR`]({{< relref "/commands/decr" >}})
+[`DECR`](/content/commands/decr.md)
 (this command is not [idempotent](https://en.wikipedia.org/wiki/Idempotence) and
 so you might need to avoid executing it more than once). Note that
 replay filters are only available in Lettuce v6.6 and above.
@@ -378,7 +379,7 @@ Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
 
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH and
-[Connect using Smart client handoffs]({{< relref "/develop/clients/lettuce/connect#connect-using-smart-client-handoffs-sch" >}})
+[Connect using Smart client handoffs](/content/develop/clients/lettuce/connect.md#connect-using-smart-client-handoffs-sch)
 for example code.

--- a/content/develop/clients/lettuce/queryjson.md
+++ b/content/develop/clients/lettuce/queryjson.md
@@ -24,17 +24,17 @@ weight: 2
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[Lettuce]({{< relref "/develop/clients/lettuce" >}}) client library if you
+[Lettuce](/content/develop/clients/lettuce/_index.md) client library if you
 haven't already done so.
 
 Add the following dependencies. All of them are applicable to both JSON and hash,
@@ -54,13 +54,13 @@ Create some test data to add to the database:
 
 Connect to your Redis database. The code below shows the most
 basic connection but see
-[Connect to the server]({{< relref "/develop/clients/lettuce/connect" >}})
+[Connect to the server](/content/develop/clients/lettuce/connect.md)
 to learn more about the available connection options.
 
 {{< clients-example set="lettuce_home_json" step="connect" description="Foundational: Establish a connection to Redis for executing search and query operations" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax]({{< relref "/develop/ai/search-and-query/query/" >}}).
+Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax](/content/develop/ai/search-and-query/query/_index.md).
 
 {{< clients-example set="lettuce_home_json" step="make_index" description="Foundational: Create a search index on JSON documents with field mappings and aliases for efficient querying" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -68,7 +68,7 @@ Create an index. In this example, only JSON documents with the key prefix `user:
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them:
 
@@ -78,7 +78,7 @@ objects automatically as you add them:
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -91,7 +91,7 @@ Specify query options to return only the `city` field:
 {{< /clients-example >}}
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< clients-example set="lettuce_home_json" step="query3" description="Aggregation: Use aggregation queries to group and count results, performing server-side data analysis" difficulty="advanced" >}}
@@ -112,8 +112,8 @@ the `idx:users` index used for JSON documents in the previous examples.
 {{< clients-example set="lettuce_home_json" step="make_hash_index" description="Foundational: Create a search index on hash documents with TargetType.HASH configuration" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-Use [`hset()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`jsonSet()`]({{< relref "/commands/json.set" >}}).
+Use [`hset()`](/content/commands/hset.md) to add the hash
+documents instead of [`jsonSet()`](/content/commands/json.set.md).
 
 {{< clients-example set="lettuce_home_json" step="add_hash_data" description="Foundational: Store hash documents in Redis using HSET command with keys matching the index prefix" difficulty="beginner" >}}
 {{< /clients-example >}}
@@ -127,5 +127,5 @@ a `List` of `SearchReply.SearchResult<String, String>` objects, as with JSON:
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/lettuce/transpipe.md
+++ b/content/develop/clients/lettuce/transpipe.md
@@ -21,11 +21,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -57,7 +57,7 @@ several clients may modify at the same time. The basic idea is to watch for
 changes to any keys that you use in a transaction while you are preparing the
 update. If the watched keys do change, Redis discards the transaction and you
 must retry using the latest value from Redis. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The example below watches a key, reads its current value, queues an update

--- a/content/develop/clients/lettuce/vecsearch.md
+++ b/content/develop/clients/lettuce/vecsearch.md
@@ -25,14 +25,14 @@ topics:
 weight: 3
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}}) 
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md) 
 reference page for more information).
 Among other things, vector fields can store *text embeddings*, which are AI-generated vector
 representations of the semantic information in pieces of text. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings indicates how similar they are semantically. By comparing the
 similarity of an embedding generated from some query text with embeddings stored in hash
 or JSON fields, Redis can retrieve documents that closely match the query in terms
@@ -146,14 +146,14 @@ Next, create the index.
 The schema in the example below includes three fields:
 
 -   The text content to index
--   A [tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+-   A [tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
     field to represent the "genre" of the text
 -   The embedding vector generated from the original text content
 
 The `embedding` field specifies
-[HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}}) 
+[HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index) 
 indexing, the
-[L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
@@ -166,7 +166,7 @@ prefix `doc:` that identifies the hash objects to index.
 ## Add data
 
 You can now supply the data objects, which will be indexed automatically
-when you add them with [`hset()`]({{< relref "/commands/hset" >}}), as long as
+when you add them with [`hset()`](/content/commands/hset.md), as long as
 you use the `doc:` prefix specified in the index definition.
 
 Use the `predict()` method of the `Predictor` object
@@ -196,10 +196,10 @@ sorted to rank them in order of ascending distance.
 
 The code below creates the query embedding using the `predict()` method, as with
 the indexing, and passes it as a parameter when the query executes (see
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about using query parameters with embeddings).
 The query is a
-[K nearest neighbors (KNN)]({{< relref "/develop/ai/search-and-query/vectors#knn-vector-search" >}})
+[K nearest neighbors (KNN)](/content/develop/ai/search-and-query/vectors/_index.md#knn-vector-search)
 search that sorts the results in order of vector distance from the query vector.
 
 {{< clients-example set="home_query_vec" step="query" lang_filter="Java-Async,Java-Reactive" description="Semantic search: Execute a KNN vector search with semantic similarity ranking on hash documents" difficulty="advanced" >}}
@@ -229,7 +229,7 @@ is the result that is most similar in meaning to the query text
 
 Indexing JSON documents is similar to hash indexing, but there are some
 important differences. JSON allows much richer data modeling with nested fields, so
-you must supply a [path]({{< relref "/develop/data-types/json/path" >}}) in the schema
+you must supply a [path](/content/develop/data-types/json/path.md) in the schema
 to identify each field you want to index. However, you can declare a short alias for each
 of these paths (using the `as()` option) to avoid typing it in full for
 every query. Also, you must specify `CreateArgs.TargetType.JSON` when you create the index.
@@ -245,8 +245,8 @@ specified using arrays of `float` instead of binary strings. This means
 you don't need to use the `ByteBufferCodec` connection, and you can use
 [`Arrays.toString()`](https://docs.oracle.com/javase/8/docs/api/java/util/Arrays.html#toString-float:A-) to convert the `float` array to a suitable JSON string.
 
-Use [`jsonSet()`]({{< relref "/commands/json.set" >}}) to add the data
-instead of [`hset()`]({{< relref "/commands/hset" >}}). Use instances
+Use [`jsonSet()`](/content/commands/json.set.md) to add the data
+instead of [`hset()`](/content/commands/hset.md). Use instances
 of `JSONObject` to supply the data instead of `Map`, as you would for
 hash objects.
 
@@ -277,6 +277,6 @@ ID: jdoc:3, Content: Today is a sunny day, Distance: 1.49569523335
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about the indexing options, distance metrics, and query format
 for vectors.

--- a/content/develop/clients/lettuce/vecsets.md
+++ b/content/develop/clients/lettuce/vecsets.md
@@ -21,14 +21,14 @@ topics:
 - vectors
 ---
 
-A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+A Redis [vector set](/content/develop/data-types/vector-sets/_index.md) lets
 you store a set of unique keys, each with its own associated vector.
 You can then retrieve keys from the set according to the similarity between
 their stored vectors and a query vector that you specify.
 
 You can use vector sets to store any type of numeric vector but they are
 particularly optimized to work with text embedding vectors (see
-[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+[Redis for AI](/content/develop/ai/_index.md) to learn more about text
 embeddings). The example below shows how to generate vector embeddings and then
 store and retrieve them using a vector set with `Lettuce`.
 
@@ -120,7 +120,7 @@ the exceptions for production).
 
 The call to `vadd()` also adds the `born` and `died` values from the
 original `people` list as attribute data. You can access this during a query
-or by using the [`vgetattr()`]({{< relref "/commands/vgetattr" >}}) method.
+or by using the [`vgetattr()`](/content/commands/vgetattr.md) method.
 
 {{< clients-example set="home_vecsets" step="add_data" lang_filter="Java-Async,Java-Reactive" description="Foundational: Generate embeddings and add vector data with attributes to a vector set" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -130,7 +130,7 @@ or by using the [`vgetattr()`]({{< relref "/commands/vgetattr" >}}) method.
 You can now query the data in the set. The basic approach is to use the
 `predict()` method to generate another embedding vector for the query text.
 (This is the same method used to add the elements to the set.) Then, pass
-the query vector to [`vsim()`]({{< relref "/commands/vsim" >}}) to return elements
+the query vector to [`vsim()`](/content/commands/vsim.md) to return elements
 of the set, ranked in order of similarity to the query.
 
 Start with a simple query for "actors":
@@ -179,7 +179,7 @@ The scientists are ranked highest, followed by the
 mathematicians. This ranking seems reasonable given the connection between mathematics and science.
 
 You can also use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 with `vsim()` to restrict the search further. For example,
 repeat the "science" query, but this time limit the results to people
 who died before the year 2000:
@@ -196,16 +196,16 @@ elements that have already been filtered out of the search.
 
 ## More information
 
-See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+See the [vector sets](/content/develop/data-types/vector-sets/_index.md)
 docs for more information and code examples. See the
-[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+[Redis for AI](/content/develop/ai/_index.md) section for more details
 about text embeddings and other AI techniques you can use with Redis.
 
 You may also be interested in
-[vector search]({{< relref "/develop/clients/lettuce/vecsearch" >}}).
+[vector search](/content/develop/clients/lettuce/vecsearch.md).
 This is a feature of
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 that lets you retrieve
-[JSON]({{< relref "/develop/data-types/json" >}}) and
-[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+[JSON](/content/develop/data-types/json/_index.md) and
+[hash](/content/develop/data-types/hashes.md) documents based on
 vector data stored in their fields.


### PR DESCRIPTION
## Summary

- Converts `content/develop/clients/lettuce/*.md` (10 files) to the DOC-6909 render-hook forms, per the DOC-7047 rollout.
- `{{< relref ... >}}` shortcodes become plain Markdown links resolved by `layouts/_default/_markup/render-link.html`, rewritten to the canonical `/content/<path>.md[#anchor]` form.
- The 5 `{{< note >}}...{{< /note >}}` callouts in this directory become `> [!NOTE]` blockquotes resolved by `layouts/_default/_markup/render-blockquote.html`.
- Uses the conversion tooling from PR #3937 (`build/migrate_shortcode_links.py`), which is not merged into this PR — it was pulled in locally via `git show`, run, and then removed before committing, since it lands via its own PR.
- One percent-delimited `{{% alert title="Tip" color="warning" %}}` shortcode in `produsage.md` was intentionally left unconverted (the tooling only targets the plain `{{< note/warning/tip/info/alert >}}` form) — consistent with the merged redis-py reference conversion, which also left similar `{{% alert title="Note" %}}` shortcodes untouched.

## Test plan

- [x] Verified no `{{< relref` or `{{< note/warning/tip/info/alert` shortcodes remain in the directory.
- [x] Verified no nested block-level shortcodes were mangled inside a converted blockquote.
- [x] Verified no custom-title alert form using the angle-bracket delimiter was present (the one percent-delimited custom alert found was left untouched, as expected).
- [x] Spot-checked rewritten links resolve to real content files (cluster-spec, active-active, rest-api, pubsub, spring-framework-cache, decr, hashes, json, transactions, protocol-spec).
- [x] Ran `.claude/hooks/check_shortcode_paths.py --scan` against the directory: 0 files with issues.
- [ ] Full-site Hugo build verification (rendered href diff) is being run centrally by the ticket owner before merge — isolated worktrees here can't run the full Hugo build, since gitignored generated deps like `data/examples.json` aren't present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout format changes with no runtime or API impact; link targets were spot-checked against real content paths.
> 
> **Overview**
> Migrates **10** Lettuce client docs under `content/develop/clients/lettuce/` to the DOC-6909 render-hook markup (DOC-7047 rollout).
> 
> **Internal links:** Every `{{< relref ... >}}` is replaced with plain Markdown links in the canonical `/content/<path>.md[#anchor]` form so `render-link.html` can resolve them at build time.
> 
> **Callouts:** Five `{{< note >}}` blocks become GitHub-style `> [!NOTE]` blockquotes for `render-blockquote.html`.
> 
> `{{< clients-example >}}` and other shortcodes are unchanged. The `{{% alert title="Tip" %}}` callout in `produsage.md` is still a shortcode, matching the prior redis-py migration scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed2cead052d5aefa8814598615f47e2b2998d340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->