### PR TITLE
Show a geo key as a map, and measure from a place

### DIFF
--- a/static/css/redis-workbench.css
+++ b/static/css/redis-workbench.css
@@ -1196,6 +1196,73 @@ body.rwb-dragging-y * {
    comes later in this file and, at equal specificity, was winning. */
 .rwb-text.rwb-failed { color: #fca5a5; }          /* red-300 */
 
+/* ---- panes inside a value ----
+   Where one value has two ways of being read (a geo key's map and its members),
+   a strip of tabs rather than one long scroll. Smaller than the dock's own tabs:
+   these sit inside a column, not across the panel. */
+.rwb-vtabs {
+  display: flex;
+  gap: 0.25rem;
+  margin: 0 0.5rem 0.5rem;
+  border-bottom: 1px solid var(--rwb-line-soft);
+}
+
+.rwb-vtab {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.125rem 0.375rem;
+}
+
+/* ---- the map ----
+   A geo key's members, plotted. Fitted rather than stretched (the SVG keeps its
+   aspect), so the dots are round and the directions are honest. */
+.rwb-map { margin: 0 0 0.5rem; }
+
+/* Sized in the markup, from the column it is drawn in, so the drawing is never
+   scaled and its labels stay the size of text. max-width keeps it honest if the
+   column narrows between the measurement and the next redraw. */
+.rwb-map-plot {
+  display: block;
+  max-width: 100%;
+}
+
+.rwb-map-dot { fill: #0284c7; }
+
+/* Every dot is a control ("measure from here"), and the one being measured from
+   wears a ring so it is findable among the rest. */
+.rwb-map-dot[role="button"] { cursor: pointer; }
+.rwb-map-dot[role="button"]:hover { fill: #38bdf8; }
+
+.rwb-map-dot-from {
+  fill: #38bdf8;
+  stroke: var(--rwb-ink);
+  stroke-width: 1.5;
+}
+
+.rwb-map-dot:focus-visible {
+  outline: 2px solid var(--rwb-focus);
+  outline-offset: 2px;
+}
+
+/* The graticule: whole degrees, well under the places. */
+.rwb-map-rule {
+  stroke: var(--rwb-line-soft);
+  stroke-width: 1;
+}
+
+.rwb-map-tick {
+  fill: var(--rwb-muted);
+  font-size: 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.rwb-map-label {
+  fill: var(--rwb-ink-2);
+  font-family: ui-monospace, "Cascadia Code", Menlo, monospace;
+  font-size: 9px;
+}
+
 /* ---- bars ----
    VSIM's neighbours: one row per result in the order the server returned them,
    with the score printed beside the bar. A score runs 1 (identical) to 0

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2740,8 +2740,19 @@
     { unit: 'mi', label: 'mi', per: 0.621371 }
   ];
 
-  dock.geoOptions = function () {
-    if (!this.geo) this.geo = { from: null, unit: 'km', radius: null };
+  dock.geoOptions = function (name) {
+    if (!this.geo) this.geo = { name: name, from: null, unit: 'km', radius: null };
+    /* Where to measure from and how far to look belong to the key they were
+       chosen on. Carried across, a member name two keys share would start a
+       search the reader never asked for on the second one, and a radius fitted
+       to Sicily is the wrong radius for a key of bike stations — and being set
+       already, it would not be fitted again. km or mi is a preference about
+       reading rather than about the data, so that one follows the reader. */
+    if (this.geo.name !== name) {
+      this.geo.name = name;
+      this.geo.from = null;
+      this.geo.radius = null;
+    }
     return this.geo;
   };
 
@@ -2762,7 +2773,7 @@
       self.renderValue(key, { view: table, commands: ran });
     }
     var members = table.geo.slice(0, MAX_MAP_POINTS);
-    var search = this.geoOptions();
+    var search = this.geoOptions(key.name);
     var where = 'GEOPOS ' + quote(key.name) + ' ' + members.map(quote).join(' ');
     /* Only for a member this key still has: a sweep can have removed the one the
        reader picked. */
@@ -2861,7 +2872,7 @@
   /* Measure from here. Re-reads rather than patching the view: the map has to
      mark the new origin and the distances all change. */
   dock.pickGeoFrom = function (key, name) {
-    var search = this.geoOptions();
+    var search = this.geoOptions(key.name);
     search.from = search.from === name ? null : name;
     return this.openKey(key.name);
   };

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2380,10 +2380,7 @@
         });
       }
       self.end();
-      if (view.geo) {
-        self.geoKeys[name] = true;
-        return self.readGeo(key, view, probe.commands, !known);
-      }
+      if (view.geo) return self.readGeo(key, view, probe.commands);
     }, function () {
       self.end();
     });
@@ -2850,13 +2847,21 @@
     };
   };
 
