### PR TITLE
DOC-7055: Migrate develop/data-types/probabilistic to render hooks

### DIFF
--- a/build/migrate_shortcode_links.py
+++ b/build/migrate_shortcode_links.py
@@ -10,6 +10,9 @@ Formalizes the three ad hoc converters used to migrate develop/clients/redis-py
 Stages, and why this order is load-bearing:
   1. relref-to-plain   -- unwrap `]({{< relref "X" >}})` to `](X)`.
   2. callouts-to-blockquote -- `{{< note >}}...{{< /note >}}` to `> [!NOTE]...`.
+     Also handles the `{{% note %}}` percent form and a `title=` attribute
+     (`alert` maps onto the `note` alert type; a title matching the type's
+     default label is dropped as redundant).
      MUST run before stage 3: shortcode callouts pipe their inner content
      through markdownify with no page context, so a link inside one resolves
      against site root, not the page -- only a native blockquote resolves
@@ -35,10 +38,24 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "hoo
 import check_shortcode_paths as csp  # noqa: E402  (reuse mount-aware path resolution)
 
 RELREF_RX = re.compile(r'\]\(\{\{<\s*relref\s+"([^"]*)"\s*>\}\}([^)]*)\)')
+# Matches both delimiter forms (`{{< note >}}` and `{{% note %}}`) and an
+# optional run of attributes on the opening tag (e.g. `title="..."`),
+# without requiring the open/close delimiter to match each other -- real
+# Hugo content always pairs them correctly, so being lenient here only
+# widens what converts, never what breaks.
 CALLOUT_RX = re.compile(
-    r'\{\{<\s*(note|warning|tip|info|alert)\s*>\}\}(.*?)\{\{<\s*/\1\s*>\}\}',
+    r'\{\{[<%]\s*(note|warning|tip|info|alert)((?:\s+\w+="[^"]*")*)\s*[%>]\}\}'
+    r'(.*?)\{\{[<%]\s*/\1\s*[%>]\}\}',
     re.DOTALL,
 )
+# The `alert` shortcode has no fixed type of its own (it's `note`/`warning`/
+# etc. with a custom title bolted on) -- render hooks have no such shortcode,
+# so it maps onto the plain `note` alert type. A `title=` attribute that just
+# restates the type's default label (e.g. `alert title="Note"`) is dropped
+# rather than carried over as a redundant `> [!NOTE] Note`.
+CALLOUT_DEFAULT_LABEL = {
+    "note": "Note", "warning": "Warning", "tip": "Tip", "info": "Info", "alert": "Note",
+}
 LINK_RX = re.compile(r'\]\(([^)\s]+)\)')
 SKIP_HREF_PREFIXES = ("http://", "https://", "mailto:", "#", "/content/")
 
@@ -54,10 +71,16 @@ def relref_to_plain(text):
 
 def callouts_to_blockquote(text):
     def repl(m):
-        kind, body = m.group(1), m.group(2).strip("\n")
+        kind, attrs, body = m.group(1), m.group(2), m.group(3).strip("\n")
+        out_type = "note" if kind == "alert" else kind
+        title_m = re.search(r'\btitle="([^"]*)"', attrs)
+        title = title_m.group(1) if title_m else ""
+        if title.strip().lower() == CALLOUT_DEFAULT_LABEL[kind].lower():
+            title = ""
+        header = f"> [!{out_type.upper()}]" + (f" {title}" if title else "")
         lines = body.split("\n")
         quoted = "\n".join(f"> {line}" if line else ">" for line in lines)
-        return f"> [!{kind.upper()}]\n{quoted}"
+        return f"{header}\n{quoted}"
 
     return CALLOUT_RX.sub(repl, text)
 

--- a/content/develop/data-types/probabilistic/_index.md
+++ b/content/develop/data-types/probabilistic/_index.md
@@ -27,6 +27,6 @@ and other sensitive data.
 
 Probabilistic data structures are available as part of Redis Open Source and they are available in Redis Software and Redis Cloud.
 See
