### PR TITLE
Note stricter Active-Active multi-key command rules on RC clustering …

### DIFF
--- a/content/operate/rc/databases/configuration/clustering.md
+++ b/content/operate/rc/databases/configuration/clustering.md
@@ -77,7 +77,9 @@ are supported, with the following limitations:
     mapped to the same hash slot.
 1. **Variadic commands**: The use of (MGET, MSET, HMGET, HMSET, etc..)
     and pipelining are supported with Redis Cloud cluster
-    like if it were a non-cluster DB.
+    as if it were a non-cluster DB.
+
+    [Active-Active databases]({{< relref "/operate/rc/databases/active-active" >}}) have stricter rules: multi-key write commands (DEL, MSET, UNLINK) can only run on keys in the same slot. Only MGET, EXISTS, and TOUCH are allowed across slots. See [Multi-key operations on Active-Active databases]({{< relref "/develop/using-commands/multi-key-operations#active-active-databases" >}}) for details.
 
 ## Hashing policies and hash tags {#manage-the-hashing-policy}
 


### PR DESCRIPTION
…page

The variadic-commands note said MGET/MSET/HMGET/HMSET work as if the database were non-clustered, but didn't call out that Active-Active databases restrict multi-key writes (DEL, MSET, UNLINK) to a single slot and only allow MGET/EXISTS/TOUCH across slots. Customers could assume cross-slot variadic writes work in Active-Active when they don't. Also fixes "like if it" to "as if it".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only clarification and cross-links; no product or runtime behavior changes.
> 
> **Overview**
> Updates the Redis Cloud **Clustering** doc so the variadic-commands note no longer implies cross-slot multi-key writes work everywhere.
> 
> Under **Variadic commands**, fixes wording from “like if it were” to **“as if it were”** a non-cluster DB, and adds an **Active-Active** callout: multi-key writes (`DEL`, `MSET`, `UNLINK`) are limited to keys in the same slot, while only `MGET`, `EXISTS`, and `TOUCH` may span slots, with links to the Active-Active database page and **Multi-key operations on Active-Active databases**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1246b0b20c7b719a97caab5d139ea0ce50f18e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->