### PR TITLE
DOC-7047: Migrate develop/clients/dotnet to render hooks

### DIFF
--- a/content/develop/clients/dotnet/_index.md
+++ b/content/develop/clients/dotnet/_index.md
@@ -24,26 +24,25 @@ weight: 3
 .NET client for Redis. It provides an API for the core Redis data types and commands.
 A separate library,
 [NRedisStack](https://github.com/redis/NRedisStack), builds upon `StackExchange.Redis` with
-support for an extended set of data types and features, such as [JSON]({{< relref "/develop/data-types/json" >}}),
-[Redis search]({{< relref "/develop/ai/search-and-query" >}}),
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}}), and
-[Time series]({{< relref "/develop/data-types/timeseries" >}}).
+support for an extended set of data types and features, such as [JSON](/content/develop/data-types/json/_index.md),
+[Redis search](/content/develop/ai/search-and-query/_index.md),
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md), and
+[Time series](/content/develop/data-types/timeseries/_index.md).
 
 The sections below explain how to install `StackExchange.Redis` and connect your application
-to a Redis database. See the [NRedisStack guide]({{< relref "/develop/clients/dotnet/nredisstack" >}}) for information about installing and using `NRedisStack` to access the extended feature set.
+to a Redis database. See the [NRedisStack guide](/content/develop/clients/dotnet/nredisstack/_index.md) for information about installing and using `NRedisStack` to access the extended feature set.
 
 `StackExchange.Redis` requires a running Redis server. For production apps,
-provision a hosted Redis resource such as [Redis Cloud]({{< relref "/operate/rc" >}})
+provision a hosted Redis resource such as [Redis Cloud](/content/operate/rc/_index.md)
 or [Azure Managed Redis](https://learn.microsoft.com/en-us/azure/redis/overview).
 For local development and testing, you can also run Redis Open Source locally.
-See [Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/" >}})
+See [Install Redis Open Source](/content/operate/oss_and_stack/install/_index.md)
 for installation instructions.
 
-{{< note >}}
-You can also access Redis with an object-mapping client interface. See
-[Redis OM for .NET]({{< relref "/integrate/redisom-for-net" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> You can also access Redis with an object-mapping client interface. See
+> [Redis OM for .NET](/content/integrate/redisom-for-net/_index.md)
+> for more information.
 
 ## Install
 

--- a/content/develop/clients/dotnet/condexec.md
+++ b/content/develop/clients/dotnet/condexec.md
@@ -16,10 +16,10 @@ weight: 60
 ---
 
 Most Redis client libraries use transactions with the
-[`WATCH`]({{< relref "/commands/watch" >}}) command as the main way to prevent
-two clients writing to the same key at once (see [Transactions]({{< relref "develop/using-commands/transactions" >}}) for more information). Unfortunately, this approach is
+[`WATCH`](/content/commands/watch.md) command as the main way to prevent
+two clients writing to the same key at once (see [Transactions](/content/develop/using-commands/transactions.md) for more information). Unfortunately, this approach is
 difficult to use explicitly in `StackExchange.Redis`. Its
-[multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}}) system
+[multiplexing](/content/develop/clients/pools-and-muxing.md) system
 is highly efficient and convenient but can also cause bad interactions
 when different connections use watched transactions at the same time.
 
@@ -31,14 +31,14 @@ are explained in the sections below.
 
 Several commands have variants that only execute if the key they change
 already exists (or alternatively, if it doesn't already exist). For
-example, the [`SET`]({{< relref "/commands/set" >}}) command has the
-variants [`SETEX`]({{< relref "/commands/setex" >}}) (set when the key exists),
-and [`SETNX`]({{< relref "/commands/setnx" >}}) (set when the key doesn't exist).
+example, the [`SET`](/content/commands/set.md) command has the
+variants [`SETEX`](/content/commands/setex.md) (set when the key exists),
+and [`SETNX`](/content/commands/setnx.md) (set when the key doesn't exist).
 
 Instead of providing the different variants of these commands, `StackExchange.Redis`
 lets you add a `When` condition to the basic command to access its variants.
 The following example demonstrates this for the
-[`HashSet()`]({{< relref "/commands/hset" >}}) command.
+[`HashSet()`](/content/commands/hset.md) command.
 
 <!-- < clients-example pipe_trans_tutorial when_condition "C#" >}}
 < /clients-example >}} -->
@@ -63,7 +63,7 @@ The available conditions are `When.Exists`, `When.NotExists`, and the default
 
 `StackExchange.Redis` also supports a more extensive set of conditions that you
 can add to transactions. They are implemented internally using
-[`WATCH`]({{< relref "/commands/watch" >}}) commands in a way that is
+[`WATCH`](/content/commands/watch.md) commands in a way that is
 guaranteed to be safe, without interactions between different clients.
 Although conditions don't provide exactly the same behavior as
 explicit `WATCH` commands, they are convenient to use and execute
@@ -72,7 +72,7 @@ efficiently.
 The example below shows how to use the `AddCondition()` method on
 a transaction to let it run only if a specified hash key does not
 already exist. See
-[Pipelines and transactions]({{< relref "/develop/clients/dotnet/transpipe" >}})
+[Pipelines and transactions](/content/develop/clients/dotnet/transpipe.md)
 for more information about transactions.
 
 <!--< clients-example pipe_trans_tutorial trans_watch "C#" >}}

