### PR TITLE
DOC-7055: Extend migrate_shortcode_links.py to handle percent-delimited callouts

### DIFF
--- a/build/migrate_shortcode_links.py
+++ b/build/migrate_shortcode_links.py
@@ -10,6 +10,9 @@ Formalizes the three ad hoc converters used to migrate develop/clients/redis-py
 Stages, and why this order is load-bearing:
   1. relref-to-plain   -- unwrap `]({{< relref "X" >}})` to `](X)`.
   2. callouts-to-blockquote -- `{{< note >}}...{{< /note >}}` to `> [!NOTE]...`.
+     Also handles the `{{% note %}}` percent form and a `title=` attribute
+     (`alert` maps onto the `note` alert type; a title matching the type's
+     default label is dropped as redundant).
      MUST run before stage 3: shortcode callouts pipe their inner content
      through markdownify with no page context, so a link inside one resolves
      against site root, not the page -- only a native blockquote resolves
@@ -35,10 +38,24 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "hoo
 import check_shortcode_paths as csp  # noqa: E402  (reuse mount-aware path resolution)
 
 RELREF_RX = re.compile(r'\]\(\{\{<\s*relref\s+"([^"]*)"\s*>\}\}([^)]*)\)')
+# Matches both delimiter forms (`{{< note >}}` and `{{% note %}}`) and an
+# optional run of attributes on the opening tag (e.g. `title="..."`),
+# without requiring the open/close delimiter to match each other -- real
+# Hugo content always pairs them correctly, so being lenient here only
+# widens what converts, never what breaks.
 CALLOUT_RX = re.compile(
-    r'\{\{<\s*(note|warning|tip|info|alert)\s*>\}\}(.*?)\{\{<\s*/\1\s*>\}\}',
+    r'\{\{[<%]\s*(note|warning|tip|info|alert)((?:\s+\w+="[^"]*")*)\s*[%>]\}\}'
+    r'(.*?)\{\{[<%]\s*/\1\s*[%>]\}\}',
     re.DOTALL,
 )
+# The `alert` shortcode has no fixed type of its own (it's `note`/`warning`/
+# etc. with a custom title bolted on) -- render hooks have no such shortcode,
+# so it maps onto the plain `note` alert type. A `title=` attribute that just
+# restates the type's default label (e.g. `alert title="Note"`) is dropped
+# rather than carried over as a redundant `> [!NOTE] Note`.
+CALLOUT_DEFAULT_LABEL = {
+    "note": "Note", "warning": "Warning", "tip": "Tip", "info": "Info", "alert": "Note",
+}
 LINK_RX = re.compile(r'\]\(([^)\s]+)\)')
 SKIP_HREF_PREFIXES = ("http://", "https://", "mailto:", "#", "/content/")
 
@@ -54,10 +71,16 @@ def relref_to_plain(text):
 
 def callouts_to_blockquote(text):
     def repl(m):
-        kind, body = m.group(1), m.group(2).strip("\n")
+        kind, attrs, body = m.group(1), m.group(2), m.group(3).strip("\n")
+        out_type = "note" if kind == "alert" else kind
+        title_m = re.search(r'\btitle="([^"]*)"', attrs)
+        title = title_m.group(1) if title_m else ""
+        if title.strip().lower() == CALLOUT_DEFAULT_LABEL[kind].lower():
+            title = ""
+        header = f"> [!{out_type.upper()}]" + (f" {title}" if title else "")
         lines = body.split("\n")
         quoted = "\n".join(f"> {line}" if line else ">" for line in lines)
-        return f"> [!{kind.upper()}]\n{quoted}"
+        return f"{header}\n{quoted}"
 
     return CALLOUT_RX.sub(repl, text)
 


### PR DESCRIPTION
## Summary
- The DOC-6909/DOC-7047 callout->blockquote converter only matched the angle-bracket `{{< note >}}` form. Extends it to also match `{{% note %}}` and an optional `title=` attribute (e.g. `{{% alert title="Note" %}}`), which the ongoing DOC-7055 data-types migration needs for 3 instances in one section.
- `alert` maps onto the `note` alert type (it has no fixed type of its own); a title that just restates the type's default label is dropped as redundant rather than carried over.

## Test plan
- [x] Ran `callouts-to-blockquote` against the 3 real target cases in `content/develop/data-types/` (timeseries/configuration.md bare `{{% warning %}}`, probabilistic/hyperloglogs.md `{{% alert title="Note" color="warning" %}}`, vector-sets/_index.md `{{< alert title="Try it out" >}}`) — all converted as expected, changes reverted after inspection (this PR is script-only).
- [x] Ran it against 5 already-known bare-angle-bracket cases — byte-identical output, no regression.
- [ ] Note for a follow-up, out of scope here: this fix would also clean up 1-2 leftover unconverted percent-alerts in `develop/clients/redis-py` and `lettuce` (DOC-7047 residue) — not touched in this PR.

Ticket: DOC-7055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Script-only change to an offline migration helper; no runtime site or auth paths affected.
> 
> **Overview**
> **Extends the `callouts-to-blockquote` stage** in `build/migrate_shortcode_links.py` so Hugo callout shortcodes beyond angle-bracket `{{< note >}}` forms are converted to GitHub-style blockquotes during migration.
> 
> The callout regex now matches **`{{% … %}}` delimiters**, optional opening-tag attributes (e.g. `title="…"`), and mixed open/close delimiter styles. **`alert` shortcodes emit `> [!NOTE]`** (render hooks have no separate alert type), and a **`title` that only repeats the type’s default label** (e.g. `title="Note"`) is omitted so headers stay `> [!NOTE]` instead of `> [!NOTE] Note`. Inline docs for stage 2 describe the new behavior and ordering constraints unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0faf61038b11ee55db49fec5de6e518c1017669b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->