### PR TITLE
DEV: (feat/cmds) docs for CMS enhancements in 8.12

### DIFF
--- a/content/commands/cms.info.md
+++ b/content/commands/cms.info.md
@@ -29,7 +29,7 @@ summary: Returns information about a sketch
 syntax_fmt: CMS.INFO key
 title: CMS.INFO
 ---
-Returns width, depth and total count of the sketch.
+Returns width, depth, count, and cell size of the sketch.
 
 ## Required arguments
 
@@ -49,6 +49,8 @@ redis> CMS.INFO test
  4) (integer) 7
  5) count
  6) (integer) 0
+ 7) cell size
+ 8) (integer) 4
 ```
 
 ## Redis Software and Redis Cloud compatibility

--- a/content/commands/cms.initbydim.md
+++ b/content/commands/cms.initbydim.md
@@ -10,6 +10,10 @@ arguments:
   type: integer
 - name: depth
   type: integer
+- name: cell_size
+  optional: true
+  token: CELL_SIZE
+  type: integer
 categories:
 - docs
 - develop
@@ -30,7 +34,7 @@ railroad_diagram: /images/railroad/cms.initbydim.svg
 since: 2.0.0
 stack_path: docs/data-types/probabilistic
 summary: Initializes a Count-Min Sketch to dimensions specified by user
-syntax_fmt: CMS.INITBYDIM key width depth
+syntax_fmt: "CMS.INITBYDIM key width depth [CELL_SIZE\_cell_size]"
 title: CMS.INITBYDIM
 ---
 Initializes a Count-Min Sketch to dimensions specified by user.
@@ -55,10 +59,20 @@ Number of counter-arrays. Reduces the probability for an error of a certain size
 
 </details>
 
+## Optional arguments
+
+<details open><summary><code>CELL_SIZE cell_size</code></summary>
+
+The size, in bytes, of each counter in the sketch. Valid values are `1`, `2`, `4`, or `8`. A smaller cell size reduces memory usage but lowers the maximum count a cell can hold before overflowing. A larger cell size supports higher counts at the cost of more memory. Default is `4`.
+
+</details>
+
 ## Examples
 
 ```
 redis> CMS.INITBYDIM test 2000 5
+OK
+redis> CMS.INITBYDIM test2 2000 5 CELL_SIZE 1
 OK
 ```
 

--- a/content/commands/cms.initbyprob.md
+++ b/content/commands/cms.initbyprob.md
@@ -10,6 +10,10 @@ arguments:
   type: double
 - name: probability
   type: double
+- name: cell_size
+  optional: true
+  token: CELL_SIZE
+  type: integer
 categories:
 - docs
 - develop
@@ -30,7 +34,7 @@ railroad_diagram: /images/railroad/cms.initbyprob.svg
 since: 2.0.0
 stack_path: docs/data-types/probabilistic
 summary: Initializes a Count-Min Sketch to accommodate requested tolerances.
-syntax_fmt: CMS.INITBYPROB key error probability
+syntax_fmt: "CMS.INITBYPROB key error probability [CELL_SIZE\_cell_size]"
 title: CMS.INITBYPROB
 ---
 Initializes a Count-Min Sketch to accommodate requested tolerances.
@@ -55,10 +59,20 @@ The desired probability for inflated count. This should be a decimal value betwe
 
 </details>
 
+## Optional arguments
+
+<details open><summary><code>CELL_SIZE cell_size</code></summary>
+
+The size, in bytes, of each counter in the sketch. Valid values are `1`, `2`, `4`, or `8`. A smaller cell size reduces memory usage but lowers the maximum count a cell can hold before overflowing. A larger cell size supports higher counts at the cost of more memory. Default is `4`.
+
+</details>
+
 ## Examples
 
 ```
 redis> CMS.INITBYPROB test 0.001 0.01
