### PR TITLE
DOC-7055: Migrate develop/data-types/vector-sets to render hooks

### DIFF
--- a/build/migrate_shortcode_links.py
+++ b/build/migrate_shortcode_links.py
@@ -10,6 +10,9 @@ Formalizes the three ad hoc converters used to migrate develop/clients/redis-py
 Stages, and why this order is load-bearing:
   1. relref-to-plain   -- unwrap `]({{< relref "X" >}})` to `](X)`.
   2. callouts-to-blockquote -- `{{< note >}}...{{< /note >}}` to `> [!NOTE]...`.
+     Also handles the `{{% note %}}` percent form and a `title=` attribute
+     (`alert` maps onto the `note` alert type; a title matching the type's
+     default label is dropped as redundant).
      MUST run before stage 3: shortcode callouts pipe their inner content
      through markdownify with no page context, so a link inside one resolves
      against site root, not the page -- only a native blockquote resolves
@@ -35,10 +38,24 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "hoo
 import check_shortcode_paths as csp  # noqa: E402  (reuse mount-aware path resolution)
 
 RELREF_RX = re.compile(r'\]\(\{\{<\s*relref\s+"([^"]*)"\s*>\}\}([^)]*)\)')
+# Matches both delimiter forms (`{{< note >}}` and `{{% note %}}`) and an
+# optional run of attributes on the opening tag (e.g. `title="..."`),
+# without requiring the open/close delimiter to match each other -- real
+# Hugo content always pairs them correctly, so being lenient here only
+# widens what converts, never what breaks.
 CALLOUT_RX = re.compile(
-    r'\{\{<\s*(note|warning|tip|info|alert)\s*>\}\}(.*?)\{\{<\s*/\1\s*>\}\}',
+    r'\{\{[<%]\s*(note|warning|tip|info|alert)((?:\s+\w+="[^"]*")*)\s*[%>]\}\}'
+    r'(.*?)\{\{[<%]\s*/\1\s*[%>]\}\}',
     re.DOTALL,
 )
+# The `alert` shortcode has no fixed type of its own (it's `note`/`warning`/
+# etc. with a custom title bolted on) -- render hooks have no such shortcode,
+# so it maps onto the plain `note` alert type. A `title=` attribute that just
+# restates the type's default label (e.g. `alert title="Note"`) is dropped
+# rather than carried over as a redundant `> [!NOTE] Note`.
+CALLOUT_DEFAULT_LABEL = {
+    "note": "Note", "warning": "Warning", "tip": "Tip", "info": "Info", "alert": "Note",
+}
 LINK_RX = re.compile(r'\]\(([^)\s]+)\)')
 SKIP_HREF_PREFIXES = ("http://", "https://", "mailto:", "#", "/content/")
 
@@ -54,10 +71,16 @@ def relref_to_plain(text):
 
 def callouts_to_blockquote(text):
     def repl(m):
-        kind, body = m.group(1), m.group(2).strip("\n")
+        kind, attrs, body = m.group(1), m.group(2), m.group(3).strip("\n")
+        out_type = "note" if kind == "alert" else kind
+        title_m = re.search(r'\btitle="([^"]*)"', attrs)
+        title = title_m.group(1) if title_m else ""
+        if title.strip().lower() == CALLOUT_DEFAULT_LABEL[kind].lower():
+            title = ""
+        header = f"> [!{out_type.upper()}]" + (f" {title}" if title else "")
         lines = body.split("\n")
         quoted = "\n".join(f"> {line}" if line else ">" for line in lines)
-        return f"> [!{kind.upper()}]\n{quoted}"
+        return f"{header}\n{quoted}"
 
     return CALLOUT_RX.sub(repl, text)
 

--- a/content/develop/data-types/vector-sets/_index.md
+++ b/content/develop/data-types/vector-sets/_index.md
@@ -27,11 +27,11 @@ Vector sets allow you to add items to a set, and then either:
 * retrieve a subset of items that are the most similar to a specified vector, or
 * retrieve a subset of items that are the most similar to the vector of an element that is already part of the vector set.
 
