### PR TITLE
DOC-7047: Migrate develop/clients/jedis to render hooks

### DIFF
--- a/content/develop/clients/jedis/_index.md
+++ b/content/develop/clients/jedis/_index.md
@@ -24,23 +24,23 @@ weight: 5
 ---
 
 [Jedis](https://github.com/redis/jedis) is a synchronous Java client for Redis.
-Use [Lettuce]({{< relref "/develop/clients/lettuce" >}}) if you need
+Use [Lettuce](/content/develop/clients/lettuce/_index.md) if you need
 a more advanced Java client that also supports asynchronous and reactive connections.
 The sections below explain how to install `Jedis` and connect your application
 to a Redis database.
 
-{{< note >}}Jedis 7.2.0 introduced a new client connection API:
+> [!NOTE]
+> Jedis 7.2.0 introduced a new client connection API:
+>
+> | New API class | Replaces | Use case |
+> | :-- | :-- | :-- |
+> | `RedisClient` | `UnifiedJedis`, `JedisPool`, `JedisPooled` | Single connection (with connection pooling) |
+> | `RedisClusterClient` | `JedisCluster` | Redis Cluster connections |
+> | `RedisSentinelClient` | `JedisSentinelPool` | Redis Sentinel connections |
+>
+> The old client classes are now considered deprecated.
 
-| New API class | Replaces | Use case |
-| :-- | :-- | :-- |
-| `RedisClient` | `UnifiedJedis`, `JedisPool`, `JedisPooled` | Single connection (with connection pooling) |
-| `RedisClusterClient` | `JedisCluster` | Redis Cluster connections |
-| `RedisSentinelClient` | `JedisSentinelPool` | Redis Sentinel connections |
-
-The old client classes are now considered deprecated.
-{{< /note >}}
-
-`Jedis` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`Jedis` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 ## Install
 
@@ -87,12 +87,12 @@ Connect to localhost on port 6379:
 {{< /clients-example >}}
 
 After you have connected, you can check the connection by storing and
-retrieving a simple [string]({{< relref "/develop/data-types/strings" >}}) value:
+retrieving a simple [string](/content/develop/data-types/strings/_index.md) value:
 
 {{< clients-example set="landing" step="set_get_string" lang_filter="Java-Sync" description="Foundational: Set and retrieve string values using SET and GET commands" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Store and retrieve a [hash]({{< relref "/develop/data-types/hashes" >}}):
+Store and retrieve a [hash](/content/develop/data-types/hashes.md):
 
 {{< clients-example set="landing" step="set_get_hash" lang_filter="Java-Sync" description="Foundational: Store and retrieve hash data structures using HSET and HGETALL" difficulty="beginner" >}}
 {{< /clients-example >}}

--- a/content/develop/clients/jedis/amr.md
+++ b/content/develop/clients/jedis/amr.md
@@ -30,7 +30,7 @@ in the Microsoft docs to learn how to configure Azure to use Entra ID authentica
 
 ## Install
 
-Install [`jedis`]({{< relref "/develop/clients/jedis" >}}) first,
+Install [`jedis`](/content/develop/clients/jedis/_index.md) first,
 if you have not already done so.
 
 If you are using Maven, add
@@ -137,7 +137,7 @@ The example below shows how to include the `TokenAuthConfig` details in a
 The connection uses
 [Transport Layer Security (TLS)](https://en.wikipedia.org/wiki/Transport_Layer_Security),
 which is recommended and enabled by default for managed identities. See
-[Connect to your production Redis with TLS]({{< relref "/develop/clients/jedis/connect#connect-to-your-production-redis-with-tls" >}}) for more information about
+[Connect to your production Redis with TLS](/content/develop/clients/jedis/connect.md#connect-to-your-production-redis-with-tls) for more information about
 TLS connections, including the implementation of the `createSslSocketFactory()`
 method used in the example.
 

--- a/content/develop/clients/jedis/connect.md
+++ b/content/develop/clients/jedis/connect.md
@@ -15,16 +15,16 @@ title: Connect to the server
 weight: 2
 ---
 
-{{< note >}}Jedis 7.2.0 introduced a new client connection API:
-
-| New API class | Replaces | Use case |
-| :-- | :-- | :-- |
-| `RedisClient` | `UnifiedJedis`, `JedisPool`, `JedisPooled` | Single connection (with connection pooling) |
-| `RedisClusterClient` | `JedisCluster` | Redis Cluster connections |
-| `RedisSentinelClient` | `JedisSentinelPool` | Redis Sentinel connections |
-
-The old client classes are now considered deprecated.
-{{< /note >}}
+> [!NOTE]
+> Jedis 7.2.0 introduced a new client connection API:
+>
+> | New API class | Replaces | Use case |
+> | :-- | :-- | :-- |
+> | `RedisClient` | `UnifiedJedis`, `JedisPool`, `JedisPooled` | Single connection (with connection pooling) |
+> | `RedisClusterClient` | `JedisCluster` | Redis Cluster connections |
+> | `RedisSentinelClient` | `JedisSentinelPool` | Redis Sentinel connections |
+>
+> The old client classes are now considered deprecated.
 
 ## Basic connection
 
@@ -78,7 +78,7 @@ RedisClusterClient jedis = RedisClusterClient.create(jedisClusterNodes);
 
 ### Connect to your production Redis with TLS
 
-When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
+When you deploy your application, use TLS and follow the [Redis security](/content/operate/oss_and_stack/management/security/_index.md) guidelines.
 
 Before connecting your application to the TLS-enabled Redis server, ensure that your certificates and private keys are in the correct format.
 
@@ -142,11 +142,11 @@ public class Main {
 
 Client-side caching is a technique to reduce network traffic between
 the client and server, resulting in better performance. See
-[Client-side caching introduction]({{< relref "/develop/clients/client-side-caching" >}})
+[Client-side caching introduction](/content/develop/clients/client-side-caching.md)
 for more information about how client-side caching works and how to use it effectively.
 
 To enable client-side caching, specify the
-[RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
+[RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
 protocol and pass a cache configuration object during the connection.
 
 The example below shows the simplest client-side caching connection to the default host and port,
@@ -154,15 +154,15 @@ The example below shows the simplest client-side caching connection to the defau
 All of the connection variants described above accept these parameters, so you can
 use client-side caching with a connection pool or a cluster connection in exactly the same way.
 
-{{< note >}}Client-side caching requires Jedis v5.2.0 or later.
-To maximize compatibility with all Redis products, client-side caching
-is supported by Redis v7.4 or later.
-
-The [Redis server products]({{< relref "/operate" >}}) support
-[opt-in/opt-out]({{< relref "/develop/reference/client-side-caching#opt-in-and-opt-out-caching" >}}) mode
-and [broadcasting mode]({{< relref "/develop/reference/client-side-caching#broadcasting-mode" >}})
-for CSC, but these modes are not currently implemented by Jedis.
-{{< /note >}}
+> [!NOTE]
+> Client-side caching requires Jedis v5.2.0 or later.
+> To maximize compatibility with all Redis products, client-side caching
+> is supported by Redis v7.4 or later.
+>
+> The [Redis server products](/content/operate/_index.md) support
+> [opt-in/opt-out](/content/develop/reference/client-side-caching.md#opt-in-and-opt-out-caching) mode
+> and [broadcasting mode](/content/develop/reference/client-side-caching.md#broadcasting-mode)
+> for CSC, but these modes are not currently implemented by Jedis.
 
 ```java
 HostAndPort endpoint = new HostAndPort("localhost", 6379);
@@ -192,8 +192,8 @@ client.get("city");     // Retrieved from cache
 ```
 
 You can see the cache working if you connect to the same Redis database
-with [`redis-cli`]({{< relref "/develop/tools/cli" >}}) and run the
-[`MONITOR`]({{< relref "/commands/monitor" >}}) command. If you run the
+with [`redis-cli`](/content/develop/tools/cli.md) and run the
+[`MONITOR`](/content/commands/monitor.md) command. If you run the
 code above but without passing `cacheConfig` during the connection,
 you should see the following in the CLI among the output from `MONITOR`:
 
@@ -219,8 +219,8 @@ call was satisfied by the cache.
 You can remove individual keys from the cache with the
 `deleteByRedisKey()` method of the cache object. This removes all cached items associated
 with each specified key, so all results from multi-key commands (such as
-[`MGET`]({{< relref "/commands/mget" >}})) and composite data structures
-(such as [hashes]({{< relref "/develop/data-types/hashes" >}})) will be
+[`MGET`](/content/commands/mget.md)) and composite data structures
+(such as [hashes](/content/develop/data-types/hashes.md)) will be
 cleared at once. The example below shows the effect of removing a single
 key from the cache:
 
@@ -272,7 +272,7 @@ one of its open connections. When you subsequently close the same connection,
 it is not actually closed but simply returned to the pool for reuse.
 This avoids the overhead of repeated connecting and disconnecting.
 See
-[Connection pools and multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}})
+[Connection pools and multiplexing](/content/develop/clients/pools-and-muxing.md)
 for more information.
 
 From Jedis 7.2.0, the `RedisClient` class provides connection pooling automatically,

--- a/content/develop/clients/jedis/error-handling.md
+++ b/content/develop/clients/jedis/error-handling.md
@@ -14,8 +14,8 @@ weight: 50
 
 Jedis uses **exceptions** to signal errors. Code examples in the documentation often omit error handling for brevity, but it is essential in production code. This page explains how Jedis's error handling works and how to apply common error handling patterns.
 
-For an overview of error types and handling strategies, see [Error handling]({{< relref "/develop/clients/error-handling" >}}).
-See also [Production usage]({{< relref "/develop/clients/jedis/produsage" >}})
+For an overview of error types and handling strategies, see [Error handling](/content/develop/clients/error-handling.md).
+See also [Production usage](/content/develop/clients/jedis/produsage.md)
 for more information on connection management, timeouts, and other aspects of
 app reliability.
 
@@ -44,7 +44,7 @@ Jedis organizes exceptions in a hierarchy rooted at `JedisException`, which exte
 ### Key exceptions
 
 The following exceptions are the most commonly encountered in Jedis applications.
-See [Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+See [Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 | Exception | When it occurs | Recoverable | Recommended action |
@@ -56,14 +56,14 @@ for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 Jedis:
 
 ### Pattern 1: Fail fast
 
 Catch specific exceptions that represent unrecoverable errors and re-throw them (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```java
@@ -78,7 +78,7 @@ try (RedisClient jedis = RedisClient.create()) {
 ### Pattern 2: Graceful degradation
 
 Catch specific errors and fall back to an alternative, where possible (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```java
@@ -99,7 +99,7 @@ return database.get(key);
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors like connection failures (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description):
 
 ```java
@@ -128,7 +128,7 @@ for (int attempt = 0; attempt < maxRetries; attempt++) {
 ### Pattern 4: Log and continue
 
 Log non-critical errors and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```java
@@ -142,5 +142,5 @@ try (RedisClient jedis = RedisClient.create()) {
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Production usage]({{< relref "/develop/clients/jedis/produsage" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Production usage](/content/develop/clients/jedis/produsage.md)

--- a/content/develop/clients/jedis/failover.md
+++ b/content/develop/clients/jedis/failover.md
@@ -27,7 +27,7 @@ weight: 50
 Jedis supports [Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. This page explains
 how to configure Jedis for failover. For an overview of the concepts,
-see the main [Client-side geographic failover]({{< relref "/develop/clients/failover" >}}) page.
+see the main [Client-side geographic failover](/content/develop/clients/failover.md) page.
 
 ## Failover configuration
 
@@ -40,10 +40,10 @@ The example below shows a simple case with a list of two servers,
 target. If `redis-east` fails, Jedis should fail over to
 `redis-west`.
 
-{{< note >}}Jedis v6 supported failover/failback using a special
-`UnifiedJedis` constructor. You should update existing code to use
-the approach shown below for Jedis v7 and later.
-{{< /note >}}
+> [!NOTE]
+> Jedis v6 supported failover/failback using a special
+> `UnifiedJedis` constructor. You should update existing code to use
+> the approach shown below for Jedis v7 and later.
 
 First, add the `resilience4j` dependencies to your project. If you
 are using [Maven](https://maven.apache.org/), add the following
@@ -77,7 +77,7 @@ compileOnly 'io.github.resilience4j:resilience4j-retry:1.7.1'
 ```
 
 In your source file, create some simple configuration for the client and
-[connection pool]({{< relref "/develop/clients/jedis/connect#connect-with-a-connection-pool" >}}),
+[connection pool](/content/develop/clients/jedis/connect.md#connect-with-a-connection-pool),
 as you would for a standard connection.
 
 ```java
@@ -95,7 +95,7 @@ poolConfig.setTimeBetweenEvictionRuns(Duration.ofSeconds(1));
 ```
 
 Supply the weighted list of endpoints using the `MultiDbConfig` builder
-(see [Selecting a failover target]({{< relref "/develop/clients/failover#selecting-a-failover-target" >}}) for a full description of how
+(see [Selecting a failover target](/content/develop/clients/failover.md#selecting-a-failover-target) for a full description of how
 the weighted list is used).
 Use the `weight` option to order the endpoints, with the highest
 weight being tried first.
@@ -149,7 +149,7 @@ but will also handle the connection management and failover transparently.
 ### Circuit breaker configuration
 
 The `MultiDbConfig.CircuitBreakerConfig` builder lets you pass several options to configure
-the circuit breaker (see [Detecting connection problems]({{< relref "/develop/clients/failover#detecting-connection-problems" >}}) for more information on how the
+the circuit breaker (see [Detecting connection problems](/content/develop/clients/failover.md#detecting-connection-problems) for more information on how the
 circuit breaker works):
 
 | Builder method | Default value | Description|
@@ -244,7 +244,7 @@ The `MultiDbConfig` builder lets you configure the failback behavior using the f
 ## Health check configuration
 
 Each health check consists of one or more separate "probes", each of which is a simple
-test (such as a [`PING`]({{< relref "/commands/ping" >}}) command) to determine if the database is available. The results of the separate probes are combined
+test (such as a [`PING`](/content/commands/ping.md) command) to determine if the database is available. The results of the separate probes are combined
 using a configurable policy to determine if the database is healthy.
 
 There are several strategies available for health checks that you can deploy using the
@@ -268,7 +268,7 @@ The sections below explain the available strategies in more detail.
 ### `PingStrategy` (default)
 
 The default strategy, `PingStrategy`, periodically sends a Redis
-[`PING`]({{< relref "/commands/ping" >}}) command
+[`PING`](/content/commands/ping.md) command
 and checks that it gives the expected response. Any unexpected response
 or exception indicates an unhealthy server. Although `PingStrategy` is
 very simple, it is a good basic approach for most Redis deployments.
@@ -293,12 +293,12 @@ MultiDbConfig.DatabaseConfig dbConfig =
 ### `LagAwareStrategy` (preview)
 
 `LagAwareStrategy` (currently in preview) is designed specifically for
-Redis Software [Active-Active]({{< relref "/operate/rs/databases/active-active" >}})
+Redis Software [Active-Active](/content/operate/rs/databases/active-active/_index.md)
 deployments. It uses the Redis Software REST API to check database availability
 and can also optionally check replication lag.
 
 `LagAwareStrategy` determines the health of the server using the
-[REST API]({{< relref "/operate/rs/references/rest-api" >}}). The example
+[REST API](/content/operate/rs/references/rest-api/_index.md). The example
 below shows how to configure `LagAwareStrategy` and activate it using
 the `healthCheckStrategy()` method of the `MultiDbConfig.DatabaseConfig`
 builder.
@@ -419,7 +419,7 @@ a healthy endpoint.
 
 You can still keep retrying commands after a `JedisTemporarilyNotAvailableException` is thrown (for example,
 you could add this exception to the `includedExceptionList`, as described
-in the [Retry configuration]({{< relref "#retry-configuration" >}}) section). However, if the number of
+in the [Retry configuration](#retry-configuration) section). However, if the number of
 failover attempts exceeds the value set by `maxNumFailoverAttempts()`, commands will throw a `JedisPermanentlyNotAvailableException`. Note that this is intended to notify your app
 that the problem is likely to be persistent, but it *doesn't* mean that Jedis will stop trying
 to connect to a healthy endpoint if one becomes available.

--- a/content/develop/clients/jedis/prob.md
+++ b/content/develop/clients/jedis/prob.md
@@ -16,7 +16,7 @@ weight: 5
 ---
 
 Redis supports several
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md)
 that let you calculate values approximately rather than exactly.
 The types fall into two basic categories:
 
@@ -32,7 +32,7 @@ counting the number of distinct IP addresses that access a website in one day.
 
 Assuming that you already have code that supplies you with each IP
 address as a string, you could record the addresses in Redis using
-a [set]({{< relref "/develop/data-types/sets" >}}):
+a [set](/content/develop/data-types/sets.md):
 
 ```java
 jedis.sadd("ip_tracker", new_ip_address)
@@ -68,11 +68,11 @@ time than the equivalent precise calculations.
 Redis supports the following approximate set operations:
 
 -   [Membership](#set-membership): The
-    [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-    [Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+    [Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+    [Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
     data types let you track whether or not a given item is a member of a set.
 -   [Cardinality](#set-cardinality): The
-    [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+    [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
     data type gives you an approximate value for the number of items in a set, also
     known as the *cardinality* of the set.
 
@@ -80,8 +80,8 @@ The sections below describe these operations in more detail.
 
 ### Set membership
 
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 objects provide a set membership operation that lets you track whether or not a
 particular item has been added to a set. These two types provide different
 trade-offs for memory usage and speed, so you can select the best one for your
@@ -90,7 +90,7 @@ absence of items in the set. If an item is reported as absent, then it is defini
 absent, but if it is reported as present, then there is a small chance it may really be
 absent.
 
-Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+Instead of storing strings directly, like a [set](/content/develop/data-types/sets.md),
 a Bloom filter records the presence or absence of the
 [hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
 This gives a very compact representation of the
@@ -112,13 +112,13 @@ Which of these two data types you choose depends on your use case.
 Bloom filters are generally faster than Cuckoo filters when adding new items,
 and also have better memory usage. Cuckoo filters are generally faster
 at checking membership and also support the delete operation. See the
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 reference pages for more information and comparison between the two types.
 
 ### Set cardinality
 
-A [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+A [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 object calculates the cardinality of a set. As you add
 items, the HyperLogLog tracks the number of distinct set members but
 doesn't let you retrieve them or query which items have been added.
@@ -142,20 +142,20 @@ Redis supports several approximate statistical calculations
 on numeric data sets:
 
 -   [Frequency](#frequency): The
-    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
     data type lets you find the approximate frequency of a labeled item in a data stream.
 -   [Quantiles](#quantiles): The
-    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
     data type estimates the quantile of a query value in a data stream.
 -   [Ranking](#ranking): The
-    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    [Top-K](/content/develop/data-types/probabilistic/top-k.md) data type
     estimates the ranking of labeled items by frequency in a data stream.
 
 The sections below describe these operations in more detail.
 
 ### Frequency
 
-A [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+A [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
 (CMS) object keeps count of a set of related items represented by
 string labels. The count is approximate, but you can specify
 how close you want to keep the count to the true value (as a fraction)
@@ -169,7 +169,7 @@ a Count-min sketch object, add data to it, and then query it.
 {{< /clients-example >}}
 
 The advantage of using a CMS over keeping an exact count with a
-[sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
+[sorted set](/content/develop/data-types/sorted-sets.md)
 is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
@@ -184,7 +184,7 @@ the value of height below which 75% of all people's heights lie.
 [Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
 to quantiles, except that the fraction is expressed as a percentage.
 
-A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+A [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 object can estimate quantiles from a set of values added to it
 without having to store each value in the set explicitly. This can
 save a lot of memory when you have a large number of samples.
@@ -202,12 +202,12 @@ data set.
 
 A t-digest object also supports several other related commands, such
 as querying by rank. See the
-[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+[t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 reference for more information.
 
 ### Ranking
 
-A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+A [Top-K](/content/develop/data-types/probabilistic/top-k.md)
 object estimates the rankings of different labeled items in a data
 stream according to frequency. For example, you could use this to
 track the top ten most frequently-accessed pages on a website, or the

--- a/content/develop/clients/jedis/produsage.md
+++ b/content/develop/clients/jedis/produsage.md
@@ -46,27 +46,27 @@ and then closes the connection at the end. However, production code
 typically uses connections many times intermittently. Repeatedly opening
 and closing connections has a performance overhead.
 
-Use [connection pooling]({{< relref "/develop/clients/pools-and-muxing" >}})
+Use [connection pooling](/content/develop/clients/pools-and-muxing.md)
 to avoid the overhead of opening and closing connections without having to
 write your own code to cache and reuse open connections. See
-[Configure a connection pool]({{< relref "/develop/clients/jedis/connect#configure-a-connection-pool" >}})
+[Configure a connection pool](/content/develop/clients/jedis/connect.md#configure-a-connection-pool)
 to learn how to use this technique with Jedis.
 
 ### Connection retries
 
 If a connection is lost before a command is completed, the command will fail with a `JedisConnectionException`. However, a connection error is often transient, in which case the
 command will succeed after one or more reconnection attempts. See
-[Retrying a command after a connection failure]({{< relref "/develop/clients/jedis/connect#retrying-a-command-after-a-connection-failure" >}})
+[Retrying a command after a connection failure](/content/develop/clients/jedis/connect.md#retrying-a-command-after-a-connection-failure)
 for an example of a simple retry loop that can recover from a transient connection error.
 
 ### Client-side caching
 
-[Client-side caching]({{< relref "/develop/clients/client-side-caching" >}})
+[Client-side caching](/content/develop/clients/client-side-caching.md)
 involves storing the results from read-only commands in a local cache. If the
 same command is executed again later, the results can be obtained from the cache,
 without contacting the server. This improves command execution time on the client,
 while also reducing network traffic and server load. See
-[Connect using client-side caching]({{< relref "/develop/clients/jedis/connect#connect-using-client-side-caching" >}})
+[Connect using client-side caching](/content/develop/clients/jedis/connect.md#connect-using-client-side-caching)
 for more information and example code.
 
 ### Timeouts
@@ -96,7 +96,7 @@ RedisClient jedisWithTimeout = RedisClient.builder()
 If your code doesn't access the Redis server continuously then it
 might be useful to make a "health check" periodically (perhaps once
 every few seconds). You can do this using a simple
-[`PING`]({{< relref "/commands/ping" >}}) command:
+[`PING`](/content/commands/ping.md) command:
 
 ```java
 ConnectionPoolConfig poolConfig = new ConnectionPoolConfig();
@@ -157,7 +157,7 @@ In general, Jedis can throw the following exceptions while executing commands:
 - `JedisException` - this exception is a catch-all exception that can be thrown for any other unexpected errors.
 
 Conditions when `JedisException` can be thrown:
-- Bad return from a health check with the [`PING`]({{< relref "/commands/ping" >}}) command
+- Bad return from a health check with the [`PING`](/content/commands/ping.md) command
 - Failure during SHUTDOWN
 - Pub/Sub failure when issuing commands (disconnect)
 - Any unknown server messages

--- a/content/develop/clients/jedis/queryjson.md
+++ b/content/develop/clients/jedis/queryjson.md
@@ -24,31 +24,31 @@ weight: 2
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
-{{< note >}}From [v6.0.0](https://github.com/redis/jedis/releases/tag/v6.0.0) onwards,
-`Jedis` uses query dialect 2 by default.
-Redis Search methods such as [`ftSearch()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v6.0.0](https://github.com/redis/jedis/releases/tag/v6.0.0) onwards,
+> `Jedis` uses query dialect 2 by default.
+> Redis Search methods such as [`ftSearch()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[Jedis]({{< relref "/develop/clients/jedis" >}}) client library if you
+[Jedis](/content/develop/clients/jedis/_index.md) client library if you
 haven't already done so.
 
 Add the following dependencies. All of them are applicable to both JSON and hash,
 except for the `Path` and `JSONObject` classes, which are specific to JSON (see
-[Path]({{< relref "/develop/data-types/json/path" >}}) for a description of the
+[Path](/content/develop/data-types/json/path.md) for a description of the
 JSON path syntax).
 
 {{< clients-example set="java_home_json" step="import" description="Foundational: Import required Jedis classes for JSON indexing and query operations" difficulty="beginner" >}}
@@ -65,7 +65,7 @@ Create some test data to add to the database:
 
 Connect to your Redis database. The code below shows the most
 basic connection but see
-[Connect to the server]({{< relref "/develop/clients/jedis/connect" >}})
+[Connect to the server](/content/develop/clients/jedis/connect.md)
 to learn more about the available connection options.
 
 {{< clients-example set="java_home_json" step="connect" description="Foundational: Establish a connection to a Redis server for query operations" difficulty="beginner" >}}
@@ -76,7 +76,7 @@ Delete any existing index called `idx:users` and any keys that start with `user:
 {{< clients-example set="java_home_json" step="cleanup_json" description="Foundational: Clean up existing indexes and data before creating new indexes" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax]({{< relref "/develop/ai/search-and-query/query/" >}}).
+Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax](/content/develop/ai/search-and-query/query/_index.md).
 
 {{< clients-example set="java_home_json" step="make_index" description="Foundational: Create a search index for JSON documents with field definitions and key prefix filtering" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -84,7 +84,7 @@ Create an index. In this example, only JSON documents with the key prefix `user:
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them:
 
@@ -94,7 +94,7 @@ objects automatically as you add them:
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -107,7 +107,7 @@ Specify query options to return only the `city` field:
 {{< /clients-example >}}
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< clients-example set="java_home_json" step="query3" description="Aggregation query: Group and count results by field values to analyze data patterns" difficulty="intermediate" >}}
@@ -135,8 +135,8 @@ Now create the new index:
 {{< clients-example set="java_home_json" step="make_hash_index" description="Foundational: Create a search index for hash documents with field definitions and key prefix filtering" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-Use [`hset()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`jsonSet()`]({{< relref "/commands/json.set" >}}).
+Use [`hset()`](/content/commands/hset.md) to add the hash
+documents instead of [`jsonSet()`](/content/commands/json.set.md).
 
 {{< clients-example set="java_home_json" step="add_hash_data" description="Foundational: Store hash documents in Redis with automatic indexing based on key prefix" difficulty="beginner" >}}
 {{< /clients-example >}}
@@ -150,5 +150,5 @@ a `List` of `Document` objects, as with JSON:
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/jedis/transpipe.md
+++ b/content/develop/clients/jedis/transpipe.md
@@ -21,11 +21,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -68,7 +68,7 @@ to different keys. The basic idea is to watch for changes to any
 keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The code below reads a string

--- a/content/develop/clients/jedis/vecsearch.md
+++ b/content/develop/clients/jedis/vecsearch.md
@@ -25,14 +25,14 @@ topics:
 weight: 3
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}}) 
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md) 
 reference page for more information).
 Among other things, vector fields can store *text embeddings*, which are AI-generated vector
 representations of the semantic information in pieces of text. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings indicates how similar they are semantically. By comparing the
 similarity of an embedding generated from some query text with embeddings stored in hash
 or JSON fields, Redis can retrieve documents that closely match the query in terms
@@ -45,14 +45,14 @@ The code is first demonstrated for hash documents with a
 separate section to explain the
 [differences with JSON documents](#differences-with-json-documents).
 
-{{< note >}}From [v6.0.0](https://github.com/redis/jedis/releases/tag/v6.0.0) onwards,
-`Jedis` uses query dialect 2 by default.
-Redis Search methods such as [`ftSearch()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v6.0.0](https://github.com/redis/jedis/releases/tag/v6.0.0) onwards,
+> `Jedis` uses query dialect 2 by default.
+> Redis Search methods such as [`ftSearch()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
@@ -136,12 +136,12 @@ the index doesn't already exist, which is why you need the
 
 Next, create the index.
 The schema in the example below includes three fields: the text content to index, a
-[tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+[tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
 field to represent the "genre" of the text, and the embedding vector generated from
 the original text content. The `embedding` field specifies
-[HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}})
+[HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index)
 indexing, the
-[L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 vector distance metric, `Float32` values to represent the vector's components,
 and 384 dimensions, as required by the `all-MiniLM-L6-v2` embedding model.
 
@@ -154,7 +154,7 @@ prefix `doc:` that identifies the hash objects to index.
 ## Add data
 
 You can now supply the data objects, which will be indexed automatically
-when you add them with [`hset()`]({{< relref "/commands/hset" >}}), as long as
+when you add them with [`hset()`](/content/commands/hset.md), as long as
 you use the `doc:` prefix specified in the index definition.
 
 Use the `predict()` method of the `Predictor` object
@@ -180,10 +180,10 @@ sorted to rank them in order of ascending distance.
 
 The code below creates the query embedding using the `predict()` method, as with
 the indexing, and passes it as a parameter when the query executes (see
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about using query parameters with embeddings).
 The query is a
-[K nearest neighbors (KNN)]({{< relref "/develop/ai/search-and-query/vectors#knn-vector-search" >}})
+[K nearest neighbors (KNN)](/content/develop/ai/search-and-query/vectors/_index.md#knn-vector-search)
 search that sorts the results in order of vector distance from the query vector.
 
 {{< clients-example set="HomeQueryVec" step="query" lang_filter="Java-Sync" description="Vector similarity search: Find semantically similar documents by comparing query embeddings with indexed vectors using L2 distance" difficulty="intermediate" >}}
@@ -212,7 +212,7 @@ is the result judged to be most similar in meaning to the query text
 
 Indexing JSON documents is similar to hash indexing, but there are some
 important differences. JSON allows much richer data modeling with nested fields, so
-you must supply a [path]({{< relref "/develop/data-types/json/path" >}}) in the schema
+you must supply a [path](/content/develop/data-types/json/path.md) in the schema
 to identify each field you want to index. However, you can declare a short alias for each
 of these paths (using the `as()` option) to avoid typing it in full for
 every query. Also, you must specify `IndexDataType.JSON` when you create the index.
@@ -227,8 +227,8 @@ An important difference with JSON indexing is that the vectors are
 specified using arrays of `float` instead of binary strings, so you don't need
 a helper method to convert the array to a binary string.
 
-Use [`jsonSet()`]({{< relref "/commands/json.set" >}}) to add the data
-instead of [`hset()`]({{< relref "/commands/hset" >}}). Use instances
+Use [`jsonSet()`](/content/commands/json.set.md) to add the data
+instead of [`hset()`](/content/commands/hset.md). Use instances
 of `JSONObject` to supply the data instead of `Map`, as you would for
 hash objects.
 
@@ -258,6 +258,6 @@ ID: jdoc:3, Distance: 1.48624765873, Content: Today is a sunny day
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about the indexing options, distance metrics, and query format
 for vectors.

--- a/content/develop/clients/jedis/vecsets.md
+++ b/content/develop/clients/jedis/vecsets.md
@@ -21,14 +21,14 @@ topics:
 - vectors
 ---
 
-A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+A Redis [vector set](/content/develop/data-types/vector-sets/_index.md) lets
 you store a set of unique keys, each with its own associated vector.
 You can then retrieve keys from the set according to the similarity between
 their stored vectors and a query vector that you specify.
 
 You can use vector sets to store any type of numeric vector but they are
 particularly optimized to work with text embedding vectors (see
-[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+[Redis for AI](/content/develop/ai/_index.md) to learn more about text
 embeddings). The example below shows how to generate vector embeddings and then
 store and retrieve them using a vector set with `Jedis`.
 
@@ -111,7 +111,7 @@ the exceptions for production).
 
 The call to `vadd()` also adds the `born` and `died` values from the
 original `people` list as attribute data. You can access this during a query
-or by using the [`vgetattr()`]({{< relref "/commands/vgetattr" >}}) method.
+or by using the [`vgetattr()`](/content/commands/vgetattr.md) method.
 
 {{< clients-example set="home_vecsets" step="add_data" lang_filter="Java-Sync" description="Foundational: Add vector embeddings and attributes to a vector set using VADD command" difficulty="beginner" >}}
 {{< /clients-example >}}
@@ -121,7 +121,7 @@ or by using the [`vgetattr()`]({{< relref "/commands/vgetattr" >}}) method.
 You can now query the data in the set. The basic approach is to use the
 `predict()` method to generate another embedding vector for the query text.
 (This is the same method used to add the elements to the set.) Then, pass
-the query vector to [`vsim()`]({{< relref "/commands/vsim" >}}) to return elements
+the query vector to [`vsim()`](/content/commands/vsim.md) to return elements
 of the set, ranked in order of similarity to the query.
 
 Start with a simple query for "actors":
@@ -170,7 +170,7 @@ The scientists are ranked highest, followed by the
 mathematicians. This ranking seems reasonable given the connection between mathematics and science.
 
 You can also use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 with `vsim()` to restrict the search further. For example,
 repeat the "science" query, but this time limit the results to people
 who died before the year 2000:
@@ -187,16 +187,16 @@ elements that have already been filtered out of the search.
 
 ## More information
 
-See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+See the [vector sets](/content/develop/data-types/vector-sets/_index.md)
 docs for more information and code examples. See the
-[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+[Redis for AI](/content/develop/ai/_index.md) section for more details
 about text embeddings and other AI techniques you can use with Redis.
 
 You may also be interested in
-[vector search]({{< relref "/develop/clients/jedis/vecsearch" >}}).
+[vector search](/content/develop/clients/jedis/vecsearch.md).
 This is a feature of
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 that lets you retrieve
-[JSON]({{< relref "/develop/data-types/json" >}}) and
-[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+[JSON](/content/develop/data-types/json/_index.md) and
+[hash](/content/develop/data-types/hashes.md) documents based on
 vector data stored in their fields.


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/jedis/` (11 files, flat directory, no nested subdirectories) from shortcodes to Hugo render hooks, per the DOC-7047 rollout of DOC-6909.
- `{{< relref >}}` links -> plain Markdown links in canonical `/content/*.md` / `/content/*/_index.md` form, anchors preserved.
- 6 `{{< note >}}` callouts (no nesting, no custom titles) -> `> [!NOTE]`-style blockquotes.
- No `{{% alert title="..." %}}` percent-delimited shortcodes found in this directory, so there's nothing to note as skipped.
- Uses the migration tooling from PR #3937 (`build/migrate_shortcode_links.py`), which is not merged into this PR — it was pulled in locally via `git show`, run, and removed before committing.

## Test plan
- [x] Confirmed no `{{< relref` or `{{< note/warning/tip/info/alert` shortcodes remain (`grep` returns 0 matches).
- [x] Manually reviewed the full diff: blockquote formatting (`> [!NOTE]` header, `>` prefix on every line, blank lines as bare `>`), no nested block-level shortcodes mangled inside a converted blockquote, and spot-checked rewritten links.
- [x] `python3 .claude/hooks/check_shortcode_paths.py --scan` over all 11 files: 0 with issues, 0 broken file refs, 0 broken relref links.
- [ ] Full-site Hugo build verification (href-diff) is being run centrally by the ticket owner before merge — this isolated worktree can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout formatting; no runtime or application code changes.
> 
> **Overview**
> Migrates all **11** pages under `content/develop/clients/jedis/` to Hugo render hooks as part of DOC-7047.
> 
> **Internal links:** Every `{{< relref "..." >}}` reference is replaced with canonical Markdown paths under `/content/...` (including `_index.md` where needed), with fragment anchors preserved. In `failover.md`, one in-page `relref` to the retry section becomes a plain `#retry-configuration` link.
> 
> **Callouts:** Six `{{< note >}}` blocks (Jedis 7.2 API table, client-side caching caveats, query dialect defaults, Jedis v6 failover note) become GitHub-flavored `> [!NOTE]` blockquotes with the same body content.
> 
> **Unchanged:** `{{< clients-example >}}` and other non-migrated shortcodes, plus all instructional text and code samples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b16114119ed030e30c21e691072819b89ee8cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->