-  dock.readGeo = function (key, table, ran, painted) {
+  dock.readGeo = function (key, table, ran) {
     var self = this;
-    /* The members table, for the cases where there is no map to draw and
-       nothing has been drawn yet. */
-    function fallback() {
-      if (painted || self.selected !== key.name) return;
-      self.renderValue(key, { view: table, commands: ran });
+    /* No coordinates, so no map — said in the map pane rather than left as it
+       was. The pane is already up saying it is reading them, and returning
+       without drawing anything left that sentence on screen for good: `run`
+       resolves even when a command errors, so there is no rejection to fall
+       back from. */
+    function noMap(why) {
+      if (self.selected !== key.name) return;
+      self.renderValue(key, {
+        commands: ran,
+        view: self.geoPanes(key, table, function () {
+          return el('p', 'rwb-hint', why);
+        })
+      });
     }
     var members = table.geo.slice(0, MAX_MAP_POINTS);
     var search = this.geoOptions(key.name);
@@ -2889,14 +2894,22 @@
         places.push({ name: members[index], lon: lon, lat: lat });
       });
       /* No coordinates came back — every member was removed between the two
-         reads, or none of them decoded. There is no map to draw, so the members
-         are what this key has to show. */
-      if (!places.length) return fallback();
+         reads, or none of them decoded. */
+      if (!places.length) {
+        var trouble = replies[0] && replies[0].error
+          ? '(error) ' + cellText(replies[0].value)
+          : 'No coordinates came back for these members.';
+        return noMap(trouble);
+      }
 
       function show(ranAll, found) {
         /* The reader may have opened something else while this was in flight.
            Their choice outranks a reply that was already on its way. */
         if (self.selected !== key.name) return;
+        /* Only now has this key had a map drawn for it. Set before the
+           coordinates arrived, a key whose GEOPOS failed would have counted as
+           mapped, and the next open of it would have skipped its first paint. */
+        self.geoKeys[key.name] = true;
         self.renderValue(key, {
           commands: ran.concat(ranAll),
           view: self.geoPanes(key, table, function () {
@@ -2941,9 +2954,9 @@
         show(commands.concat([query]), found[0]);
       });
     }, function () {
-      /* GEOPOS itself failed. Whatever the reason, the members are still worth
-         showing if nothing else has been. */
-      fallback();
+      /* The request itself never got a reply — offline, or the sandbox refused
+         the batch. */
+      noMap('Could not read where these places are.');
     });
   };
 

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -306,6 +306,34 @@
   var GEO_SCORE_FLOOR = 1e12;
   var GEO_SCORE_CEILING = 4503599627370496;      /* 2^52, the whole geohash space */
 
+  /* Where a map is on offer at all. A geo key is a sorted set — GEOADD writes
+     the geohash as the score — and nothing in the reply says which it is, so a
+     score alone cannot decide it: a rate limiter written with
+     `ZADD key <now_ms> <request>` has scores of about 1.76e12, inside the
+     geohash range, and those decode to a pile of dots off Antarctica.
+
+     The page is the honest signal. On the pages that teach these commands the
+     reader is looking at coordinates; anywhere else a sorted set is a sorted
+     set. The paths are matched loosely at the end, so /commands/geoadd/ works
+     the same under /docs/latest/ and under a staging prefix. */
+  var GEO_COMMANDS = ['geoadd', 'geodist', 'geohash', 'geopos', 'georadius',
+    'georadiusbymember', 'georadiusbymember_ro', 'geosearch', 'geosearchstore'];
+
+  function pageWantsMap() {
+    var path;
+    try {
+      path = window.location.pathname.replace(/\/+$/, '');
+    } catch (err) {
+      return false;
+    }
+    if (/\/develop\/data-types\/geospatial$/.test(path)) return true;
+    for (var i = 0; i < GEO_COMMANDS.length; i += 1) {
+      var tail = '/commands/' + GEO_COMMANDS[i];
+      if (path.length >= tail.length && path.slice(-tail.length) === tail) return true;
+    }
+    return false;
+  }
+
   function looksGeo(rows) {
     if (!rows.length) return false;
     return rows.every(function (row) {
@@ -775,9 +803,9 @@
               kind: 'table',
               head: ['Member', 'Score'],
               rows: rows,
-              /* A geo key *is* a sorted set — GEOADD writes the geohash as the
-                 score — so the map is offered off the same reply. */
-              geo: looksGeo(rows)
+              /* The map is offered off this same reply, on the pages where a
+                 sorted set of geohashes is what the reader came to read. */
+              geo: pageWantsMap() && looksGeo(rows)
                 ? rows.map(function (row) { return cellText(row[0]); }) : null,
               limited: known && size > PREVIEW_ITEMS
                 ? { shown: rows.length, of: plural(size, 'member') } : null

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2774,10 +2774,18 @@
     }
     var members = table.geo.slice(0, MAX_MAP_POINTS);
     var search = this.geoOptions(key.name);
-    var where = 'GEOPOS ' + quote(key.name) + ' ' + members.map(quote).join(' ');
     /* Only for a member this key still has: a sweep can have removed the one the
-       reader picked. */
-    var from = search.from && members.indexOf(search.from) !== -1 ? search.from : null;
+       reader picked. Looked for in the whole key rather than in the slice being
+       drawn — the distances come from GEOSEARCH, which answers with the nearest
+       members, and the nearest need not be among the first MAX_MAP_POINTS in
+       geohash order. Clicking one of those rows used to set an origin this read
+       then treated as missing, and the measurement disappeared. */
+    var from = search.from && table.geo.indexOf(search.from) !== -1
+      ? search.from : null;
+    /* And it is plotted whether or not it fell in the slice, so the map can mark
+       where the measuring is from. */
+    if (from && members.indexOf(from) === -1) members.push(from);
+    var where = 'GEOPOS ' + quote(key.name) + ' ' + members.map(quote).join(' ');
     /* Both in one batch when the radius is already known. It is not known on the
        first pick, or after the unit changed, and fitting one needs the
        coordinates GEOPOS is being asked for — so that case takes a second round

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2985,6 +2985,14 @@
   dock.renderDistances = function (section) {
     var self = this;
     var reply = section.reply;
+    /* No reply yet, which is not the same as an empty one. The map goes up
+       before the search that measures from it comes back — on the first pick and
+       after a unit change, where the radius has to be fitted to the coordinates
+       first — and reading that as "nothing in range" told the reader something
+       untrue about their own data for a round trip. */
+    if (reply === null || reply === undefined) {
+      return el('p', 'rwb-hint', 'Measuring from ' + section.from + '…');
+    }
     if (reply && reply.error) {
       return el('p', 'rwb-text rwb-failed', '(error) ' + cellText(reply.value));
     }

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -317,7 +317,8 @@
      set. The paths are matched loosely at the end, so /commands/geoadd/ works
      the same under /docs/latest/ and under a staging prefix. */
   var GEO_COMMANDS = ['geoadd', 'geodist', 'geohash', 'geopos', 'georadius',
-    'georadiusbymember', 'georadiusbymember_ro', 'geosearch', 'geosearchstore'];
+    'georadius_ro', 'georadiusbymember', 'georadiusbymember_ro', 'geosearch',
+    'geosearchstore'];
 
   function pageWantsMap() {
     var path;

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2720,9 +2720,12 @@
     }, function () { self.end(); });
   };
 
-  /* How many places to plot. Beyond this the dots are a smudge and the labels are
-     unreadable, and the table underneath still holds every one of them. */
-  var MAX_MAP_POINTS = 60;
+  /* How many places to plot, and how many distances to measure. A readability
+     limit rather than a technical one: GEOPOS with this many members is 151
+     arguments against the sandbox's cap of 1024, so a few hundred would fit in
+     the one command. Past this the dots crowd into a smudge — and the members
+     table underneath still holds every one of them, whatever the map draws. */
+  var MAX_MAP_POINTS = 150;
 
   /* Which pane of a value the reader last had open, by key name. */
   dock.valueTabs = {};

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -1730,6 +1730,9 @@
     this.expiredName = null;
     this.openElement = null;
     this.jsonPath = null;
+    /* No key survives a flush, so no map has been drawn for one. */
+    this.geoKeys = {};
+    this.valueShown = null;
     /* Nothing left to filter by. */
     this.indexFilter = null;
     this.indexDocs = null;