-Vector sets also provide for optional [filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}}). You can associate attributes with all or some elements in a vector set, and then use the `FILTER` option of the [`VSIM`]({{< relref "/commands/vsim" >}}) command to retrieve items similar to a given vector while applying simple mathematical filters to those attributes. Here's a sample filter: `".year > 1950"`.
+Vector sets also provide for optional [filtered search](/content/develop/data-types/vector-sets/filtered-search.md). You can associate attributes with all or some elements in a vector set, and then use the `FILTER` option of the [`VSIM`](/content/commands/vsim.md) command to retrieve items similar to a given vector while applying simple mathematical filters to those attributes. Here's a sample filter: `".year > 1950"`.
 
 ## Endianness considerations for FP32 format
 
-When using the FP32 blob format with vector set commands like [`VADD`]({{< relref "/commands/vadd" >}}) and [`VSIM`]({{< relref "/commands/vsim" >}}), the binary data must be encoded in little-endian byte order. This is important for cross-platform compatibility, as some ARM variants and other architectures may use different endianness.
+When using the FP32 blob format with vector set commands like [`VADD`](/content/commands/vadd.md) and [`VSIM`](/content/commands/vsim.md), the binary data must be encoded in little-endian byte order. This is important for cross-platform compatibility, as some ARM variants and other architectures may use different endianness.
 
 If your platform uses big-endian or mixed-endian encoding, you have two options:
 - Manually convert the byte order to little-endian before passing the blob to Redis.
@@ -43,7 +43,7 @@ The following examples give an overview of how to use vector sets. For clarity,
 we will use a set of two-dimensional vectors that represent points in the
 Cartesian coordinate plane. However, in real use cases, the vectors will typically
 represent *text embeddings* and have hundreds of dimensions. See
-[Redis for AI]({{< relref "/develop/ai" >}}) for more information about using text
+[Redis for AI](/content/develop/ai/_index.md) for more information about using text
 embeddings.
 
 The points we will use are A: (1.0, 1.0), B: (-1.0, -1.0), C: (-1.0, 1.0), D: (1.0. -1.0), and
@@ -54,8 +54,8 @@ E: (1.0, 0), shown in the diagram below.
 ### Basic operations
 
 Start by adding the point vectors to a set called `points` using
-[`VADD`]({{< relref "/commands/vadd" >}}). This also creates the vector set object.
-The [`TYPE`]({{< relref "/commands/type" >}}) command returns a type of `vectorset`
+[`VADD`](/content/commands/vadd.md). This also creates the vector set object.
+The [`TYPE`](/content/commands/type.md) command returns a type of `vectorset`
 for this object.
 
 {{< clients-example set="vecset_tutorial" step="vadd" description="Foundational: Use VADD to create a new vector set and populate it with vectors" prereq="true" >}}
@@ -75,8 +75,8 @@ vectorset
 
 
 Get the number of elements in the set (also known as the *cardinality* of the set)
-using [`VCARD`]({{< relref "/commands/vcard" >}}) and the number of dimensions of
-the vectors using [`VDIM`]({{< relref "/commands/vdim" >}}):
+using [`VCARD`](/content/commands/vcard.md) and the number of dimensions of
+the vectors using [`VDIM`](/content/commands/vdim.md):
 
 {{< clients-example set="vecset_tutorial" step="vcardvdim" description="Metadata retrieval: Use VCARD to get the number of elements and VDIM to get vector dimensions when you need to inspect vector set properties" buildsUpon="vadd" needs_prereq="true" >}}
 > VCARD points
@@ -85,10 +85,10 @@ the vectors using [`VDIM`]({{< relref "/commands/vdim" >}}):
 (integer) 2
 {{< /clients-example >}}
 
-Get the coordinate values from the elements using [`VEMB`]({{< relref "/commands/vemb" >}}).
+Get the coordinate values from the elements using [`VEMB`](/content/commands/vemb.md).
 Note that the values will not typically be the exact values you supplied when you added
 the vector because
-[quantization]({{< relref "/develop/data-types/vector-sets/performance#quantization-effects" >}})
+[quantization](/content/develop/data-types/vector-sets/performance.md#quantization-effects)
 is applied to improve performance.
 
 {{< clients-example set="vecset_tutorial" step="vemb" description="Vector retrieval: Use VEMB to retrieve the approximate vector values of elements when you need to inspect the actual vector data stored in the set" buildsUpon="vadd" needs_prereq="true" >}}
@@ -109,7 +109,7 @@ is applied to improve performance.
 2) "0"
 {{< /clients-example >}}
 