--- a/content/develop/clients/dotnet/connect.md
+++ b/content/develop/clients/dotnet/connect.md
@@ -44,7 +44,7 @@ Console.WriteLine(db.StringGet("foo")); // prints bar
 ## Connect to a Redis cluster
 
 The basic connection will use the
-[Cluster API]({{< relref "/operate/rs/clusters/optimize/oss-cluster-api" >}})
+[Cluster API](/content/operate/rs/clusters/optimize/oss-cluster-api.md)
 if it is available without any special configuration. However, if you know
 the addresses and ports of several cluster nodes, you can specify them all
 during connection in the `Endpoints` parameter:
@@ -69,7 +69,7 @@ Console.WriteLine(db.StringGet("foo")); // prints bar
 
 ## Connect to your production Redis with TLS
 
-When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
+When you deploy your application, use TLS and follow the [Redis security](/content/operate/oss_and_stack/management/security/_index.md) guidelines.
 
 Before connecting your application to the TLS-enabled Redis server, ensure that your certificates and private keys are in the correct format.
 
@@ -144,5 +144,5 @@ connections efficiently. StackExchange.Redis uses a different approach called
 single connection. StackExchange.Redis manages multiplexing for you automatically.
 This gives high performance without requiring any extra coding.
 See
-[Connection pools and multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}})
+[Connection pools and multiplexing](/content/develop/clients/pools-and-muxing.md)
 for more information.

--- a/content/develop/clients/dotnet/error-handling.md
+++ b/content/develop/clients/dotnet/error-handling.md
@@ -17,8 +17,8 @@ documentation often omit error handling for brevity, but it is essential in prod
 This page explains how error handling works in `StackExchange.Redis` and how to apply common
 error handling patterns.
 
-For an overview of error types and handling strategies, see [Error handling]({{< relref "/develop/clients/error-handling" >}}).
-See also [Production usage]({{< relref "/develop/clients/dotnet/produsage" >}})
+For an overview of error types and handling strategies, see [Error handling](/content/develop/clients/error-handling.md).
+See also [Production usage](/content/develop/clients/dotnet/produsage.md)
 for more information on connection management, timeouts, and other aspects of
 app reliability.
 
@@ -33,19 +33,19 @@ app reliability.
 | `RedisCommandException` | Invalid command or arguments | ❌ | Fix the command or arguments |
 | `RedisServerException` | Invalid operation on server | ❌ | Fix the operation or data |
 
-See [Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+See [Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}}) overview
+The [Error handling](/content/develop/clients/error-handling.md) overview
 describes four main patterns. The sections below show how to implement them in
 `StackExchange.Redis`:
 
 ### Pattern 1: Fail fast
 
 Catch specific exceptions that represent unrecoverable errors and re-throw them (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description):
 
 ```csharp
@@ -66,7 +66,7 @@ try {
 ### Pattern 2: Graceful degradation
 
 Catch specific errors and fall back to an alternative, where possible (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description):
 
 ```csharp