+OK
+redis> CMS.INITBYPROB test2 0.001 0.01 CELL_SIZE 1
 OK
 ```
 

--- a/content/commands/cms.merge.md
+++ b/content/commands/cms.merge.md
@@ -49,7 +49,7 @@ This command's behavior varies in clustered Redis environments. See the [multi-k
 {{< /note >}}
 
 
-Merges several sketches into one sketch. All sketches must have identical width and depth. Weights can be used to multiply certain sketches. Default weight is 1. 
+Merges several sketches into one sketch. All sketches must have identical width, depth, and cell size. Weights can be used to multiply certain sketches. Default weight is 1. 
 
 ## Required arguments
 
@@ -101,13 +101,13 @@ OK
 One of the following:
 
 * [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
-* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: non-existent key or destination key is not of the same width and/or depth.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: non-existent key or destination key is not of the same width, depth, and/or cell size.
 
 -tab-sep-
 
 One of the following:
 
 * [Simple string reply]({{< relref "/develop/reference/protocol-spec#simple-strings" >}}) `OK` if executed correctly.
-* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: non-existent key or destination key is not of the same width and/or depth.
+* [Simple error reply]({{< relref "/develop/reference/protocol-spec#simple-errors" >}}) in these cases: non-existent key or destination key is not of the same width, depth, and/or cell size.
 
 {{< /multitabs >}}

--- a/data/commands_redisbloom.json
+++ b/data/commands_redisbloom.json
@@ -503,6 +503,12 @@
       {
         "name": "depth",
         "type": "integer"
+      },
+      {
+        "name": "cell_size",
+        "type": "integer",
+        "token": "CELL_SIZE",
+        "optional": true
       }
     ],
     "since": "2.0.0",
@@ -523,6 +529,12 @@
       {
         "name": "probability",
         "type": "double"
+      },
+      {
+        "name": "cell_size",
+        "type": "integer",
+        "token": "CELL_SIZE",
+        "optional": true
       }
     ],
     "since": "2.0.0",

--- a/static/images/railroad/cms.initbydim.svg
+++ b/static/images/railroad/cms.initbydim.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="62" viewBox="0 0 461.0 62" width="461.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="71" viewBox="0 0 724.0 71" width="724.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -43,9 +43,14 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 
 /* ]]> */
 </style><g>
-<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
-<path d="M50 31h0.0"></path><path d="M411.0 31h0.0"></path><g class="terminal ">
-<path d="M50.0 31h0.0"></path><path d="M180.5 31h0.0"></path><rect height="22" rx="10" ry="10" width="130.5" x="50.0" y="20"></rect><text x="115.25" y="35">CMS.INITBYDIM</text></g><path d="M180.5 31h10"></path><path d="M190.5 31h10"></path><g class="non-terminal ">
-<path d="M200.5 31h0.0"></path><path d="M246.0 31h0.0"></path><rect height="22" width="45.5" x="200.5" y="20"></rect><text x="223.25" y="35">key</text></g><path d="M246.0 31h10"></path><path d="M256.0 31h10"></path><g class="non-terminal ">
-<path d="M266.0 31h0.0"></path><path d="M328.5 31h0.0"></path><rect height="22" width="62.5" x="266.0" y="20"></rect><text x="297.25" y="35">width</text></g><path d="M328.5 31h10"></path><path d="M338.5 31h10"></path><g class="non-terminal ">
-<path d="M348.5 31h0.0"></path><path d="M411.0 31h0.0"></path><rect height="22" width="62.5" x="348.5" y="20"></rect><text x="379.75" y="35">depth</text></g></g><path d="M411.0 31h10"></path><path d="M 421.0 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M674.0 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M180.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="130.5" x="50.0" y="29"></rect><text x="115.25" y="44">CMS.INITBYDIM</text></g><path d="M180.5 40h10"></path><path d="M190.5 40h10"></path><g class="non-terminal ">
+<path d="M200.5 40h0.0"></path><path d="M246.0 40h0.0"></path><rect height="22" width="45.5" x="200.5" y="29"></rect><text x="223.25" y="44">key</text></g><path d="M246.0 40h10"></path><path d="M256.0 40h10"></path><g class="non-terminal ">
+<path d="M266.0 40h0.0"></path><path d="M328.5 40h0.0"></path><rect height="22" width="62.5" x="266.0" y="29"></rect><text x="297.25" y="44">width</text></g><path d="M328.5 40h10"></path><path d="M338.5 40h10"></path><g class="non-terminal ">
+<path d="M348.5 40h0.0"></path><path d="M411.0 40h0.0"></path><rect height="22" width="62.5" x="348.5" y="29"></rect><text x="379.75" y="44">depth</text></g><path d="M411.0 40h10"></path><g>
+<path d="M421.0 40h0.0"></path><path d="M674.0 40h0.0"></path><path d="M421.0 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M441.0 20h213.0"></path></g><path d="M654.0 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M421.0 40h20"></path><g>
+<path d="M441.0 40h0.0"></path><path d="M654.0 40h0.0"></path><g class="terminal ">
+<path d="M441.0 40h0.0"></path><path d="M537.5 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="441.0" y="29"></rect><text x="489.25" y="44">CELL&#95;SIZE</text></g><path d="M537.5 40h10"></path><path d="M547.5 40h10"></path><g class="non-terminal ">
+<path d="M557.5 40h0.0"></path><path d="M654.0 40h0.0"></path><rect height="22" width="96.5" x="557.5" y="29"></rect><text x="605.75" y="44">cell&#95;size</text></g></g><path d="M654.0 40h20"></path></g></g><path d="M674.0 40h10"></path><path d="M 684.0 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>

--- a/static/images/railroad/cms.initbyprob.svg
+++ b/static/images/railroad/cms.initbyprob.svg
@@ -1,4 +1,4 @@
-<svg class="railroad-diagram" height="62" viewBox="0 0 520.5 62" width="520.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg class="railroad-diagram" height="71" viewBox="0 0 783.5 71" width="783.5" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <defs>
 <style type="text/css"><![CDATA[
 svg.railroad-diagram { background-color: transparent; }
@@ -43,9 +43,14 @@ circle { fill: #DC382D !important; stroke: #DC382D !important; }
 
 /* ]]> */
 </style><g>
-<path d="M20 21v20m10 -20v20m-10 -10h20"></path></g><path d="M40 31h10"></path><g>
-<path d="M50 31h0.0"></path><path d="M470.5 31h0.0"></path><g class="terminal ">
-<path d="M50.0 31h0.0"></path><path d="M189.0 31h0.0"></path><rect height="22" rx="10" ry="10" width="139.0" x="50.0" y="20"></rect><text x="119.5" y="35">CMS.INITBYPROB</text></g><path d="M189.0 31h10"></path><path d="M199.0 31h10"></path><g class="non-terminal ">
-<path d="M209.0 31h0.0"></path><path d="M254.5 31h0.0"></path><rect height="22" width="45.5" x="209.0" y="20"></rect><text x="231.75" y="35">key</text></g><path d="M254.5 31h10"></path><path d="M264.5 31h10"></path><g class="non-terminal ">
-<path d="M274.5 31h0.0"></path><path d="M337.0 31h0.0"></path><rect height="22" width="62.5" x="274.5" y="20"></rect><text x="305.75" y="35">error</text></g><path d="M337.0 31h10"></path><path d="M347.0 31h10"></path><g class="non-terminal ">
-<path d="M357.0 31h0.0"></path><path d="M470.5 31h0.0"></path><rect height="22" width="113.5" x="357.0" y="20"></rect><text x="413.75" y="35">probability</text></g></g><path d="M470.5 31h10"></path><path d="M 480.5 31 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>
+<path d="M20 30v20m10 -20v20m-10 -10h20"></path></g><path d="M40 40h10"></path><g>
+<path d="M50 40h0.0"></path><path d="M733.5 40h0.0"></path><g class="terminal ">
+<path d="M50.0 40h0.0"></path><path d="M189.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="139.0" x="50.0" y="29"></rect><text x="119.5" y="44">CMS.INITBYPROB</text></g><path d="M189.0 40h10"></path><path d="M199.0 40h10"></path><g class="non-terminal ">
+<path d="M209.0 40h0.0"></path><path d="M254.5 40h0.0"></path><rect height="22" width="45.5" x="209.0" y="29"></rect><text x="231.75" y="44">key</text></g><path d="M254.5 40h10"></path><path d="M264.5 40h10"></path><g class="non-terminal ">
+<path d="M274.5 40h0.0"></path><path d="M337.0 40h0.0"></path><rect height="22" width="62.5" x="274.5" y="29"></rect><text x="305.75" y="44">error</text></g><path d="M337.0 40h10"></path><path d="M347.0 40h10"></path><g class="non-terminal ">
+<path d="M357.0 40h0.0"></path><path d="M470.5 40h0.0"></path><rect height="22" width="113.5" x="357.0" y="29"></rect><text x="413.75" y="44">probability</text></g><path d="M470.5 40h10"></path><g>
+<path d="M480.5 40h0.0"></path><path d="M733.5 40h0.0"></path><path d="M480.5 40a10 10 0 0 0 10 -10v0a10 10 0 0 1 10 -10"></path><g>
+<path d="M500.5 20h213.0"></path></g><path d="M713.5 20a10 10 0 0 1 10 10v0a10 10 0 0 0 10 10"></path><path d="M480.5 40h20"></path><g>
+<path d="M500.5 40h0.0"></path><path d="M713.5 40h0.0"></path><g class="terminal ">
+<path d="M500.5 40h0.0"></path><path d="M597.0 40h0.0"></path><rect height="22" rx="10" ry="10" width="96.5" x="500.5" y="29"></rect><text x="548.75" y="44">CELL&#95;SIZE</text></g><path d="M597.0 40h10"></path><path d="M607.0 40h10"></path><g class="non-terminal ">
+<path d="M617.0 40h0.0"></path><path d="M713.5 40h0.0"></path><rect height="22" width="96.5" x="617.0" y="29"></rect><text x="665.25" y="44">cell&#95;size</text></g></g><path d="M713.5 40h20"></path></g></g><path d="M733.5 40h10"></path><path d="M 743.5 40 h 20 m -10 -10 v 20 m 10 -20 v 20"></path></g></svg>


### PR DESCRIPTION
This is a Redis OSS 8.12 feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated command metadata/diagrams only; no runtime or application code changes.
> 
> **Overview**
> Documents Redis OSS **8.12** Count-Min Sketch (**CMS**) enhancements around configurable counter **cell size**.
> 
> **`CMS.INITBYDIM`** and **`CMS.INITBYPROB`** now document an optional **`CELL_SIZE cell_size`** argument (bytes per counter: `1`, `2`, `4`, or `8`; default `4`), with updated syntax, examples, command metadata in `data/commands_redisbloom.json`, and railroad diagrams.
> 
> **`CMS.INFO`** is updated to include **cell size** in the returned sketch metadata and example output. **`CMS.MERGE`** docs now require matching **width, depth, and cell size** across sketches, including merge error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63e2e81a2bb8a83ef7b068d7e2d0682ac8e7a54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->