### PR TITLE
DOC-7055: Migrate develop/data-types/json to render hooks

### DIFF
--- a/build/migrate_shortcode_links.py
+++ b/build/migrate_shortcode_links.py
@@ -10,6 +10,9 @@ Formalizes the three ad hoc converters used to migrate develop/clients/redis-py
 Stages, and why this order is load-bearing:
   1. relref-to-plain   -- unwrap `]({{< relref "X" >}})` to `](X)`.
   2. callouts-to-blockquote -- `{{< note >}}...{{< /note >}}` to `> [!NOTE]...`.
+     Also handles the `{{% note %}}` percent form and a `title=` attribute
+     (`alert` maps onto the `note` alert type; a title matching the type's
+     default label is dropped as redundant).
      MUST run before stage 3: shortcode callouts pipe their inner content
      through markdownify with no page context, so a link inside one resolves
      against site root, not the page -- only a native blockquote resolves
@@ -35,10 +38,24 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "hoo
 import check_shortcode_paths as csp  # noqa: E402  (reuse mount-aware path resolution)
 
 RELREF_RX = re.compile(r'\]\(\{\{<\s*relref\s+"([^"]*)"\s*>\}\}([^)]*)\)')
+# Matches both delimiter forms (`{{< note >}}` and `{{% note %}}`) and an
+# optional run of attributes on the opening tag (e.g. `title="..."`),
+# without requiring the open/close delimiter to match each other -- real
+# Hugo content always pairs them correctly, so being lenient here only
+# widens what converts, never what breaks.
 CALLOUT_RX = re.compile(
-    r'\{\{<\s*(note|warning|tip|info|alert)\s*>\}\}(.*?)\{\{<\s*/\1\s*>\}\}',
+    r'\{\{[<%]\s*(note|warning|tip|info|alert)((?:\s+\w+="[^"]*")*)\s*[%>]\}\}'
+    r'(.*?)\{\{[<%]\s*/\1\s*[%>]\}\}',
     re.DOTALL,
 )
+# The `alert` shortcode has no fixed type of its own (it's `note`/`warning`/
+# etc. with a custom title bolted on) -- render hooks have no such shortcode,
+# so it maps onto the plain `note` alert type. A `title=` attribute that just
+# restates the type's default label (e.g. `alert title="Note"`) is dropped
+# rather than carried over as a redundant `> [!NOTE] Note`.
+CALLOUT_DEFAULT_LABEL = {
+    "note": "Note", "warning": "Warning", "tip": "Tip", "info": "Info", "alert": "Note",
+}
 LINK_RX = re.compile(r'\]\(([^)\s]+)\)')
 SKIP_HREF_PREFIXES = ("http://", "https://", "mailto:", "#", "/content/")
 
@@ -54,10 +71,16 @@ def relref_to_plain(text):
 
 def callouts_to_blockquote(text):
     def repl(m):
-        kind, body = m.group(1), m.group(2).strip("\n")
+        kind, attrs, body = m.group(1), m.group(2), m.group(3).strip("\n")
+        out_type = "note" if kind == "alert" else kind
+        title_m = re.search(r'\btitle="([^"]*)"', attrs)
+        title = title_m.group(1) if title_m else ""
+        if title.strip().lower() == CALLOUT_DEFAULT_LABEL[kind].lower():
+            title = ""
+        header = f"> [!{out_type.upper()}]" + (f" {title}" if title else "")
         lines = body.split("\n")
         quoted = "\n".join(f"> {line}" if line else ">" for line in lines)
-        return f"> [!{kind.upper()}]\n{quoted}"
+        return f"{header}\n{quoted}"
 
     return CALLOUT_RX.sub(repl, text)
 