@@ -84,7 +84,7 @@ try {
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors such as timeouts (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description):
 
 ```csharp
@@ -105,13 +105,13 @@ for (int attempt = 0; attempt < maxRetries; attempt++) {
 }
 ```
 
-See also [Timeouts]({{< relref "/develop/clients/dotnet/produsage#timeouts" >}})
+See also [Timeouts](/content/develop/clients/dotnet/produsage.md#timeouts)
 for more information on configuring timeouts in `StackExchange.Redis`.
 
 ### Pattern 4: Log and continue
 
 Log non-critical errors and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description):
 
 ```csharp
@@ -151,5 +151,5 @@ async Task<string> GetWithFallbackAsync(string key) {
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Production usage]({{< relref "/develop/clients/dotnet/produsage" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Production usage](/content/develop/clients/dotnet/produsage.md)

--- a/content/develop/clients/dotnet/failover.md
+++ b/content/develop/clients/dotnet/failover.md
@@ -27,7 +27,7 @@ weight: 55
 StackExchange.Redis supports [Client-side geographic failover](https://en.wikipedia.org/wiki/Failover)
 to improve the availability of connections to Redis databases. This page explains
 how to configure StackExchange.Redis for failover. For an overview of the concepts,
-see the main [Client-side geographic failover]({{< relref "/develop/clients/failover" >}}) page.
+see the main [Client-side geographic failover](/content/develop/clients/failover.md) page.
 
 ## Failover configuration
 
@@ -40,25 +40,25 @@ using StackExchange.Redis;
 using StackExchange.Redis.Availability;
 ```
 
-{{< note >}}The failover feature is fully supported and intended for production use.
-However, because it is a large, new API surface, the types in the
-`StackExchange.Redis.Availability` namespace are marked with the `[Experimental]`
-attribute so that the library can reserve the right to adjust them without the usual
-backwards-compatibility guarantees. (This marker is expected to be removed in a later
-3.1.x release.) As a result, the compiler reports the `SER007` diagnostic when you use
-these types. Suppressing this diagnostic is the normal way to use the feature. To do so,
-either add the following to your `.csproj` file:
-
-```xml
-<NoWarn>$(NoWarn);SER007</NoWarn>
-```
-
-or suppress it locally in your source file:
-
-```csharp
-#pragma warning disable SER007
-```
-{{< /note >}}
+> [!NOTE]
+> The failover feature is fully supported and intended for production use.
+> However, because it is a large, new API surface, the types in the
+> `StackExchange.Redis.Availability` namespace are marked with the `[Experimental]`
+> attribute so that the library can reserve the right to adjust them without the usual
+> backwards-compatibility guarantees. (This marker is expected to be removed in a later
+> 3.1.x release.) As a result, the compiler reports the `SER007` diagnostic when you use
+> these types. Suppressing this diagnostic is the normal way to use the feature. To do so,
+> either add the following to your `.csproj` file:
+>
+> ```xml
+> <NoWarn>$(NoWarn);SER007</NoWarn>
+> ```
+>
+> or suppress it locally in your source file:
+>
+> ```csharp
+> #pragma warning disable SER007
+> ```
 
 The example below shows a simple case with a list of two servers,
 `redis-east` and `redis-west`, where `redis-east` is the preferred
@@ -88,7 +88,7 @@ RedisValue value = await db.StringGetAsync("mykey");
 
 `ConnectGroupAsync()` returns a connection that you use
 just like a standard multiplexer, but it also handles the connection management and
-failover transparently. The [`IDatabase`]({{< relref "/develop/clients/dotnet/connect" >}})
+failover transparently. The [`IDatabase`](/content/develop/clients/dotnet/connect.md)
 and `ISubscriber` instances obtained from the multiplexer also work with a group
 as they do with an individual endpoint.
 
@@ -96,7 +96,7 @@ as they do with an individual endpoint.
 
 Each endpoint is represented by a `ConnectionGroupMember`, which you can create from a
 connection string or from a
-[`ConfigurationOptions`]({{< relref "/develop/clients/dotnet/connect" >}}) instance.
+[`ConfigurationOptions`](/content/develop/clients/dotnet/connect.md) instance.
 Use `ConfigurationOptions` when you need to provide credentials, TLS settings, or other
 options for each endpoint individually:
 
@@ -128,7 +128,7 @@ endpoint:
 
 | Property | Default | Description |
 | :-- | :-- | :-- |
-| `Weight` | `0` | Priority of the endpoint, with higher values being tried first (see [Selecting a failover target]({{< relref "/develop/clients/failover#selecting-a-failover-target" >}}) for a full description of how the weighted list is used). |
+| `Weight` | `0` | Priority of the endpoint, with higher values being tried first (see [Selecting a failover target](/content/develop/clients/failover.md#selecting-a-failover-target) for a full description of how the weighted list is used). |
 | `HealthCheck` | Group default | Per-member [health check](#health-check-configuration) override. |
 | `CircuitBreaker` | Group default | Per-member [circuit breaker](#circuit-breaker-configuration) override. |
 | `FailbackDelay` | Group default | Per-member [failback delay](#failback-configuration) override. |
@@ -182,7 +182,7 @@ await using var conn = await ConnectionMultiplexer.ConnectGroupAsync(members, op
 
 A circuit breaker passively monitors the traffic already flowing over a connection and
 closes the connection when it detects that the connection has become unstable
-(see [Detecting connection problems]({{< relref "/develop/clients/failover#detecting-connection-problems" >}}) for more information on how the
+(see [Detecting connection problems](/content/develop/clients/failover.md#detecting-connection-problems) for more information on how the
 circuit breaker works). Configure the circuit breaker for the whole group using the
 `CircuitBreaker` option of `MultiGroupOptions`:
 
@@ -262,7 +262,7 @@ The `RetryPolicy.Builder` class provides the following properties:
 | `JitterMax` | `0.5` | Upper bound of the random delay (in seconds) added to each retry, to avoid stampedes. |
 | `FailoverDelay` | `5` | Maximum time (in seconds) to wait when a retry is expecting a failover. |
 | `MaxCommandRetryCategory` | `CommandRetryWriteLastWins` | The most "dangerous" command category that will be retried (see [Which operations are safe to retry?](#which-operations-are-safe-to-retry)) |
-| `MaxAttemptsOnWatchConflict` | `3` | Maximum number of attempts allowed for a watched transaction that keeps failing (see [Watch keys for changes]({{< relref "/develop/clients/dotnet/transpipe#watch-keys-for-changes" >}}) for more information). |
+| `MaxAttemptsOnWatchConflict` | `3` | Maximum number of attempts allowed for a watched transaction that keeps failing (see [Watch keys for changes](/content/develop/clients/dotnet/transpipe.md#watch-keys-for-changes) for more information). |
 
 The retry mechanism classifies errors in the same way as the circuit breaker
 (see [Circuit breaker configuration](#circuit-breaker-configuration)). Only transient
@@ -272,7 +272,7 @@ errors are retried.
 
 Commands are generally safe to retry if they are *idempotent* (that is to say, multiple invocations
 of the same command have the same result as a single invocation). This excludes
-commands like [`INCR`]({{< relref "/commands/incr" >}}) that modify whatever value
+commands like [`INCR`](/content/commands/incr.md) that modify whatever value
 is currently stored in the database.
 
 Each command belongs to a *retry category* that describes how "dangerous" it is
@@ -341,7 +341,7 @@ for more information).
 ## Health check configuration
 
 Each health check consists of one or more separate *probes*, each of which is a simple
-test (such as a [`PING`]({{< relref "/commands/ping" >}}) command) to determine if the
+test (such as a [`PING`](/content/commands/ping.md) command) to determine if the
 member is available. The results of the separate probes are combined using a configurable
 policy to determine whether the member is healthy. When a member fails its health check,
 it is flagged as unhealthy and traffic is routed to other healthy members instead. When
@@ -390,7 +390,7 @@ StackExchange.Redis provides the following built-in probe types:
 
 | Probe | Description |
 | :-- | :-- |
-| `HealthCheckProbe.Ping` (default) | Sends a [`PING`]({{< relref "/commands/ping" >}}) command. Lightweight, and recommended for most scenarios. |
+| `HealthCheckProbe.Ping` (default) | Sends a [`PING`](/content/commands/ping.md) command. Lightweight, and recommended for most scenarios. |
 | `HealthCheckProbe.IsConnected` | Checks the socket connection status without sending any command. Even more lightweight than `Ping`, but only verifies the connection, not that Redis is responsive. |
 | `HealthCheckProbe.StringSet` | Writes a random value and reads it back to verify read/write capability. More comprehensive, but higher overhead than `Ping`. This probe automatically skips replica servers. |
 
@@ -487,7 +487,7 @@ conn.ConnectionChanged += (sender, args) =>
 
 ## Pub/Sub and re-subscription
 
-A connection group supports [Pub/Sub]({{< relref "/develop/pubsub" >}}) messaging with
+A connection group supports [Pub/Sub](/content/develop/pubsub/_index.md) messaging with
 automatic re-subscription to channels during failover, so you don't have to detect
 failovers and re-subscribe manually. When you subscribe to a channel, the subscription is
 established against *all* members (for immediate pickup during a failover), and the library

--- a/content/develop/clients/dotnet/nredisstack/_index.md
+++ b/content/develop/clients/dotnet/nredisstack/_index.md
@@ -16,23 +16,22 @@ title: NRedisStack extensions guide
 weight: 30
 ---
 
-[NRedisStack](https://github.com/redis/NRedisStack) is a library that builds upon [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis) and provides an API for the extended set of Redis data types and features, such as [JSON]({{< relref "/develop/data-types/json" >}}), [Redis search]({{< relref "/develop/ai/search-and-query" >}}),
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}}), and [Time series]({{< relref "/develop/data-types/timeseries" >}}).
+[NRedisStack](https://github.com/redis/NRedisStack) is a library that builds upon [StackExchange.Redis](https://github.com/StackExchange/StackExchange.Redis) and provides an API for the extended set of Redis data types and features, such as [JSON](/content/develop/data-types/json/_index.md), [Redis search](/content/develop/ai/search-and-query/_index.md),
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md), and [Time series](/content/develop/data-types/timeseries/_index.md).
 The sections below explain how to install `NRedisStack`. Note that this also installs
 `StackExchange.Redis` as a dependency, so you don't need to install it as a separate step.
 
 `NRedisStack` requires a running Redis server. For production apps, provision
-a hosted Redis resource such as [Redis Cloud]({{< relref "/operate/rc" >}}) or
+a hosted Redis resource such as [Redis Cloud](/content/operate/rc/_index.md) or
 [Azure Managed Redis](https://learn.microsoft.com/en-us/azure/redis/overview). For
 local development and testing, you can also run Redis Open Source locally. See
-[Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/" >}})
+[Install Redis Open Source](/content/operate/oss_and_stack/install/_index.md)
 for installation instructions.
 
-{{< note >}}
-You can also access Redis with an object-mapping client interface. See
-[Redis OM for .NET]({{< relref "/integrate/redisom-for-net" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> You can also access Redis with an object-mapping client interface. See
+> [Redis OM for .NET](/content/integrate/redisom-for-net/_index.md)
+> for more information.
 
 ## Install
 

--- a/content/develop/clients/dotnet/nredisstack/prob.md
+++ b/content/develop/clients/dotnet/nredisstack/prob.md
@@ -18,7 +18,7 @@ weight: 45
 ---
 
 Redis supports several
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md)
 that let you calculate values approximately rather than exactly.
 The types fall into two basic categories:
 
@@ -34,7 +34,7 @@ counting the number of distinct IP addresses that access a website in one day.
 
 Assuming that you already have code that supplies you with each IP
 address as a string, you could record the addresses in Redis using
-a [set]({{< relref "/develop/data-types/sets" >}}):
+a [set](/content/develop/data-types/sets.md):
 
 ```cs
 db.SetAdd("ip_tracker", new_ip_address);
@@ -70,11 +70,11 @@ time than the equivalent precise calculations.
 Redis supports the following approximate set operations:
 
 -   [Membership](#set-membership): The
-    [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-    [Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+    [Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+    [Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
     data types let you track whether or not a given item is a member of a set.
 -   [Cardinality](#set-cardinality): The
-    [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+    [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
     data type gives you an approximate value for the number of items in a set, also
     known as the *cardinality* of the set.
 
@@ -82,8 +82,8 @@ The sections below describe these operations in more detail.
 
 ### Set membership
 
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 objects provide a set membership operation that lets you track whether or not a
 particular item has been added to a set. These two types provide different
 trade-offs for memory usage and speed, so you can select the best one for your
@@ -92,7 +92,7 @@ absence of items in the set. If an item is reported as absent, then it is defini
 absent, but if it is reported as present, then there is a small chance it may really be
 absent.
 
-Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+Instead of storing strings directly, like a [set](/content/develop/data-types/sets.md),
 a Bloom filter records the presence or absence of the
 [hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
 This gives a very compact representation of the
@@ -116,13 +116,13 @@ Which of these two data types you choose depends on your use case.
 Bloom filters are generally faster than Cuckoo filters when adding new items,
 and also have better memory usage. Cuckoo filters are generally faster
 at checking membership and also support the delete operation. See the
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 reference pages for more information and comparison between the two types.
 
 ### Set cardinality
 
-A [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+A [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 object calculates the cardinality of a set. As you add
 items, the HyperLogLog tracks the number of distinct set members but
 doesn't let you retrieve them or query which items have been added.
@@ -146,20 +146,20 @@ Redis supports several approximate statistical calculations
 on numeric data sets:
 
 -   [Frequency](#frequency): The
-    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
     data type lets you find the approximate frequency of a labeled item in a data stream.
 -   [Quantiles](#quantiles): The
-    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
     data type estimates the quantile of a query value in a data stream.
 -   [Ranking](#ranking): The
-    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    [Top-K](/content/develop/data-types/probabilistic/top-k.md) data type
     estimates the ranking of labeled items by frequency in a data stream.
 
 The sections below describe these operations in more detail.
 
 ### Frequency
 
-A [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+A [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
 (CMS) object keeps count of a set of related items represented by
 string labels. The count is approximate, but you can specify
 how close you want to keep the count to the true value (as a fraction)
@@ -175,7 +175,7 @@ sketch commands.
 {{< /clients-example >}}
 
 The advantage of using a CMS over keeping an exact count with a
-[sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
+[sorted set](/content/develop/data-types/sorted-sets.md)
 is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
@@ -190,7 +190,7 @@ the value of height below which 75% of all people's heights lie.
 [Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
 to quantiles, except that the fraction is expressed as a percentage.
 
-A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+A [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 object can estimate quantiles from a set of values added to it
 without having to store each value in the set explicitly. This can
 save a lot of memory when you have a large number of samples.
@@ -209,12 +209,12 @@ t-digest commands.
 
 A t-digest object also supports several other related commands, such
 as querying by rank. See the
-[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+[t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 reference for more information.
 
 ### Ranking
 
-A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+A [Top-K](/content/develop/data-types/probabilistic/top-k.md)
 object estimates the rankings of different labeled items in a data
 stream according to frequency. For example, you could use this to
 track the top ten most frequently-accessed pages on a website, or the

--- a/content/develop/clients/dotnet/nredisstack/queryjson.md
+++ b/content/develop/clients/dotnet/nredisstack/queryjson.md
@@ -27,26 +27,26 @@ weight: 30
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
-{{< note >}}From [v1.0.0](https://github.com/redis/NRedisStack/releases/tag/v1.0.0)
-onwards, `NRedisStack` uses query dialect 2 by default.
-Redis Search methods such as [`FT().Search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v1.0.0](https://github.com/redis/NRedisStack/releases/tag/v1.0.0)
+> onwards, `NRedisStack` uses query dialect 2 by default.
+> Redis Search methods such as [`FT().Search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[`NRedisStack`]({{< relref "/develop/clients/dotnet" >}}) client library if you
+[`NRedisStack`](/content/develop/clients/dotnet/_index.md) client library if you
 haven't already done so. 
 
 Add the following dependencies:
@@ -65,7 +65,7 @@ Create some test data to add to the database:
 
 Connect to your Redis database. The code below shows the most
 basic connection but see
-[Connect to the server]({{< relref "/develop/clients/dotnet/connect" >}})
+[Connect to the server](/content/develop/clients/dotnet/connect.md)
 to learn more about the available connection options.
 
 {{< clients-example set="cs_home_json" step="connect" description="Foundational: Establish a connection to a Redis server for query operations" difficulty="beginner" >}}
@@ -76,7 +76,7 @@ Delete any existing index called `idx:users` and any keys that start with `user:
 {{< clients-example set="cs_home_json" step="cleanup_json" description="Foundational: Clean up existing indexes and documents to prepare for fresh example data" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax]({{< relref "/develop/ai/search-and-query/query/" >}}).
+Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax](/content/develop/ai/search-and-query/query/_index.md).
 
 {{< clients-example set="cs_home_json" step="make_index" description="Foundational: Create a search index for JSON documents with field definitions and key prefix filtering" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -84,7 +84,7 @@ Create an index. In this example, only JSON documents with the key prefix `user:
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them:
 
@@ -94,7 +94,7 @@ objects automatically as you add them:
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -107,7 +107,7 @@ Specify query options to return only the `city` field:
 {{< /clients-example >}}
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< clients-example set="cs_home_json" step="query3" description="Aggregation queries: Use GROUP BY and COUNT operations to summarize and analyze indexed data" difficulty="advanced" >}}
@@ -135,8 +135,8 @@ Now create the new index:
 {{< clients-example set="cs_home_json" step="make_hash_index" description="Foundational: Create a search index for hash documents with HASH index type and field definitions" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-You use [`HashSet()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`JSON.Set()`]({{< relref "/commands/json.set" >}}).
+You use [`HashSet()`](/content/commands/hset.md) to add the hash
+documents instead of [`JSON.Set()`](/content/commands/json.set.md).
 Also, you must add the fields as key-value pairs instead of combining them
 into a single object.
 
@@ -154,5 +154,5 @@ in a string under the key `json`):
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/dotnet/nredisstack/vecsearch.md
+++ b/content/develop/clients/dotnet/nredisstack/vecsearch.md
@@ -27,14 +27,14 @@ topics:
 weight: 40
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}}) 
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md) 
 reference page for more information).
 Among other things, vector fields can store *text embeddings*, which are AI-generated vector
 representations of the semantic information in pieces of text. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings indicates how similar they are semantically. By comparing the
 similarity of an embedding generated from some query text with embeddings stored in hash
 or JSON fields, Redis can retrieve documents that closely match the query in terms
@@ -48,14 +48,14 @@ for the embeddings. The code is first demonstrated for hash documents with a
 separate section to explain the
 [differences with JSON documents](#differences-with-json-documents).
 
-{{< note >}}From [v1.0.0](https://github.com/redis/NRedisStack/releases/tag/v1.0.0)
-onwards, `NRedisStack` uses query dialect 2 by default.
-Redis Search methods such as [`FT().Search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v1.0.0](https://github.com/redis/NRedisStack/releases/tag/v1.0.0)
+> onwards, `NRedisStack` uses query dialect 2 by default.
+> Redis Search methods such as [`FT().Search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 ## Initialize
 
 The example is probably easiest to follow if you start with a new
@@ -113,9 +113,9 @@ using Azure.AI.OpenAI;
 
 ## Define a function to obtain the embedding model
 
-{{< note >}}Ignore this step if you are using an Azure OpenAI
-embedding model.
-{{< /note >}}
+> [!NOTE]
+> Ignore this step if you are using an Azure OpenAI
+> embedding model.
 
 A few steps are involved in initializing the embedding model
 (known as a `PredictionEngine`, in Microsoft terminology), so
@@ -163,9 +163,9 @@ static PredictionEngine<TextData, TransformedTextData> GetPredictionEngine(){
 
 ## Define a function to generate an embedding
 
-{{< note >}}Ignore this step if you are using an Azure OpenAI
-embedding model.
-{{< /note >}}
+> [!NOTE]
+> Ignore this step if you are using an Azure OpenAI
+> embedding model.
 
 Our embedding model represents the vectors as an array of `float` values,
 but when you store vectors in a Redis hash object, you must encode the vector
@@ -203,9 +203,9 @@ static byte[] GetEmbedding(
 
 ## Generate an embedding from Azure OpenAI
 
-{{< note >}}Ignore this step if you are using a Microsoft.ML
-embedding model.
-{{< /note >}}
+> [!NOTE]
+> Ignore this step if you are using a Microsoft.ML
+> embedding model.
 
 Azure OpenAI can be a convenient way to access an embedding model, because
 you don't need to manage and scale the server infrastructure yourself.
@@ -257,12 +257,12 @@ try { db.FT().DropIndex("vector_idx");} catch {}
 
 Next, create the index.
 The schema in the example below includes three fields: the text content to index, a
-[tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+[tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
 field to represent the "genre" of the text, and the embedding vector generated from
 the original text content. The `embedding` field specifies
-[HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}}) 
+[HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index) 
 indexing, the
-[L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 vector distance metric, `Float32` values to represent the vector's components,
 and 150 dimensions, as required by our embedding model.
 
@@ -294,7 +294,7 @@ db.FT().Create(
 ## Add data
 
 You can now supply the data objects, which will be indexed automatically
-when you add them with [`HashSet()`]({{< relref "/commands/hset" >}}), as long as
+when you add them with [`HashSet()`](/content/commands/hset.md), as long as
 you use the `doc:` prefix specified in the index definition.
 
 Firstly, create an instance of the `PredictionEngine` model using our
@@ -351,10 +351,10 @@ sorted to rank them in order of ascending distance.
 
 The code below creates the query embedding using the `GetEmbedding()` method, as with
 the indexing, and passes it as a parameter when the query executes (see
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about using query parameters with embeddings).
 The query is a
-[K nearest neighbors (KNN)]({{< relref "/develop/ai/search-and-query/vectors#knn-vector-search" >}})
+[K nearest neighbors (KNN)](/content/develop/ai/search-and-query/vectors/_index.md#knn-vector-search)
 search that sorts the results in order of vector distance from the query vector.
 
 (As before, replace `GetEmbedding()` with `GetEmbeddingFromAzure()` if you are using
@@ -386,9 +386,9 @@ foreach (var doc in res.Documents) {
 
 ## Declare `TextData` and `TransformedTextData`
 
-{{< note >}}Ignore this step if you are using an Azure OpenAI
-embedding model.
-{{< /note >}}
+> [!NOTE]
+> Ignore this step if you are using an Azure OpenAI
+> embedding model.
 
 As we noted in the section above about the
 [embedding model](#define-a-function-to-obtain-the-embedding-model),
@@ -441,7 +441,7 @@ is the result that is most similar in meaning to the query text
 
 Indexing JSON documents is similar to hash indexing, but there are some
 important differences. JSON allows much richer data modeling with nested fields, so
-you must supply a [path]({{< relref "/develop/data-types/json/path" >}}) in the schema
+you must supply a [path](/content/develop/data-types/json/path.md) in the schema
 to identify each field you want to index. However, you can declare a short alias for each
 of these paths to avoid typing it in full for
 every query. Also, you must specify `IndexType.JSON` with the `On()` option when you
@@ -502,8 +502,8 @@ static float[] GetFloatEmbedding(
 You should make a similar modification to the `GetEmbeddingFromAzure()` function
 if you are using Azure OpenAI with JSON.
 
-Use [`JSON().set()`]({{< relref "/commands/json.set" >}}) to add the data
-instead of [`HashSet()`]({{< relref "/commands/hset" >}}):
+Use [`JSON().set()`](/content/commands/json.set.md) to add the data
+instead of [`HashSet()`](/content/commands/hset.md):
 
 ```cs
 var jSentence1 = "That is a very happy person";
@@ -590,6 +590,6 @@ ID: jdoc:3, Properties: [
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about the indexing options, distance metrics, and query format
 for vectors.

--- a/content/develop/clients/dotnet/nredisstack/vecsearch.md
+++ b/content/develop/clients/dotnet/nredisstack/vecsearch.md
@@ -66,7 +66,7 @@ dotnet new console -n VecQueryExample
 ```
 
 In the app's project folder, add
-[`NRedisStack`]({{< relref "/develop/clients/dotnet" >}}`):
+[`NRedisStack`](/content/develop/clients/dotnet/_index.md):
 
 ```bash
 dotnet add package NRedisStack

--- a/content/develop/clients/dotnet/produsage.md
+++ b/content/develop/clients/dotnet/produsage.md
@@ -110,10 +110,10 @@ the most common Redis exceptions:
 - `RedisCommandException`: Thrown when you issue an invalid command.
 - `RedisServerException`: Thrown when you attempt an invalid operation
   (for example, trying to access a
-  [stream entry]({{< relref "/develop/data-types/streams#entry-ids" >}})
+  [stream entry](/content/develop/data-types/streams/_index.md#entry-ids)
   using an invalid ID).
 
-See [Error handling]({{< relref "/develop/clients/dotnet/error-handling" >}})
+See [Error handling](/content/develop/clients/dotnet/error-handling.md)
 for more information on handling exceptions.
 
 ### Retries

--- a/content/develop/clients/dotnet/transpipe.md
+++ b/content/develop/clients/dotnet/transpipe.md
@@ -21,11 +21,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -58,13 +58,13 @@ to different keys. The basic idea is to watch for changes to any
 keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The approach to optimistic locking that other clients use
-(adding the [`WATCH`]({{< relref "/commands/watch" >}}) command
+(adding the [`WATCH`](/content/commands/watch.md) command
 explicitly to a transaction) doesn't work well with the
-[multiplexing]({{< relref "/develop/clients/pools-and-muxing" >}})
+[multiplexing](/content/develop/clients/pools-and-muxing.md)
 system that `StackExchange.Redis` uses.
 Instead, `StackExchange.Redis` relies on conditional execution of commands
 to get a similar effect.
@@ -85,5 +85,5 @@ You can also use a `When` condition on certain individual commands to
 specify that they only execute when a certain condition holds
 (for example, the command does not change an existing key).
 See
-[Conditional execution]({{< relref "/develop/clients/dotnet/condexec" >}})
+[Conditional execution](/content/develop/clients/dotnet/condexec.md)
 for a full description of transaction and command conditions.

--- a/content/develop/clients/dotnet/vecsets.md
+++ b/content/develop/clients/dotnet/vecsets.md
@@ -21,14 +21,14 @@ topics:
 - vectors
 ---
 
-A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+A Redis [vector set](/content/develop/data-types/vector-sets/_index.md) lets
 you store a set of unique keys, each with its own associated vector.
 You can then retrieve keys from the set according to the similarity between
 their stored vectors and a query vector that you specify.
 
 You can use vector sets to store any type of numeric vector but they are
 particularly optimized to work with text embedding vectors (see
-[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+[Redis for AI](/content/develop/ai/_index.md) to learn more about text
 embeddings). The example below shows how to use the
 [`Microsoft.ML`](https://dotnet.microsoft.com/en-us/apps/ai/ml-dotnet)
 library to generate vector embeddings and then
@@ -97,11 +97,11 @@ elements to a vector set called `famousPeople`.
 
 Use the `GetEmbedding()` function declared above to generate the
 embedding as a `byte` array that you can pass to the
-[`VectorSetAdd()`]({{< relref "/commands/vadd" >}}) command to set the embedding.
+[`VectorSetAdd()`](/content/commands/vadd.md) command to set the embedding.
 
 The call to `VectorSetAdd()` also adds the `born` and `died` values from the
 original dictionary as attribute data. You can access this during a query
-or by using the [`VectorSetGetAttributesJson()`]({{< relref "/commands/vgetattr" >}}) method.
+or by using the [`VectorSetGetAttributesJson()`](/content/commands/vgetattr.md) method.
 
 {{< clients-example set="home_vecsets" step="add_data" lang_filter="C#-Sync (SE.Redis)" description="Foundational: Add vector embeddings and attributes to a vector set using VADD command" difficulty="beginner" >}}
 {{< /clients-example >}}
@@ -111,7 +111,7 @@ or by using the [`VectorSetGetAttributesJson()`]({{< relref "/commands/vgetattr"
 You can now query the data in the set. The basic approach is to use the
 `GetEmbedding()` function to generate another embedding vector for the query text.
 (This is the same method used to add the elements to the set.) Then, pass
-the query vector to [`VectorSetSimilaritySearch()`]({{< relref "/commands/vsim" >}}) to 
+the query vector to [`VectorSetSimilaritySearch()`](/content/commands/vsim.md) to 
 return elements of the set, ranked in order of similarity to the query.
 
 Start with a simple query for "actors":
@@ -161,7 +161,7 @@ mathematicians. This seems reasonable given the connection between mathematics
 and science.
 
 You can also use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 with `VectorSetSimilaritySearch()` to restrict the search further. For example,
 repeat the "science" query, but this time limit the results to people
 who died before the year 2000:
@@ -178,16 +178,16 @@ elements that have already been filtered out of the search.
 
 ## More information
 
-See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+See the [vector sets](/content/develop/data-types/vector-sets/_index.md)
 docs for more information and code examples. See the
-[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+[Redis for AI](/content/develop/ai/_index.md) section for more details
 about text embeddings and other AI techniques you can use with Redis.
 
 You may also be interested in
-[vector search]({{< relref "/develop/clients/dotnet/nredisstack/vecsearch" >}}).
+[vector search](/content/develop/clients/dotnet/nredisstack/vecsearch.md).
 This is a feature of 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 that lets you retrieve
-[JSON]({{< relref "/develop/data-types/json" >}}) and
-[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+[JSON](/content/develop/data-types/json/_index.md) and
+[hash](/content/develop/data-types/hashes.md) documents based on
 vector data stored in their fields.


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/dotnet/` to the DOC-6909 render hooks, at both levels: the 8 top-level files and the 4 files in the nested `nredisstack/` subdirectory (12 files total).
- `{{< relref >}}` shortcodes -> plain Markdown links -> canonical `/content/<path>.md[#anchor]` form (119 links rewritten).
- `{{< note/warning/tip/info/alert >}}` callout shortcodes -> `> [!NOTE]`-style native blockquotes (9 callout blocks converted).
- Uses the tooling from PR #3937 (`build/migrate_shortcode_links.py`, not yet merged and not included in this PR — pulled locally via `git show` as an untracked helper, run, then deleted).

## Notes
- One pre-existing malformed relref shortcode in `nredisstack/vecsearch.md` (`{{< relref "/develop/clients/dotnet" >}}` followed by a stray backtick before the closing paren) predates this branch and doesn't match the converter's regex. Left untouched rather than hand-fixed, per house style (flag a syntax defect, don't silently correct it).
- No percent-delimited `{{% alert %}}` forms were found in this section (the converter doesn't handle that form; same accepted gap as the redis-py reference conversion).
- No nested block-level shortcodes were found mangled inside any converted blockquote.
- `check_shortcode_paths.py --scan` reports 0 files with issues across all 12 files.

## Test plan
- [x] Reviewed the full diff across all 12 files (both levels) for correct blockquote formatting, no remaining `{{< relref` / callout shortcodes (except the one noted malformed exception), and correctly rewritten links.
- [x] Ran `.claude/hooks/check_shortcode_paths.py --scan` over all 12 files: 0 with issues.
- [ ] Full-site Hugo build verification (href-diff) is being run centrally by the ticket owner before merge — this isolated worktree can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout formatting; no runtime or application code changes. Main risk is broken internal links if `/content/...` paths don’t resolve in the new renderer.
> 
> **Overview**
> Migrates **12** StackExchange.Redis / NRedisStack docs under `content/develop/clients/dotnet/` (including `nredisstack/`) to the DOC-6909 render-hook style.
> 
> **Links:** Replaces Hugo `{{< relref >}}` shortcodes with plain Markdown links using the canonical `/content/...` path form (including fragment anchors where needed)—on the order of **~119** rewrites across connection, failover, error handling, pipelines, vector search, and related pages.
> 
> **Callouts:** Converts `{{< note >}}` (and similar) shortcodes to GitHub-flavored `> [!NOTE]` blockquotes (**9** blocks), including the long failover experimental-API note and NRedisStack query-dialect notes.
> 
> `{{< clients-example >}}` shortcodes are **unchanged**. One pre-existing malformed `relref` in `nredisstack/vecsearch.md` was left as-is per house style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a14c91d283ac00cbb7bdcc48150dcd64fbbc06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->