### PR TITLE
RC: Clarify Active-Passive External source can't cross Redis Cloud accounts

### DIFF
--- a/content/operate/rc/databases/migrate-databases.md
+++ b/content/operate/rc/databases/migrate-databases.md
@@ -54,8 +54,6 @@ To migrate data using Active-Passive syncing, specify the target database as an 
 {{< note >}}
 Before you use Active-Passive, be aware of the following limitations:
 
-- An error will appear when syncing the two databases if the source and target databases are hosted on different Redis Cloud accounts. [Contact support](https://redis.io/support/) if you want to migrate a database between accounts using Active-Passive.
-
 - As long as Active-Passive is enabled, data in the target database will not expire and will not be evicted regardless of the set [data eviction policy]({{< relref "/operate/rc/databases/configuration/data-eviction-policies.md" >}}). **Do not write to the target database while Active-Passive is enabled.** We recommend that you turn off Active-Passive after the databases are synced. 
 
 - Turning on Active-Passive will flush the target database. Make sure that your target database has no important data before you turn on Active-Passive.
@@ -83,13 +81,15 @@ Follow these detailed steps to migrate data using Active-Passive syncing:
 
     {{<image filename="images/rc/migrate-data-add-active-passive.png" alt="The Add Active-Passive Redis screen." width=70% >}}
 
-    - Select **Current account** if the source database is located in this Redis Cloud account. 
-    
-        Select the source database from the **Source database** list. You can type in the database's name to find it.
+    - **Source database in this Redis Cloud account**: select **Current account**, then select the source database from the **Source database** list. You can type in the database's name to find it.
 
         {{<image filename="images/rc/database-add-account-path-list.png" alt="Select the Source database from the database list." width=70% >}}
 
-    - If the source database is hosted externally, select **External**.
+    - **Source database not hosted on Redis Cloud** (for example, a self-managed Redis deployment): select **External**.
+
+        {{< note >}}
+Don't select **External** to sync from a database hosted in a *different* Redis Cloud account. Redis Cloud rejects Active-Passive connections between accounts and returns an error, even if you enter that database's public endpoint here. [Contact support](https://redis.io/support/) to migrate a database between Redis Cloud accounts using Active-Passive.
+        {{< /note >}}
 
         1.  In the **Enter the source URI** field, type `redis://` and then paste in the public endpoint details. 
 


### PR DESCRIPTION
The cross-account limitation was stated in a general note before the configuration steps, disconnected from where a customer actually picks External as the source location. Move it inline with that step, and split "Current account" vs. "External" into explicit cases so it's clear External is only for databases not hosted on Redis Cloud.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to migration guidance with no product or code behavior changes.
> 
> **Overview**
> **Clarifies when to use Current account vs External** in the Active-Passive migration walkthrough by labeling the two paths explicitly (same Redis Cloud account vs sources not on Redis Cloud, such as self-managed Redis).
> 
> **Moves the cross-account limitation** out of the upfront limitations note and into a **note directly under the External option**, stating that **External must not be used** to sync from a database in another Redis Cloud account (the connection is rejected even with a public endpoint) and to **contact support** for cross-account migration.
> 
> The general limitations note no longer mentions cross-account syncing; eviction/flush warnings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 777241d882a973d5ac93540a76af48a54730e3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->