-Remove an unwanted element with [`VREM`]({{< relref "/commands/vrem" >}})
+Remove an unwanted element with [`VREM`](/content/commands/vrem.md)
 
 {{< clients-example set="vecset_tutorial" step="vrem" description="Element removal: Use VREM to delete elements from a vector set when you need to remove vectors from the collection" buildsUpon="vadd" needs_prereq="true" >}}
 > VADD points VALUES 2 0 0 pt:F
@@ -123,8 +123,8 @@ Remove an unwanted element with [`VREM`]({{< relref "/commands/vrem" >}})
 {{< /clients-example >}}
 
 Set and retrieve an element's JSON attribute data using
-[`VSETATTR`]({{< relref "/commands/vsetattr" >}})
-and [`VGETATTR`]({{< relref "/commands/vgetattr" >}}). You can also pass an empty string
+[`VSETATTR`](/content/commands/vsetattr.md)
+and [`VGETATTR`](/content/commands/vgetattr.md). You can also pass an empty string
 to `VSETATTR` to delete the attribute data:
 
 {{< clients-example set="vecset_tutorial" step="attr" description="Attribute management: Use VSETATTR to store JSON attributes on elements and VGETATTR to retrieve them when you need to associate metadata with vectors" buildsUpon="vadd" needs_prereq="true" >}}
@@ -140,7 +140,7 @@ to `VSETATTR` to delete the attribute data:
 
 ### Vector similarity search
 
-Use [`VSIM`]({{< relref "/commands/vsim" >}}) to rank the points in order of their vector distance from a sample point:
+Use [`VSIM`](/content/commands/vsim.md) to rank the points in order of their vector distance from a sample point:
 
 {{< clients-example set="vecset_tutorial" step="vsim_basic" description="Similarity search: Use VSIM to find elements most similar to a query vector when you need to perform vector similarity searches" difficulty="intermediate" buildsUpon="vadd" needs_prereq="true" >}}
 > VSIM points values 2 0.9 0.1
@@ -166,7 +166,7 @@ Find the four elements that are closest to point A and show their distance "scor
 {{< /clients-example >}}
 
 Add some JSON attributes and use
-[filter expressions]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+[filter expressions](/content/develop/data-types/vector-sets/filtered-search.md)
 to include them in the search:
 
 {{< clients-example set="vecset_tutorial" step="vsim_filter" description="Filtered similarity search: Use VSIM with FILTER option to apply attribute-based conditions to similarity results when you need to combine vector similarity with attribute filtering" difficulty="advanced" buildsUpon="vadd" needs_prereq="true" >}}
@@ -195,9 +195,8 @@ to include them in the search:
 2) "pt:B"
 {{< /clients-example >}}
 &nbsp;
