### PR TITLE
DOC-7047: Migrate develop/clients/nodejs to render hooks

### DIFF
--- a/content/develop/clients/nodejs/_index.md
+++ b/content/develop/clients/nodejs/_index.md
@@ -25,17 +25,17 @@ weight: 4
 The sections below explain how to install `node-redis` and connect your application
 to a Redis database.
 
-{{< note >}}node-redis is the recommended client library for Node.js/JavaScript,
-but we also support and document our older JavaScript client
-[`ioredis`]({{< relref "/develop/clients/ioredis" >}}). See
-[Migrate from ioredis]({{< relref "/develop/clients/nodejs/migration" >}})
-if you are interested in converting an existing `ioredis` project to `node-redis`.
-{{< /note >}}
+> [!NOTE]
+> node-redis is the recommended client library for Node.js/JavaScript,
+> but we also support and document our older JavaScript client
+> [`ioredis`](/content/develop/clients/ioredis/_index.md). See
+> [Migrate from ioredis](/content/develop/clients/nodejs/migration.md)
+> if you are interested in converting an existing `ioredis` project to `node-redis`.
 
-`node-redis` requires a running Redis server. See [here]({{< relref "/operate/oss_and_stack/install/" >}}) for Redis Open Source installation instructions.
+`node-redis` requires a running Redis server. See [here](/content/operate/oss_and_stack/install/_index.md) for Redis Open Source installation instructions.
 
 You can also access Redis with an object-mapping client interface. See
-[RedisOM for Node.js]({{< relref "/integrate/redisom-for-node-js" >}})
+[RedisOM for Node.js](/content/integrate/redisom-for-node-js/_index.md)
 for more information.
 
 ## Install

--- a/content/develop/clients/nodejs/amr.md
+++ b/content/develop/clients/nodejs/amr.md
@@ -28,7 +28,7 @@ The `@redis/entraid` code fetches and renews the authentication tokens for you a
 
 ## Install
 