-[Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
-[Install Redis Software]({{< relref "/operate/rs/installing-upgrading/install" >}})
+[Install Redis Open Source](/content/operate/oss_and_stack/install/install-stack/_index.md) or
+[Install Redis Software](/content/operate/rs/installing-upgrading/install/_index.md)
 for full installation instructions.

--- a/content/develop/data-types/probabilistic/configuration.md
+++ b/content/develop/data-types/probabilistic/configuration.md
@@ -17,13 +17,12 @@ linkTitle: Configuration
 title: Configuration Parameters
 weight: 100
 ---
-{{< note >}}
-As of Redis 8 in Redis Open Source (Redis 8), configuration parameters for the probabilistic data structures are now set in the following ways:
-* At load time via your `redis.conf` file.
-* At run time (where applicable) using the [`CONFIG SET`]({{< relref "/commands/config-set" >}}) command.
-
-Also, Redis 8 persists probabilistic configuration parameters just like any other configuration parameters (e.g., using the [`CONFIG REWRITE`]({{< relref "/commands/config-rewrite/" >}}) command).
-{{< /note >}}
+> [!NOTE]
+> As of Redis 8 in Redis Open Source (Redis 8), configuration parameters for the probabilistic data structures are now set in the following ways:
+> * At load time via your `redis.conf` file.
+> * At run time (where applicable) using the [`CONFIG SET`](/content/commands/config-set.md) command.
+>
+> Also, Redis 8 persists probabilistic configuration parameters just like any other configuration parameters (e.g., using the [`CONFIG REWRITE`](/content/commands/config-rewrite.md) command).
 
 
 ## Redis probabilistic data structure configuration parameters
@@ -46,19 +45,17 @@ The following table summarizes which Cuckoo filter configuration parameters can 
 | CF_MAX_EXPANSIONS  | [cf-max-expansions](#cf-max-expansions)     | :white_check_mark: | <span title="Supported">&#x2705; Supported</span><br /><span><br /></span> | <span title="Supported">&#x2705; Flexible & Annual</span><br /><span title="Not supported"><nobr>&#x274c; Free & Fixed</nobr></span> |
 |                    | [cf-max-iterations](#cf-max-iterations)     | :white_check_mark: |||
 
-{{< note >}}
-Parameter names for Redis Open Source versions < 8.0, while deprecated, will still be supported in Redis 8.
-{{< /note >}}
+> [!NOTE]
+> Parameter names for Redis Open Source versions < 8.0, while deprecated, will still be supported in Redis 8.
 
-See also [Redis configuration]({{< relref "/operate/oss_and_stack/management/config" >}}).
+See also [Redis configuration](/content/operate/oss_and_stack/management/config.md).
 
 ---
 
-{{< warning >}}
-A filter should always be sized for the expected capacity and the desired error rate.
-Using the `INSERT` family commands with the default values should be used in cases where many small filters exist and the expectation is most will remain at around the default sizes.
-Not optimizing a filter for its intended use will result in degradation of performance and memory efficiency.
-{{< /warning >}}
+> [!WARNING]
+> A filter should always be sized for the expected capacity and the desired error rate.
+> Using the `INSERT` family commands with the default values should be used in cases where many small filters exist and the expectation is most will remain at around the default sizes.
+> Not optimizing a filter for its intended use will result in degradation of performance and memory efficiency.
 
 ## Default parameters for Bloom filters
 
@@ -160,13 +157,13 @@ These methods are deprecated beginning with Redis 8.
 
 Setting configuration parameters at load-time is done by appending arguments after the `--loadmodule` argument when starting a server from the command line or after the `loadmodule` directive in a Redis config file. For example:
 
-In [redis.conf]({{< relref "/operate/oss_and_stack/management/config" >}}):
+In [redis.conf](/content/operate/oss_and_stack/management/config.md):
 
 ```sh
 loadmodule ./redisbloom.so [OPT VAL]...
 ```
 
-From the [Redis CLI]({{< relref "/develop/tools/cli" >}}), using the [MODULE LOAD]({{< relref "/commands/module-load" >}}) command:
+From the [Redis CLI](/content/develop/tools/cli.md), using the [MODULE LOAD](/content/commands/module-load.md) command:
 
 ```
 127.0.0.6379> MODULE LOAD redisbloom.so [OPT VAL]...

--- a/content/develop/data-types/probabilistic/count-min-sketch.md
+++ b/content/develop/data-types/probabilistic/count-min-sketch.md
@@ -105,7 +105,7 @@ or
 error = threshold/total_count
 ```
 
-where `total_count` is the sum of the count of all elements that can be obtained from the `count` key of the result of the [`CMS.INFO`]({{< relref "commands/cms.info/" >}}) command and is of course dynamic - it changes with every new increment in the sketch. At creation time you can approximate the `total_count` ratio as a product of the average count you'll be expecting in the sketch and the average number of elements.
+where `total_count` is the sum of the count of all elements that can be obtained from the `count` key of the result of the [`CMS.INFO`](/content/commands/cms.info.md) command and is of course dynamic - it changes with every new increment in the sketch. At creation time you can approximate the `total_count` ratio as a product of the average count you'll be expecting in the sketch and the average number of elements.
 
 Since the threshold is a function of the total count in the filter it's very important to note that it will grow as  the count grows, but knowing the total count we can always dynamically calculate the threshold. If a result is below it - it can be discarded.
 

--- a/content/develop/data-types/probabilistic/cuckoo-filter.md
+++ b/content/develop/data-types/probabilistic/cuckoo-filter.md
@@ -52,7 +52,7 @@ Note> In addition to these two cases, Cuckoo filters serve very well all the Blo
 
 ## Examples
 
-> You'll learn how to create an empty cuckoo filter with an initial capacity for 1,000 items, add items, check their existence, and remove them. Even though the [`CF.ADD`]({{< relref "commands/cf.add/" >}}) command can create a new filter if one isn't present, it might not be optimally sized for your needs. It's better to use the [`CF.RESERVE`]({{< relref "commands/cf.reserve/" >}}) command to set up a filter with your preferred capacity.
+> You'll learn how to create an empty cuckoo filter with an initial capacity for 1,000 items, add items, check their existence, and remove them. Even though the [`CF.ADD`](/content/commands/cf.add.md) command can create a new filter if one isn't present, it might not be optimally sized for your needs. It's better to use the [`CF.RESERVE`](/content/commands/cf.reserve.md) command to set up a filter with your preferred capacity.
 
 {{< clients-example set="cuckoo_tutorial" step="cuckoo" description="Cuckoo filter operations: Use CF.RESERVE to create a filter, CF.ADD to add items, CF.EXISTS to check membership, and CF.DEL to remove items when you need space-efficient probabilistic set membership testing with deletion support" difficulty="intermediate" >}}
 > CF.RESERVE bikes:models 1000
@@ -120,18 +120,18 @@ When bucket size of 1 is used the fill rate is 55% and false positive error rate
 
 ### Choosing the scaling factor (`EXPANSION`)
 
-When the filter self-declares itself full, it will auto-expand by generating additional sub-filters at the cost of reduced performance and increased error rate. The new sub-filter is created with size of the previous sub-filter multiplied by `EXPANSION` (chosen on filter creation). Like bucket size, additional sub-filters grow the error rate linearly (the compound error is a sum of all subfilters' errors). The size of the new sub-filter is the size of the last sub-filter multiplied by expansion and this is something very important to keep in mind. If you know you'll have to scale at some point it's better to choose a higher expansion value. The default is [`cf-expansion-factor`]({{< relref "develop/data-types/probabilistic/configuration/#cf-expansion-factor" >}}).
+When the filter self-declares itself full, it will auto-expand by generating additional sub-filters at the cost of reduced performance and increased error rate. The new sub-filter is created with size of the previous sub-filter multiplied by `EXPANSION` (chosen on filter creation). Like bucket size, additional sub-filters grow the error rate linearly (the compound error is a sum of all subfilters' errors). The size of the new sub-filter is the size of the last sub-filter multiplied by expansion and this is something very important to keep in mind. If you know you'll have to scale at some point it's better to choose a higher expansion value. The default is [`cf-expansion-factor`](/content/develop/data-types/probabilistic/configuration.md#cf-expansion-factor).
 
 Maybe you're wondering "Why would I create a smaller filter with a high expansion rate if I know I'm going to scale anyway?"; the answer is: for cases where you need to keep many filters (let's say a filter per user, or per product) and most of them will stay small, but some with more activity will have to scale. 
 
 The expansion factor will be rounded up to the next "power of two (2<sup>n</sup>)" number.
 
 ### Choosing the maximum number of iterations (`MAXITERATIONS`)
-`MAXITERATIONS` dictates the number of attempts to find a slot for the incoming fingerprint. Once the filter gets full, a high MAXITERATIONS value will slow down insertions. The default value is [`cf-max-iterations`]({{< relref "develop/data-types/probabilistic/configuration/#cf-max-iterations" >}}).
+`MAXITERATIONS` dictates the number of attempts to find a slot for the incoming fingerprint. Once the filter gets full, a high MAXITERATIONS value will slow down insertions. The default value is [`cf-max-iterations`](/content/develop/data-types/probabilistic/configuration.md#cf-max-iterations).
 
 ### Interesting facts: 
 - Unused capacity in prior sub-filters is automatically used when possible. 
-- The filter can grow up to [`cf-max-expansions`]({{< relref "develop/data-types/probabilistic/configuration/#cf-max-expansions" >}}) times.
+- The filter can grow up to [`cf-max-expansions`](/content/develop/data-types/probabilistic/configuration.md#cf-max-expansions) times.
 - You can delete items to stay within filter limits instead of rebuilding
 - Adding the same element multiple times will create multiple entries, thus filling up your filter.
 

--- a/content/develop/data-types/probabilistic/hyperloglogs.md
+++ b/content/develop/data-types/probabilistic/hyperloglogs.md
@@ -37,20 +37,20 @@ constant amount of memory; 12k bytes in the worst case, or a lot less if your
 HyperLogLog (We'll just call them HLL from now) has seen very few elements.
 
 HLLs in Redis, while technically a different data structure, are encoded
-as a Redis string, so you can call [`GET`]({{< relref "/commands/get" >}}) to serialize a HLL, and [`SET`]({{< relref "/commands/set" >}})
+as a Redis string, so you can call [`GET`](/content/commands/get.md) to serialize a HLL, and [`SET`](/content/commands/set.md)
 to deserialize it back to the server.
 
 Conceptually the HLL API is like using Sets to do the same task. You would
-[`SADD`]({{< relref "/commands/sadd" >}}) every observed element into a set, and would use [`SCARD`]({{< relref "/commands/scard" >}}) to check the
-number of elements inside the set, which are unique since [`SADD`]({{< relref "/commands/sadd" >}}) will not
+[`SADD`](/content/commands/sadd.md) every observed element into a set, and would use [`SCARD`](/content/commands/scard.md) to check the
+number of elements inside the set, which are unique since [`SADD`](/content/commands/sadd.md) will not
 re-add an existing element.
 
 While you don't really *add items* into an HLL, because the data structure
 only contains a state that does not include actual elements, the API is the
 same:
 
-* Every time you see a new element, you add it to the count with [`PFADD`]({{< relref "/commands/pfadd" >}}).
-* When you want to retrieve the current approximation of unique elements added using the [`PFADD`]({{< relref "/commands/pfadd" >}}) command, you can use the [`PFCOUNT`]({{< relref "/commands/pfcount" >}}) command. If you need to merge two different HLLs, the [`PFMERGE`]({{< relref "/commands/pfmerge" >}}) command is available. Since HLLs provide approximate counts of unique elements, the result of the merge will give you an approximation of the number of unique elements across both source HLLs.
+* Every time you see a new element, you add it to the count with [`PFADD`](/content/commands/pfadd.md).
+* When you want to retrieve the current approximation of unique elements added using the [`PFADD`](/content/commands/pfadd.md) command, you can use the [`PFCOUNT`](/content/commands/pfcount.md) command. If you need to merge two different HLLs, the [`PFMERGE`](/content/commands/pfmerge.md) command is available. Since HLLs provide approximate counts of unique elements, the result of the merge will give you an approximation of the number of unique elements across both source HLLs.
 
 {{< clients-example set="hll_tutorial" step="pfadd" description="HyperLogLog operations: Use PFADD to add items to a HyperLogLog, PFCOUNT to estimate cardinality, and PFMERGE to combine HyperLogLogs when you need space-efficient cardinality estimation" difficulty="intermediate" >}}
 > PFADD bikes Hyperion Deimos Phoebe Quaoar
@@ -69,7 +69,7 @@ Some examples of use cases for this data structure is counting unique queries
 performed by users in a search form every day, number of unique visitors to a web page and other similar cases.
 
 Redis is also able to perform the union of HLLs, please check the
-[full documentation]({{< relref "/commands#hyperloglog" >}}) for more information.
+[full documentation](/commands#hyperloglog) for more information.
 
 ## Use cases
 
@@ -81,17 +81,15 @@ This application answers these questions:
 - How many unique users have played this song? 
 - How many unique users have viewed this video? 
 
-{{% alert title="Note" color="warning" %}}
- 
-Storing the IP address or any other kind of personal identifier is against the law in some countries, which makes it impossible to get unique visitor statistics on your website.
-
-{{% /alert %}}
+> [!NOTE]
+>  
+> Storing the IP address or any other kind of personal identifier is against the law in some countries, which makes it impossible to get unique visitor statistics on your website.
 
 One HyperLogLog is created per page (video/song) per period, and every IP/identifier is added to it on every visit.
 
 ## Performance
 
-Writing ([`PFADD`]({{< relref "/commands/pfadd" >}})) to and reading from ([`PFCOUNT`]({{< relref "/commands/pfcount" >}})) the HyperLogLog is done in constant time and space.
+Writing ([`PFADD`](/content/commands/pfadd.md)) to and reading from ([`PFCOUNT`](/content/commands/pfcount.md)) the HyperLogLog is done in constant time and space.
 Merging HLLs is O(n), where _n_ is the number of sketches.
 
 ## Limits

--- a/content/develop/data-types/probabilistic/hyperloglogs.md
+++ b/content/develop/data-types/probabilistic/hyperloglogs.md
@@ -69,7 +69,7 @@ Some examples of use cases for this data structure is counting unique queries
 performed by users in a search form every day, number of unique visitors to a web page and other similar cases.
 
 Redis is also able to perform the union of HLLs, please check the
-[full documentation](/commands#hyperloglog) for more information.
+[full documentation](/commands?group=hyperloglog) for more information.
 
 ## Use cases
 

--- a/content/develop/data-types/probabilistic/t-digest.md
+++ b/content/develop/data-types/probabilistic/t-digest.md
@@ -78,7 +78,7 @@ You measure the IP packets transferred over your network each second and try to 
 
 ## Examples
 
-In the following example, you'll create a t-digest with a compression of 100 and add items to it. The `COMPRESSION` argument is used to specify the tradeoff between accuracy and memory consumption. The default value is 100. Higher values mean more accuracy. Note: unlike some of the other probabilistic data structures, the [`TDIGEST.ADD`]({{< relref "commands/tdigest.add/" >}}) command will not create a new structure if the key does not exist.
+In the following example, you'll create a t-digest with a compression of 100 and add items to it. The `COMPRESSION` argument is used to specify the tradeoff between accuracy and memory consumption. The default value is 100. Higher values mean more accuracy. Note: unlike some of the other probabilistic data structures, the [`TDIGEST.ADD`](/content/commands/tdigest.add.md) command will not create a new structure if the key does not exist.
 
 {{< clients-example set="tdigest_tutorial" step="tdig_start" description="t-digest creation and data addition: Use TDIGEST.CREATE to initialize a sketch and TDIGEST.ADD to insert values when you need to build a percentile estimation data structure" >}}
 > TDIGEST.CREATE bikes:sales COMPRESSION 100
@@ -90,13 +90,13 @@ OK
 {{< /clients-example >}}
 
 
-You can repeat calling [TDIGEST.ADD]({{< relref "commands/tdigest.add" >}}) whenever new observations are available
+You can repeat calling [TDIGEST.ADD](/content/commands/tdigest.add.md) whenever new observations are available
 
 #### Estimating fractions or ranks by values
 
 Another helpful feature in t-digest is CDF (definition of rank) which gives us the fraction of observations smaller or equal to a certain value. This command is very useful to answer questions like "*What's the percentage of observations with a value lower or equal to X*".
 
->More precisely, [`TDIGEST.CDF`]({{< relref "commands/tdigest.cdf/" >}}) will return the estimated fraction of observations in the sketch that are smaller than X plus half the number of observations that are equal to X. We can also use the [`TDIGEST.RANK`]({{< relref "commands/tdigest.rank/" >}}) command, which is very similar. Instead of returning a fraction, it returns the ----estimated---- rank of a value. The [`TDIGEST.RANK`]({{< relref "commands/tdigest.rank/" >}}) command is also variadic, meaning you can use a single command to retrieve estimations for one or more values.
+>More precisely, [`TDIGEST.CDF`](/content/commands/tdigest.cdf.md) will return the estimated fraction of observations in the sketch that are smaller than X plus half the number of observations that are equal to X. We can also use the [`TDIGEST.RANK`](/content/commands/tdigest.rank.md) command, which is very similar. Instead of returning a fraction, it returns the ----estimated---- rank of a value. The [`TDIGEST.RANK`](/content/commands/tdigest.rank.md) command is also variadic, meaning you can use a single command to retrieve estimations for one or more values.
 
 Here's an example. Given a set of biker's ages, you can ask a question like "What's the percentage of bike racers that are younger than 50 years?"
 
@@ -115,7 +115,7 @@ OK
 {{< /clients-example >}}
 
 
-And lastly, `TDIGEST.REVRANK key value...` is similar to [TDIGEST.RANK]({{< relref "commands/tdigest.rank" >}}), but returns, for each input value, an estimation of the number of (observations larger than a given value + half the observations equal to the given value).
+And lastly, `TDIGEST.REVRANK key value...` is similar to [TDIGEST.RANK](/content/commands/tdigest.rank.md), but returns, for each input value, an estimation of the number of (observations larger than a given value + half the observations equal to the given value).
 
 
 #### Estimating values by fractions or ranks
@@ -149,7 +149,7 @@ If `destKey` is an existing sketch, its values are merged with the values of the
 
 #### Retrieving sketch information
 
-Use [`TDIGEST.MIN`]({{< relref "commands/tdigest.min/" >}}) and [`TDIGEST.MAX`]({{< relref "commands/tdigest.max/" >}}) to retrieve the minimal and maximal values in the sketch, respectively.
+Use [`TDIGEST.MIN`](/content/commands/tdigest.min.md) and [`TDIGEST.MAX`](/content/commands/tdigest.max.md) to retrieve the minimal and maximal values in the sketch, respectively.
 
 {{< clients-example set="tdigest_tutorial" step="tdig_min" description="Sketch metadata retrieval: Use TDIGEST.MIN and TDIGEST.MAX to retrieve the minimum and maximum values in a sketch when you need to inspect the bounds of your data" buildsUpon="tdig_cdf" needs_prereq="true" >}}
 > TDIGEST.MIN racer_ages

--- a/content/develop/data-types/probabilistic/top-k.md
+++ b/content/develop/data-types/probabilistic/top-k.md
@@ -42,25 +42,25 @@ This application answers these questions:
 
 Data flow is the incoming social media posts from which you parse out the different hashtags. 
 
-The [`TOPK.LIST`]({{< relref "commands/topk.list/" >}}) command has a time complexity of `O(K*log(k))` so if `K` is small, there is no need to keep a separate set or sorted set of all the hashtags. You can query directly from the Top K itself. 
+The [`TOPK.LIST`](/content/commands/topk.list.md) command has a time complexity of `O(K*log(k))` so if `K` is small, there is no need to keep a separate set or sorted set of all the hashtags. You can query directly from the Top K itself. 
 
 ## Example
 
 This example will show you how to track key words used "bike" when shopping online; e.g., "bike store" and "bike handlebars". Proceed as follows.
 ​
-* Use [`TOPK.RESERVE`]({{< relref "commands/topk.reserve/" >}}) to initialize a top K sketch with specific parameters. Note: the `width`, `depth`, and `decay_constant` parameters can be omitted, as they will be set to the default values 7, 8, and 0.9, respectively, if not present.
+* Use [`TOPK.RESERVE`](/content/commands/topk.reserve.md) to initialize a top K sketch with specific parameters. Note: the `width`, `depth`, and `decay_constant` parameters can be omitted, as they will be set to the default values 7, 8, and 0.9, respectively, if not present.
 ​
  ```
  > TOPK.RESERVE key k width depth decay_constant
  ```
  
- * Use [`TOPK.ADD`]({{< relref "commands/topk.add/" >}}) to add items to the sketch. As you can see, multiple items can be added at the same time. If an item is returned when adding additional items, it means that item was demoted out of the min heap of the top items, below it will mean the returned item is no longer in the top 5, otherwise `nil` is returned. This allows dynamic heavy-hitter detection of items being entered or expelled from top K list.
+ * Use [`TOPK.ADD`](/content/commands/topk.add.md) to add items to the sketch. As you can see, multiple items can be added at the same time. If an item is returned when adding additional items, it means that item was demoted out of the min heap of the top items, below it will mean the returned item is no longer in the top 5, otherwise `nil` is returned. This allows dynamic heavy-hitter detection of items being entered or expelled from top K list.
 ​
 In the example below, "pedals" displaces "handlebars", which is returned after "pedals" is added. Also note that the addition of both "store" and "seat" a second time don't return anything, as they're already in the top K.
  
- * Use [`TOPK.LIST`]({{< relref "commands/topk.list/" >}}) to list the items entered thus far.
+ * Use [`TOPK.LIST`](/content/commands/topk.list.md) to list the items entered thus far.
 ​
- * Use [`TOPK.QUERY`]({{< relref "commands/topk.query/" >}}) to see if an item is on the top K list. Just like [`TOPK.ADD`]({{< relref "commands/topk.add/" >}}) multiple items can be queried at the same time.
+ * Use [`TOPK.QUERY`](/content/commands/topk.query.md) to see if an item is on the top K list. Just like [`TOPK.ADD`](/content/commands/topk.add.md) multiple items can be queried at the same time.
 {{< clients-example set="topk_tutorial" step="topk" description="Top-K operations: Use TOPK.RESERVE to initialize a sketch, TOPK.ADD to track item frequencies, TOPK.LIST to retrieve top items, and TOPK.QUERY to check membership when you need to identify the most frequent items in a data stream" difficulty="intermediate" >}}
 > TOPK.RESERVE bikes:keywords 5 2000 7 0.925
 OK


### PR DESCRIPTION
## Summary
- Migrates `content/develop/data-types/probabilistic/` (unit B of DOC-7055) from Hugo shortcodes to native-Markdown render hooks, using `build/migrate_shortcode_links.py all`.
- `{{< relref "..." >}}` links converted to plain `](/content/...)` links; `{{< note >}}`/`{{< warning >}}`/`{{% alert title="Note" color="warning" %}}` converted to `> [!NOTE]` / `> [!WARNING]` blockquote alerts.
- `bloom-filter.md` had no shortcodes to convert, so it's unchanged.

Stacked on #3965 (percent-form/attributed-callout support in the migration script) — base is that branch, not `main`, so this doesn't have to wait for it to merge. GitHub will retarget automatically once #3965 merges.

## Test plan
- [x] Reviewed the full diff; spot-checked `configuration.md` (2 notes + 1 warning, bare angle-bracket) and `hyperloglogs.md` (`{{% alert title="Note" color="warning" %}}` → bare `> [!NOTE]`, redundant title dropped, `color=` silently dropped as expected).
- [x] `hugo --minify` build before/after; `python3 build/diff_rendered_hrefs.py` scoped to `develop/data-types/probabilistic` reports zero href differences (8 vs 8 pages, 0 changed).
- [x] Diffed full build warning/error output before vs after — no new warnings; the single pre-existing site-wide render error (`/commands/cf.reserve/index.html` JS minification) and one unrelated warning (`clients/go/vecsets.md`, from concurrent parallel-unit activity) appear on both sides.
- [x] Checked rendered HTML for the converted alert in `hyperloglogs.md` — it sits between a `<ul>` and a `<p>`, not adjacent to the page's `clients-example` widget, so no `&nbsp;` spacer fix was needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout rewrites in one content subtree; PR validation reports unchanged rendered hrefs for that scope.
> 
> **Overview**
> Migrates **`content/develop/data-types/probabilistic/`** from Hugo shortcodes to native Markdown render hooks: internal **`{{< relref ... >}}`** links become canonical **`/content/...`** paths, and **`{{< note >}}` / `{{< warning >}}` / `{{% alert ... %}}`** callouts become **`> [!NOTE]`** / **`> [!WARNING]`** blockquotes (including the percent-form alert in `hyperloglogs.md`, with redundant default titles dropped).
> 
> **`build/migrate_shortcode_links.py`** is extended so the callout stage accepts **`{{<` and `{{%`** delimiters, optional attributes such as **`title=`**, maps **`alert`** to the note alert type, and documents that behavior—supporting the automated **`all`** migration used on this section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd17fde2f93caf19ad926dc198f2aa7bee9fac84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->