@@ -2249,6 +2252,10 @@
   /* Nothing selected, or nothing left to select. Says which, because "no keys
      yet" and "pick one" are different situations for a reader. */
   dock.clearValue = function () {
+    /* No key's value is on screen now — said here as well as in renderValue,
+       because a geo key that is reopened checks this to decide whether its map
+       is still up. Left stale, it would hold the empty pane while GEOPOS ran. */
+    this.valueShown = null;
     this.valuePane.replaceChildren();
     this.valuePane.appendChild(el('p', 'rwb-empty', this.expiredName
       ? this.expiredName + ' has expired.'
@@ -2398,6 +2405,8 @@
   dock.renderVectorElement = function (key, element, detail) {
     var self = this;
     var pane = this.valuePane;
+    /* An element of a vector set, not the value of a key. */
+    this.valueShown = null;
     pane.replaceChildren();
 
     var head = el('div', 'rwb-value-head');
@@ -3082,6 +3091,8 @@
      Insight puts under it. Everything else FT.INFO returns is left to FT.INFO. */
   dock.renderIndex = function (name, info) {
     var pane = this.valuePane;
+    /* An index's schema, not the value of a key. */
+    this.valueShown = null;
     pane.replaceChildren();
 
     var head = el('div', 'rwb-value-head');

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -793,9 +793,15 @@
           }
         };
       case 'zset':
+        /* On a geo page this one reply is also the map's list of places, so it
+           reads as much of the key as the map can draw rather than the preview
+           every other type gets: a map of the first hundred members of a
+           two-hundred-member key is a map with a hole in it, and the hole is
+           wherever geohash order happens to cut. */
+        var zsetWanted = pageWantsMap() ? MAX_MAP_POINTS : PREVIEW_ITEMS;
         return {
           commands: ['ZRANGE ' + key + ' 0 '
-            + (known && size <= PREVIEW_ITEMS ? '-1' : String(PREVIEW_ITEMS - 1))
+            + (known && size <= zsetWanted ? '-1' : String(zsetWanted - 1))
             + ' WITHSCORES'],
           build: function (r) {
             var rows = pairs(ok(r[0]));
@@ -807,7 +813,7 @@
                  sorted set of geohashes is what the reader came to read. */
               geo: pageWantsMap() && looksGeo(rows)
                 ? rows.map(function (row) { return cellText(row[0]); }) : null,
-              limited: known && size > PREVIEW_ITEMS
+              limited: known && size > zsetWanted
                 ? { shown: rows.length, of: plural(size, 'member') } : null
             };
           }
@@ -2757,12 +2763,12 @@
     }, function () { self.end(); });
   };
 
-  /* How many places to plot, and how many distances to measure. A readability
-     limit rather than a technical one: GEOPOS with this many members is 151
-     arguments against the sandbox's cap of 1024, so a few hundred would fit in
-     the one command. Past this the dots crowd into a smudge — and the members
-     table underneath still holds every one of them, whatever the map draws. */
-  var MAX_MAP_POINTS = 150;
+  /* How many places to read, plot and measure. This is the argument budget, not
+     a matter of taste: GEOPOS names every member it asks about, and the backend
+     refuses a command of more than 1024 arguments. Every place that is read is
+     drawn — a map that quietly leaves some out is worse than a crowded one —
+     and a key with more members than this says so under the plot. */
+  var MAX_MAP_POINTS = 1000;
 
   /* Which pane of a value the reader last had open, by key name. */
   dock.valueTabs = {};
@@ -2875,7 +2881,11 @@
                 var block = el('div');
                 block.appendChild(renderMap(places, {
                   from: from,
-                  of: table.geo.length > places.length ? table.geo.length : 0,
+                  /* Against the key's own length: the list this was read from
+                     is itself capped, so comparing the two said nothing about
+                     the members that were never read. */
+                  of: typeof key.size === 'number' && key.size > places.length
+                    ? key.size : 0,
                   /* The pane is in the document already, so its width is known
                      before the map is built. Less the padding either side. */
                   width: (self.valuePane.clientWidth || 0) - 20,

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -292,6 +292,29 @@
     return cli().formatReply(value);
   }
 
+  /* Does this sorted set hold places? There is no geo type to ask about: GEOADD
+     writes a member's 52-bit geohash as its score, and TYPE answers `zset` either
+     way. A geohash is a whole number in the top of that range — 1367859900908957
+     for San Francisco — where the scores of a leaderboard, a rate limiter or a
+     priority queue are small, and often fractional. So: every score a whole
+     number above the floor, or no map.
+
+     Getting it wrong is cheap in one direction and not the other. A plain sorted
+     set drawn as a map would be nonsense — GEOPOS decodes score 1 to the corner
+     of the world, (-180, -85.05) — so the test is deliberately strict, and a geo
+     key whose members all sit near longitude -180 simply keeps its table. */
+  var GEO_SCORE_FLOOR = 1e12;
+  var GEO_SCORE_CEILING = 4503599627370496;      /* 2^52, the whole geohash space */
+
+  function looksGeo(rows) {
+    if (!rows.length) return false;
+    return rows.every(function (row) {
+      var score = Number(cellText(row[1]));
+      return isFinite(score) && score % 1 === 0
+        && score >= GEO_SCORE_FLOOR && score <= GEO_SCORE_CEILING;
+    });
+  }
+
   /* [a, b, c, d] -> [[a, b], [c, d]]; the RESP2 shape of HGETALL, ZRANGE
      WITHSCORES, TS.INFO and friends. */
   function pairs(flat) {
@@ -752,6 +775,10 @@
               kind: 'table',
               head: ['Member', 'Score'],
               rows: rows,
+              /* A geo key *is* a sorted set — GEOADD writes the geohash as the
+                 score — so the map is offered off the same reply. */
+              geo: looksGeo(rows)
+                ? rows.map(function (row) { return cellText(row[0]); }) : null,
               limited: known && size > PREVIEW_ITEMS
                 ? { shown: rows.length, of: plural(size, 'member') } : null
             };
@@ -880,6 +907,12 @@
     setupRan: {},
     ranCommands: [],
     jsonPath: null,
+    /* The key the value column is showing, so a redraw of the same one can keep
+       the reader's scroll position. */
+    valueShown: null,
+    /* Keys a map has been drawn for, by name: their second round trip is
+       expected, so the pane waits for it rather than flashing the table. */
+    geoKeys: {},
     selected: null,
     truncated: false,
     /* command batches seen while closed, discovered at first open */
@@ -1130,6 +1163,9 @@
     split.appendChild(this.columnDivider('Resize the key list', 1));
 
     var valueColumn = el('div', 'rwb-col rwb-col-value');
+    /* The column scrolls, not the pane inside it — so this is what has to be put
+       back where the reader left it when the pane is redrawn. */
+    this.valueColumn = valueColumn;
     var valueHead = el('div', 'rwb-col-head');
     valueHead.appendChild(el('span', 'rwb-col-title', 'Value'));
     valueColumn.appendChild(valueHead);
@@ -2275,11 +2311,22 @@
       return Promise.resolve();
     }
     return run(commands).then(function (replies) {
-      self.renderValue(key, {
-        view: probe.build(replies),
-        commands: probe.commands
-      });
+      var view = probe.build(replies);
+      /* The table first, the map a moment later. Where the coordinates are can
+         only be asked once the members are known, so it is a second round trip —
+         and one worth not making the reader wait for.
+
+         Except on a key already known to be geo: then what is on screen is a
+         map, and painting the members table over it for the length of a round
+         trip put a frame of table between every click on a map and the map
+         coming back. Nothing is drawn until the coordinates land. */
+      var known = view.geo && self.geoKeys[name];
+      if (!known) self.renderValue(key, { view: view, commands: probe.commands });
       self.end();
+      if (view.geo) {
+        self.geoKeys[name] = true;
+        return self.readGeo(key, view, probe.commands);
+      }
     }, function () {
       self.end();
     });
@@ -2670,6 +2717,277 @@
     }, function () { self.end(); });
   };
 
