### PR TITLE
Adding info about configuring Postgres

### DIFF
--- a/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
+++ b/content/integrate/redis-data-integration/data-pipelines/prepare-dbs/postgresql.md
@@ -82,6 +82,13 @@ Follow the steps below to enable CDC with [Amazon RDS for PostgreSQL](https://aw
     [security for PostgreSQL logical replication](https://www.postgresql.org/docs/current/logical-replication-security.html)
     for more information.
 
+
+## Azure Database for PostgreSQL
+If you are using [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/services/postgresql/) you need to 
+manually set the `wal_level` parameter in the Azure portal for your PostgreSQL server. Go to the `server parameters` 
+section, search for `wal_level` and set it to logical. Then save and restart the server.
+
+
 ## Install the logical decoding output plug-in
 
 As of PostgreSQL 9.4, the only way to read changes to the write-ahead-log is to


### PR DESCRIPTION
Just a small addition regarding how to configure the wal_level when using Postgres on Azure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, security, or data-handling impact.
> 
> **Overview**
> Adds an **Azure Database for PostgreSQL** section to the RDI PostgreSQL prep guide, alongside the existing Amazon RDS instructions.
> 
> Readers are told to set **`wal_level`** to **`logical`** in the Azure portal under **server parameters**, then save and restart the server so logical replication/CDC can work with RDI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b12232513cd1791d5a20d126dfac09982f5eb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->