--- a/content/develop/data-types/json/_index.md
+++ b/content/develop/data-types/json/_index.md
@@ -24,18 +24,18 @@ weight: 60
 [![Discord](https://img.shields.io/discord/697882427875393627?style=flat-square)](https://discord.gg/QUkjSsk)
 [![Github](https://img.shields.io/static/v1?label=&message=repository&color=5961FF&logo=github)](https://github.com/RedisJSON/RedisJSON/)
 
-The JSON capability of Redis Open Source provides JavaScript Object Notation (JSON) support for Redis. It lets you store, update, and retrieve JSON values in a Redis database, similar to any other Redis data type. Redis JSON also works seamlessly with [Redis Search]({{< relref "/develop/ai/search-and-query/" >}}) to let you [index and query JSON documents]({{< relref "/develop/ai/search-and-query/indexing/" >}}).
+The JSON capability of Redis Open Source provides JavaScript Object Notation (JSON) support for Redis. It lets you store, update, and retrieve JSON values in a Redis database, similar to any other Redis data type. Redis JSON also works seamlessly with [Redis Search](/content/develop/ai/search-and-query/_index.md) to let you [index and query JSON documents](/content/develop/ai/search-and-query/indexing/_index.md).
 
 ## Primary features
 
 * Full support for the JSON standard
-* A [JSONPath](http://goessner.net/articles/JsonPath/) syntax for selecting/updating elements inside documents (see [JSONPath syntax]({{< relref "/develop/data-types/json/path#jsonpath-syntax" >}}))
+* A [JSONPath](http://goessner.net/articles/JsonPath/) syntax for selecting/updating elements inside documents (see [JSONPath syntax](/content/develop/data-types/json/path.md#jsonpath-syntax))
 * Documents stored as binary data in a tree structure, allowing fast access to sub-elements
 * Typed atomic operations for all JSON value types
 
 ## Use Redis with JSON
 
-The first JSON command to try is [`JSON.SET`]({{< relref "commands/json.set/" >}}), which sets a Redis key with a JSON value. [`JSON.SET`]({{< relref "commands/json.set/" >}}) accepts all JSON value types. This example creates a JSON string:
+The first JSON command to try is [`JSON.SET`](/content/commands/json.set.md), which sets a Redis key with a JSON value. [`JSON.SET`](/content/commands/json.set.md) accepts all JSON value types. This example creates a JSON string:
 
 {{< clients-example set="json_tutorial" step="set_get" description="Foundational: Set and retrieve JSON values using JSON.SET and JSON.GET to store and access JSON documents" prereq="true" >}}
 > JSON.SET bike $ '"Hyperion"'
@@ -46,9 +46,9 @@ OK
 1) "string"
 {{< /clients-example >}}
 
-Note how the commands include the dollar sign character `$`. This is the [path]({{< relref "/develop/data-types/json/path" >}}) to the value in the JSON document (in this case it just means the root).
+Note how the commands include the dollar sign character `$`. This is the [path](/content/develop/data-types/json/path.md) to the value in the JSON document (in this case it just means the root).
 
-Here are a few more string operations. [`JSON.STRLEN`]({{< relref "commands/json.strlen/" >}}) tells you the length of the string, and you can append another string to it with [`JSON.STRAPPEND`]({{< relref "commands/json.strappend/" >}}).
+Here are a few more string operations. [`JSON.STRLEN`](/content/commands/json.strlen.md) tells you the length of the string, and you can append another string to it with [`JSON.STRAPPEND`](/content/commands/json.strappend.md).
 
 {{< clients-example set="json_tutorial" step="str" description="String operations: Manipulate JSON strings using JSON.STRLEN to get length and JSON.STRAPPEND to concatenate values" buildsUpon="set_get" needs_prereq="true" >}}
 > JSON.STRLEN bike $
@@ -59,7 +59,7 @@ Here are a few more string operations. [`JSON.STRLEN`]({{< relref "commands/json
 "[\"Hyperion (Enduro bikes)\"]"
 {{< /clients-example >}}
 
-Numbers can be [incremented]({{< relref "commands/json.numincrby/" >}}) and [multiplied]({{< relref "commands/json.nummultby/" >}}):
+Numbers can be [incremented](/content/commands/json.numincrby.md) and [multiplied](/content/commands/json.nummultby.md):
 
 {{< clients-example set="json_tutorial" step="num" description="Numeric operations: Perform atomic arithmetic on JSON numbers using JSON.NUMINCRBY to increment and JSON.NUMMULTBY to multiply values" buildsUpon="set_get" >}}
 > JSON.SET crashes $ 0
@@ -89,7 +89,7 @@ OK
 "[[\"Deimos\",{\"crashes\":0}]]"
 {{< /clients-example >}}
 
-Beginning with Redis 8.8, the JSON data type supports the ability to force a particular type when storing floating point homogeneous arrays (FPHAs)using the `FPHA BF16|FP16|FP32|FP64` option to the [`JSON.SET`]({{< relref "/commands/json.set" >}}) command. Here's an example:
+Beginning with Redis 8.8, the JSON data type supports the ability to force a particular type when storing floating point homogeneous arrays (FPHAs)using the `FPHA BF16|FP16|FP32|FP64` option to the [`JSON.SET`](/content/commands/json.set.md) command. Here's an example:
 
 ```
 > JSON.SET fp_array $ '[[1,2,3,4e3],[5,6.0,7,8]]' FPHA FP16
@@ -98,7 +98,7 @@ OK
 "[[[1.0,2.0,3.0,4000.0],[5.0,6.0,7.0,8.0]]]"
 ```
 
-The [`JSON.DEL`]({{< relref "commands/json.del/" >}}) command deletes any JSON value you specify with the `path` parameter.
+The [`JSON.DEL`](/content/commands/json.del.md) command deletes any JSON value you specify with the `path` parameter.
 
 You can manipulate arrays with a dedicated subset of JSON commands:
 
@@ -139,10 +139,10 @@ OK
 ## Format CLI output
 
 The CLI has a raw output mode that lets you add formatting to the output from
-[`JSON.GET`]({{< relref "commands/json.get/" >}}) to make
+[`JSON.GET`](/content/commands/json.get.md) to make
 it more readable. To use this, run `redis-cli` with the `--raw` option
 and include formatting keywords such as `INDENT`, `NEWLINE`, and `SPACE`
-with [`JSON.GET`]({{< relref "commands/json.get/" >}}):
+with [`JSON.GET`](/content/commands/json.get.md):
 
 ```bash
 $ redis-cli --raw
@@ -160,8 +160,8 @@ $ redis-cli --raw
 
 The Redis JSON data type is part of Redis Open Source and it is also available in Redis Software and Redis Cloud.
 See
-[Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
-[Install Redis Software]({{< relref "/operate/rs/installing-upgrading/install" >}})
+[Install Redis Open Source](/content/operate/oss_and_stack/install/install-stack/_index.md) or
+[Install Redis Software](/content/operate/rs/installing-upgrading/install/_index.md)
 for full installation instructions.
 
 ## Limitation

--- a/content/develop/data-types/json/developer.md
+++ b/content/develop/data-types/json/developer.md
@@ -161,7 +161,7 @@ $ REDIS_PORT=6379 make test
 ```
 
 ## Debugging
-To include debugging information, you need to set the [`DEBUG`]({{< relref "/commands/debug" >}}) environment variable before you compile RedisJSON. For example, run `export DEBUG=1`.
+To include debugging information, you need to set the [`DEBUG`](/content/commands/debug.md) environment variable before you compile RedisJSON. For example, run `export DEBUG=1`.
 
 You can add breakpoints to Python tests in single-test mode. To set a breakpoint, call the ```BB()``` function inside a test.
 

--- a/content/develop/data-types/json/indexing_JSON.md
+++ b/content/develop/data-types/json/indexing_JSON.md
@@ -15,8 +15,8 @@ title: Index/Search JSON documents
 weight: 2
 ---
 
-In addition to storing JSON documents, you can also index them using the [Redis Search]({{< relref "/develop/ai/search-and-query/" >}}) feature. This enables full-text search capabilities and document retrieval based on their content.
+In addition to storing JSON documents, you can also index them using the [Redis Search](/content/develop/ai/search-and-query/_index.md) feature. This enables full-text search capabilities and document retrieval based on their content.
 
-To use these features, install [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}}).
+To use these features, install [Redis Open Source](/content/operate/oss_and_stack/_index.md).
 
-See the [tutorial]({{< relref "/develop/ai/search-and-query/indexing/" >}}) to learn how to search and query your JSON.
+See the [tutorial](/content/develop/ai/search-and-query/indexing/_index.md) to learn how to search and query your JSON.

--- a/content/develop/data-types/json/path.md
+++ b/content/develop/data-types/json/path.md
@@ -33,7 +33,7 @@ RedisJSON v2.0 introduced [JSONPath](http://goessner.net/articles/JsonPath/) sup
 
 A JSONPath query can resolve to several locations in a JSON document. In this case, the JSON commands apply the operation to every possible location. This is a major improvement over [legacy path](#legacy-path-syntax) queries, which only operate on the first path.
 
-Notice that the structure of the command response often differs when using JSONPath. See the [Commands]({{< relref "/commands/" >}}?group=json) page for more details.
+Notice that the structure of the command response often differs when using JSONPath. See the [Commands](/commands/?group=json) page for more details.
 
 The new syntax supports bracket notation, which allows the use of special characters like colon ":" or whitespace in key names.
 
@@ -84,12 +84,11 @@ Beginning with Redis 8.10, the JSON data type supports a richer JSONPath syntax,
 
 These operators can be used within a filter expression (`?()`). Functions can appear inside filter expressions and, when they return a value, as top-level [projection expressions](#projection-expressions). A function can be written in prefix form, `length($.arr)`, or in postfix (method) form, `$.arr.length()`. A path segment immediately followed by `(` is a method call, so `$.arr.length()` is a function call while `$.arr.length` is a reference to a field named `length`.
 
-{{< warning >}}
-Beginning with Redis 8.10, two changes to path parsing may affect existing queries:
-
-- To access a field whose name contains a tilde (`~`), use bracket notation, for example `$["a~b"]`. A tilde is no longer valid in a field name using dot notation.
-- The words `in`, `nin`, `subsetof`, `anyof`, `noneof`, `size`, `sizeof`, and `empty` are now reserved as operators. To access a field with one of these names, use `$.size` or `$["size"]`.
-{{< /warning >}}
+> [!WARNING]
+> Beginning with Redis 8.10, two changes to path parsing may affect existing queries:
+>
+> - To access a field whose name contains a tilde (`~`), use bracket notation, for example `$["a~b"]`. A tilde is no longer valid in a field name using dot notation.
+> - The words `in`, `nin`, `subsetof`, `anyof`, `noneof`, `size`, `sizeof`, and `empty` are now reserved as operators. To access a field with one of these names, use `$.size` or `$["size"]`.
 
 ## Evaluation semantics
 
@@ -164,7 +163,7 @@ First, create the JSON document in your database:
 
 ### Access examples
 
-The following examples use the [`JSON.GET`]({{< relref "commands/json.get/" >}}) command to retrieve data from various paths in the JSON document.
+The following examples use the [`JSON.GET`](/content/commands/json.get.md) command to retrieve data from various paths in the JSON document.
 
 You can use the wildcard operator `*` to return a list of all items in the inventory:
 
@@ -501,7 +500,7 @@ OK
 
 #### `append()`
 
-`append(value, ...)` returns the matched array with the given value or values added after its elements. It is a read-only query-time projection and does not modify the stored document — to mutate an array in place, use the [`JSON.ARRAPPEND`]({{< relref "commands/json.arrappend/" >}}) command instead. A multiple-value argument is added as a single element (it is not spread), and a *Nothing* argument makes the whole result *Nothing*.
+`append(value, ...)` returns the matched array with the given value or values added after its elements. It is a read-only query-time projection and does not modify the stored document — to mutate an array in place, use the [`JSON.ARRAPPEND`](/content/commands/json.arrappend.md) command instead. A multiple-value argument is added as a single element (it is not spread), and a *Nothing* argument makes the whole result *Nothing*.
 
 {{< clients-example set="json_path_ops" step="func_append" description="Append function: Use append() as a read-only, query-time projection that adds a value after an array's elements without modifying the stored document" difficulty="advanced" >}}
 > JSON.SET doc $ '{"arr":[1,2,3]}'
@@ -518,7 +517,7 @@ OK
 
 You can also use JSONPath queries when you want to update specific sections of a JSON document.
 
-For example, you can pass a JSONPath to the [`JSON.SET`]({{< relref "commands/json.set/" >}}) command to update a specific field. This example changes the price of the first item in the headphones list:
+For example, you can pass a JSONPath to the [`JSON.SET`](/content/commands/json.set.md) command to update a specific field. This example changes the price of the first item in the headphones list:
 
 {{< clients-example set="json_tutorial" step="update_bikes" description="Bulk updates: Use JSONPath with JSON.NUMINCRBY to update multiple numeric values across the document when you need to apply arithmetic operations to multiple fields" difficulty="intermediate" buildsUpon="get_bikes" needs_prereq="true" >}}
 > JSON.GET bikes:inventory $..price
@@ -538,7 +537,7 @@ OK
 "[1500,2072,3264,1500,3941]"
 {{< /clients-example >}}
 
-JSONPath queries also work with other JSON commands that accept a path as an argument. For example, you can add a new color option for a set of headphones with [`JSON.ARRAPPEND`]({{< relref "commands/json.arrappend/" >}}):
+JSONPath queries also work with other JSON commands that accept a path as an argument. For example, you can add a new color option for a set of headphones with [`JSON.ARRAPPEND`](/content/commands/json.arrappend.md):
 
 {{< clients-example set="json_tutorial" step="update_filters2" description="Array updates with filters: Use JSON.ARRAPPEND with filter expressions to add elements to arrays matching conditions when you need to modify collections selectively" difficulty="advanced" buildsUpon="update_filters1" needs_prereq="true" >}}
 > JSON.ARRAPPEND bikes:inventory '$.inventory.*[?(@.price<2000)].colors' '"pink"'
@@ -569,14 +568,14 @@ OK
 "[]"
 {{< /clients-example >}}
 
-When [`JSON.GET`]({{< relref "commands/json.get/" >}}) is given more than one path, projections and plain paths can be mixed, and each path becomes a key in the returned object. The order of keys in that object is not guaranteed.
+When [`JSON.GET`](/content/commands/json.get.md) is given more than one path, projections and plain paths can be mixed, and each path becomes a key in the returned object. The order of keys in that object is not guaranteed.
 
 {{< clients-example set="json_path_ops" step="proj_multipath" description="Multi-path queries: Pass more than one path to JSON.GET to have each path's result returned under its own key in a single reply" difficulty="advanced" >}}
 > JSON.GET doc '$.a + 1' '$.b'
 "{\"$.a + 1\":[3],\"$.b\":[4]}"
 {{< /clients-example >}}
 
-[`JSON.MGET`]({{< relref "commands/json.mget/" >}}) evaluates the projection independently for each key. A missing key, or a per-key evaluation error, yields a null reply for that key rather than failing the whole request.
+[`JSON.MGET`](/content/commands/json.mget.md) evaluates the projection independently for each key. A missing key, or a per-key evaluation error, yields a null reply for that key rather than failing the whole request.
 
 ## Legacy path syntax
 

--- a/content/develop/data-types/json/performance/_index.md
+++ b/content/develop/data-types/json/performance/_index.md
@@ -69,7 +69,7 @@ Last but not least, some adding and multiplying:
 
 ### Baseline
 
-To establish a baseline, we'll use the Redis [`PING`]({{< relref "/commands/ping" >}}) command.
+To establish a baseline, we'll use the Redis [`PING`](/content/commands/ping.md) command.
 First, lets see what `redis-benchmark` reports:
 
 ```

--- a/content/develop/data-types/json/ram.md
+++ b/content/develop/data-types/json/ram.md
@@ -15,10 +15,9 @@ title: Redis JSON RAM Usage
 weight: 6
 ---
 
-{{< note >}}
-Because of ongoing feature additions, improvements, and optimizations, JSON memory consumption may vary depending on the Redis version.
-Redis 8 in Redis Open Source was used for the examples on this page.
-{{< /note >}}
+> [!NOTE]
+> Because of ongoing feature additions, improvements, and optimizations, JSON memory consumption may vary depending on the Redis version.
+> Redis 8 in Redis Open Source was used for the examples on this page.
 
 Every key in Redis takes memory and requires at least the amount of RAM to store the key name, as
 well as some per-key overhead that Redis uses. On top of that, the value in the key also requires
@@ -27,7 +26,7 @@ RAM.
 Redis JSON stores JSON values as binary data after deserialization. This representation is often more
 expensive, size-wise, than the serialized form. All JSON values occupy at least 8 bytes (on 64-bit architectures) because each is represented as a thin wrapper around a pointer. The type information is stored in the lower bits of the pointer, which are guaranteed to be zero due to alignment restrictions. This allows those bits to be repurposed to store some auxiliary data.
 
-For some types of JSON values, 8 bytes is all that’s needed. Nulls and booleans don’t require any additional storage. Small integers are stored in static memory because they’re frequently used, so they also use only the initial 8 bytes. Similarly, empty strings, arrays, and objects don’t require any bookkeeping. Instead, they point to static instances of a _null_ string, array, or object. Here are some examples that use the [JSON.DEBUG MEMORY]({{< relref "/commands/json.debug-memory" >}}) command to report on memory consumption:
+For some types of JSON values, 8 bytes is all that’s needed. Nulls and booleans don’t require any additional storage. Small integers are stored in static memory because they’re frequently used, so they also use only the initial 8 bytes. Similarly, empty strings, arrays, and objects don’t require any bookkeeping. Instead, they point to static instances of a _null_ string, array, or object. Here are some examples that use the [JSON.DEBUG MEMORY](/content/commands/json.debug-memory.md) command to report on memory consumption:
 
 ```
 127.0.0.1:6379> JSON.SET boolean . 'true'

--- a/content/develop/data-types/json/use_cases.md
+++ b/content/develop/data-types/json/use_cases.md
@@ -31,4 +31,4 @@ JSON allows you to atomically run operations like incrementing a value, adding, 
 
 When you store JSON objects as Redis strings, there's no good way to query those objects. On the other hand, storing these objects as JSON lets you index and query them. This capability is provided by Redis Search.
 
-With the `FPHA` option to the [`JSON.SET`]({{< relref "/commands/json.set" >}}) command, Redis provides the user with a flexible way to store floating point vectors for vector search.
+With the `FPHA` option to the [`JSON.SET`](/content/commands/json.set.md) command, Redis provides the user with a flexible way to store floating point vectors for vector search.


### PR DESCRIPTION
## Summary
- Migrate `content/develop/data-types/json/**` (unit A of DOC-7055) from Hugo shortcodes to native-Markdown render hooks: `{{< relref >}}` links become plain `](path)` links, and `{{< note >}}`/`{{< warning >}}` become `> [!NOTE]`/`> [!WARNING]` blockquote alerts.
- Ran `build/migrate_shortcode_links.py all` (stacked on #3965's percent-callout support) across all 8 pages; 7/8 changed (`resp3.md` had no shortcode links to convert).

## Verification
- `git diff --stat`: 7 files changed, 34 insertions, 36 deletions — reviewed the full diff by hand.
- Built the site before/after with Hugo and ran `build/diff_rendered_hrefs.py` scoped to `develop/data-types/json`: **0 href differences** across all 8 rendered pages.
- Diffed full build warning/error output before vs after: **identical** (144 lines each side, no new warnings).
- Checked the callout-adjacency risk called out for `path.md` (a `{{< warning >}}` immediately before `## Evaluation semantics`): the shipped page `content/develop/clients/dotnet/nredisstack/vecsearch.md` already has the same blockquote-directly-before-heading pattern with no spacer, and renders fine (headings carry their own top margin). **No `&nbsp;` spacer needed.** `ram.md`'s `{{< note >}}` converted cleanly with no adjacency risk, as expected.

This PR targets `DOC-7055-callout-percent-form-support` (#3965, not yet merged) since it depends on that branch's percent-callout support in the migration script; GitHub will auto-retarget to `main` once #3965 merges.

## Test plan
- [x] `git diff` reviewed by hand
- [x] Hugo build before/after, `diff_rendered_hrefs.py` — 0 differences
- [x] Build warning/error output diffed — identical
- [x] Rendered HTML checked for callout adjacency — no spacer needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only shortcode-to-Markdown migration with verified equivalent rendered links; no runtime or API changes.
> 
> **Overview**
> Migrates the **Redis JSON** docs under `content/develop/data-types/json/**` (DOC-7055 unit A) from Hugo shortcodes to native Markdown render hooks.
> 
> **Internal links:** Every `{{< relref ... >}}` reference is replaced with standard Markdown links pointing at `/content/...` paths (commands, Search/Query, install guides, JSON path anchors, etc.) across `_index.md`, `developer.md`, `indexing_JSON.md`, `path.md`, `performance/_index.md`, `ram.md`, and `use_cases.md`.
> 
> **Callouts:** `{{< warning >}}` in `path.md` and `{{< note >}}` in `ram.md` become GitHub-style alert blockquotes (`> [!WARNING]` / `> [!NOTE]`). Other shortcodes (e.g. `clients-example`, `command-group`) are unchanged.
> 
> Verification in the PR reports **zero rendered href differences** for this section after Hugo build; risk is mainly doc-tooling/rendering parity, not product behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd19a00c492cd578df46cd5ad99f4023456bf5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->