### PR TITLE
DOC-7047: Migrate develop/clients/go to render hooks

### DIFF
--- a/content/develop/clients/go/_index.md
+++ b/content/develop/clients/go/_index.md
@@ -23,7 +23,7 @@ weight: 7
 [`go-redis`](https://github.com/redis/go-redis) is the [Go](https://go.dev/) client for Redis.
 The sections below explain how to install `go-redis` and connect your application to a Redis database.
 
-`go-redis` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`go-redis` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 ## Install
 
@@ -67,12 +67,12 @@ client := redis.NewClient(opt)
 ```
 
 After connecting, you can test the connection by  storing and retrieving
-a simple [string]({{< relref "/develop/data-types/strings" >}}):
+a simple [string](/content/develop/data-types/strings/_index.md):
 
 {{< clients-example set="landing" step="set_get_string" lang_filter="Go" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-You can also easily store and retrieve a [hash]({{< relref "/develop/data-types/hashes" >}}):
+You can also easily store and retrieve a [hash](/content/develop/data-types/hashes.md):
 
 {{< clients-example set="landing" step="set_get_hash" lang_filter="Go" description="Foundational: Store and retrieve hash data structures using HSET and HGET commands" difficulty="beginner" >}}
 {{< /clients-example >}}

--- a/content/develop/clients/go/amr.md
+++ b/content/develop/clients/go/amr.md
@@ -26,7 +26,7 @@ letting `go-redis-entraid` fetch and renew the authentication tokens for you aut
 
 ## Install
 
-Install [`go-redis`]({{< relref "/develop/clients/go" >}}) if you
+Install [`go-redis`](/content/develop/clients/go/_index.md) if you
 have not already done so. Note that `go-redis-entraid`
 requires `go-redis` v9.9.0 or above, so you should upgrade if you
 are using an earlier version.

--- a/content/develop/clients/go/autopipeline.md
+++ b/content/develop/clients/go/autopipeline.md
@@ -16,10 +16,10 @@ title: Automatic pipelining
 weight: 42
 ---
 
-[Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) sends a batch
+[Pipelining](/content/develop/using-commands/pipelining.md) sends a batch
 of commands to the server in a single communication, which avoids the network
 and processing overhead of sending each command separately. Normally you build
-a pipeline by hand (see [Pipelines and transactions]({{< relref "/develop/clients/go/transpipe" >}})),
+a pipeline by hand (see [Pipelines and transactions](/content/develop/clients/go/transpipe.md)),
 but this means you must know in advance which commands you want to batch.
 
 *Automatic pipelining* removes that requirement. When many goroutines issue
@@ -183,7 +183,7 @@ span many slots. Ordering is per key: same-key commands stay in order, while
 sub-pipelines on different nodes run concurrently.
 
 Commands that must reach every node or shard, such as
-[`FLUSHALL`]({{< relref "/commands/flushall" >}}), cannot be added to a pipeline, so
+[`FLUSHALL`](/content/commands/flushall.md), cannot be added to a pipeline, so
 the cluster client rejects them with an error rather than let them spoil a
 batch shared with other callers. Run them on the plain client instead.
 
@@ -192,8 +192,8 @@ batch shared with other callers. Run them on the plain client instead.
 -   A command's context is not honored once it is queued, because batches
     execute on the autopipeliner's own context. Use a plain client if you need
     per-command deadlines.
--   Blocking commands such as [`BLPOP`]({{< relref "/commands/blpop" >}}) and
-    [`WAIT`]({{< relref "/commands/wait" >}}) are never batched and run directly
+-   Blocking commands such as [`BLPOP`](/content/commands/blpop.md) and
+    [`WAIT`](/content/commands/wait.md) are never batched and run directly
     on your context.
 -   The generic `Do`, `DoRaw`, and `DoRawWriteTo` methods run outside the
     pipeline, on a normal connection, because an arbitrary command name can

--- a/content/develop/clients/go/connect.md
+++ b/content/develop/clients/go/connect.md
@@ -48,7 +48,7 @@ client := redis.NewClient(opt)
 ```
 
 After connecting, you can test the connection by  storing and retrieving
-a simple [string]({{< relref "/develop/data-types/strings" >}}):
+a simple [string](/content/develop/data-types/strings/_index.md):
 
 ```go
 ctx := context.Background()
@@ -83,7 +83,7 @@ client := redis.NewClusterClient(&redis.ClusterOptions{
 ## Connect to your production Redis with TLS
 
 When you deploy your application, use TLS and follow the
-[Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
+[Redis security](/content/operate/oss_and_stack/management/security/_index.md) guidelines.
 
 Establish a secure connection with your Redis database:
 
@@ -133,13 +133,13 @@ fmt.Println("foo", val)
 Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH.
 
-{{< note >}}Using SCH with go-redis requires v9.16.0 or later for
-basic connections, and v9.18.0 or later for
-[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
-{{< /note >}}
+> [!NOTE]
+> Using SCH with go-redis requires v9.16.0 or later for
+> basic connections, and v9.18.0 or later for
+> [OSS Cluster API](/content/operate/rs/databases/configure/oss-cluster-api.md) connections.
 
 By default, `go-redis` always attempts to connect via SCH but falls back to
 a non-SCH connection if the server doesn't support it. However, you can configure SCH
@@ -161,9 +161,9 @@ rdb := redis.NewClient(&redis.Options{
 })
 ```
 
-{{< note >}}SCH requires the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
-protocol, so you must set `Protocol:3` explicitly when you connect.
-{{< /note >}}
+> [!NOTE]
+> SCH requires the [RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
+> protocol, so you must set `Protocol:3` explicitly when you connect.
 
 The `maintnotifications.Config` object accepts the following parameters:
 
@@ -176,34 +176,34 @@ The `maintnotifications.Config` object accepts the following parameters:
 | `PostHandoffRelaxedDuration` | The duration to continue using relaxed timeouts after a successful handoff (this provides extra resilience during cluster transitions). The default is 20 seconds. |
 | `MaxHandoffRetries` | The maximum number of times to retry connecting to the replacement node. The default is 3. |
 
-{{< note >}} Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
-either [AWS PrivateLink]({{< relref "/operate/rc/security/aws-privatelink" >}}) or
-[Google Cloud Private Service Connect]({{< relref "/operate/rc/security/private-service-connect" >}})
-(see [Smart client handoffs]({{< relref "/develop/clients/sch#redis-cloud" >}}) for more information).
-To use relaxed timeouts with these services, you should set `EndpointType: maintnotifications.EndpointTypeNone`
-when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.
-{{< /note >}}
+> [!NOTE]
+>  Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
+> either [AWS PrivateLink](/content/operate/rc/security/aws-privatelink.md) or
+> [Google Cloud Private Service Connect](/content/operate/rc/security/private-service-connect.md)
+> (see [Smart client handoffs](/content/develop/clients/sch.md#redis-cloud) for more information).
+> To use relaxed timeouts with these services, you should set `EndpointType: maintnotifications.EndpointTypeNone`
+> when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.
 
 ## Connect using client-side caching
 
 Client-side caching is a technique to reduce network traffic between
 the client and server, resulting in better performance. See
-[Client-side caching introduction]({{< relref "/develop/clients/client-side-caching" >}})
+[Client-side caching introduction](/content/develop/clients/client-side-caching.md)
 for more information about how client-side caching works and how to use it effectively.
 
-{{< note >}}Client-side caching is an experimental feature of go-redis and its
-API may change in a minor release.
-
-Client-side caching requires go-redis v9.22.0 or later.
-To maximize compatibility with all Redis products, client-side caching
-is supported by Redis v7.4 or later.
-
-Client-side caching requires the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
-protocol, so you must set `Protocol: 3` explicitly when you connect. On a RESP2
-connection, client-side caching silently does nothing. It is also limited to
-standalone clients and to logical database 0; on any other database it is
-disabled with a log warning.
-{{< /note >}}
+> [!NOTE]
+> Client-side caching is an experimental feature of go-redis and its
+> API may change in a minor release.
+>
+> Client-side caching requires go-redis v9.22.0 or later.
+> To maximize compatibility with all Redis products, client-side caching
+> is supported by Redis v7.4 or later.
+>
+> Client-side caching requires the [RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
+> protocol, so you must set `Protocol: 3` explicitly when you connect. On a RESP2
+> connection, client-side caching silently does nothing. It is also limited to
+> standalone clients and to logical database 0; on any other database it is
+> disabled with a log warning.
 
 To enable client-side caching, pass a `ClientSideCacheConfig` object when you
 connect on a `Protocol: 3` client. Passing an empty `ClientSideCacheConfig{}`
@@ -231,8 +231,8 @@ func main() {
 ```
 
 You can see the cache working if you connect to the same Redis database
-with [`redis-cli`]({{< relref "/develop/tools/cli" >}}) and run the
-[`MONITOR`]({{< relref "/commands/monitor" >}}) command. With caching enabled,
+with [`redis-cli`](/content/develop/tools/cli.md) and run the
+[`MONITOR`](/content/commands/monitor.md) command. With caching enabled,
 the server sees the first `Get("city")` call but not the second, which the
 client satisfies from the cache.
 
@@ -306,11 +306,11 @@ client := redis.NewClient(&redis.Options{
 })
 ```
 
-{{< note >}}Embed the concrete `*redis.LocalCache` type, as shown above, rather
-than the `Cache` interface. Cache statistics come from an optional `Stats()`
-method that the `Cache` interface doesn't declare, so a wrapper that embeds the
-interface still compiles but makes `CSCStats()` report zeros.
-{{< /note >}}
+> [!NOTE]
+> Embed the concrete `*redis.LocalCache` type, as shown above, rather
+> than the `Cache` interface. Cache statistics come from an optional `Stats()`
+> method that the `Cache` interface doesn't declare, so a wrapper that embeds the
+> interface still compiles but makes `CSCStats()` report zeros.
 
 To write a cache from scratch, you should implement all eight `Cache` methods: `Get()` for
 lookups, `Reserve()`, `FulfillOwned()`, and `Cancel()` to ensure that only one

--- a/content/develop/clients/go/error-handling.md
+++ b/content/develop/clients/go/error-handling.md
@@ -16,8 +16,8 @@ go-redis uses **explicit error returns** following Go's idiomatic error handling
 but it is essential in production code.
 This page explains how go-redis's error handling works and how to apply
 some common error handling patterns. For an overview of error types and handling
-strategies, see [Error handling]({{< relref "/develop/clients/error-handling" >}}).
-See also [Production usage]({{< relref "/develop/clients/go/produsage" >}})
+strategies, see [Error handling](/content/develop/clients/error-handling.md).
+See also [Production usage](/content/develop/clients/go/produsage.md)
 for more information on connection management, timeouts, and other aspects of
 app reliability.
 
@@ -41,19 +41,19 @@ Common error types from go-redis include:
 | `net.OpError` | Network error | ✅ | Retry with backoff or fall back to alternative |
 | `redis.ResponseError` | Redis error response | ❌ | Fix the command or arguments |
 
-See [Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+See [Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 go-redis:
 
 ### Pattern 1: Fail fast
 
 Return the error immediately if it represents an unrecoverable situation (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```go
@@ -67,7 +67,7 @@ if err != nil {
 ### Pattern 2: Graceful degradation
 
 Check for specific errors and fall back to an alternative (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```go
@@ -90,16 +90,16 @@ return result, nil
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors such as timeouts (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description). go-redis has built-in retry logic with
-configurable timing and backoffs. See [Retries]({{< relref "/develop/clients/go/produsage#retries" >}}) for more information. Note also that
+configurable timing and backoffs. See [Retries](/content/develop/clients/go/produsage.md#retries) for more information. Note also that
 you can configure timeouts (which are one of the most common causes of
-temporary errors) for connections and commands. See [Timeouts]({{< relref "/develop/clients/go/produsage#timeouts" >}}) for more information.
+temporary errors) for connections and commands. See [Timeouts](/content/develop/clients/go/produsage.md#timeouts) for more information.
 
 ### Pattern 4: Log and continue
 
 Log non-critical errors and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```go
@@ -115,10 +115,10 @@ if err != nil {
 ```
 
 Note that go-redis also supports [OpenTelemetry](https://opentelemetry.io/)
-instrumentation to monitor performance and trace the execution of Redis commands. See [Observability]({{< relref "/develop/clients/go#observability" >}}) for more information.
+instrumentation to monitor performance and trace the execution of Redis commands. See [Observability](/content/develop/clients/go/_index.md#observability) for more information.
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Production usage]({{< relref "/develop/clients/go/produsage" >}})
-- [Observability]({{< relref "/develop/clients/go#observability" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Production usage](/content/develop/clients/go/produsage.md)
+- [Observability](/content/develop/clients/go/_index.md#observability)

--- a/content/develop/clients/go/observability.md
+++ b/content/develop/clients/go/observability.md
@@ -19,7 +19,7 @@ weight: 75
 instrumentation to collect metrics. This can be very helpful for
 diagnosing problems and improving the performance and connection resiliency of
 your application. See the
-[Observability overview]({{< relref "/develop/clients/observability" >}})
+[Observability overview](/content/develop/clients/observability.md)
 for an introduction to Redis client observability and a reference guide for the
 available metrics.
 
@@ -71,7 +71,7 @@ The available option methods for `redisotel.Config` are described in the table b
 | Method | Type | Description |
 | --- | --- | --- |
 | `WithEnabled` | `bool` | Enable or disable OTel instrumentation. Default is `false`, so you must enable it explicitly. |
-| `WithMetricGroups` | `MetricGroupFlag` | Bitmap of metric groups to enable. By default, all metrics are enabled (equivalent to `MetricGroupAll`). See [Redis metric groups]({{< relref "/develop/clients/observability#redis-metric-groups" >}}) for a list of available groups. |
+| `WithMetricGroups` | `MetricGroupFlag` | Bitmap of metric groups to enable. By default, all metrics are enabled (equivalent to `MetricGroupAll`). See [Redis metric groups](/content/develop/clients/observability.md#redis-metric-groups) for a list of available groups. |
 | `WithIncludeCommands` | `[]string` | List of Redis commands to track. If set, only these commands will be tracked. Note that you should use the Redis command name rather than the Go method name (for example `LPOP` rather than `LPopCount`). |
 | `WithExcludeCommands` | `[]string` | List of Redis commands to exclude from tracking. If set, all commands except these will be tracked. Note that you should use the Redis command name rather than the Go method name (for example `LPOP` rather than `LPopCount`). |
 | `WithHidePubSubChannelNames` | `bool` | If true, channel names in pub/sub metrics will be hidden. |

--- a/content/develop/clients/go/prob.md
+++ b/content/develop/clients/go/prob.md
@@ -16,7 +16,7 @@ weight: 45
 ---
 
 Redis supports several
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md)
 that let you calculate values approximately rather than exactly.
 The types fall into two basic categories:
 
@@ -32,7 +32,7 @@ counting the number of distinct IP addresses that access a website in one day.
 
 Assuming that you already have code that supplies you with each IP
 address as a string, you could record the addresses in Redis using
-a [set]({{< relref "/develop/data-types/sets" >}}):
+a [set](/content/develop/data-types/sets.md):
 
 ```go
 rdb.SAdd(ctx, "ip_tracker", new_ip_address)
@@ -68,11 +68,11 @@ time than the equivalent precise calculations.
 Redis supports the following approximate set operations:
 
 -   [Membership](#set-membership): The
-    [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-    [Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+    [Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+    [Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
     data types let you track whether or not a given item is a member of a set.
 -   [Cardinality](#set-cardinality): The
-    [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+    [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
     data type gives you an approximate value for the number of items in a set, also
     known as the *cardinality* of the set.
 
@@ -80,8 +80,8 @@ The sections below describe these operations in more detail.
 
 ### Set membership
 
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 objects provide a set membership operation that lets you track whether or not a
 particular item has been added to a set. These two types provide different
 trade-offs for memory usage and speed, so you can select the best one for your
@@ -90,7 +90,7 @@ absence of items in the set. If an item is reported as absent, then it is defini
 absent, but if it is reported as present, then there is a small chance it may really be
 absent.
 
-Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+Instead of storing strings directly, like a [set](/content/develop/data-types/sets.md),
 a Bloom filter records the presence or absence of the
 [hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
 This gives a very compact representation of the
@@ -111,13 +111,13 @@ Which of these two data types you choose depends on your use case.
 Bloom filters are generally faster than Cuckoo filters when adding new items,
 and also have better memory usage. Cuckoo filters are generally faster
 at checking membership and also support the delete operation. See the
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 reference pages for more information and comparison between the two types.
 
 ### Set cardinality
 
-A [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+A [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 object calculates the cardinality of a set. As you add
 items, the HyperLogLog tracks the number of distinct set members but
 doesn't let you retrieve them or query which items have been added.
@@ -141,20 +141,20 @@ Redis supports several approximate statistical calculations
 on numeric data sets:
 
 -   [Frequency](#frequency): The
-    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
     data type lets you find the approximate frequency of a labeled item in a data stream.
 -   [Quantiles](#quantiles): The
-    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
     data type estimates the quantile of a query value in a data stream.
 -   [Ranking](#ranking): The
-    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    [Top-K](/content/develop/data-types/probabilistic/top-k.md) data type
     estimates the ranking of labeled items by frequency in a data stream.
 
 The sections below describe these operations in more detail.
 
 ### Frequency
 
-A [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+A [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
 (CMS) object keeps count of a set of related items represented by
 string labels. The count is approximate, but you can specify
 how close you want to keep the count to the true value (as a fraction)
@@ -168,7 +168,7 @@ a Count-min sketch object, add data to it, and then query it.
 {{< /clients-example >}}
 
 The advantage of using a CMS over keeping an exact count with a
-[sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
+[sorted set](/content/develop/data-types/sorted-sets.md)
 is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
@@ -183,7 +183,7 @@ the value of height below which 75% of all people's heights lie.
 [Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
 to quantiles, except that the fraction is expressed as a percentage.
 
-A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+A [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 object can estimate quantiles from a set of values added to it
 without having to store each value in the set explicitly. This can
 save a lot of memory when you have a large number of samples.
@@ -201,12 +201,12 @@ data set.
 
 A t-digest object also supports several other related commands, such
 as querying by rank. See the
-[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+[t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 reference for more information.
 
 ### Ranking
 
-A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+A [Top-K](/content/develop/data-types/probabilistic/top-k.md)
 object estimates the rankings of different labeled items in a data
 stream according to frequency. For example, you could use this to
 track the top ten most frequently-accessed pages on a website, or the

--- a/content/develop/clients/go/produsage.md
+++ b/content/develop/clients/go/produsage.md
@@ -43,7 +43,7 @@ of them may not apply to your particular use case.
 If your code doesn't access the Redis server continuously then it
 might be useful to make a "health check" periodically (perhaps once
 every few seconds). You can do this using a simple
-[`PING`]({{< relref "/commands/ping" >}}) command:
+[`PING`](/content/commands/ping.md) command:
 
 ```go
 err := rdb.Ping(ctx).Err()
@@ -64,7 +64,7 @@ you should also always check that the error value is `nil` before
 proceeding. Errors can be returned for failed connections, network
 problems, and invalid command parameters, among other things.
 
-See [Error handling]({{< relref "/develop/clients/go/error-handling" >}}) for a
+See [Error handling](/content/develop/clients/go/error-handling.md) for a
 more detailed discussion of error handling approaches in `go-redis`.
 
 ### Monitor performance and errors
@@ -72,7 +72,7 @@ more detailed discussion of error handling approaches in `go-redis`.
 `go-redis` supports [OpenTelemetry](https://opentelemetry.io/). This lets
 you trace command execution and monitor your server's performance.
 You can use this information to detect problems before they are reported
-by users. See [Observability]({{< relref "/develop/clients/go/observability" >}})
+by users. See [Observability](/content/develop/clients/go/observability.md)
 for more information.
 
 ### Retries
@@ -134,7 +134,7 @@ Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
 
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH and
-[Connect using Smart client handoffs]({{< relref "/develop/clients/go/connect#connect-using-smart-client-handoffs-sch" >}})
+[Connect using Smart client handoffs](/content/develop/clients/go/connect.md#connect-using-smart-client-handoffs-sch)
 for example code.

--- a/content/develop/clients/go/queryjson.md
+++ b/content/develop/clients/go/queryjson.md
@@ -24,26 +24,26 @@ weight: 20
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
-{{< note >}}From [v9.8.0](https://github.com/redis/go-redis/releases/tag/v9.8.0) onwards,
-`go-redis` uses query dialect 2 by default.
-Redis Search methods such as [`FTSearch()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v9.8.0](https://github.com/redis/go-redis/releases/tag/v9.8.0) onwards,
+> `go-redis` uses query dialect 2 by default.
+> Redis Search methods such as [`FTSearch()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[`go-redis`]({{< relref "/develop/clients/go" >}}) client library if you
+[`go-redis`](/content/develop/clients/go/_index.md) client library if you
 haven't already done so.
 
 Add the following dependencies:
@@ -63,48 +63,48 @@ below is compatible with both JSON and hash objects.
 
 Connect to your Redis database. The code below shows the most
 basic connection but see
-[Connect to the server]({{< relref "/develop/clients/go/connect" >}})
+[Connect to the server](/content/develop/clients/go/connect.md)
 to learn more about the available connection options.
 
 {{< clients-example set="go_home_json" step="connect" description="Foundational: Establish a connection to Redis with RESP2 protocol for Redis Search operations" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-{{< note >}}The connection options in the example specify
-[RESP2]({{< relref "/develop/reference/protocol-spec" >}}) in the `Protocol`
-field. We recommend that you use RESP2 for Redis Search operations in `go-redis`
-because some of the response structures for the default RESP3 are currently
-incomplete and so you must handle the "raw" responses in your own code.
-
-If you do want to use RESP3, you should set the `UnstableResp3` option when
-you connect:
-
-```go
-rdb := redis.NewClient(&redis.Options{
-    UnstableResp3: true,
-    // Other options...
-})
-```
-
-You must also access command results using the `RawResult()` and `RawVal()` methods
-rather than the usual `Result()` and `Val()`:
-
-```go
-res1, err := client.FTSearchWithArgs(
-    ctx, "txt", "foo bar", &redis.FTSearchOptions{},
-).RawResult()
-val1 := client.FTSearchWithArgs(
-    ctx, "txt", "foo bar", &redis.FTSearchOptions{},
-).RawVal()
-```
-{{< /note >}}
+> [!NOTE]
+> The connection options in the example specify
+> [RESP2](/content/develop/reference/protocol-spec.md) in the `Protocol`
+> field. We recommend that you use RESP2 for Redis Search operations in `go-redis`
+> because some of the response structures for the default RESP3 are currently
+> incomplete and so you must handle the "raw" responses in your own code.
+>
+> If you do want to use RESP3, you should set the `UnstableResp3` option when
+> you connect:
+>
+> ```go
+> rdb := redis.NewClient(&redis.Options{
+>     UnstableResp3: true,
+>     // Other options...
+> })
+> ```
+>
+> You must also access command results using the `RawResult()` and `RawVal()` methods
+> rather than the usual `Result()` and `Val()`:
+>
+> ```go
+> res1, err := client.FTSearchWithArgs(
+>     ctx, "txt", "foo bar", &redis.FTSearchOptions{},
+> ).RawResult()
+> val1 := client.FTSearchWithArgs(
+>     ctx, "txt", "foo bar", &redis.FTSearchOptions{},
+> ).RawVal()
+> ```
 
 Use the code below to create a search index. The `FTCreateOptions` parameter enables
 indexing only for JSON objects where the key has a `user:` prefix.
 The
-[schema]({{< relref "/develop/ai/search-and-query/indexing" >}})
+[schema](/content/develop/ai/search-and-query/indexing/_index.md)
 for the index has three fields for the user's name, age, and city.
 The `FieldName` field of the `FieldSchema` struct specifies a
-[JSON path]({{< relref "/develop/data-types/json/path" >}})
+[JSON path](/content/develop/data-types/json/path.md)
 that identifies which data field to index. Use the `As` struct field
 to provide an alias for the JSON path expression. You can use
 the alias in queries as a short and intuitive way to refer to the
@@ -116,7 +116,7 @@ expression, instead of typing it in full:
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them:
 
@@ -126,7 +126,7 @@ objects automatically as you add them:
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -146,7 +146,7 @@ returning the documents themselves.
 {{< /clients-example >}}
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< clients-example set="go_home_json" step="query3" description="Aggregation: Perform aggregation queries to group and count documents by field values using FTAggregateWithArgs" difficulty="intermediate" >}}
@@ -167,8 +167,8 @@ the `idx:users` index used for JSON documents in the previous examples.
 {{< clients-example set="go_home_json" step="make_hash_index" description="Foundational: Create a search index for hash documents with OnHash option and simplified field schema" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-You use [`HSet()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`JSONSet()`]({{< relref "/commands/json.set" >}}),
+You use [`HSet()`](/content/commands/hset.md) to add the hash
+documents instead of [`JSONSet()`](/content/commands/json.set.md),
 but the same flat `userX` maps work equally well with either
 hash or JSON:
 
@@ -186,5 +186,5 @@ in a string under the key "$"):
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/go/queryjson.md
+++ b/content/develop/clients/go/queryjson.md
@@ -68,6 +68,7 @@ to learn more about the available connection options.
 
 {{< clients-example set="go_home_json" step="connect" description="Foundational: Establish a connection to Redis with RESP2 protocol for Redis Search operations" difficulty="beginner" >}}
 {{< /clients-example >}}
+&nbsp;
 
 > [!NOTE]
 > The connection options in the example specify

--- a/content/develop/clients/go/scan-buffer.md
+++ b/content/develop/clients/go/scan-buffer.md
@@ -17,9 +17,9 @@ weight: 37
 
 `go-redis` can convert command results directly into Go values. This is useful
 when you want to keep application code close to your domain types instead of
-working with strings and maps everywhere. You can scan [hash]({{< relref "/develop/data-types/hashes" >}})
+working with strings and maps everywhere. You can scan [hash](/content/develop/data-types/hashes.md)
 results into structs, scan list-style command results into slices, and use
-byte buffers for large [string]({{< relref "/develop/data-types/strings" >}})
+byte buffers for large [string](/content/develop/data-types/strings/_index.md)
 values.
 
 ## Initialize
@@ -40,14 +40,14 @@ Use struct tags of the form `redis:"field"` to map Redis hash fields to Go
 struct fields. The `Scan()` method converts matching fields to the destination
 types and returns an error if a conversion fails.
 
-The following example stores a hash with [`HSET`]({{< relref "/commands/hset" >}})
-and then scans the result of [`HGETALL`]({{< relref "/commands/hgetall" >}})
+The following example stores a hash with [`HSET`](/content/commands/hset.md)
+and then scans the result of [`HGETALL`](/content/commands/hgetall.md)
 into a `Bike` struct:
 
 {{< clients-example set="go_scan_buffer" step="scan_hash" lang_filter="Go" description="Structured results: Scan all hash fields into a Go struct using redis field tags" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-You can also scan a subset of fields with [`HMGET`]({{< relref "/commands/hmget" >}}).
+You can also scan a subset of fields with [`HMGET`](/content/commands/hmget.md).
 Fields that are not returned keep their Go zero values:
 
 {{< clients-example set="go_scan_buffer" step="scan_hash_subset" lang_filter="Go" description="Structured results: Scan selected hash fields and leave missing fields at their zero values" difficulty="intermediate" buildsUpon="scan_hash" >}}
@@ -55,7 +55,7 @@ Fields that are not returned keep their Go zero values:
 
 ## Scan lists into slices
 
-Commands that return a list of strings, such as [`LRANGE`]({{< relref "/commands/lrange" >}}),
+Commands that return a list of strings, such as [`LRANGE`](/content/commands/lrange.md),
 can use `ScanSlice()` to convert the result into a typed Go slice:
 
 {{< clients-example set="go_scan_buffer" step="scan_list" lang_filter="Go" description="Structured results: Convert a list command result into a typed Go slice with ScanSlice" difficulty="beginner" >}}
@@ -67,10 +67,9 @@ For large string payloads, you can avoid creating a new string for every read by
 providing a caller-owned byte buffer. Use `SetFromBuffer()` to write a `[]byte`
 value and `GetToBuffer()` to read the value into an existing buffer.
 
-{{< note >}}
-The buffer APIs require `github.com/redis/go-redis/v9` v9.21.0
-or later.
-{{< /note >}}
+> [!NOTE]
+> The buffer APIs require `github.com/redis/go-redis/v9` v9.21.0
+> or later.
 &nbsp;
 
 {{< clients-example set="go_scan_buffer" step="buffer_round_trip" lang_filter="Go" description="Buffer optimization: Write and read Redis string values using caller-owned byte buffers" difficulty="intermediate" >}}
@@ -81,12 +80,11 @@ to get the number of bytes read, `Bytes()` to access the populated slice
 (`buf[:n]`), and `Err()` to check for errors such as `redis.Nil` when the key
 does not exist.
 
-{{< note >}}
-`GetToBuffer()` requires a buffer large enough to hold the whole value. It also
-opts out of automatic retries because a failed read might already have written
-partial data into your buffer. If a buffer is too small, `Err()` reports a
-`buffer too small` error.
-{{< /note >}}
+> [!NOTE]
+> `GetToBuffer()` requires a buffer large enough to hold the whole value. It also
+> opts out of automatic retries because a failed read might already have written
+> partial data into your buffer. If a buffer is too small, `Err()` reports a
+> `buffer too small` error.
 
 The following example shows how to detect a buffer that is too small:
 
@@ -94,7 +92,7 @@ The following example shows how to detect a buffer that is too small:
 {{< /clients-example >}}
 
 `SetFromBuffer()` does not set an expiration. If you need a TTL, call
-[`EXPIRE`]({{< relref "/commands/expire" >}}) separately with `Expire()`, or use
+[`EXPIRE`](/content/commands/expire.md) separately with `Expire()`, or use
 `Set()` with an expiration when the extra allocation is acceptable.
 
 ## More information

--- a/content/develop/clients/go/transpipe.md
+++ b/content/develop/clients/go/transpipe.md
@@ -21,16 +21,16 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 If you want the client to batch concurrent commands into pipelines for you
 without writing any pipeline code, see
-[Automatic pipelining]({{< relref "/develop/clients/go/autopipeline" >}}).
+[Automatic pipelining](/content/develop/clients/go/autopipeline.md).
 
 ## Execute a pipeline
 
@@ -81,7 +81,7 @@ to different keys. The basic idea is to watch for changes to any
 keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The code below reads a string

--- a/content/develop/clients/go/vecsearch.md
+++ b/content/develop/clients/go/vecsearch.md
@@ -25,14 +25,14 @@ topics:
 weight: 30
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}}) 
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md) 
 reference page for more information).
 Among other things, vector fields can store *text embeddings*, which are AI-generated vector
 representations of the semantic information in pieces of text. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings indicates how similar they are semantically. By comparing the
 similarity of an embedding generated from some query text with embeddings stored in hash
 or JSON fields, Redis can retrieve documents that closely match the query in terms
@@ -45,18 +45,18 @@ Redis Search.  The code is first demonstrated for hash documents with a
 separate section to explain the
 [differences with JSON documents](#differences-with-json-documents).
 
-{{< note >}}From [v9.8.0](https://github.com/redis/go-redis/releases/tag/v9.8.0) onwards,
-`go-redis` uses query dialect 2 by default.
-Redis Search methods such as [`FTSearch()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v9.8.0](https://github.com/redis/go-redis/releases/tag/v9.8.0) onwards,
+> `go-redis` uses query dialect 2 by default.
+> Redis Search methods such as [`FTSearch()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-First, install [`go-redis`]({{< relref "/develop/clients/go" >}})
+First, install [`go-redis`](/content/develop/clients/go/_index.md)
 if you haven't already done so. Then, install
 [`Hugot`](https://pkg.go.dev/github.com/knights-analytics/hugot)
 using the following command:
@@ -74,7 +74,7 @@ Add the following imports to your module's main program file:
 
 The `Hugot` model outputs the embeddings as a
 `[]float32` array. If you are storing your documents as
-[hash]({{< relref "/develop/data-types/hashes" >}}) objects, then you
+[hash](/content/develop/data-types/hashes.md) objects, then you
 must convert this array to a `byte` string before adding it as a hash field.
 The function shown below uses Go's [`binary`](https://pkg.go.dev/encoding/binary)
 package to produce the `byte` string:
@@ -82,7 +82,7 @@ package to produce the `byte` string:
 {{< clients-example set="home_query_vec" step="helper" lang_filter="Go" description="Foundational: Create a helper function to convert float32 embeddings to binary format for hash storage" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Note that if you are using [JSON]({{< relref "/develop/data-types/json" >}})
+Note that if you are using [JSON](/content/develop/data-types/json/_index.md)
 objects to store your documents instead of hashes, then you should store
 the `[]float32` array directly without first converting it to a `byte`
 string (see [Differences with JSON documents](#differences-with-json-documents)
@@ -99,12 +99,12 @@ created with the name `vector_idx`:
 Next, create the index.
 The schema in the example below specifies hash objects for storage and includes
 three fields: the text content to index, a
-[tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+[tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
 field to represent the "genre" of the text, and the embedding vector generated from
 the original text content. The `embedding` field specifies
-[HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}})
+[HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index)
 indexing, the
-[L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
@@ -124,7 +124,7 @@ model:
 ## Add data
 
 You can now supply the data objects, which will be indexed automatically
-when you add them with [`HSet()`]({{< relref "/commands/hset" >}}), as long as
+when you add them with [`HSet()`](/content/commands/hset.md), as long as
 you use the `doc:` prefix specified in the index definition.
 
 Use the `RunPipeline()` method of `FeatureExtractionPipeline`
@@ -149,7 +149,7 @@ results in order of this numeric similarity value.
 The code below creates the query embedding using `RunPipeline()`, as with
 the indexing, and passes it as a parameter when the query executes
 (see
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about using query parameters with embeddings).
 
 {{< clients-example set="home_query_vec" step="query" lang_filter="Go" description="Vector similarity search: Find semantically similar documents by comparing query embeddings with indexed vectors using L2 distance" difficulty="intermediate" >}}
@@ -176,7 +176,7 @@ is the result that is most similar in meaning to the query text
 
 Indexing JSON documents is similar to hash indexing, but there are some
 important differences. JSON allows much richer data modelling with nested fields, so
-you must supply a [path]({{< relref "/develop/data-types/json/path" >}}) in the schema
+you must supply a [path](/content/develop/data-types/json/path.md) in the schema
 to identify each field you want to index. However, you can declare a short alias for each
 of these paths (using the `As` option) to avoid typing it in full for
 every query. Also, you must set `OnJSON` to `true` when you create the index.
@@ -187,8 +187,8 @@ the one created previously for hashes:
 {{< clients-example set="home_query_vec" step="json_index" lang_filter="Go" description="Foundational: Create a vector search index for JSON documents with OnJSON option and JSON path specifications" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-Use [`JSONSet()`]({{< relref "/commands/json.set" >}}) to add the data
-instead of [`HSet()`]({{< relref "/commands/hset" >}}). The maps
+Use [`JSONSet()`](/content/commands/json.set.md) to add the data
+instead of [`HSet()`](/content/commands/hset.md). The maps
 that specify the fields have the same structure as the ones used for `HSet()`.
 
 An important difference with JSON indexing is that the vectors are
@@ -221,6 +221,6 @@ ID: jdoc:2, Distance:43.7771987915, Content:'Today is a sunny day'
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about the indexing options, distance metrics, and query format
 for vectors.

--- a/content/develop/clients/go/vecsets.md
+++ b/content/develop/clients/go/vecsets.md
@@ -21,14 +21,14 @@ topics:
 - vectors
 ---
 
-A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+A Redis [vector set](/content/develop/data-types/vector-sets/_index.md) lets
 you store a set of unique keys, each with its own associated vector.
 You can then retrieve keys from the set according to the similarity between
 their stored vectors and a query vector that you specify.
 
 You can use vector sets to store any type of numeric vector but they are
 particularly optimized to work with text embedding vectors (see
-[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+[Redis for AI](/content/develop/ai/_index.md) to learn more about text
 embeddings). The example below shows how to use the
 [`Hugot`](https://github.com/knights-analytics/hugot)
 library to generate vector embeddings and then
@@ -36,7 +36,7 @@ store and retrieve them using a vector set with `go-redis`.
 
 ## Initialize
 
-Start by [installing]({{< relref "/develop/clients/go#install" >}}) `go-redis` if you haven't already done so. Note that you need `go-redis`
+Start by [installing](/content/develop/clients/go/_index.md#install) `go-redis` if you haven't already done so. Note that you need `go-redis`
 [v9.10.0](https://github.com/redis/go-redis/releases/tag/v9.10.0)
 or later to use vector sets.
 
@@ -84,11 +84,11 @@ Use the
 embedding as an array of `float32` values, then use a loop like the one
 shown below to convert the `float32` array to a `float64` array.
 You can then pass this array to the
-[`VAdd()`]({{< relref "/commands/vadd" >}}) command to set the embedding.
+[`VAdd()`](/content/commands/vadd.md) command to set the embedding.
 
 The call to `VAdd()` also adds the `born` and `died` values from the
 original map as attribute data. You can access this during a query
-or by using the [`VGetAttr()`]({{< relref "/commands/vgetattr" >}}) method.
+or by using the [`VGetAttr()`](/content/commands/vgetattr.md) method.
 
 {{< clients-example set="home_vecsets" step="add_data" lang_filter="Go" description="Foundational: Generate embeddings and add data to a vector set with VAdd including attribute metadata" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -98,7 +98,7 @@ or by using the [`VGetAttr()`]({{< relref "/commands/vgetattr" >}}) method.
 You can now query the data in the set. The basic approach is to use the
 `RunPipeline()` method to generate another embedding vector for the query text.
 (This is the same method used to add the elements to the set.) Then, pass
-the query vector to [`VSim()`]({{< relref "/commands/vsim" >}}) to return elements
+the query vector to [`VSim()`](/content/commands/vsim.md) to return elements
 of the set, ranked in order of similarity to the query.
 
 Start with a simple query for "actors":
@@ -146,7 +146,7 @@ mathematicians. This seems reasonable given the connection between mathematics
 and science.
 
 You can also use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 with `VSimWithArgs()` to restrict the search further. For example,
 repeat the "science" query, but this time limit the results to people
 who died before the year 2000:
@@ -163,16 +163,16 @@ elements that have already been filtered out of the search.
 
 ## More information
 
-See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+See the [vector sets](/content/develop/data-types/vector-sets/_index.md)
 docs for more information and code examples. See the
-[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+[Redis for AI](/content/develop/ai/_index.md) section for more details
 about text embeddings and other AI techniques you can use with Redis.
 
 You may also be interested in
-[vector search]({{< relref "/develop/clients/go/vecsearch" >}}).
+[vector search](/content/develop/clients/go/vecsearch.md).
 This is a feature of
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 that lets you retrieve
-[JSON]({{< relref "/develop/data-types/json" >}}) and
-[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+[JSON](/content/develop/data-types/json/_index.md) and
+[hash](/content/develop/data-types/hashes.md) documents based on
 vector data stored in their fields.


### PR DESCRIPTION
## Summary

- Converts `content/develop/clients/go/` from the `relref`/callout shortcodes to the DOC-6909 render hooks, per the DOC-7047 rollout. Directory is flat (verified via `find -mindepth 2`) — all 13 `.md` files were in scope: `_index.md`, `amr.md`, `autopipeline.md`, `connect.md`, `error-handling.md`, `observability.md`, `prob.md`, `produsage.md`, `queryjson.md`, `scan-buffer.md`, `transpipe.md`, `vecsearch.md`, `vecsets.md`.
- 121 `{{< relref >}}` links rewritten to plain `/content/*.md[#anchor]` / `/content/*/_index.md[#anchor]` form.
- 10 `{{< note >}}` callouts (no `warning`/`tip`/`info`/`alert` types present in this section) converted to `> [!NOTE]` blockquotes, including one with an embedded fenced Go code block, which renders correctly as quoted lines.
- No `{{% alert %}}` (percent-delimited) shortcodes found in this section, so the documented tooling gap (converter doesn't handle that form, matching the redis-py reference conversion) doesn't apply here.
- No nested block-level shortcodes were found inside any callout.
- Uses the migration tooling from PR #3937 (`build/migrate_shortcode_links.py`, not yet merged) — pulled via `git show` as an untracked helper and removed before committing; it is not part of this PR's diff.

## Test plan

- [x] Verified no `{{< relref` or `{{< note/warning/tip/info/alert` shortcodes remain in `content/develop/clients/go/`.
- [x] Verified no `{{%` percent-delimited shortcodes are present (none found).
- [x] Reviewed the full diff by hand: link targets, blockquote formatting (`> [!NOTE]` header, `>` prefix on every line including blank lines, embedded code fence), and no mangled nested shortcodes.
- [x] `python3 .claude/hooks/check_shortcode_paths.py --scan` on all 13 files reports 0 issues.
- [ ] Full-site Hugo build verification (rendered-href diff) is being run centrally by the ticket owner before merge — this isolated worktree can't run the full Hugo build since gitignored generated deps (e.g. `data/examples.json`) aren't present here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markup migration with no runtime or application code; main risk is a broken internal link if a `/content/...` path is wrong, which the PR’s path checker and Hugo build are meant to catch.
> 
> **Overview**
> Migrates all **13** pages under `content/develop/clients/go/` from Hugo `{{< relref >}}` and `{{< note >}}` shortcodes to the **DOC-6909 render-hook** style used in the DOC-7047 rollout.
> 
> **Links:** Roughly **121** internal references now use plain markdown targets such as `/content/.../*.md` and `/content/.../_index.md` (with anchors where needed), instead of `relref`. Cross-links to install docs, data types, commands, Redis Search, SCH, security, and sibling go-redis pages are updated consistently across `_index.md`, `connect.md`, `queryjson.md`, `vecsearch.md`, and the rest of the section.
> 
> **Callouts:** **10** `{{< note >}}` blocks become GitHub-flavored `> [!NOTE]` blockquotes, including multi-paragraph notes and ones that embed fenced Go examples (e.g. RESP2/RESP3 guidance in `queryjson.md`, SCH and client-side caching in `connect.md`). `scan-buffer.md` and search pages follow the same pattern.
> 
> **Unchanged:** `{{< clients-example >}}` shortcodes and page front matter are left as-is; there is no prose or API change—only link and admonition markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5949c2600004ad70bcc72381f6c9e46047ac342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->