+  /* How many places to plot. Beyond this the dots are a smudge and the labels are
+     unreadable, and the table underneath still holds every one of them. */
+  var MAX_MAP_POINTS = 60;
+
+  /* Which pane of a value the reader last had open, by key name. */
+  dock.valueTabs = {};
+
+  dock.chosenPane = function (of, panes) {
+    var wanted = this.valueTabs[of];
+    var found = panes.filter(function (spec) { return spec.id === wanted; })[0];
+    return found || panes[0];
+  };
+
+  /* Distances are asked for in one of these; the second is what a reader in the
+     United States would reach for. GEOSEARCH takes both. */
+  var GEO_UNITS = [
+    { unit: 'km', label: 'km', per: 1 },
+    { unit: 'mi', label: 'mi', per: 0.621371 }
+  ];
+
+  dock.geoOptions = function () {
+    if (!this.geo) this.geo = { from: null, unit: 'km', radius: null };
+    return this.geo;
+  };
+
+  /* Where the members of a geo key are, and — once one of them has been picked —
+     how far the rest are from it.
+
+     GEOPOS rather than decoding the geohash scores here: it is one command, it is
+     the command a reader would run, and it goes in the READ WITH line with the
+     rest. Distances come from GEOSEARCH FROMMEMBER rather than a GEODIST per
+     pair: one command instead of N, sorted by the server, and the same command
+     the docs teach for "what is near this". */
+  dock.readGeo = function (key, table, ran) {
+    var self = this;
+    var members = table.geo.slice(0, MAX_MAP_POINTS);
+    var search = this.geoOptions();
+    var where = 'GEOPOS ' + quote(key.name) + ' ' + members.map(quote).join(' ');
+    /* Only for a member this key still has: a sweep can have removed the one the
+       reader picked. */
+    var from = search.from && members.indexOf(search.from) !== -1 ? search.from : null;
+    /* Both in one batch when the radius is already known. It is not known on the
+       first pick, or after the unit changed, and fitting one needs the
+       coordinates GEOPOS is being asked for — so that case takes a second round
+       trip rather than searching a radius of nothing. */
+    var commands = from && search.radius
+      ? [where, geoSearchCommand(key.name, from, search)] : [where];
+
+    return run(commands).then(function (replies) {
+      var places = [];
+      (ok(replies[0]) || []).forEach(function (spot, index) {
+        if (!Array.isArray(spot) || spot.length < 2) return;
+        var lon = Number(cellText(spot[0]));
+        var lat = Number(cellText(spot[1]));
+        if (!isFinite(lon) || !isFinite(lat)) return;
+        places.push({ name: members[index], lon: lon, lat: lat });
+      });
+      if (!places.length) return;
+
+      function show(ranAll, found) {
+        self.renderValue(key, {
+          commands: ran.concat(ranAll),
+          view: {
+            kind: 'panes',
+            of: key.name,
+            facts: table.facts,
+            panes: [
+              /* The value itself first, and so the default: this column answers
+                 "what is in this key", and for a geo key that is a sorted set of
+                 members and geohashes. The map is the reading of it, one click
+                 away. */
+              { id: 'members', label: 'Members', render: function () {
+                var block = el('div');
+                block.appendChild(renderTable(table.head, table.rows));
+                if (table.limited) {
+                  block.appendChild(el('p', 'rwb-limited', 'Showing '
+                    + table.limited.shown + ' of ' + table.limited.of));
+                }
+                return block;
+              } },
+              { id: 'map', label: 'Map', render: function () {
+                var block = el('div');
+                block.appendChild(renderMap(places, {
+                  from: from,
+                  of: table.geo.length > places.length ? table.geo.length : 0,
+                  /* The pane is in the document already, so its width is known
+                     before the map is built. Less the padding either side. */
+                  width: (self.valuePane.clientWidth || 0) - 20,
+                  pick: function (name) { self.pickGeoFrom(key, name); }
+                }));
+                if (from) {
+                  block.appendChild(el('div', 'rwb-group', 'Distance from ' + from));
+                  block.appendChild(self.geoControls(key, search));
+                  block.appendChild(self.renderDistances({
+                    from: from, reply: found, key: key, search: search
+                  }));
+                } else {
+                  block.appendChild(el('p', 'rwb-hint',
+                    'Click a place to measure from it — GEOSEARCH answers with '
+                    + 'what is within a radius of it, nearest first.'));
+                }
+                return block;
+              } }
+            ]
+          }
+        });
+      }
+
+      if (!from) return show(commands, null);
+      if (commands.length > 1) return show(commands, replies[1]);
+      /* Far enough to hold the whole key, so the first search answers with
+         everything rather than nothing. */
+      search.radius = fittingRadius(places, search.unit);
+      var query = geoSearchCommand(key.name, from, search);
+      /* The map goes up now; the distances land a moment later. */
+      show(commands, null);
+      return run([query]).then(function (found) {
+        show(commands.concat([query]), found[0]);
+      });
+    }, function () { /* no map, and the table is already up */ });
+  };
+
+  /* Measure from here. Re-reads rather than patching the view: the map has to
+     mark the new origin and the distances all change. */
+  dock.pickGeoFrom = function (key, name) {
+    var search = this.geoOptions();
+    search.from = search.from === name ? null : name;
+    return this.openKey(key.name);
+  };
+
+  function geoSearchCommand(name, from, search) {
+    return 'GEOSEARCH ' + quote(name) + ' FROMMEMBER ' + quote(from)
+      + ' BYRADIUS ' + search.radius + ' ' + search.unit
+      + ' ASC WITHDIST COUNT ' + MAX_MAP_POINTS;
+  }
+
+  /* A radius that reaches every place in the key, rounded up so it reads as a
+     round number in the box. Worked out here rather than asked of the server:
+     the coordinates are already in hand. */
+  function fittingRadius(places, unit) {
+    var far = 0;
+    places.forEach(function (one) {
+      places.forEach(function (other) {
+        far = Math.max(far, haversine(one, other));
+      });
+    });
+    var per = GEO_UNITS.filter(function (each) { return each.unit === unit; })[0].per;
+    var wanted = Math.max(1, far * per) * 1.1;
+    var size = Math.pow(10, Math.floor(Math.log(wanted) / Math.LN10));
+    return Math.ceil(wanted / size) * size;
+  }
+
+  /* Great-circle distance in kilometres. The same formula GEODIST uses, on the
+     same sphere radius Redis assumes (6372.797 km). */
+  function haversine(one, other) {
+    var rad = Math.PI / 180;
+    var dLat = (other.lat - one.lat) * rad;
+    var dLon = (other.lon - one.lon) * rad;
+    var a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+      + Math.cos(one.lat * rad) * Math.cos(other.lat * rad)
+      * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+    return 6372.797 * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+
+  /* The radius to search, and the unit to say it in — the two arguments of
+     GEOSEARCH BYRADIUS a reader would change by hand. */
+  dock.geoControls = function (key, search) {
+    var self = this;
+    var row = el('form', 'rwb-vsim-controls');
+
+    var units = el('div', 'rwb-vsim-counts');
+    units.setAttribute('role', 'group');
+    units.setAttribute('aria-label', 'Distance unit');
+    GEO_UNITS.forEach(function (choice) {
+      var on = choice.unit === search.unit;
+      var chip = el('button', 'rwb-chip' + (on ? ' rwb-chip-on' : ''), choice.label);
+      chip.type = 'button';
+      chip.title = 'Measure in ' + choice.label;
+      chip.setAttribute('aria-pressed', on ? 'true' : 'false');
+      chip.addEventListener('click', function () {
+        if (on) return;
+        search.unit = choice.unit;
+        /* The radius went with the old unit: 1000 km is not 1000 mi. Dropped, so
+           the next read fits one to the key again. */
+        search.radius = null;
+        self.openKey(key.name);
+      });
+      units.appendChild(chip);
+    });
+    row.appendChild(units);
+
+    var radius = el('input', 'rwb-vsim-filter');
+    radius.type = 'text';
+    radius.inputMode = 'decimal';
+    radius.value = String(search.radius);
+    radius.title = 'How far to search, in ' + search.unit;
+    radius.setAttribute('aria-label', 'Radius in ' + search.unit);
+    row.appendChild(radius);
+
+    var go = el('button', 'rwb-btn', 'Search');
+    go.type = 'submit';
+    go.title = 'Run GEOSEARCH with this radius';
+    row.appendChild(go);
+
+    row.addEventListener('submit', function (event) {
+      event.preventDefault();
+      var wanted = parseFloat(radius.value);
+      if (isFinite(wanted) && wanted > 0) search.radius = wanted;
+      /* Where the caret was, to put it back in the box that replaces this one:
+         the reply redraws the pane, so the box the reader typed into is gone by
+         the time the distances are up. */
+      var caret = radius.selectionStart;
+      var back = function () { self.focusGeoRadius(caret); };
+      var reading = self.openKey(key.name);
+      if (reading && reading.then) reading.then(back); else back();
+    });
+    return row;
+  };
+
+  dock.focusGeoRadius = function (caret) {
+    if (!this.valuePane) return;
+    var box = this.valuePane.querySelector('.rwb-vsim-filter');
+    if (!box) return;
+    /* preventScroll, or focusing the box scrolls the column to it — which is
+       the very thing the reader did not ask for. */
+    box.focus({ preventScroll: true });
+    var at = typeof caret === 'number' ? Math.min(caret, box.value.length)
+      : box.value.length;
+    box.setSelectionRange(at, at);
+  };
+
+  /* GEOSEARCH's answer: the places within the radius, nearest first, each with
+     its distance. The bar is the distance as a share of the farthest one — so
+     the nearest is a stub and the farthest fills the track, which is the way
+     round a reader expects "further" to look. */
+  dock.renderDistances = function (section) {
+    var self = this;
+    var reply = section.reply;
+    if (reply && reply.error) {
+      return el('p', 'rwb-text rwb-failed', '(error) ' + cellText(reply.value));
+    }
+    var rows = (ok(reply) || []).map(function (hit) {
+      return Array.isArray(hit)
+        ? { name: cellText(hit[0]), away: Number(cellText(hit[1])) }
+        : { name: cellText(hit), away: NaN };
+    });
+    if (!rows.length) {
+      return el('p', 'rwb-empty',
+        'Nothing within ' + section.search.radius + ' ' + section.search.unit + '.');
+    }
+    var far = Math.max.apply(null, rows.map(function (row) {
+      return isNaN(row.away) ? 0 : row.away;
+    })) || 1;
+    return renderBars(rows.map(function (row) {
+      var here = row.name === section.from;
+      return {
+        name: row.name,
+        share: isNaN(row.away) ? 0 : row.away / far,
+        label: isNaN(row.away) ? '—' : trimNumber(row.away) + ' ' + section.search.unit,
+        mark: here ? 'from here' : null,
+        title: 'Measure from ' + row.name + ' instead',
+        pick: here ? null : function () { self.pickGeoFrom(section.key, row.name); }
+      };
+    }));
+  };
+
+  /* 8955.05, 12.3, 0.4 — two decimals at most, and none where they say nothing. */
+  function trimNumber(value) {
+    return String(Math.round(value * 100) / 100);
+  }
+
   dock.openIndex = function (name) {
     var self = this;
     this.selected = name;
@@ -2841,6 +3159,14 @@
       ? { name: typing.dataset.rwbKey, text: typing.value,
           caret: typing.selectionStart, focused: document.activeElement === typing }
       : null;
+    /* And where the reader had scrolled to, if this is the same key being
+       redrawn. Every command redraws this column, so a reader who had scrolled
+       down to the controls under a map was sent back to the top by their own
+       Enter. A different key starts at the top, which is where its value
+       begins. */
+    var column = this.valueColumn;
+    var keepScroll = column && this.valueShown === key.name ? column.scrollTop : 0;
+    this.valueShown = key.name;
     pane.replaceChildren();
 
     var head = el('div', 'rwb-value-head');
@@ -2895,6 +3221,7 @@
       this.pathCarried = null;
       this.focusJsonPath(caret);
     }
+    if (column && keepScroll) column.scrollTop = keepScroll;
   };
 
   function renderView(view, onOpenRow) {
@@ -2916,6 +3243,43 @@
       });
       return wrap;
     }
