### PR TITLE
Enhance redis-py guide with Redis Agent Memory information

### DIFF
--- a/content/develop/use-cases/agent-memory/redis-py/_index.md
+++ b/content/develop/use-cases/agent-memory/redis-py/_index.md
@@ -16,6 +16,10 @@ weight: 1
 
 This guide shows you how to build a small Redis-backed agent memory layer in Python with [`redis-py`]({{< relref "/develop/clients/redis-py" >}}) and the [`sentence-transformers`](https://www.sbert.net/) library, using only standard Redis commands — no agent-memory SDK, no managed service. It includes a local web server built with the Python standard library so you can send turns at the agent, watch working memory update in place, see semantically similar long-term memories recalled in real time, watch the write-time deduplication skip near-duplicates, and inspect the per-thread event log.
 
+{{% note %}}
+[Redis Agent Memory in Redis Iris](https://redis.io/agent-memory/) is Redis’s official managed path for teams that want agent memory as a service, not another subsystem to build and operate themselves. [Redis Iris](https://redis.io/iris/) is the real-time context engine for agents, designed to deliver fresh, relevant context at runtime, and Redis Agent Memory is the part of Iris that makes context compound across turns, sessions, channels, and agents.
+{{% /note %}}
+
 ## Overview
 
 The memory layer splits across three Redis primitives, each handling one tier:


### PR DESCRIPTION
Added note about Redis Agent Memory and Redis Iris for managed service options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with external marketing links; no code or behavior changes.
> 
> **Overview**
> Adds a **Hugo note** near the top of the **redis-py agent memory guide**, right after the DIY introduction, so readers see a managed alternative before the technical overview.
> 
> The note links to **Redis Agent Memory** and **Redis Iris**, framing Iris as the real-time context engine and Agent Memory as the managed way to compound context across turns, sessions, channels, and agents—without changing the rest of the tutorial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb3346590e07e6be3aa52a518fcc17868f755d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->