-{{< alert title="Try it out" >}}
-Experiment with vector set commands interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.
-{{< /alert >}}
+> [!NOTE] Try it out
+> Experiment with vector set commands interactively in the [Redis playground](https://redis.io/try/sandbox) — no installation required.
 
 ## More information
 

--- a/content/develop/data-types/vector-sets/filtered-search.md
+++ b/content/develop/data-types/vector-sets/filtered-search.md
@@ -16,7 +16,7 @@ weight: 10
 
 ## Overview
 
-Filtered search lets you combine vector similarity search with scalar filtering. You can associate JSON attributes with elements in a vector set, and then filter results using those attributes during [`VSIM`]({{< relref "/commands/vsim" >}}) queries.
+Filtered search lets you combine vector similarity search with scalar filtering. You can associate JSON attributes with elements in a vector set, and then filter results using those attributes during [`VSIM`](/content/commands/vsim.md) queries.
 
 This allows queries such as:
 
@@ -32,13 +32,13 @@ You can associate attributes when adding a new vector using the `SETATTR` argume
 VADD vset VALUES 3 1 1 1 a SETATTR '{"year": 1950}'
 ```
 
-Or update them later with the [`VSETATTR`]({{< relref "/commands/vsetattr" >}}) command:
+Or update them later with the [`VSETATTR`](/content/commands/vsetattr.md) command:
 
 ```bash
 VSETATTR vset a '{"year": 1960}'
 ```
 
-You can retrieve attributes with the [`VGETATTR`]({{< relref "/commands/vgetattr" >}}) command:
+You can retrieve attributes with the [`VGETATTR`](/content/commands/vgetattr.md) command:
 
 ```bash
 VGETATTR vset a
@@ -46,7 +46,7 @@ VGETATTR vset a
 
 ## Filtering during similarity search
 
-To filter by attributes, pass the `FILTER` option to the [`VSIM`]({{< relref "/commands/vsim" >}}) command:
+To filter by attributes, pass the `FILTER` option to the [`VSIM`](/content/commands/vsim.md) command:
 
 ```bash
 VSIM vset VALUES 3 0 0 0 FILTER '.year > 1950'
@@ -113,7 +113,7 @@ VSIM movies VALUES 3 0.5 0.8 0.2 FILTER '(.year - 2000) ** 2 < 100 and .rating /
 
 ## See also
 
-- [VSIM]({{< relref "/commands/vsim" >}})
-- [VADD]({{< relref "/commands/vadd" >}})
-- [VSETATTR]({{< relref "/commands/vsetattr" >}})
-- [VGETATTR]({{< relref "/commands/vgetattr" >}})
+- [VSIM](/content/commands/vsim.md)
+- [VADD](/content/commands/vadd.md)
+- [VSETATTR](/content/commands/vsetattr.md)
+- [VGETATTR](/content/commands/vgetattr.md)

--- a/content/develop/data-types/vector-sets/memory.md
+++ b/content/develop/data-types/vector-sets/memory.md
@@ -64,7 +64,7 @@ High-dimensional vectors increase storage:
 - 300 components at `FP32` = 1200 bytes/vector
 - 300 components at `Q8` = 300 bytes/vector
 
-You can reduce this using the `REDUCE` option during [`VADD`]({{< relref "/commands/vadd" >}}), which applies [random projection](https://en.wikipedia.org/wiki/Random_projection):
+You can reduce this using the `REDUCE` option during [`VADD`](/content/commands/vadd.md), which applies [random projection](https://en.wikipedia.org/wiki/Random_projection):
 
 {{< clients-example set="vecset_tutorial" step="add_reduce" description="Dimension reduction: Use the REDUCE option with VADD to apply random projection and reduce vector dimensions when you need to optimize memory usage while maintaining search quality" difficulty="advanced" runnable="false" try_it="false" >}}
 >VADD setNotReduced VALUES 300 ... element
@@ -92,5 +92,5 @@ This projects a 300-dimensional vector into 100 dimensions, reducing size and im
 
 ## See also
 
-- [Performance]({{< relref "/develop/data-types/vector-sets/performance" >}})
-- [Scalability]({{< relref "/develop/data-types/vector-sets/scalability" >}})
+- [Performance](/content/develop/data-types/vector-sets/performance.md)
+- [Scalability](/content/develop/data-types/vector-sets/scalability.md)

--- a/content/develop/data-types/vector-sets/performance.md
+++ b/content/develop/data-types/vector-sets/performance.md
@@ -16,7 +16,7 @@ weight: 15
 
 ## Query performance
 
-Vector similarity queries using the [`VSIM`]({{< relref "/commands/vsim" >}}) are threaded by default. Redis uses up to 32 threads to process these queries in parallel.
+Vector similarity queries using the [`VSIM`](/content/commands/vsim.md) are threaded by default. Redis uses up to 32 threads to process these queries in parallel.
 
 - `VSIM` performance scales nearly linearly with available CPU cores.
 - Expect ~50,000 similarity queries per second for a 3M-item set with 300-dim vectors using int8 quantization.
@@ -26,7 +26,7 @@ Vector similarity queries using the [`VSIM`]({{< relref "/commands/vsim" >}}) ar
 
 ## Insertion performance
 
-Inserting vectors with the [`VADD`]({{< relref "/commands/vadd" >}}) command is more computationally expensive than querying:
+Inserting vectors with the [`VADD`](/content/commands/vadd.md) command is more computationally expensive than querying:
 
 - Insertion is single-threaded by default.
 - Use the `CAS` option to offload candidate graph search to a background thread.
@@ -67,7 +67,7 @@ due to floating point rounding.
 
 ## Deletion performance
 
-Deleting large vector sets using the [`DEL`]({{< relref "/commands/del" >}}) can cause latency spikes:
+Deleting large vector sets using the [`DEL`](/content/commands/del.md) can cause latency spikes:
 
 - Redis must unlink and restructure many graph nodes.
 - Latency is most noticeable when deleting millions of elements.
@@ -91,6 +91,6 @@ Example: A 3M vector set with 300 components loads in ~15 seconds.
 
 ## See also
 
-- [Memory usage]({{< relref "/develop/data-types/vector-sets/memory" >}})
-- [Scalability]({{< relref "/develop/data-types/vector-sets/scalability" >}})
-- [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
+- [Memory usage](/content/develop/data-types/vector-sets/memory.md)
+- [Scalability](/content/develop/data-types/vector-sets/scalability.md)
+- [Filtered search](/content/develop/data-types/vector-sets/filtered-search.md)

--- a/content/develop/data-types/vector-sets/scalability.md
+++ b/content/develop/data-types/vector-sets/scalability.md
@@ -34,7 +34,7 @@ VADD vset:0 VALUES 3 0.1 0.2 0.3 item1
 VADD vset:1 VALUES 3 0.4 0.5 0.6 item2
 ```
 
-To run a similarity search across all shards, send [`VSIM`]({{< relref "/commands/vsim" >}}) commands to each key and then merge the results client-side:
+To run a similarity search across all shards, send [`VSIM`](/content/commands/vsim.md) commands to each key and then merge the results client-side:
 
 ```bash
 VSIM vset:0 VALUES ... WITHSCORES
@@ -46,8 +46,8 @@ Then combine and sort the results by score.
 
 ## Key properties
 
-- Write operations ([`VADD`]({{< relref "/commands/vadd" >}}), [`VREM`]({{< relref "/commands/vrem" >}})) scale linearly—you can insert in parallel across instances.
-- Read operations ([`VSIM`]({{< relref "/commands/vsim" >}})) do not scale linearly—you must query all shards for a full result set.
+- Write operations ([`VADD`](/content/commands/vadd.md), [`VREM`](/content/commands/vrem.md)) scale linearly—you can insert in parallel across instances.
+- Read operations ([`VSIM`](/content/commands/vsim.md)) do not scale linearly—you must query all shards for a full result set.
 - Smaller vector sets yield faster queries, so distributing them helps reduce query time per node.
 - Merging results client-side keeps logic simple and doesn't add server-side overhead.
 
@@ -78,6 +78,6 @@ This makes total latency close to the worst-case shard time, not the sum of all 
 
 ## See also
 
-- [Performance]({{< relref "/develop/data-types/vector-sets/performance" >}})
-- [Filtered search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
-- [Memory usage]({{< relref "/develop/data-types/vector-sets/memory" >}})
+- [Performance](/content/develop/data-types/vector-sets/performance.md)
+- [Filtered search](/content/develop/data-types/vector-sets/filtered-search.md)
+- [Memory usage](/content/develop/data-types/vector-sets/memory.md)

--- a/content/develop/data-types/vector-sets/troubleshooting.md
+++ b/content/develop/data-types/vector-sets/troubleshooting.md
@@ -20,7 +20,7 @@ Vector sets are approximate by design. That makes debugging trickier than with e
 
 ## Low recall or missing results
 
-If [`VSIM`]({{< relref "/commands/vsim" >}}) doesn't return expected items:
+If [`VSIM`](/content/commands/vsim.md) doesn't return expected items:
 
 - Increase the `EF` parameter:
 
@@ -45,7 +45,7 @@ Filters silently exclude items if:
 - The JSON is invalid
 - A type doesn’t match the expression (for example, `.rating > 8` when `.rating` is a string)
 
-Try retrieving the attributes with [`VGETATTR`]({{< relref "/commands/vgetattr" >}}):
+Try retrieving the attributes with [`VGETATTR`](/content/commands/vgetattr.md):
 
 ```bash
 VGETATTR myset myelement
@@ -66,7 +66,7 @@ Use default `Q8` quantization and compact attributes to save space.
 
 ## Inspecting the graph
 
-Use [`VLINKS`]({{< relref "/commands/vlinks" >}}) to examine a node’s connections:
+Use [`VLINKS`](/content/commands/vlinks.md) to examine a node’s connections:
 
 ```bash
 VLINKS myset myelement WITHSCORES
@@ -84,7 +84,7 @@ Large sets deleted using the `DEL` command can briefly spike latency as Redis re
 - `VADD` with `REDUCE` does not replicate the random projection matrix.
 - Replicas will produce different projected vectors for the same inputs.
 
-This doesn't affect similarity searches but does affect [`VEMB`]({{< relref "/commands/vemb" >}}) output.
+This doesn't affect similarity searches but does affect [`VEMB`](/content/commands/vemb.md) output.
 
 ## Summary
 
@@ -97,6 +97,6 @@ This doesn't affect similarity searches but does affect [`VEMB`]({{< relref "/co
 
 ## See also
 
-- [Filtered Search]({{< relref "/develop/data-types/vector-sets/filtered-search" >}})
-- [Memory Usage]({{< relref "/develop/data-types/vector-sets/memory" >}})
-- [Performance]({{< relref "/develop/data-types/vector-sets/performance" >}})
+- [Filtered Search](/content/develop/data-types/vector-sets/filtered-search.md)
+- [Memory Usage](/content/develop/data-types/vector-sets/memory.md)
+- [Performance](/content/develop/data-types/vector-sets/performance.md)


### PR DESCRIPTION
## Summary
- Migrates all 6 pages in `content/develop/data-types/vector-sets/` from Hugo shortcodes to native-Markdown render hooks (DOC-7055, unit C), using `build/migrate_shortcode_links.py all` (relref-to-plain, callouts-to-blockquote, linkify).
- `_index.md`'s `{{< alert title="Try it out" >}}...{{< /alert >}}` converts to `> [!NOTE] Try it out`, preserving the custom title.

## Verification
- Scoped before/after Hugo build (`hugo --minify`) + `build/diff_rendered_hrefs.py`: **zero href differences** for `develop/data-types/vector-sets`.
- Full-build warning/error output before vs. after is identical once sorted and the one random temp-filename suffix is normalized (a known Hugo build-nondeterminism artifact, not a regression). Pre-existing, unrelated build errors (jupyter-example shortcode `readFile` failures, and a JS-minify error on `/commands/cf.reserve/`) reproduce identically in both before and after builds.
- Checked the pre-existing `&nbsp;` spacer between the `vecset_tutorial` clients-example widget and the alert in `_index.md`: it still renders as a real non-breaking space between the two block elements. It now sits inside its own `<p>` tag (new blockquote rendering) instead of as bare text (old shortcode rendering) — a real structural difference, but one that preserves or increases the visible gap rather than collapsing it.

## Test plan
- [x] `git diff` reviewed for all 6 files — link and callout conversions look correct and match the DOC-7047 convention already used in `content/develop/clients/`.
- [x] `python3 build/diff_rendered_hrefs.py` reports 0 href differences.
- [x] Full build warning/error diff reviewed — no new warnings.
- [x] Spacer/gap around the `_index.md` alert-to-blockquote conversion inspected in rendered HTML.

Base is `DOC-7055-callout-percent-form-support` (PR #3965), not `main`, since this stacks on that not-yet-merged script extension. GitHub will retarget to `main` once #3965 merges.

Ticket: DOC-7055

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout syntax changes with verified equivalent rendered hrefs; no product or runtime behavior changes.
> 
> **Overview**
> Migrates all six **vector sets** docs under `content/develop/data-types/vector-sets/` from Hugo **`relref`** shortcodes to plain Markdown links (for example `/content/commands/vsim.md` and cross-section anchors like `#quantization-effects`).
> 
> On **`_index.md`**, the **Try it out** **`alert`** shortcode becomes a **`> [!NOTE] Try it out`** blockquote callout; the Redis playground link and surrounding **`&nbsp;`** spacer are unchanged in source.
> 
> **See also** sections on the sibling pages get the same link treatment. **`command-group`**, **`clients-example`**, and **`image`** shortcodes are untouched—this is link/callout migration only, aligned with DOC-7055 and the existing clients docs convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825d44976be7c4414039697c5c537ce96e3605af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->