+    /* Panes rather than one long column, where a value has two ways of being
+       read that a reader picks between — a geo key's map and its members. The
+       choice is remembered per key: a sweep re-renders the value on every
+       command, and having that snap back to the first pane would make the map
+       unusable while typing. */
+    if (view.kind === 'panes') {
+      var panes = el('div', 'rwb-vpanes');
+      var strip = el('div', 'rwb-vtabs');
+      strip.setAttribute('role', 'tablist');
+      var body = el('div', 'rwb-vbody');
+      var chosen = dock.chosenPane(view.of, view.panes);
+
+      view.panes.forEach(function (spec) {
+        var tab = el('button', 'rwb-tab rwb-vtab', spec.label);
+        tab.type = 'button';
+        tab.setAttribute('role', 'tab');
+        tab.setAttribute('aria-selected', spec.id === chosen.id ? 'true' : 'false');
+        tab.addEventListener('click', function () {
+          if (spec.id === chosen.id) return;
+          dock.valueTabs[view.of] = spec.id;
+          chosen = spec;
+          [].forEach.call(strip.children, function (other, index) {
+            other.setAttribute('aria-selected',
+              view.panes[index].id === spec.id ? 'true' : 'false');
+          });
+          /* Both panes are built from replies already in hand, so switching is a
+             redraw and not another round trip. */
+          body.replaceChildren(spec.render());
+        });
+        strip.appendChild(tab);
+      });
+      panes.appendChild(strip);
+      body.appendChild(chosen.render());
+      panes.appendChild(body);
+      return panes;
+    }
+
     if (view.kind === 'sections') {
       var sections = el('div', 'rwb-sections');
       view.sections.forEach(function (section) {
@@ -2926,6 +3290,238 @@
     }
     return el('p', 'rwb-empty', 'Nothing to show.');
   }
+
+  /* A round step that puts two or three lines across the span — the steps a map
+     is drawn with (degrees, then halves, then minutes), not 0.37 of a degree. */
+  var STEPS = [0.01, 0.02, 0.05, 0.1, 0.2, 0.25, 0.5, 1, 2, 5, 10, 15, 20, 30, 45, 60];
+
+  function niceStep(span) {
+    var want = Math.abs(span) / 3;
+    for (var i = 0; i < STEPS.length; i += 1) {
+      if (STEPS[i] >= want) return STEPS[i];
+    }
+    return STEPS[STEPS.length - 1];
+  }
+
+  /* ---- the map ----
+     Places, plotted. Both axes get the same scale — longitude squeezed by the
+     cosine of the latitude they sit at, which is what keeps a city block square
+     rather than stretched — and the drawing is fitted inside the box rather than
+     stretched to fill it (preserveAspectRatio, unlike the time series plot). A
+     map that stretches with the pane is a map that lies about direction. */
+  var MAP = { width: 320, maxWidth: 520, height: 160, pad: 16, dot: '#0284c7',
+    maxLabels: 12 };
+
+  function renderMap(points, section) {
+    var of = section && section.of;
+    var from = section && section.from;
+    var pick = section && section.pick;
+    var wrap = el('div', 'rwb-map');
+    /* Drawn at the size it will be shown at, rather than drawn at 320 wide and
+       scaled to fit: an SVG scaled to a wide column takes its text and its dots
+       up with it, and a map with 18px labels on it is unreadable. The caller
+       measures the column; these bounds keep it a map either way. */
+    var box = {
+      /* Wide enough to read at the narrowest the column gets, and no wider than
+         a map of a handful of places wants to be: past this it is a few dots in
+         an empty field, and the distances below it are pushed off the pane. */
+      width: Math.max(260, Math.min(MAP.maxWidth,
+        Math.round(section && section.width) || MAP.width))
+    };
+    /* Half as tall as it is wide — the aspect a row of places reads best at. */
+    box.height = Math.round(box.width / 2);
+    /* Room for a name at the edge of the plot, in proportion to the plot. A
+       margin narrower than a name means the place at the edge of the key loses
+       its label, so this is wide enough to hold one. */
+    box.pad = Math.max(24, Math.round(box.width * 0.09));
+    var mid = points.reduce(function (sum, place) { return sum + place.lat; }, 0)
+      / points.length;
+    /* Degrees of longitude are shorter than degrees of latitude everywhere but
+       the equator, by this much. */
+    var squeeze = Math.cos(mid * Math.PI / 180) || 1;
+
+    var xs = points.map(function (place) { return place.lon * squeeze; });
+    var ys = points.map(function (place) { return -place.lat; });
+    var lowX = Math.min.apply(null, xs);
+    var highX = Math.max.apply(null, xs);
+    var lowY = Math.min.apply(null, ys);
+    var highY = Math.max.apply(null, ys);
+    var room = { x: box.width - box.pad * 2, y: box.height - box.pad * 2 };
+    /* One scale for both axes, so nothing is distorted; a single place, or a row
+       of places on one line, has no span to fit and simply sits in the middle. */
+    var scale = Math.min(
+      highX - lowX ? room.x / (highX - lowX) : Infinity,
+      highY - lowY ? room.y / (highY - lowY) : Infinity
+    );
+    if (!isFinite(scale)) scale = 1;
+    var centre = { x: (lowX + highX) / 2, y: (lowY + highY) / 2 };
+
+    function at(place, index) {
+      return {
+        x: box.width / 2 + (place.lon * squeeze - centre.x) * scale,
+        y: box.height / 2 + (-place.lat - centre.y) * scale,
+        index: index
+      };
+    }
+
+    var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('class', 'rwb-map-plot');
+    svg.setAttribute('viewBox', '0 0 ' + box.width + ' ' + box.height);
+    svg.setAttribute('width', String(box.width));
+    svg.setAttribute('height', String(box.height));
+    /* Fitted, not stretched — and with the box measured from the column, there
+       is nothing left to fit: one unit of the drawing is one pixel on screen. */
+    svg.setAttribute('preserveAspectRatio', 'xMidYMid meet');
+    svg.setAttribute('role', 'img');
+    svg.setAttribute('aria-label', plural(points.length, 'place') + ' plotted, '
+      + points.map(function (place) { return place.name; }).join(', '));
+
+    /* Whole degrees of latitude and longitude, drawn under the places and
+       labelled at the edges. Without them the dots say how the places sit
+       relative to each other but not where on earth they are, or how far apart:
+       three dots in a triangle look the same across a city and across a
+       continent. Two or three lines per axis — enough to read the position and
+       the scale off, few enough to stay out of the way. */
+    var span = {
+      lon: { low: (centre.x - (box.width / 2) / scale) / squeeze,
+        high: (centre.x + (box.width / 2) / scale) / squeeze },
+      /* y grows downwards, so the top edge is the higher latitude. */
+      lat: { low: -(centre.y + (box.height / 2) / scale),
+        high: -(centre.y - (box.height / 2) / scale) }
+    };
+    [
+      { of: 'lon', at: function (value) {
+        return box.width / 2 + (value * squeeze - centre.x) * scale; } },
+      { of: 'lat', at: function (value) {
+        return box.height / 2 + (-value - centre.y) * scale; } }
+    ].forEach(function (axis) {
+      var range = span[axis.of];
+      var step = niceStep(range.high - range.low);
+      var first = Math.ceil(range.low / step);
+      /* Counted from the first line rather than added up, so a step of 0.1 does
+         not drift into 0.30000000000000004 by the third one. */
+      for (var n = 0; first * step + n * step <= range.high; n += 1) {
+        var value = (first + n) * step;
+        var place = axis.at(value);
+        var down = axis.of === 'lat';
+        var rule = document.createElementNS(svg.namespaceURI, 'line');
+        rule.setAttribute('class', 'rwb-map-rule');
+        rule.setAttribute('x1', String(down ? 0 : place));
+        rule.setAttribute('x2', String(down ? box.width : place));
+        rule.setAttribute('y1', String(down ? place : 0));
+        rule.setAttribute('y2', String(down ? place : box.height));
+        rule.setAttribute('vector-effect', 'non-scaling-stroke');
+        svg.appendChild(rule);
+
+        var tick = document.createElementNS(svg.namespaceURI, 'text');
+        tick.setAttribute('class', 'rwb-map-tick');
+        tick.setAttribute('x', String(down ? 3 : place + 3));
+        tick.setAttribute('y', String(down ? place - 3 : box.height - 4));
+        tick.textContent = degreeLabel(value, axis.of);
+        svg.appendChild(tick);
+      }
+    });
+
+    var named = [];
+    points.forEach(function (place, index) {
+      var spot = at(place, index);
+      var here = place.name === from;
+      var dot = document.createElementNS(svg.namespaceURI, 'circle');
+      dot.setAttribute('class', 'rwb-map-dot' + (here ? ' rwb-map-dot-from' : ''));
+      dot.setAttribute('cx', String(spot.x));
+      dot.setAttribute('cy', String(spot.y));
+      dot.setAttribute('r', here ? '5' : '3');
+      /* Exact coordinates on hover, for every point — the labels are only for
+         the few, and rounding is for reading, not for trusting. */
+      var title = document.createElementNS(svg.namespaceURI, 'title');
+      title.textContent = place.name + ' — ' + place.lat.toFixed(5) + ', '
+        + place.lon.toFixed(5);
+      dot.appendChild(title);
+      /* A dot is the handle for "measure from here". Focusable and answering to
+         Enter as well as a click: it is a control, whatever it is drawn as. */
+      if (pick) {
+        dot.setAttribute('role', 'button');
+        dot.setAttribute('tabindex', '0');
+        dot.setAttribute('aria-pressed', here ? 'true' : 'false');
+        dot.addEventListener('click', function () { pick(place.name); });
+        dot.addEventListener('keydown', function (event) {
+          if (event.key !== 'Enter' && event.key !== ' ') return;
+          event.preventDefault();
+          pick(place.name);
+        });
+      }
+      svg.appendChild(dot);
+
+      if (points.length <= MAP.maxLabels) named.push({ name: place.name, spot: spot });
+    });
+
+    /* Names, while there are few enough for them to be read. Each takes the
+       first place that is inside the plot and clear of the names already put
+       down: right of its dot, then left, then a line under either. A name with
+       nowhere to go is left off rather than printed over its neighbour — the dot
+       still says who it is on hover. Naples sat on top of Bari before this, and
+       Catania sat on top of Caltanissetta after the first attempt at it. */
+    var taken = [];
+    named.forEach(function (item) {
+      /* How wide the name will be, near enough: the labels are 10px, so six
+         pixels a character is a safe overestimate. Measuring would mean being in
+         the document, and this drawing is not in it yet. */
+      var wide = item.name.length * 6;
+      var tries = [
+        { x: item.spot.x + 6, y: item.spot.y + 3, end: false },
+        { x: item.spot.x - 6, y: item.spot.y + 3, end: true },
+        { x: item.spot.x + 6, y: item.spot.y + 14, end: false },
+        { x: item.spot.x - 6, y: item.spot.y + 14, end: true },
+        { x: item.spot.x + 6, y: item.spot.y - 8, end: false },
+        { x: item.spot.x - 6, y: item.spot.y - 8, end: true }
+      ];
+      for (var i = 0; i < tries.length; i += 1) {
+        var spot = tries[i];
+        var left = spot.end ? spot.x - wide : spot.x;
+        var right = left + wide;
+        var top = spot.y - 8;
+        if (left < 2 || right > box.width - 2) continue;
+        if (top < 0 || spot.y > box.height - 2) continue;
+        var clash = taken.some(function (other) {
+          return left < other.right + 2 && right + 2 > other.left
+            && top < other.bottom && spot.y > other.top;
+        });
+        if (clash) continue;
+        taken.push({ left: left, right: right, top: top, bottom: spot.y + 2 });
+        var label = document.createElementNS(svg.namespaceURI, 'text');
+        label.setAttribute('class', 'rwb-map-label');
+        label.setAttribute('x', String(spot.x));
+        label.setAttribute('y', String(spot.y));
+        if (spot.end) label.setAttribute('text-anchor', 'end');
+        label.textContent = item.name;
+        svg.appendChild(label);
+        return;
+      }
+    });
+    wrap.appendChild(svg);
+
+    /* The span of the plot is on the axes, and the count is in the key list, so
+       neither needs saying under the map. What does need saying is a map that is
+       not all of the key — in the same words the rest of the dock uses. */
+    if (of) {
+      wrap.appendChild(el('p', 'rwb-limited',
+        'Showing ' + points.length + ' of ' + plural(of, 'place')));
+    }
+    return wrap;
+  }
+
+  /* 45°N, 9°E — a signed number leaves the reader working out which way is which,
+     and a bare 9 could be either axis. */
+  function degreeLabel(value, axis) {
+    /* A step that lands on zero can land on -0.0000001 instead. */
+    var at = Math.abs(value) < 1e-9 ? 0 : value;
+    var text = String(Math.round(Math.abs(at) * 100) / 100) + '°';
+    /* The equator and the prime meridian belong to no hemisphere. */
+    if (!at) return text;
+    if (axis === 'lat') return text + (at > 0 ? 'N' : 'S');
+    return text + (at > 0 ? 'E' : 'W');
+  }
+
 
   function renderTable(head, rows, onOpenRow) {
     if (!rows || !rows.length) return el('p', 'rwb-empty', 'Empty.');

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2320,12 +2320,15 @@
          map, and painting the members table over it for the length of a round
          trip put a frame of table between every click on a map and the map
          coming back. Nothing is drawn until the coordinates land. */
-      var known = view.geo && self.geoKeys[name];
+      /* Held back only when what is on screen is this key's own map: holding it
+         back while another key's value is up would leave the reader looking at
+         the key they just left for the length of a round trip. */
+      var known = view.geo && self.geoKeys[name] && self.valueShown === name;
       if (!known) self.renderValue(key, { view: view, commands: probe.commands });
       self.end();
       if (view.geo) {
         self.geoKeys[name] = true;
-        return self.readGeo(key, view, probe.commands);
+        return self.readGeo(key, view, probe.commands, !known);
       }
     }, function () {
       self.end();
@@ -2750,8 +2753,14 @@
      rest. Distances come from GEOSEARCH FROMMEMBER rather than a GEODIST per
      pair: one command instead of N, sorted by the server, and the same command
      the docs teach for "what is near this". */
-  dock.readGeo = function (key, table, ran) {
+  dock.readGeo = function (key, table, ran, painted) {
     var self = this;
+    /* The members table, for the cases where there is no map to draw and
+       nothing has been drawn yet. */
+    function fallback() {
+      if (painted || self.selected !== key.name) return;
+      self.renderValue(key, { view: table, commands: ran });
+    }
     var members = table.geo.slice(0, MAX_MAP_POINTS);
     var search = this.geoOptions();
     var where = 'GEOPOS ' + quote(key.name) + ' ' + members.map(quote).join(' ');
@@ -2774,9 +2783,15 @@
         if (!isFinite(lon) || !isFinite(lat)) return;
         places.push({ name: members[index], lon: lon, lat: lat });
       });
-      if (!places.length) return;
+      /* No coordinates came back — every member was removed between the two
+         reads, or none of them decoded. There is no map to draw, so the members
+         are what this key has to show. */
+      if (!places.length) return fallback();
 
       function show(ranAll, found) {
+        /* The reader may have opened something else while this was in flight.
+           Their choice outranks a reply that was already on its way. */
+        if (self.selected !== key.name) return;
         self.renderValue(key, {
           commands: ran.concat(ranAll),
           view: {
@@ -2836,7 +2851,11 @@
       return run([query]).then(function (found) {
         show(commands.concat([query]), found[0]);
       });
-    }, function () { /* no map, and the table is already up */ });
+    }, function () {
+      /* GEOPOS itself failed. Whatever the reason, the members are still worth
+         showing if nothing else has been. */
+      fallback();
+    });
   };
 
   /* Measure from here. Re-reads rather than patching the view: the map has to

--- a/static/js/redis-workbench.js
+++ b/static/js/redis-workbench.js
@@ -2366,7 +2366,19 @@
          back while another key's value is up would leave the reader looking at
          the key they just left for the length of a round trip. */
       var known = view.geo && self.geoKeys[name] && self.valueShown === name;
-      if (!known) self.renderValue(key, { view: view, commands: probe.commands });
+      if (!known) {
+        /* A geo key gets its tabs from this reply, with the map pane saying what
+           it is waiting for: the strip appearing when GEOPOS answered pushed the
+           table down a round trip after the reader began reading it. */
+        self.renderValue(key, {
+          commands: probe.commands,
+          view: view.geo
+            ? self.geoPanes(key, view, function () {
+              return el('p', 'rwb-hint', 'Reading where these places are…');
+            })
+            : view
+        });
+      }
       self.end();
       if (view.geo) {
         self.geoKeys[name] = true;
@@ -2811,6 +2823,33 @@
      rest. Distances come from GEOSEARCH FROMMEMBER rather than a GEODIST per
      pair: one command instead of N, sorted by the server, and the same command
      the docs teach for "what is near this". */
+  /* Members and Map, from whatever is known so far. The strip is drawn from the
+     first reply rather than waiting for the coordinates: appearing a round trip
+     later, it pushed the table down just as the reader started reading it. Until
+     GEOPOS answers, the map pane says what it is waiting for. */
+  dock.geoPanes = function (key, table, drawMap) {
+    return {
+      kind: 'panes',
+      of: key.name,
+      facts: table.facts,
+      panes: [
+        /* The value itself first, and so the default: this column answers "what
+           is in this key", and for a geo key that is a sorted set of members and
+           geohashes. The map is the reading of it, one click away. */
+        { id: 'members', label: 'Members', render: function () {
+          var block = el('div');
+          block.appendChild(renderTable(table.head, table.rows));
+          if (table.limited) {
+            block.appendChild(el('p', 'rwb-limited', 'Showing '
+              + table.limited.shown + ' of ' + table.limited.of));
+          }
+          return block;
+        } },
+        { id: 'map', label: 'Map', render: drawMap }
+      ]
+    };
+  };
+
   dock.readGeo = function (key, table, ran, painted) {
     var self = this;
     /* The members table, for the cases where there is no map to draw and
@@ -2860,25 +2899,7 @@
         if (self.selected !== key.name) return;
         self.renderValue(key, {
           commands: ran.concat(ranAll),
-          view: {
-            kind: 'panes',
-            of: key.name,
-            facts: table.facts,
-            panes: [
-              /* The value itself first, and so the default: this column answers
-                 "what is in this key", and for a geo key that is a sorted set of
-                 members and geohashes. The map is the reading of it, one click
-                 away. */
-              { id: 'members', label: 'Members', render: function () {
-                var block = el('div');
-                block.appendChild(renderTable(table.head, table.rows));
-                if (table.limited) {
-                  block.appendChild(el('p', 'rwb-limited', 'Showing '
-                    + table.limited.shown + ' of ' + table.limited.of));
-                }
-                return block;
-              } },
-              { id: 'map', label: 'Map', render: function () {
+          view: self.geoPanes(key, table, function () {
                 var block = el('div');
                 block.appendChild(renderMap(places, {
                   from: from,
@@ -2904,9 +2925,7 @@
                     + 'what is within a radius of it, nearest first.'));
                 }
                 return block;
-              } }
-            ]
-          }
+          })
         });
       }
 