-Install [`node-redis`]({{< relref "/develop/clients/nodejs" >}}) and
+Install [`node-redis`](/content/develop/clients/nodejs/_index.md) and
 `@redis/entraid` with the following commands:
 
 ```bash
@@ -338,13 +338,13 @@ console.log(`Database size is ${size}`);
 ## RESP2 PUB/SUB limitations
 
 If you are using the
-[RESP2]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
+[RESP2](/content/develop/reference/protocol-spec.md#resp-versions)
 protocol, you should
-be aware that [pub/sub]({{< relref "/develop/pubsub" >}}) can
+be aware that [pub/sub](/content/develop/pubsub/_index.md) can
 cause complications with reauthentication.
 
 After a connection enters PUB/SUB mode, the socket is blocked and can't process
-out-of-band commands like [`AUTH`]({{< relref "/commands/auth" >}}). This means that
+out-of-band commands like [`AUTH`](/content/commands/auth.md). This means that
 connections in PUB/SUB mode can't be reauthenticated when the tokens are refreshed.
 As a result, PUB/SUB connections will be evicted by the Redis proxy when their tokens expire. 
 You must reconnect with fresh tokens when this happens.

--- a/content/develop/clients/nodejs/connect.md
+++ b/content/develop/clients/nodejs/connect.md
@@ -99,7 +99,7 @@ await cluster.close();
 
 ## Connect to your production Redis with TLS
 
-When you deploy your application, use TLS and follow the [Redis security]({{< relref "/operate/oss_and_stack/management/security/" >}}) guidelines.
+When you deploy your application, use TLS and follow the [Redis security](/content/operate/oss_and_stack/management/security/_index.md) guidelines.
 
 ```js
 const client = createClient({
@@ -132,21 +132,21 @@ You can also use discrete parameters and UNIX sockets. Details can be found in t
 
 Client-side caching is a technique to reduce network traffic between
 the client and server, resulting in better performance. See
-[Client-side caching introduction]({{< relref "/develop/clients/client-side-caching" >}})
+[Client-side caching introduction](/content/develop/clients/client-side-caching.md)
 for more information about how client-side caching works and how to use it effectively.
 
-{{< note >}}Client-side caching requires `node-redis` v5.1.0 or later.
-To maximize compatibility with all Redis products, client-side caching
-is supported by Redis v7.4 or later.
-
-The [Redis server products]({{< relref "/operate" >}}) support
-[opt-in/opt-out]({{< relref "/develop/reference/client-side-caching#opt-in-and-opt-out-caching" >}}) mode
-and [broadcasting mode]({{< relref "/develop/reference/client-side-caching#broadcasting-mode" >}})
-for CSC, but these modes are not currently implemented by `node-redis`.
-{{< /note >}}
+> [!NOTE]
+> Client-side caching requires `node-redis` v5.1.0 or later.
+> To maximize compatibility with all Redis products, client-side caching
+> is supported by Redis v7.4 or later.
+>
+> The [Redis server products](/content/operate/_index.md) support
+> [opt-in/opt-out](/content/develop/reference/client-side-caching.md#opt-in-and-opt-out-caching) mode
+> and [broadcasting mode](/content/develop/reference/client-side-caching.md#broadcasting-mode)
+> for CSC, but these modes are not currently implemented by `node-redis`.
 
 To enable client-side caching, specify the
-[RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
+[RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
 protocol and configure the cache with the `clientSideCache` parameter
 when you connect. If you want `node-redis` to create the cache for you,
 then you can pass a simple configuration object in `clientSideCache`, as
@@ -216,8 +216,8 @@ client.get("city");     // Retrieved from cache
 ```
 
 You can see the cache working if you connect to the same Redis database
-with [`redis-cli`]({{< relref "/develop/tools/cli" >}}) and run the
-[`MONITOR`]({{< relref "/commands/monitor" >}}) command. If you run the
+with [`redis-cli`](/content/develop/tools/cli.md) and run the
+[`MONITOR`](/content/commands/monitor.md) command. If you run the
 code above but without passing `clientSideCache` during the connection,
 you should see the following in the CLI among the output from `MONITOR`:
 
@@ -335,13 +335,13 @@ createClient({
 Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH.
 
-{{< note >}}Using SCH with node-redis requires v5.9.0 or later for
-basic connections, and v5.11.0 or later for
-[OSS Cluster API]({{< relref "/operate/rs/databases/configure/oss-cluster-api" >}}) connections.
-{{< /note >}}
+> [!NOTE]
+> Using SCH with node-redis requires v5.9.0 or later for
+> basic connections, and v5.11.0 or later for
+> [OSS Cluster API](/content/operate/rs/databases/configure/oss-cluster-api.md) connections.
 
 Use the configuration options shown in the example below to enable SCH
 during the connection:
@@ -357,9 +357,9 @@ const client = createClient({
 });
 ```
 
-{{< note >}}SCH requires the [RESP3]({{< relref "/develop/reference/protocol-spec#resp-versions" >}})
-protocol, so you must set the `RESP:3` option explicitly when you connect.
-{{< /note >}}
+> [!NOTE]
+> SCH requires the [RESP3](/content/develop/reference/protocol-spec.md#resp-versions)
+> protocol, so you must set the `RESP:3` option explicitly when you connect.
 
 The available options are:
 
@@ -380,13 +380,13 @@ The available options are:
 -   `maintRelaxedSocketTimeout`: (`number`) The socket timeout to use while the server is 
     performing maintenance. The default is 10000 (10 seconds). If a timeout happens during the maintenance period, the client receives a `SocketTimeoutDuringMaintenance` error.
 
-{{< note >}} Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
-either [AWS PrivateLink]({{< relref "/operate/rc/security/aws-privatelink" >}}) or
-[Google Cloud Private Service Connect]({{< relref "/operate/rc/security/private-service-connect" >}})
-(see [Smart client handoffs]({{< relref "/develop/clients/sch#redis-cloud" >}}) for more information).
-To use relaxed timeouts with these services, you should set `maintEndpointType: 'none'`
-when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.
-{{< /note >}}
+> [!NOTE]
+>  Redis Cloud supports relaxed timeouts *only* (and not pre-handoffs) for SCH if you are using
+> either [AWS PrivateLink](/content/operate/rc/security/aws-privatelink.md) or
+> [Google Cloud Private Service Connect](/content/operate/rc/security/private-service-connect.md)
+> (see [Smart client handoffs](/content/develop/clients/sch.md#redis-cloud) for more information).
+> To use relaxed timeouts with these services, you should set `maintEndpointType: 'none'`
+> when you connect. All other configurations have full support for both relaxed timeouts and pre-handoffs.
 
 ## Connection events
 
@@ -403,7 +403,7 @@ related to connection:
 -   `reconnecting`: (No parameters) The client is about to try reconnecting after the
     connection was lost due to an error.
 -   `sharded-channel-moved`: The cluster slot of a subscribed
-    [sharded pub/sub channel]({{< relref "/develop/pubsub#sharded-pubsub" >}})
+    [sharded pub/sub channel](/content/develop/pubsub/_index.md#sharded-pubsub)
     has been moved to another shard. Note that when you use a
     [`RedisCluster`](#connect-to-a-redis-cluster) connection, this event is automatically
     handled for you. See

--- a/content/develop/clients/nodejs/error-handling.md
+++ b/content/develop/clients/nodejs/error-handling.md
@@ -20,8 +20,8 @@ handling for brevity. This page shows how to apply error handling
 techniques in node-redis for real world code.
 For an overview of some common general error types and strategies for
 handling them, see
-[Error handling]({{< relref "/develop/clients/error-handling" >}}).
-See also [Production usage]({{< relref "/develop/clients/nodejs/produsage" >}})
+[Error handling](/content/develop/clients/error-handling.md).
+See also [Production usage](/content/develop/clients/nodejs/produsage.md)
 for more information on connection management, timeouts, and other aspects of
 app reliability.
 
@@ -39,7 +39,7 @@ node-redis throws errors as rejected promises. Common error types include:
 | `ReplyError` (`WRONGTYPE`) | Type mismatch | ❌ | Fix schema or code |
 | `ReplyError` (`BUSY`, `TRYAGAIN`, `LOADING`) | Redis busy/loading | ⚠️ | Retry with backoff (bounded) |
 
-See [Categories of errors]({{< relref "/develop/clients/error-handling#categories-of-errors" >}})
+See [Categories of errors](/content/develop/clients/error-handling.md#categories-of-errors)
 for a more detailed discussion of these errors and their causes.
 
 ## Async/await in examples
@@ -93,14 +93,14 @@ client.on('error', error => {
 
 ## Applying error handling patterns
 
-The [Error handling]({{< relref "/develop/clients/error-handling" >}})
+The [Error handling](/content/develop/clients/error-handling.md)
 overview describes four common error handling patterns. The sections
 below show how to implement these patterns in node-redis:
 
 ### Pattern 1: Fail fast
 
 Catch specific errors that represent unrecoverable errors and re-throw them (see
-[Pattern 1: Fail fast]({{< relref "/develop/clients/error-handling#pattern-1-fail-fast" >}})
+[Pattern 1: Fail fast](/content/develop/clients/error-handling.md#pattern-1-fail-fast)
 for a full description).
 
 ```javascript
@@ -117,7 +117,7 @@ try {
 ### Pattern 2: Graceful degradation
 
 Catch connection errors and fall back to an alternative (see
-[Pattern 2: Graceful degradation]({{< relref "/develop/clients/error-handling#pattern-2-graceful-degradation" >}})
+[Pattern 2: Graceful degradation](/content/develop/clients/error-handling.md#pattern-2-graceful-degradation)
 for a full description).
 
 ```javascript
@@ -137,7 +137,7 @@ return database.get(key);
 ### Pattern 3: Retry with backoff
 
 Retry on temporary errors like timeouts (see
-[Pattern 3: Retry with backoff]({{< relref "/develop/clients/error-handling#pattern-3-retry-with-backoff" >}})
+[Pattern 3: Retry with backoff](/content/develop/clients/error-handling.md#pattern-3-retry-with-backoff)
 for a full description).
 
 ```javascript
@@ -164,13 +164,13 @@ async function getWithRetry(key, { attempts = 3, baseDelayMs = 100 } = {}) {
 
 Note that you can also configure node-redis to reconnect to the
 server automatically when the connection is lost. See
-[Reconnect after disconnection]({{< relref "/develop/clients/nodejs/connect#reconnect-after-disconnection" >}})
+[Reconnect after disconnection](/content/develop/clients/nodejs/connect.md#reconnect-after-disconnection)
 for more information.
 
 ### Pattern 4: Log and continue
 
 Log non-critical errors and continue (see
-[Pattern 4: Log and continue]({{< relref "/develop/clients/error-handling#pattern-4-log-and-continue" >}})
+[Pattern 4: Log and continue](/content/develop/clients/error-handling.md#pattern-4-log-and-continue)
 for a full description).
 
 ```javascript
@@ -187,5 +187,5 @@ try {
 
 ## See also
 
-- [Error handling]({{< relref "/develop/clients/error-handling" >}})
-- [Production usage]({{< relref "/develop/clients/nodejs/produsage" >}})
+- [Error handling](/content/develop/clients/error-handling.md)
+- [Production usage](/content/develop/clients/nodejs/produsage.md)

--- a/content/develop/clients/nodejs/migration.md
+++ b/content/develop/clients/nodejs/migration.md
@@ -15,10 +15,10 @@ title: Migrate from ioredis
 weight: 10
 ---
 
-Redis previously recommended the [`ioredis`]({{< relref "/develop/clients/ioredis" >}})
+Redis previously recommended the [`ioredis`](/content/develop/clients/ioredis/_index.md)
 client library for development with [Node.js](https://nodejs.org/en),
 but this library is now deprecated in favor of
-[`node-redis`]({{< relref "/develop/clients/nodejs" >}}). This guide
+[`node-redis`](/content/develop/clients/nodejs/_index.md). This guide
 outlines the main similarities and differences between the two libraries.
 You may find this information useful if you are an `ioredis` user and you want to
 start a new Node.js project or migrate an existing `ioredis` project to `node-redis`.
@@ -94,7 +94,7 @@ await client.connect(); // Requires explicit connection.
 Both `ioredis` and `node-redis` automatically attempt to reconnect if the connection
 was lost due to an error. `node-redis` also lets you add a custom reconnection strategy
 when you create the client object. See
-[Reconnect after disconnection]({{< relref "/develop/clients/nodejs/connect#reconnect-after-disconnection" >}})
+[Reconnect after disconnection](/content/develop/clients/nodejs/connect.md#reconnect-after-disconnection)
 for more information.
 
 ### Connection events
@@ -102,7 +102,7 @@ for more information.
 The `connect`, `ready`, `error`, and `close` events that `ioredis` emits
 are equivalent to the `connect`, `ready`, `error`, and `end` events
 in `node-redis`, but `node-redis` also emits a `reconnecting` event.
-See [Connection events]({{< relref "/develop/clients/nodejs/connect#connection-events" >}})
+See [Connection events](/content/develop/clients/nodejs/connect.md#connection-events)
 for more information.
 
 ### Command case
@@ -124,7 +124,7 @@ client.hSet('key', 'field', 'value');
 ### Command argument handling
 
 `ioredis` parses command arguments to strings and then passes them to
-the server, in a similar way to [`redis-cli`]({{< relref "/develop/tools/cli" >}}).
+the server, in a similar way to [`redis-cli`](/content/develop/tools/cli.md).
 
 ```js
 // Equivalent to the command line `SET key 100 EX 10`.
@@ -208,7 +208,7 @@ legacyClient.set("mykey", "myvalue", (err, result) => {
 ### Arbitrary command execution
 
 `ioredis` lets you issue arbitrary commands in a similar format to
-[`redis-cli`]({{< relref "/develop/tools/cli" >}}) using the `call()`
+[`redis-cli`](/content/develop/tools/cli.md) using the `call()`
 command:
 
 ```js
@@ -238,7 +238,7 @@ Both `ioredis` and `node-redis` will pipeline commands automatically if
 they are executed in the same "tick" of the
 [event loop](https://nodejs.org/en/learn/asynchronous-work/event-loop-timers-and-nexttick#what-is-the-event-loop)
 (see
-[Execute a pipeline]({{< relref "/develop/clients/nodejs/transpipe#execute-a-pipeline" >}})
+[Execute a pipeline](/content/develop/clients/nodejs/transpipe.md#execute-a-pipeline)
 for more information).
 
 You can also create a pipeline with explicit commands in both clients.
@@ -278,7 +278,7 @@ client.multi()
 ### Scan iteration
 
 `ioredis` supports the `scanStream()` method to create a readable stream
-from the set of keys returned by the [`SCAN`]({{< relref "/commands/scan" >}})
+from the set of keys returned by the [`SCAN`](/content/commands/scan.md)
 command:
 
 ```js
@@ -306,7 +306,7 @@ respectively.
 (and the corresponding `hscanIterator()`, `sscanIterator()`, and
 `zscanIterator()` methods). These return a collection object for
 each page scanned by the cursor (this can be helpful to improve
-efficiency using [`MGET`]({{< relref "/commands/mget" >}}) and
+efficiency using [`MGET`](/content/commands/mget.md) and
 other multi-key commands):
 
 ```js
@@ -320,7 +320,7 @@ for await (const keys of client.scanIterator()) {
 
 `ioredis` reports incoming pub/sub messages with a `message`
 event on the client object (see
-[Publish/subscribe]({{< relref "/develop/pubsub" >}}) for more
+[Publish/subscribe](/content/develop/pubsub/_index.md) for more
 information about messages):
 
 ```js
@@ -346,14 +346,14 @@ await subscriber.subscribe('channel', (message) => {
 
 ### `SETNX` command
 
-`ioredis` implements the  [`SETNX`]({{< relref "/commands/setnx" >}})
+`ioredis` implements the  [`SETNX`](/content/commands/setnx.md)
 command with an explicit method:
 
 ```js
 client.setnx('bike:1', 'bike');
 ```
 
-`node-redis` provides a `SETNX` method but this command is deprecated. Use the `NX` option to the [`SET`]({{< relref "/commands/set" >}})
+`node-redis` provides a `SETNX` method but this command is deprecated. Use the `NX` option to the [`SET`](/content/commands/set.md)
 command to get the same functionality as `SETNX`:
 
 ```js
@@ -362,10 +362,10 @@ await client.set('bike:1', 'bike', {'NX': true});
 
 ### `HMSET` command
 
-The [`HMSET`]({{< relref "/commands/hmset" >}}) command has been deprecated
+The [`HMSET`](/content/commands/hmset.md) command has been deprecated
 since Redis v4.0.0, but it is still supported by `ioredis`. With `node-redis`
-you should use the [`HSET`]({{< relref "/commands/hset" >}}) command with
-multiple key-value pairs. See the [`HSET`]({{< relref "/commands/hset" >}})
+you should use the [`HSET`](/content/commands/hset.md) command with
+multiple key-value pairs. See the [`HSET`](/content/commands/hset.md)
 command page for more information.
 
 ### `CONFIG` command
@@ -378,10 +378,10 @@ client.config('SET', 'notify-keyspace-events', 'KEA');
 ```
 
 `node-redis` doesn't have a `config()` method, but instead supports the
-standard commands [`configSet()`]({{< relref "/commands/config-set" >}}),
-[`configGet()`]({{< relref "/commands/config-get" >}}),
-[`configResetStat()`]({{< relref "/commands/config-resetstat" >}}), and
-[`configRewrite`]({{< relref "/commands/config-rewrite" >}}):
+standard commands [`configSet()`](/content/commands/config-set.md),
+[`configGet()`](/content/commands/config-get.md),
+[`configResetStat()`](/content/commands/config-resetstat.md), and
+[`configRewrite`](/content/commands/config-rewrite.md):
 
 ```js
 await client.configSet('maxclients', '2000');

--- a/content/develop/clients/nodejs/observability.md
+++ b/content/develop/clients/nodejs/observability.md
@@ -19,7 +19,7 @@ weight: 75
 instrumentation to collect metrics. This can be very helpful for
 diagnosing problems and improving the performance and connection resiliency of
 your application. See the
-[Observability overview]({{< relref "/develop/clients/observability" >}})
+[Observability overview](/content/develop/clients/observability.md)
 for an introduction to Redis client observability and a reference guide for the
 available metrics.
 
@@ -74,13 +74,13 @@ The available options for `MetricConfig` are described in the table below:
 | `meterProvider` |  | Uses this provider instead of the global provider from `@opentelemetry/api`. |
 | `includeCommands` | `[]` | List of Redis commands to track. If set, only these commands will be tracked. Note that you should use the Redis command name rather than the node-redis method name where the two differ. |
 | `excludeCommands` | `[]` | List of Redis commands to exclude from tracking. If set, all commands except these will be tracked. Note that you should use the Redis command name rather than the node-redis method name where the two differ. |
-| `enabledMetricGroups` | `['connection-basic', 'resiliency']` | List of metric groups to enable. By default, only `connection-basic` and `resiliency` are enabled. See [Redis metric groups]({{< relref "/develop/clients/observability#redis-metric-groups" >}}) for a list of available groups. |
+| `enabledMetricGroups` | `['connection-basic', 'resiliency']` | List of metric groups to enable. By default, only `connection-basic` and `resiliency` are enabled. See [Redis metric groups](/content/develop/clients/observability.md#redis-metric-groups) for a list of available groups. |
 | `hidePubSubChannelNames` | `false` | If true, channel names in pub/sub metrics will be hidden. |
 | `hideStreamNames` | `false` | If true, stream names in streaming metrics will be hidden. |
-| `bucketsOperationDuration` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`operation.duration`]({{< relref "/develop/clients/observability/#metric-db.client.operation.duration" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
-| `bucketsConnectionCreateTime` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`connection.create_time`]({{< relref "/develop/clients/observability/#metric-db.client.connection.create_time" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
-| `bucketsConnectionWaitTime` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`connection.wait_time`]({{< relref "/develop/clients/observability/#metric-db.client.connection.wait_time" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
-| `bucketsStreamProcessingDuration` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`stream.lag`]({{< relref "/develop/clients/observability/#metric-redis.client.stream.lag" >}}) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `bucketsOperationDuration` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`operation.duration`](/content/develop/clients/observability.md#metric-db.client.operation.duration) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `bucketsConnectionCreateTime` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`connection.create_time`](/content/develop/clients/observability.md#metric-db.client.connection.create_time) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `bucketsConnectionWaitTime` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`connection.wait_time`](/content/develop/clients/observability.md#metric-db.client.connection.wait_time) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
+| `bucketsStreamProcessingDuration` | `[0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10]` | List of bucket boundaries for the [`stream.lag`](/content/develop/clients/observability.md#metric-redis.client.stream.lag) histogram (see [Custom histogram buckets](#custom-histogram-buckets) below). |
 
 ### Custom histogram buckets
 

--- a/content/develop/clients/nodejs/prob.md
+++ b/content/develop/clients/nodejs/prob.md
@@ -16,7 +16,7 @@ weight: 5
 ---
 
 Redis supports several
-[probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}})
+[probabilistic data types](/content/develop/data-types/probabilistic/_index.md)
 that let you calculate values approximately rather than exactly.
 The types fall into two basic categories:
 
@@ -32,7 +32,7 @@ counting the number of distinct IP addresses that access a website in one day.
 
 Assuming that you already have code that supplies you with each IP
 address as a string, you could record the addresses in Redis using
-a [set]({{< relref "/develop/data-types/sets" >}}):
+a [set](/content/develop/data-types/sets.md):
 
 ```js
 await client.sAdd("ip_tracker", new_ip_address);
@@ -68,11 +68,11 @@ time than the equivalent precise calculations.
 Redis supports the following approximate set operations:
 
 -   [Membership](#set-membership): The
-    [Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-    [Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+    [Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+    [Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
     data types let you track whether or not a given item is a member of a set.
 -   [Cardinality](#set-cardinality): The
-    [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+    [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
     data type gives you an approximate value for the number of items in a set, also
     known as the *cardinality* of the set.
 
@@ -80,8 +80,8 @@ The sections below describe these operations in more detail.
 
 ### Set membership
 
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 objects provide a set membership operation that lets you track whether or not a
 particular item has been added to a set. These two types provide different
 trade-offs for memory usage and speed, so you can select the best one for your
@@ -90,7 +90,7 @@ absence of items in the set. If an item is reported as absent, then it is defini
 absent, but if it is reported as present, then there is a small chance it may really be
 absent.
 
-Instead of storing strings directly, like a [set]({{< relref "/develop/data-types/sets" >}}),
+Instead of storing strings directly, like a [set](/content/develop/data-types/sets.md),
 a Bloom filter records the presence or absence of the
 [hash value](https://en.wikipedia.org/wiki/Hash_function) of a string.
 This gives a very compact representation of the
@@ -145,13 +145,13 @@ Which of these two data types you choose depends on your use case.
 Bloom filters are generally faster than Cuckoo filters when adding new items,
 and also have better memory usage. Cuckoo filters are generally faster
 at checking membership and also support the delete operation. See the
-[Bloom filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) and
-[Cuckoo filter]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Bloom filter](/content/develop/data-types/probabilistic/bloom-filter.md) and
+[Cuckoo filter](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 reference pages for more information and comparison between the two types.
 
 ### Set cardinality
 
-A [HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
+A [HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
 object calculates the cardinality of a set. As you add
 items, the HyperLogLog tracks the number of distinct set members but
 doesn't let you retrieve them or query which items have been added.
@@ -192,20 +192,20 @@ Redis supports several approximate statistical calculations
 on numeric data sets:
 
 -   [Frequency](#frequency): The
-    [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+    [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
     data type lets you find the approximate frequency of a labeled item in a data stream.
 -   [Quantiles](#quantiles): The
-    [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+    [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
     data type estimates the quantile of a query value in a data stream.
 -   [Ranking](#ranking): The
-    [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}}) data type
+    [Top-K](/content/develop/data-types/probabilistic/top-k.md) data type
     estimates the ranking of labeled items by frequency in a data stream.
 
 The sections below describe these operations in more detail.
 
 ### Frequency
 
-A [Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+A [Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
 (CMS) object keeps count of a set of related items represented by
 string labels. The count is approximate, but you can specify
 how close you want to keep the count to the true value (as a fraction)
@@ -254,7 +254,7 @@ console.log(res19);  // >>> [400, 200, 350, 100]
 ```
 
 The advantage of using a CMS over keeping an exact count with a
-[sorted set]({{< relref "/develop/data-types/sorted-sets" >}})
+[sorted set](/content/develop/data-types/sorted-sets.md)
 is that a CMS has very low and fixed memory usage, even for
 large numbers of items. Use CMS objects to keep daily counts of
 items sold, accesses to individual web pages on your site, and
@@ -269,7 +269,7 @@ the value of height below which 75% of all people's heights lie.
 [Percentiles](https://en.wikipedia.org/wiki/Percentile) are equivalent
 to quantiles, except that the fraction is expressed as a percentage.
 
-A [t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+A [t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 object can estimate quantiles from a set of values added to it
 without having to store each value in the set explicitly. This can
 save a lot of memory when you have a large number of samples.
@@ -330,12 +330,12 @@ console.log(res30);  // >>> [175.5]
 
 A t-digest object also supports several other related commands, such
 as querying by rank. See the
-[t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+[t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 reference for more information.
 
 ### Ranking
 
-A [Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+A [Top-K](/content/develop/data-types/probabilistic/top-k.md)
 object estimates the rankings of different labeled items in a data
 stream according to frequency. For example, you could use this to
 track the top ten most frequently-accessed pages on a website, or the

--- a/content/develop/clients/nodejs/produsage.md
+++ b/content/develop/clients/nodejs/produsage.md
@@ -40,7 +40,7 @@ Node-Redis provides [multiple events to handle various scenarios](https://github
 
 This event is triggered whenever an error occurs within the client, and
 it is very important to set a handler to listen for it.
-See [Error events]({{< relref "/develop/clients/nodejs/error-handling#error-events" >}})
+See [Error events](/content/develop/clients/nodejs/error-handling.md#error-events)
 for more information and an example of setting an error handler.
 
 ### Handling reconnections
@@ -50,7 +50,7 @@ the client can automatically restore the connection.  A simple
 [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff) strategy
 for reconnection is enabled by default, but you can replace this with your
 own custom strategy. See
-[Reconnect after disconnection]({{< relref "/develop/clients/nodejs/connect#reconnect-after-disconnection" >}})
+[Reconnect after disconnection](/content/develop/clients/nodejs/connect.md#reconnect-after-disconnection)
 for more information.
 
 ### Timeouts
@@ -119,7 +119,7 @@ Redis Software servers that lets them actively notify clients
 about planned server maintenance shortly before it happens. This
 lets a client take action to avoid disruptions in service.
 
-See [Smart client handoffs]({{< relref "/develop/clients/sch" >}})
+See [Smart client handoffs](/content/develop/clients/sch.md)
 for more information about SCH and
-[Connect using Smart client handoffs]({{< relref "/develop/clients/nodejs/connect#connect-using-smart-client-handoffs-sch" >}})
+[Connect using Smart client handoffs](/content/develop/clients/nodejs/connect.md#connect-using-smart-client-handoffs-sch)
 for example code.

--- a/content/develop/clients/nodejs/queryjson.md
+++ b/content/develop/clients/nodejs/queryjson.md
@@ -24,26 +24,26 @@ weight: 2
 ---
 
 This example shows how to create a
-[search index]({{< relref "/develop/ai/search-and-query/indexing" >}})
-for [JSON]({{< relref "/develop/data-types/json" >}}) documents and
+[search index](/content/develop/ai/search-and-query/indexing/_index.md)
+for [JSON](/content/develop/data-types/json/_index.md) documents and
 run queries against the index. It then goes on to show the slight differences
-in the equivalent code for [hash]({{< relref "/develop/data-types/hashes" >}})
+in the equivalent code for [hash](/content/develop/data-types/hashes.md)
 documents.
 
-{{< note >}}From [v5.0.0](https://github.com/redis/node-redis/releases/tag/redis%405.0.0)
-onwards, `node-redis` uses query dialect 2 by default.
-Redis Search methods such as [`ft.search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v5.0.0](https://github.com/redis/node-redis/releases/tag/redis%405.0.0)
+> onwards, `node-redis` uses query dialect 2 by default.
+> Redis Search methods such as [`ft.search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
-Make sure that you have [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}})
+Make sure that you have [Redis Open Source](/content/operate/oss_and_stack/_index.md)
 or another Redis server available. Also install the
-[`node-redis`]({{< relref "/develop/clients/nodejs" >}}) client library if you
+[`node-redis`](/content/develop/clients/nodejs/_index.md) client library if you
 haven't already done so.
 
 Add the following dependencies:
@@ -63,13 +63,13 @@ below is compatible with both JSON and hash objects.
 
 Connect to your Redis database. The code below shows the most
 basic connection but see
-[Connect to the server]({{< relref "/develop/clients/nodejs/connect" >}})
+[Connect to the server](/content/develop/clients/nodejs/connect.md)
 to learn more about the available connection options.
 
 {{< clients-example set="js_home_query" step="connect" lang_filter="Node.js" description="Foundational: Establish a connection to Redis for query operations" difficulty="beginner" >}}
 {{< /clients-example >}}
 
-Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax]({{< relref "/develop/ai/search-and-query/query/" >}}).
+Create an index. In this example, only JSON documents with the key prefix `user:` are indexed. For more information, see [Query syntax](/content/develop/ai/search-and-query/query/_index.md).
 
 First, drop any existing index to avoid a collision. (The callback is required
 to avoid an error if the index doesn't already exist.)
@@ -85,11 +85,11 @@ Then create the index:
 ## Add the data
 
 Add the three sets of user data to the database as
-[JSON]({{< relref "/develop/data-types/json" >}}) objects.
+[JSON](/content/develop/data-types/json/_index.md) objects.
 If you use keys with the `user:` prefix then Redis will index the
 objects automatically as you add them. Note that placing
 the commands in a `Promise.all()` call is an easy way to create a
-[pipeline]({{< relref "/develop/clients/nodejs/transpipe" >}}),
+[pipeline](/content/develop/clients/nodejs/transpipe.md),
 which is more efficient than sending the commands individually.
 
 {{< clients-example set="js_home_query" step="add_data" lang_filter="Node.js" description="Foundational: Add JSON documents with indexed key prefixes using Promise.all() for efficient pipelining" difficulty="intermediate" >}}
@@ -98,7 +98,7 @@ which is more efficient than sending the commands individually.
 ## Query the data
 
 You can now use the index to search the JSON objects. The
-[query]({{< relref "/develop/ai/search-and-query/query" >}})
+[query](/content/develop/ai/search-and-query/query/_index.md)
 below searches for objects that have the text "Paul" in any field
 and have an `age` value in the range 30 to 40:
 
@@ -111,7 +111,7 @@ Specify query options to return only the `city` field:
 {{< /clients-example >}}
 
 Use an
-[aggregation query]({{< relref "/develop/ai/search-and-query/query/aggregation" >}})
+[aggregation query](/content/develop/ai/search-and-query/query/aggregation.md)
 to count all users in each city.
 
 {{< clients-example set="js_home_query" step="query3" lang_filter="Node.js" description="Aggregate query results: Use aggregation queries to group and count results by field values for analytics" difficulty="advanced" >}}
@@ -139,8 +139,8 @@ Then create the new index:
 {{< clients-example set="js_home_query" step="create_hash_index" lang_filter="Node.js" description="Foundational: Create a search index for hash documents with HASH type specification" difficulty="intermediate" >}}
 {{< /clients-example >}}
 
-You use [`hSet()`]({{< relref "/commands/hset" >}}) to add the hash
-documents instead of [`json.set()`]({{< relref "/commands/json.set" >}}),
+You use [`hSet()`](/content/commands/hset.md) to add the hash
+documents instead of [`json.set()`](/content/commands/json.set.md),
 but the same flat `userX` objects work equally well with either
 hash or JSON:
 
@@ -156,5 +156,5 @@ also the same:
 
 ## More information
 
-See the [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) docs
+See the [Redis Search](/content/develop/ai/search-and-query/_index.md) docs
 for a full description of all query features with examples.

--- a/content/develop/clients/nodejs/transpipe.md
+++ b/content/develop/clients/nodejs/transpipe.md
@@ -21,11 +21,11 @@ There are two types of batch that you can use:
 -   **Pipelines** avoid network and processing overhead by sending several commands
     to the server together in a single communication. The server then sends back
     a single communication with all the responses. See the
-    [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}) page for more
+    [Pipelining](/content/develop/using-commands/pipelining.md) page for more
     information.
 -   **Transactions** guarantee that all the included commands will execute
     to completion without being interrupted by commands from other clients.
-    See the [Transactions]({{< relref "develop/using-commands/transactions" >}})
+    See the [Transactions](/content/develop/using-commands/transactions.md)
     page for more information.
 
 ## Execute a pipeline
@@ -60,7 +60,7 @@ await Promise.all([
 ```
 
 You can also create a pipeline object using the
-[`multi()`]({{< relref "/commands/multi" >}}) method
+[`multi()`](/content/commands/multi.md) method
 and then add commands to it using methods that resemble the standard
 command methods (for example, `set()` and `get()`). The commands are
 buffered in the pipeline and only execute when you call the
@@ -112,7 +112,7 @@ to different keys. The basic idea is to watch for changes to any
 keys that you use in a transaction while you are processing the
 updates. If the watched keys do change, you must restart the updates
 with the latest data from the keys. See
-[Transactions]({{< relref "develop/using-commands/transactions" >}})
+[Transactions](/content/develop/using-commands/transactions.md)
 for more information about optimistic locking.
 
 The code below reads a string

--- a/content/develop/clients/nodejs/vecsearch.md
+++ b/content/develop/clients/nodejs/vecsearch.md
@@ -25,15 +25,15 @@ topics:
 weight: 3
 ---
 
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
-lets you index vector fields in [hash]({{< relref "/develop/data-types/hashes" >}})
-or [JSON]({{< relref "/develop/data-types/json" >}}) objects (see the
-[Vectors]({{< relref "/develop/ai/search-and-query/vectors" >}}) 
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
+lets you index vector fields in [hash](/content/develop/data-types/hashes.md)
+or [JSON](/content/develop/data-types/json/_index.md) objects (see the
+[Vectors](/content/develop/ai/search-and-query/vectors/_index.md) 
 reference page for more information).
 
 Vector fields can store *text embeddings*, which are AI-generated vector
 representations of text content. The
-[vector distance]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+[vector distance](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
 between two embeddings measures their semantic similarity. When you compare the
 similarity of a query embedding with stored embeddings, Redis can retrieve documents
 that closely match the query's meaning.
@@ -45,20 +45,20 @@ Redis Search. The code is first demonstrated for hash documents with a
 separate section to explain the
 [differences with JSON documents](#differences-with-json-documents).
 
-{{< note >}}From [v5.0.0](https://github.com/redis/node-redis/releases/tag/redis%405.0.0)
-onwards, `node-redis` uses query dialect 2 by default.
-Redis Search methods such as [`ft.search()`]({{< relref "/commands/ft.search" >}})
-will explicitly request this dialect, overriding the default set for the server.
-See
-[Query dialects]({{< relref "/develop/ai/search-and-query/advanced-concepts/dialects" >}})
-for more information.
-{{< /note >}}
+> [!NOTE]
+> From [v5.0.0](https://github.com/redis/node-redis/releases/tag/redis%405.0.0)
+> onwards, `node-redis` uses query dialect 2 by default.
+> Redis Search methods such as [`ft.search()`](/content/commands/ft.search.md)
+> will explicitly request this dialect, overriding the default set for the server.
+> See
+> [Query dialects](/content/develop/ai/search-and-query/advanced-concepts/dialects.md)
+> for more information.
 
 ## Initialize
 
 Install the required dependencies:
 
-1. Install [`node-redis`]({{< relref "/develop/clients/nodejs" >}}) if you haven't already.
+1. Install [`node-redis`](/content/develop/clients/nodejs/_index.md) if you haven't already.
 2. Install `@xenova/transformers`:
 
 ```bash
@@ -94,13 +94,13 @@ First, connect to Redis and remove any existing index named `vector_idx`:
 
 Next, create the index with the following schema:
 -   `content`: Text field for the content to index
--   `genre`: [Tag]({{< relref "/develop/ai/search-and-query/advanced-concepts/tags" >}})
+-   `genre`: [Tag](/content/develop/ai/search-and-query/advanced-concepts/tags.md)
     field representing the text's genre
--   `embedding`: [Vector]({{< relref "/develop/ai/search-and-query/vectors" >}})
+-   `embedding`: [Vector](/content/develop/ai/search-and-query/vectors/_index.md)
     field with:
-    -   [HNSW]({{< relref "/develop/ai/search-and-query/vectors#hnsw-index" >}})
+    -   [HNSW](/content/develop/ai/search-and-query/vectors/_index.md#hnsw-index)
         indexing
-    -   [L2]({{< relref "/develop/ai/search-and-query/vectors#distance-metrics" >}})
+    -   [L2](/content/develop/ai/search-and-query/vectors/_index.md#distance-metrics)
         distance metric
     -   Float32 values
     -   768 dimensions (matching the embedding model)
@@ -180,5 +180,5 @@ jdoc:3: 'Today is a sunny day', Score: 1.50889515877
 ## Learn more
 
 See
-[Vector search]({{< relref "/develop/ai/search-and-query/query/vector-search" >}})
+[Vector search](/content/develop/ai/search-and-query/query/vector-search.md)
 for more information about indexing options, distance metrics, and query format.

--- a/content/develop/clients/nodejs/vecsets.md
+++ b/content/develop/clients/nodejs/vecsets.md
@@ -21,14 +21,14 @@ topics:
 - vectors
 ---
 
-A Redis [vector set]({{< relref "/develop/data-types/vector-sets" >}}) lets
+A Redis [vector set](/content/develop/data-types/vector-sets/_index.md) lets
 you store a set of unique keys, each with its own associated vector.
 You can then retrieve keys from the set according to the similarity between
 their stored vectors and a query vector that you specify.
 
 You can use vector sets to store any type of numeric vector but they are
 particularly optimized to work with text embedding vectors (see
-[Redis for AI]({{< relref "/develop/ai" >}}) to learn more about text
+[Redis for AI](/content/develop/ai/_index.md) to learn more about text
 embeddings). The example below shows how to use the
 [`@xenova/transformers`](https://www.npmjs.com/package/@xenova/transformers)
 library to generate vector embeddings and then
@@ -36,7 +36,7 @@ store and retrieve them using a vector set with `node-redis`.
 
 ## Initialize
 
-Start by [installing]({{< relref "/develop/clients/nodejs#install" >}}) `node-redis`
+Start by [installing](/content/develop/clients/nodejs/_index.md#install) `node-redis`
 if you haven't already done so. Also, install `@xenova/transformers`:
 
 ```bash
@@ -86,11 +86,11 @@ and adds corresponding elements to a vector set called `famousPeople`.
 Use the `pipe()` function created above to generate the
 embedding and then use `Array.from()` to convert the embedding to an array
 of `float32` values that you can pass to the
-[`vAdd()`]({{< relref "/commands/vadd" >}}) command to set the embedding.
+[`vAdd()`](/content/commands/vadd.md) command to set the embedding.
 
 The call to `vAdd()` also adds the `born` and `died` values from the
 `peopleData` object as attribute data. You can access this during a query
-or by using the [`vGetAttr()`]({{< relref "/commands/vgetattr" >}}) method.
+or by using the [`vGetAttr()`](/content/commands/vgetattr.md) method.
 
 {{< clients-example set="home_vecsets" step="add_data" lang_filter="Node.js" description="Practical pattern: Generate embeddings and add elements to a vector set with vAdd() and attribute metadata" difficulty="intermediate" >}}
 {{< /clients-example >}}
@@ -100,7 +100,7 @@ or by using the [`vGetAttr()`]({{< relref "/commands/vgetattr" >}}) method.
 You can now query the data in the set. The basic approach is to use the
 `pipe()` function to generate another embedding vector for the query text.
 (This is the same method used to add the elements to the set.) Then, pass
-the query vector to [`vSim()`]({{< relref "/commands/vsim" >}}) to return elements
+the query vector to [`vSim()`](/content/commands/vsim.md) to return elements
 of the set, ranked in order of similarity to the query.
 
 Start with a simple query for "actors":
@@ -149,7 +149,7 @@ mathematicians. This seems reasonable given the connection between mathematics
 and science.
 
 You can also use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 with `vSim()` to restrict the search further. For example,
 repeat the "science" query, but this time limit the results to people
 who died before the year 2000:
@@ -166,16 +166,16 @@ elements that have already been filtered out of the search.
 
 ## More information
 
-See the [vector sets]({{< relref "/develop/data-types/vector-sets" >}})
+See the [vector sets](/content/develop/data-types/vector-sets/_index.md)
 docs for more information and code examples. See the
-[Redis for AI]({{< relref "/develop/ai" >}}) section for more details
+[Redis for AI](/content/develop/ai/_index.md) section for more details
 about text embeddings and other AI techniques you can use with Redis.
 
 You may also be interested in
-[vector search]({{< relref "/develop/clients/nodejs/vecsearch" >}}).
+[vector search](/content/develop/clients/nodejs/vecsearch.md).
 This is a feature of
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 that lets you retrieve
-[JSON]({{< relref "/develop/data-types/json" >}}) and
-[hash]({{< relref "/develop/data-types/hashes" >}}) documents based on
+[JSON](/content/develop/data-types/json/_index.md) and
+[hash](/content/develop/data-types/hashes.md) documents based on
 vector data stored in their fields.


### PR DESCRIPTION
## Summary
- Converts `content/develop/clients/nodejs/` (12 files, flat directory — no nested subdirectories) from the `relref`/callout shortcodes to the DOC-6909 render hooks, per the DOC-7047 rollout.
- `{{< relref ... >}}` links unwrapped and rewritten to the canonical `/content/<path>.md[#anchor]` form (resolved by `layouts/_default/_markup/render-link.html`).
- 7 `{{< note >}}` callouts (all plain type, no nesting, no custom titles) converted to `> [!NOTE]`-style blockquotes (resolved by `layouts/_default/_markup/render-blockquote.html`).
- No percent-delimited `{{% alert ... %}}` shortcodes exist in this directory, so there was nothing to leave untouched for that known gap.
- Uses the tooling from PR #3937 (`build/migrate_shortcode_links.py`), which is not merged into this PR — it was pulled in as an untracked helper, used, then deleted before committing.

## Test plan
- [x] Confirmed no `{{< relref` or `{{< note/warning/tip/info/alert` shortcodes remain in the directory.
- [x] Confirmed no percent-delimited `{{% alert %}}` shortcodes exist in the directory.
- [x] Confirmed no nested block-level shortcodes were mangled inside any converted blockquote (none were nested to begin with).
- [x] Reviewed blockquote formatting for all 7 callouts: correct `> [!NOTE]` header, `>` prefix on every line, blank lines preserved as bare `>`.
- [x] Spot-checked rewritten links resolve to real content files in `/content/<path>.md` or `/content/<path>/_index.md` form with anchors preserved.
- [x] Ran `.claude/hooks/check_shortcode_paths.py --scan` over the directory: 0 files with issues.
- [ ] Full-site Hugo build verification (href-diff) is being run centrally by the ticket owner before merge — isolated worktrees here can't run the full Hugo build (gitignored generated deps like `data/examples.json` aren't present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout markup migration with no runtime or security impact; main risk is broken internal links if a canonical path is wrong.
> 
> **Overview**
> **DOC-7047 rollout** for `content/develop/clients/nodejs/`: twelve markdown pages are updated so internal navigation and callouts use Hugo render hooks instead of shortcodes.
> 
> **Links:** Every `{{< relref "..." >}}` reference is replaced with canonical `/content/...` paths (`.md` or `_index.md`, anchors preserved) for `render-link.html`.
> 
> **Callouts:** Seven plain `{{< note >}}` blocks become GitHub-style `> [!NOTE]` blockquotes for `render-blockquote.html` (client-side caching, SCH, query dialect notes, etc.).
> 
> No application or client-library code changes; `clients-example` / `jupyter-example` shortcodes are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12dca5bb4fea62fe7bcc37e2939d516906e3b00a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->