### PR DESCRIPTION
A geo key is a sorted set whose scores are 52-bit geohashes, so the value pane showed Palermo as 3479099956230698. True, and no use to anybody: the reader cannot tell from it where Palermo is, which places are near it, or that this key holds places at all.

A sorted set whose every score is a plausible geohash gets a second pane. GEOPOS answers where its members are and they are plotted: both axes to the same scale with longitude squeezed by the cosine of the latitude, so a city block stays square, and the drawing fitted inside the box rather than stretched to fill it — a map that stretches with the pane is a map that lies about direction. Axes in degrees with N/E rather than signed numbers, names on the dots while there are few enough to read, and the exact coordinates on hover, because rounding is for reading and not for trusting.

Clicking a dot measures from it: GEOSEARCH FROMMEMBER, nearest first, drawn with the same bars the VSIM neighbours use. The radius starts wide enough to hold the whole key and is the reader's to change, in km or miles. Nothing else in these docs answers "what is near this" without leaving the page.

The test is deliberately strict — every score a whole number inside the geohash range — because a plain sorted set drawn as a map is nonsense: GEOPOS decodes a score of 1 to the corner of the world at (-180, -85.05). A geo key whose members all sit near longitude -180 keeps its table, and that is the right way to be wrong.

The pane a reader chose is remembered per key. Every command redraws this column, and having the map snap back to the members table while they typed would make it unusable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-side Redis workbench UI only; extra GEOPOS/GEOSEARCH calls on geo pages with strict heuristics to avoid mis-mapping ordinary zsets.
> 
> **Overview**
> On **geo command and geospatial docs pages**, sorted sets that look like geohash-backed geo keys (whole-number scores in the geohash range, gated by URL) now get a **Members / Map** tabbed value view instead of only a member/score table.
> 
> The **Map** pane loads coordinates via **GEOPOS** (up to 1000 members), draws an **SVG plot** with graticule and clickable dots, and supports **measure-from-here** using **GEOSEARCH FROMMEMBER** with radius/unit controls (km/mi) and distance bars reused from VSIM-style ranking. Rendering avoids flashing the table over an existing map on re-open, remembers the chosen tab per key, and **preserves value-column scroll** across redraws.
> 
> New **CSS** covers inline value tabs (`.rwb-vtabs`) and map styling; failed JSONPath reads keep failure color when combined with `.rwb-json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e37667caf614cc040d7060c59c542fadcaa7056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->