### PR TITLE
DOC-7055: Migrate develop/data-types top-level pages to render hooks

### DIFF
--- a/build/migrate_shortcode_links.py
+++ b/build/migrate_shortcode_links.py
@@ -10,6 +10,9 @@ Formalizes the three ad hoc converters used to migrate develop/clients/redis-py
 Stages, and why this order is load-bearing:
   1. relref-to-plain   -- unwrap `]({{< relref "X" >}})` to `](X)`.
   2. callouts-to-blockquote -- `{{< note >}}...{{< /note >}}` to `> [!NOTE]...`.
+     Also handles the `{{% note %}}` percent form and a `title=` attribute
+     (`alert` maps onto the `note` alert type; a title matching the type's
+     default label is dropped as redundant).
      MUST run before stage 3: shortcode callouts pipe their inner content
      through markdownify with no page context, so a link inside one resolves
      against site root, not the page -- only a native blockquote resolves
@@ -35,10 +38,24 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "hoo
 import check_shortcode_paths as csp  # noqa: E402  (reuse mount-aware path resolution)
 
 RELREF_RX = re.compile(r'\]\(\{\{<\s*relref\s+"([^"]*)"\s*>\}\}([^)]*)\)')
+# Matches both delimiter forms (`{{< note >}}` and `{{% note %}}`) and an
+# optional run of attributes on the opening tag (e.g. `title="..."`),
+# without requiring the open/close delimiter to match each other -- real
+# Hugo content always pairs them correctly, so being lenient here only
+# widens what converts, never what breaks.
 CALLOUT_RX = re.compile(
-    r'\{\{<\s*(note|warning|tip|info|alert)\s*>\}\}(.*?)\{\{<\s*/\1\s*>\}\}',
+    r'\{\{[<%]\s*(note|warning|tip|info|alert)((?:\s+\w+="[^"]*")*)\s*[%>]\}\}'
+    r'(.*?)\{\{[<%]\s*/\1\s*[%>]\}\}',
     re.DOTALL,
 )
+# The `alert` shortcode has no fixed type of its own (it's `note`/`warning`/
+# etc. with a custom title bolted on) -- render hooks have no such shortcode,
+# so it maps onto the plain `note` alert type. A `title=` attribute that just
+# restates the type's default label (e.g. `alert title="Note"`) is dropped
+# rather than carried over as a redundant `> [!NOTE] Note`.
+CALLOUT_DEFAULT_LABEL = {
+    "note": "Note", "warning": "Warning", "tip": "Tip", "info": "Info", "alert": "Note",
+}
 LINK_RX = re.compile(r'\]\(([^)\s]+)\)')
 SKIP_HREF_PREFIXES = ("http://", "https://", "mailto:", "#", "/content/")
 
@@ -54,10 +71,16 @@ def relref_to_plain(text):
 
 def callouts_to_blockquote(text):
     def repl(m):
-        kind, body = m.group(1), m.group(2).strip("\n")
+        kind, attrs, body = m.group(1), m.group(2), m.group(3).strip("\n")
+        out_type = "note" if kind == "alert" else kind
+        title_m = re.search(r'\btitle="([^"]*)"', attrs)
+        title = title_m.group(1) if title_m else ""
+        if title.strip().lower() == CALLOUT_DEFAULT_LABEL[kind].lower():
+            title = ""
+        header = f"> [!{out_type.upper()}]" + (f" {title}" if title else "")
         lines = body.split("\n")
         quoted = "\n".join(f"> {line}" if line else ">" for line in lines)
-        return f"> [!{kind.upper()}]\n{quoted}"
+        return f"{header}\n{quoted}"
 
     return CALLOUT_RX.sub(repl, text)
 

--- a/content/develop/data-types/_index.md
+++ b/content/develop/data-types/_index.md
@@ -20,15 +20,15 @@ weight: 35
 ---
 
 Redis is a data structure server.
-At its core, Redis provides a collection of native data types that help you solve a wide variety of problems, from [caching]({{< relref "/develop/data-types/strings" >}}) to
-[queuing]({{< relref "/develop/data-types/lists" >}}) to
-[event processing]({{< relref "/develop/data-types/streams" >}}).
+At its core, Redis provides a collection of native data types that help you solve a wide variety of problems, from [caching](/content/develop/data-types/strings/_index.md) to
+[queuing](/content/develop/data-types/lists.md) to
+[event processing](/content/develop/data-types/streams/_index.md).
 Below is a short description of each data type, with links to broader overviews and command references.
 Each overview includes a comprehensive tutorial with code samples.
 
 ## Data types
 
-[Redis Open Source]({{< relref "/operate/oss_and_stack" >}})
+[Redis Open Source](/content/operate/oss_and_stack/_index.md)
 implements the following data types:
 
 - [Strings](#strings)
@@ -46,78 +46,78 @@ implements the following data types:
 - [Time series](#time-series)
 - [Vector sets](#vector-sets)
 
-See [Compare data types]({{< relref "/develop/data-types/compare-data-types" >}})
+See [Compare data types](/content/develop/data-types/compare-data-types.md)
 for advice on which of the general-purpose data types is best for common tasks.
 
 ### Strings 
 
-[Redis strings]({{< relref "/develop/data-types/strings" >}}) are the most basic Redis data type, representing a sequence of bytes.
+[Redis strings](/content/develop/data-types/strings/_index.md) are the most basic Redis data type, representing a sequence of bytes.
 For more information, see:
 
-* [Overview of Redis strings]({{< relref "/develop/data-types/strings" >}})
-* [Redis string command reference]({{< relref "/commands/" >}}?group=string)
+* [Overview of Redis strings](/content/develop/data-types/strings/_index.md)
+* [Redis string command reference](/commands/?group=string)
 
 ### Bitfields
 
-[Redis bitfields]({{< relref "/develop/data-types/strings/bitfields" >}}) efficiently encode multiple counters in a string value.
+[Redis bitfields](/content/develop/data-types/strings/bitfields.md) efficiently encode multiple counters in a string value.
 Bitfields provide atomic get, set, and increment operations and support different overflow policies.
 For more information, see:
 
-* [Overview of Redis bitfields]({{< relref "/develop/data-types/strings/bitfields" >}})
-* The [`BITFIELD`]({{< relref "/commands/bitfield" >}}) command.
+* [Overview of Redis bitfields](/content/develop/data-types/strings/bitfields.md)
+* The [`BITFIELD`](/content/commands/bitfield.md) command.
 
 ### Bitmaps
 
-[Redis bitmaps]({{< relref "/develop/data-types/strings/bitmaps" >}}) let you perform bitwise operations on strings. 
+[Redis bitmaps](/content/develop/data-types/strings/bitmaps.md) let you perform bitwise operations on strings. 
 For more information, see:
 
-* [Overview of Redis bitmaps]({{< relref "/develop/data-types/strings/bitmaps" >}})
-* [Redis bitmap command reference]({{< relref "/commands/" >}}?group=bitmap)
+* [Overview of Redis bitmaps](/content/develop/data-types/strings/bitmaps.md)
+* [Redis bitmap command reference](/commands/?group=bitmap)
 
 ### Arrays
 
-[Redis arrays]({{< relref "/develop/data-types/arrays" >}}) are sparse, index-addressable sequences of strings.
+[Redis arrays](/content/develop/data-types/arrays.md) are sparse, index-addressable sequences of strings.
 For more information, see:
 
-* [Overview of Redis arrays]({{< relref "/develop/data-types/arrays" >}})
-* [Redis array command reference]({{< relref "/commands/" >}}?group=array)
+* [Overview of Redis arrays](/content/develop/data-types/arrays.md)
+* [Redis array command reference](/commands/?group=array)
 
 ### Geospatial indexes
 
-[Redis geospatial indexes]({{< relref "/develop/data-types/geospatial" >}}) are useful for finding locations within a given geographic radius or bounding box.
+[Redis geospatial indexes](/content/develop/data-types/geospatial.md) are useful for finding locations within a given geographic radius or bounding box.
 For more information, see:
 
-* [Overview of Redis geospatial indexes]({{< relref "/develop/data-types/geospatial" >}})
-* [Redis geospatial indexes command reference]({{< relref "/commands/" >}}?group=geo)
+* [Overview of Redis geospatial indexes](/content/develop/data-types/geospatial.md)
+* [Redis geospatial indexes command reference](/commands/?group=geo)
 
 ### Hashes
 
-[Redis hashes]({{< relref "/develop/data-types/hashes" >}}) are record types modeled as collections of field-value pairs.
+[Redis hashes](/content/develop/data-types/hashes.md) are record types modeled as collections of field-value pairs.
 As such, Redis hashes resemble [Python dictionaries](https://docs.python.org/3/tutorial/datastructures.html#dictionaries), [Java HashMaps](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html), and [Ruby hashes](https://ruby-doc.org/core-3.1.2/Hash.html).
 For more information, see:
 
-* [Overview of Redis hashes]({{< relref "/develop/data-types/hashes" >}})
-* [Redis hashes command reference]({{< relref "/commands/" >}}?group=hash)
+* [Overview of Redis hashes](/content/develop/data-types/hashes.md)
+* [Redis hashes command reference](/commands/?group=hash)
 
 ### JSON
 
-[Redis JSON]({{< relref "/develop/data-types/json" >}}) provides
+[Redis JSON](/content/develop/data-types/json/_index.md) provides
 structured, hierarchical arrays and key-value objects that match
 the popular [JSON](https://www.json.org/json-en.html) text file
 format. You can import JSON text into Redis objects and access,
 modify, and query individual data elements.
 For more information, see:
 
-- [Overview of Redis JSON]({{< relref "/develop/data-types/json" >}})
-- [JSON command reference]({{< relref "/commands" >}}?group=json)
+- [Overview of Redis JSON](/content/develop/data-types/json/_index.md)
+- [JSON command reference](/commands?group=json)
 
 ### Lists
 
-[Redis lists]({{< relref "/develop/data-types/lists" >}}) are lists of strings sorted by insertion order.
+[Redis lists](/content/develop/data-types/lists.md) are lists of strings sorted by insertion order.
 For more information, see:
 
-* [Overview of Redis lists]({{< relref "/develop/data-types/lists" >}})
-* [Redis list command reference]({{< relref "/commands/" >}}?group=list)
+* [Overview of Redis lists](/content/develop/data-types/lists.md)
+* [Redis list command reference](/commands/?group=list)
 
 ### Probabilistic data types
 
@@ -134,103 +134,103 @@ available:
 
 ### Bloom filter
 
-[Redis Bloom filters]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}})
+[Redis Bloom filters](/content/develop/data-types/probabilistic/bloom-filter.md)
 let you check for the presence or absence of an element in a set. For more
 information, see:
 
-- [Overview of Redis Bloom filters]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}})
-- [Bloom filter command reference]({{< relref "/commands" >}}?group=bf)
+- [Overview of Redis Bloom filters](/content/develop/data-types/probabilistic/bloom-filter.md)
+- [Bloom filter command reference](/commands?group=bf)
 
 ### Count-min sketch
 
-[Redis Count-min sketch]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
+[Redis Count-min sketch](/content/develop/data-types/probabilistic/count-min-sketch.md)
 estimate the frequency of a data point within a stream of values.
 For more information, see:
 
-- [Redis Count-min sketch overview]({{< relref "/develop/data-types/probabilistic/count-min-sketch" >}})
-- [Count-min sketch command reference]({{< relref "/commands" >}}?group=cms)
+- [Redis Count-min sketch overview](/content/develop/data-types/probabilistic/count-min-sketch.md)
+- [Count-min sketch command reference](/commands?group=cms)
 
 ### Cuckoo filter
 
-[Redis Cuckoo filters]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
+[Redis Cuckoo filters](/content/develop/data-types/probabilistic/cuckoo-filter.md)
 let you check for the presence or absence of an element in a set. They are similar to
 [Bloom filters](#bloom-filter) but with slightly different trade-offs between features
 and performance. For more information, see:
 
-- [Overview of Redis Cuckoo filters]({{< relref "/develop/data-types/probabilistic/cuckoo-filter" >}})
-- [Cuckoo filter command reference]({{< relref "/commands" >}}?group=cf)
+- [Overview of Redis Cuckoo filters](/content/develop/data-types/probabilistic/cuckoo-filter.md)
+- [Cuckoo filter command reference](/commands?group=cf)
 
 ### HyperLogLog
 
-The [Redis HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}}) data structures provide probabilistic estimates of the cardinality (i.e., number of elements) of large sets. For more information, see:
+The [Redis HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md) data structures provide probabilistic estimates of the cardinality (i.e., number of elements) of large sets. For more information, see:
 
-* [Overview of Redis HyperLogLog]({{< relref "/develop/data-types/probabilistic/hyperloglogs" >}})
-* [Redis HyperLogLog command reference]({{< relref "/commands/" >}}?group=hyperloglog)
+* [Overview of Redis HyperLogLog](/content/develop/data-types/probabilistic/hyperloglogs.md)
+* [Redis HyperLogLog command reference](/commands/?group=hyperloglog)
 
 ### t-digest
 
-[Redis t-digest]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
+[Redis t-digest](/content/develop/data-types/probabilistic/t-digest.md)
 structures estimate percentiles from a stream of data values. For more
 information, see:
 
-- [Redis t-digest overview]({{< relref "/develop/data-types/probabilistic/t-digest" >}})
-- [t-digest command reference]({{< relref "/commands" >}}?group=tdigest)
+- [Redis t-digest overview](/content/develop/data-types/probabilistic/t-digest.md)
+- [t-digest command reference](/commands?group=tdigest)
 
 ### Top-K
 
-[Redis Top-K]({{< relref "/develop/data-types/probabilistic/top-k" >}})
+[Redis Top-K](/content/develop/data-types/probabilistic/top-k.md)
 structures estimate the ranking of a data point within a stream of values.
 For more information, see:
 
-- [Redis Top-K overview]({{< relref "/develop/data-types/probabilistic/top-k" >}})
-- [Top-K command reference]({{< relref "/commands" >}}?group=topk)
+- [Redis Top-K overview](/content/develop/data-types/probabilistic/top-k.md)
+- [Top-K command reference](/commands?group=topk)
 
 ### Sets
 
-[Redis sets]({{< relref "/develop/data-types/sets" >}}) are unordered collections of unique strings that act like the sets from your favorite programming language (for example, [Java HashSets](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html), [Python sets](https://docs.python.org/3.10/library/stdtypes.html#set-types-set-frozenset), and so on).
+[Redis sets](/content/develop/data-types/sets.md) are unordered collections of unique strings that act like the sets from your favorite programming language (for example, [Java HashSets](https://docs.oracle.com/javase/7/docs/api/java/util/HashSet.html), [Python sets](https://docs.python.org/3.10/library/stdtypes.html#set-types-set-frozenset), and so on).
 With a Redis set, you can add, remove, and test for existence in O(1) time (in other words, regardless of the number of set elements).
 For more information, see:
 
-* [Overview of Redis sets]({{< relref "/develop/data-types/sets" >}})
-* [Redis set command reference]({{< relref "/commands/" >}}?group=set)
+* [Overview of Redis sets](/content/develop/data-types/sets.md)
+* [Redis set command reference](/commands/?group=set)
 
 ### Sorted sets
 
-[Redis sorted sets]({{< relref "/develop/data-types/sorted-sets" >}}) are collections of unique strings that maintain order by each string's associated score.
+[Redis sorted sets](/content/develop/data-types/sorted-sets.md) are collections of unique strings that maintain order by each string's associated score.
 For more information, see:
 
-* [Overview of Redis sorted sets]({{< relref "/develop/data-types/sorted-sets" >}})
-* [Redis sorted set command reference]({{< relref "/commands/" >}}?group=sorted-set)
+* [Overview of Redis sorted sets](/content/develop/data-types/sorted-sets.md)
+* [Redis sorted set command reference](/commands/?group=sorted-set)
 
 ### Streams
 
-A [Redis stream]({{< relref "/develop/data-types/streams" >}}) is a data structure that acts like an append-only log.
+A [Redis stream](/content/develop/data-types/streams/_index.md) is a data structure that acts like an append-only log.
 Streams help record events in the order they occur and then syndicate them for processing.
 For more information, see:
 
-* [Overview of Redis Streams]({{< relref "/develop/data-types/streams" >}})
-* [Redis Streams command reference]({{< relref "/commands/" >}}?group=stream)
+* [Overview of Redis Streams](/content/develop/data-types/streams/_index.md)
+* [Redis Streams command reference](/commands/?group=stream)
 
 ### Time series
 
-[Redis time series]({{< relref "/develop/data-types/timeseries" >}})
+[Redis time series](/content/develop/data-types/timeseries/_index.md)
 structures let you store and query timestamped data points.
 For more information, see:
 
-- [Redis time series overview]({{< relref "/develop/data-types/timeseries" >}})
-- [Time series command reference]({{< relref "/commands" >}}?group=timeseries)
+- [Redis time series overview](/content/develop/data-types/timeseries/_index.md)
+- [Time series command reference](/commands?group=timeseries)
 
 ### Vector sets
 
-[Redis vector sets]({{< relref "/develop/data-types/vector-sets" >}}) are a specialized data type designed for managing high-dimensional vector data, enabling fast and efficient vector similarity search within Redis. Vector sets are optimized for use cases involving machine learning, recommendation systems, and semantic search, where each vector represents a data point in multi-dimensional space. Vector sets supports the [HNSW](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world) (hierarchical navigable small world) algorithm, allowing you to store, index, and query vectors based on the cosine similarity metric. With vector sets, Redis provides native support for hybrid search, combining vector similarity with structured [filters]({{< relref "/develop/data-types/vector-sets/filtered-search" >}}).
+[Redis vector sets](/content/develop/data-types/vector-sets/_index.md) are a specialized data type designed for managing high-dimensional vector data, enabling fast and efficient vector similarity search within Redis. Vector sets are optimized for use cases involving machine learning, recommendation systems, and semantic search, where each vector represents a data point in multi-dimensional space. Vector sets supports the [HNSW](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world) (hierarchical navigable small world) algorithm, allowing you to store, index, and query vectors based on the cosine similarity metric. With vector sets, Redis provides native support for hybrid search, combining vector similarity with structured [filters](/content/develop/data-types/vector-sets/filtered-search.md).
 For more information, see:
 
-* [Overview of Redis vector sets]({{< relref "/develop/data-types/vector-sets" >}})
-* [Redis vector set command reference]({{< relref "/commands/" >}}?group=vector_set)
+* [Overview of Redis vector sets](/content/develop/data-types/vector-sets/_index.md)
+* [Redis vector set command reference](/commands/?group=vector_set)
 
 ## Adding extensions
 
 To extend the features provided by the included data types, use one of these options:
 
-1. Write your own custom [server-side functions in Lua]({{< relref "/develop/programmability/" >}}).
-1. Write your own Redis module using the [modules API]({{< relref "/develop/reference/modules/" >}}) or check out the [community-supported modules]({{< relref "/operate/oss_and_stack/stack-with-enterprise/" >}}).
+1. Write your own custom [server-side functions in Lua](/content/develop/programmability/_index.md).
+1. Write your own Redis module using the [modules API](/content/develop/reference/modules/_index.md) or check out the [community-supported modules](/content/operate/oss_and_stack/stack-with-enterprise/_index.md).

--- a/content/develop/data-types/arrays.md
+++ b/content/develop/data-types/arrays.md
@@ -23,7 +23,7 @@ Redis arrays are sparse, index-addressable data structures that map integer inde
 
 ## Basic usage
 
-Use [`ARSET`]({{< relref "/commands/arset" >}}) to write one or more contiguous values starting at a given index, and [`ARGET`]({{< relref "/commands/arget" >}}) to read the value at an index. Accessing an unset index returns a nil reply.
+Use [`ARSET`](/content/commands/arset.md) to write one or more contiguous values starting at a given index, and [`ARGET`](/content/commands/arget.md) to read the value at an index. Accessing an unset index returns a nil reply.
 
 {{< clients-example set="arrays_tutorial" step="arset_arget" description="Write contiguous values with ARSET and read a single index with ARGET; an unset index returns nil" >}}
 > ARSET events:1 0 "login" "click" "purchase"
@@ -34,7 +34,7 @@ Use [`ARSET`]({{< relref "/commands/arset" >}}) to write one or more contiguous 
 (nil)
 {{< /clients-example >}}
 
-To write values at arbitrary, non-contiguous indexes, use [`ARMSET`]({{< relref "/commands/armset" >}}). To read several indexes in one round trip, use [`ARMGET`]({{< relref "/commands/armget" >}}):
+To write values at arbitrary, non-contiguous indexes, use [`ARMSET`](/content/commands/armset.md). To read several indexes in one round trip, use [`ARMGET`](/content/commands/armget.md):
 
 {{< clients-example set="arrays_tutorial" step="armset_armget" description="Write to arbitrary, non-contiguous indexes with ARMSET and read several indexes in one round trip with ARMGET" >}}
 > ARMSET metrics 0 "10" 5 "20" 100 "30"
@@ -50,8 +50,8 @@ To write values at arbitrary, non-contiguous indexes, use [`ARMSET`]({{< relref 
 
 Redis arrays expose two distinct size measurements:
 
-- [`ARLEN`]({{< relref "/commands/arlen" >}}) returns the *logical length*: the highest set index plus one.
-- [`ARCOUNT`]({{< relref "/commands/arcount" >}}) returns the number of *non-empty* elements.
+- [`ARLEN`](/content/commands/arlen.md) returns the *logical length*: the highest set index plus one.
+- [`ARCOUNT`](/content/commands/arcount.md) returns the number of *non-empty* elements.
 
 For a sparse array, these values can differ substantially:
 
@@ -68,7 +68,7 @@ For a sparse array, these values can differ substantially:
 
 ## Reading ranges
 
-[`ARGETRANGE`]({{< relref "/commands/argetrange" >}}) returns every position in a range—including empty slots as nil—in index order. Reversing `start` and `end` reverses the direction:
+[`ARGETRANGE`](/content/commands/argetrange.md) returns every position in a range—including empty slots as nil—in index order. Reversing `start` and `end` reverses the direction:
 
 {{< clients-example set="arrays_tutorial" step="argetrange" description="Read every position in a range with ARGETRANGE, including empty slots returned as nil" >}}
 > ARMSET seq 0 "a" 1 "b" 3 "d"
@@ -80,7 +80,7 @@ For a sparse array, these values can differ substantially:
 4) "d"
 {{< /clients-example >}}
 
-To iterate only the elements that exist and retrieve their indexes alongside their values, use [`ARSCAN`]({{< relref "/commands/arscan" >}}). It skips empty slots and returns a flat list of alternating index-value pairs, with an optional `LIMIT` to cap the result size:
+To iterate only the elements that exist and retrieve their indexes alongside their values, use [`ARSCAN`](/content/commands/arscan.md). It skips empty slots and returns a flat list of alternating index-value pairs, with an optional `LIMIT` to cap the result size:
 
 {{< clients-example set="arrays_tutorial" step="arscan" description="Iterate only the elements that exist with ARSCAN, retrieving each index alongside its value" buildsUpon="argetrange" >}}
 > ARSCAN seq 0 3
@@ -94,7 +94,7 @@ To iterate only the elements that exist and retrieve their indexes alongside the
 
 ## Sequential insertion
 
-[`ARINSERT`]({{< relref "/commands/arinsert" >}}) appends values using an internal cursor that advances automatically after each call. Use [`ARNEXT`]({{< relref "/commands/arnext" >}}) to inspect where the next insert would land, and [`ARSEEK`]({{< relref "/commands/arseek" >}}) to reposition the cursor:
+[`ARINSERT`](/content/commands/arinsert.md) appends values using an internal cursor that advances automatically after each call. Use [`ARNEXT`](/content/commands/arnext.md) to inspect where the next insert would land, and [`ARSEEK`](/content/commands/arseek.md) to reposition the cursor:
 
 {{< clients-example set="arrays_tutorial" step="arinsert" description="Append values with ARINSERT using an auto-advancing cursor, inspect it with ARNEXT, and reposition it with ARSEEK" >}}
 > ARINSERT log "event1"
@@ -111,7 +111,7 @@ To iterate only the elements that exist and retrieve their indexes alongside the
 
 ## Ring buffer mode
 
-[`ARRING`]({{< relref "/commands/arring" >}}) turns an array into a fixed-size circular buffer. Each call inserts a value at `insert_idx % size`, wrapping back to index `0` once the window is full and overwriting the oldest entry:
+[`ARRING`](/content/commands/arring.md) turns an array into a fixed-size circular buffer. Each call inserts a value at `insert_idx % size`, wrapping back to index `0` once the window is full and overwriting the oldest entry:
 
 {{< clients-example set="arrays_tutorial" step="arring" description="Use ARRING to maintain a fixed-size circular buffer that wraps and overwrites the oldest entry once full" >}}
 > ARRING readings 3 "v0"
@@ -126,7 +126,7 @@ To iterate only the elements that exist and retrieve their indexes alongside the
 "v3"
 {{< /clients-example >}}
 
-[`ARLASTITEMS`]({{< relref "/commands/arlastitems" >}}) retrieves the *N* most recently inserted elements in chronological order. Pass the `REV` flag to reverse the order:
+[`ARLASTITEMS`](/content/commands/arlastitems.md) retrieves the *N* most recently inserted elements in chronological order. Pass the `REV` flag to reverse the order:
 
 {{< clients-example set="arrays_tutorial" step="arlastitems" description="Retrieve the N most recently inserted elements with ARLASTITEMS, optionally reversing the order with REV" buildsUpon="arring" >}}
 > ARLASTITEMS readings 3
@@ -141,7 +141,7 @@ To iterate only the elements that exist and retrieve their indexes alongside the
 
 ## Aggregate operations
 
-[`AROP`]({{< relref "/commands/arop" >}}) performs a single-pass aggregate over a contiguous range of elements:
+[`AROP`](/content/commands/arop.md) performs a single-pass aggregate over a contiguous range of elements:
 
 | Operation | Description |
 |-----------|-------------|
@@ -165,7 +165,7 @@ To iterate only the elements that exist and retrieve their indexes alongside the
 
 ## Searching elements
 
-[`ARGREP`]({{< relref "/commands/argrep" >}}) finds elements in a range whose values match one or more textual predicates and returns their indexes. Empty slots are skipped. Four predicate forms are supported: `EXACT` (full equality), `MATCH` (substring), `GLOB` (the same wildcard syntax as [`SCAN`]({{< relref "/commands/scan" >}}) `MATCH`), and `RE` (regular expression). Multiple predicates are combined with `OR` by default, or with `AND` when the option is given. Pass `NOCASE` for case-insensitive comparisons, `WITHVALUES` to return matching values alongside their indexes, and `LIMIT` to cap the number of matches.
+[`ARGREP`](/content/commands/argrep.md) finds elements in a range whose values match one or more textual predicates and returns their indexes. Empty slots are skipped. Four predicate forms are supported: `EXACT` (full equality), `MATCH` (substring), `GLOB` (the same wildcard syntax as [`SCAN`](/content/commands/scan.md) `MATCH`), and `RE` (regular expression). Multiple predicates are combined with `OR` by default, or with `AND` when the option is given. Pass `NOCASE` for case-insensitive comparisons, `WITHVALUES` to return matching values alongside their indexes, and `LIMIT` to cap the number of matches.
 
 This is particularly useful when an array stores line-indexed text such as a log file, where each element holds one line:
 
@@ -188,7 +188,7 @@ The special values `-` and `+` denote the first and last index of the array. Com
 
 ## Deleting elements
 
-[`ARDEL`]({{< relref "/commands/ardel" >}}) deletes one or more elements by index and returns the count of elements actually removed. [`ARDELRANGE`]({{< relref "/commands/ardelrange" >}}) removes all elements within an index range; reversing `start` and `end` is supported:
+[`ARDEL`](/content/commands/ardel.md) deletes one or more elements by index and returns the count of elements actually removed. [`ARDELRANGE`](/content/commands/ardelrange.md) removes all elements within an index range; reversing `start` and `end` is supported:
 
 {{< clients-example set="arrays_tutorial" step="ardel" description="Delete elements by index with ARDEL or remove a whole index range with ARDELRANGE" buildsUpon="arop" >}}
 > ARDEL scores 1
@@ -201,7 +201,7 @@ Deleting the last remaining element removes the key entirely.
 
 ## Introspection
 
-[`ARINFO`]({{< relref "/commands/arinfo" >}}) returns metadata about an array's internal structure, including its logical length, element count, and next insert index. Pass the `FULL` option to include per-slice statistics such as fill rates and counts of dense versus sparse slices:
+[`ARINFO`](/content/commands/arinfo.md) returns metadata about an array's internal structure, including its logical length, element count, and next insert index. Pass the `FULL` option to include per-slice statistics such as fill rates and counts of dense versus sparse slices:
 
 ```
 > ARINFO readings
@@ -221,20 +221,20 @@ The following configuration parameters affect array behavior:
 - `array-sparse-kmax`
 - `array-sparse-kmin`
 
-See the [Redis configuration page]({{< relref "/operate/oss_and_stack/management/config" >}}) for details.
+See the [Redis configuration page](/content/operate/oss_and_stack/management/config.md) for details.
 
 ## Performance
 
-Most array commands are O(1), including [`ARSET`]({{< relref "/commands/arset" >}}), [`ARGET`]({{< relref "/commands/arget" >}}), [`ARDEL`]({{< relref "/commands/ardel" >}}), [`ARINSERT`]({{< relref "/commands/arinsert" >}}), [`ARNEXT`]({{< relref "/commands/arnext" >}}), [`ARSEEK`]({{< relref "/commands/arseek" >}}), [`ARCOUNT`]({{< relref "/commands/arcount" >}}), and [`ARLEN`]({{< relref "/commands/arlen" >}}). Operations that touch N elements—such as [`ARGETRANGE`]({{< relref "/commands/argetrange" >}}), [`ARSCAN`]({{< relref "/commands/arscan" >}}), [`ARDELRANGE`]({{< relref "/commands/ardelrange" >}}), [`AROP`]({{< relref "/commands/arop" >}}), and [`ARLASTITEMS`]({{< relref "/commands/arlastitems" >}})—are O(N). The underlying sliced-array encoding handles both dense and sparse access patterns efficiently, so large index gaps consume very little memory.
+Most array commands are O(1), including [`ARSET`](/content/commands/arset.md), [`ARGET`](/content/commands/arget.md), [`ARDEL`](/content/commands/ardel.md), [`ARINSERT`](/content/commands/arinsert.md), [`ARNEXT`](/content/commands/arnext.md), [`ARSEEK`](/content/commands/arseek.md), [`ARCOUNT`](/content/commands/arcount.md), and [`ARLEN`](/content/commands/arlen.md). Operations that touch N elements—such as [`ARGETRANGE`](/content/commands/argetrange.md), [`ARSCAN`](/content/commands/arscan.md), [`ARDELRANGE`](/content/commands/ardelrange.md), [`AROP`](/content/commands/arop.md), and [`ARLASTITEMS`](/content/commands/arlastitems.md)—are O(N). The underlying sliced-array encoding handles both dense and sparse access patterns efficiently, so large index gaps consume very little memory.
 
 ## Alternatives
 
 Arrays complement rather than replace the other Redis collection types:
 
-- Use [Redis lists]({{< relref "/develop/data-types/lists" >}}) when you need push/pop operations at either end, or when you need to insert elements between existing ones.
-- Use [Redis hashes]({{< relref "/develop/data-types/hashes" >}}) when values are addressed by field name rather than by numeric index.
-- Use [Redis streams]({{< relref "/develop/data-types/streams" >}}) when you need an append-only event log with consumer groups and acknowledgements.
+- Use [Redis lists](/content/develop/data-types/lists.md) when you need push/pop operations at either end, or when you need to insert elements between existing ones.
+- Use [Redis hashes](/content/develop/data-types/hashes.md) when values are addressed by field name rather than by numeric index.
+- Use [Redis streams](/content/develop/data-types/streams/_index.md) when you need an append-only event log with consumer groups and acknowledgements.
 
 ## Limits
 
-[`ARGETRANGE`]({{< relref "/commands/argetrange" >}}) enforces a hard limit of 1,000,000 elements per call to guard against accidentally large range reads.
+[`ARGETRANGE`](/content/commands/argetrange.md) enforces a hard limit of 1,000,000 elements per call to guard against accidentally large range reads.

--- a/content/develop/data-types/compare-data-types.md
+++ b/content/develop/data-types/compare-data-types.md
@@ -18,35 +18,35 @@ weight: 1
 Redis provides a wide range of data types to store your data.
 The following are highly specialized for precise purposes:
 
--   [Geospatial]({{< relref "/develop/data-types/geospatial" >}}):
+-   [Geospatial](/content/develop/data-types/geospatial.md):
     store strings with associated coordinates for geospatial queries.
--   [Probabilistic data types]({{< relref "/develop/data-types/probabilistic" >}}):
+-   [Probabilistic data types](/content/develop/data-types/probabilistic/_index.md):
     keep approximate counts and other statistics for large datasets.
--   [Time series]({{< relref "/develop/data-types/timeseries" >}}):
+-   [Time series](/content/develop/data-types/timeseries/_index.md):
     store real-valued data points along with the time they were collected.
--   [Vector sets]({{< relref "/develop/data-types/vector-sets" >}}):
+-   [Vector sets](/content/develop/data-types/vector-sets/_index.md):
     store strings with associated vector data (and optional metadata)
     for vector similarity queries.
 
 The remaining data types are more general-purpose:
 
--   [Strings]({{< relref "/develop/data-types/strings" >}}):
+-   [Strings](/content/develop/data-types/strings/_index.md):
     store text or binary data.
--   [Arrays]({{< relref "/develop/data-types/arrays" >}}):
+-   [Arrays](/content/develop/data-types/arrays.md):
     store strings addressed by integer index, with support for sparse
     indices and server-side aggregation.
--   [Hashes]({{< relref "/develop/data-types/hashes" >}}):
+-   [Hashes](/content/develop/data-types/hashes.md):
     store key-value pairs within a single key.
--   [JSON]({{< relref "/develop/data-types/json" >}}):
+-   [JSON](/content/develop/data-types/json/_index.md):
     store structured, hierarchical arrays and key-value objects that match
     the popular [JSON](https://www.json.org/json-en.html) text file format.
--   [Lists]({{< relref "/develop/data-types/lists" >}}):
+-   [Lists](/content/develop/data-types/lists.md):
     store a simple sequence of strings.
--   [Sets]({{< relref "/develop/data-types/sets" >}}):
+-   [Sets](/content/develop/data-types/sets.md):
     store a collection of unique strings.
--   [Sorted sets]({{< relref "/develop/data-types/sorted-sets" >}}):
+-   [Sorted sets](/content/develop/data-types/sorted-sets.md):
     store a collection of unique strings with associated scores.
--   [Streams]({{< relref "/develop/data-types/streams" >}}):
+-   [Streams](/content/develop/data-types/streams/_index.md):
     store a sequence of entries, each with a set of field-value pairs.
 
 The general-purpose data types have some overlap among their features
@@ -77,9 +77,9 @@ in the string to use as bit sets, integers, or floating-point numbers.
 -   **Operations**: get, set, delete, range read, range scan, sequential insert, aggregate.
 -   **Suitable for**: Event logs, ring buffers, sensor readings, and other append-heavy or sparse sequences.
 
-Arrays store values addressed by integer index, making random access O(1) regardless of the array's logical size. Because arrays are sparse, setting an element at index 1,000,000 does not allocate memory for the million empty slots in between, so large index gaps are inexpensive. Arrays distinguish between *logical length* (the highest set index plus one, returned by [`ARLEN`]({{< relref "/commands/arlen" >}})) and *element count* (the number of non-empty slots, returned by [`ARCOUNT`]({{< relref "/commands/arcount" >}})).
+Arrays store values addressed by integer index, making random access O(1) regardless of the array's logical size. Because arrays are sparse, setting an element at index 1,000,000 does not allocate memory for the million empty slots in between, so large index gaps are inexpensive. Arrays distinguish between *logical length* (the highest set index plus one, returned by [`ARLEN`](/content/commands/arlen.md)) and *element count* (the number of non-empty slots, returned by [`ARCOUNT`](/content/commands/arcount.md)).
 
-In addition to direct index access, arrays support sequential insertion via [`ARINSERT`]({{< relref "/commands/arinsert" >}}), which advances an internal cursor automatically. The cursor can be repositioned with [`ARSEEK`]({{< relref "/commands/arseek" >}}), enabling flexible append patterns. [`ARRING`]({{< relref "/commands/arring" >}}) makes the ring buffer pattern explicit: it inserts values modulo a fixed size, wrapping around and overwriting the oldest entries when the buffer is full. [`AROP`]({{< relref "/commands/arop" >}}) performs single-pass aggregations (sum, min, max, bitwise operations, value matching) over a range without fetching each element individually.
+In addition to direct index access, arrays support sequential insertion via [`ARINSERT`](/content/commands/arinsert.md), which advances an internal cursor automatically. The cursor can be repositioned with [`ARSEEK`](/content/commands/arseek.md), enabling flexible append patterns. [`ARRING`](/content/commands/arring.md) makes the ring buffer pattern explicit: it inserts values modulo a fixed size, wrapping around and overwriting the oldest entries when the buffer is full. [`AROP`](/content/commands/arop.md) performs single-pass aggregations (sum, min, max, bitwise operations, value matching) over a range without fetching each element individually.
 
 ### Hashes
 
@@ -95,7 +95,7 @@ The field values are strings, but hashes provide commands to treat
 them as integers or floating-point numbers and perform simple arithmetic
 operations on them. You can set expirations on individual hash fields
 and you can also index and query hash documents using
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}}).
+[Redis Search](/content/develop/ai/search-and-query/_index.md).
 
 ### JSON
 
@@ -107,7 +107,7 @@ and you can also index and query hash documents using
 JSON provides rich data modeling capabilities with nested fields and arrays.
 You can use a simple path syntax to access any subset of the data within
 a JSON document. JSON also has more powerful and flexible
-[Redis Search]({{< relref "/develop/ai/search-and-query" >}})
+[Redis Search](/content/develop/ai/search-and-query/_index.md)
 features compared to hashes.
 
 ### Lists

--- a/content/develop/data-types/geospatial.md
+++ b/content/develop/data-types/geospatial.md
@@ -25,13 +25,13 @@ weight: 40
 Redis geospatial indexes let you store coordinates and search for them.
 This data structure is useful for finding nearby points within a given radius or bounding box.
 
-{{< note >}}Take care not to confuse the Geospatial data type with the
-[Geospatial]({{< relref "/develop/ai/search-and-query/advanced-concepts/geo" >}})
-features in [Redis Search]({{< relref "/develop/ai/search-and-query" >}}).
-Although there are some similarities between these two features, the data type is intended
-for simpler use cases and doesn't have the range of format options and queries
-available in Redis Search.
-{{< /note >}}
+> [!NOTE]
+> Take care not to confuse the Geospatial data type with the
+> [Geospatial](/content/develop/ai/search-and-query/advanced-concepts/geo.md)
+> features in [Redis Search](/content/develop/ai/search-and-query/_index.md).
+> Although there are some similarities between these two features, the data type is intended
+> for simpler use cases and doesn't have the range of format options and queries
+> available in Redis Search.
 
 ## Examples
 

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -79,7 +79,7 @@ as well, like [`HINCRBY`](/content/commands/hincrby.md):
 (integer) 4972
 {{< /clients-example >}}
 
-You can find the [full list of hash commands in the documentation](/commands#hash).
+You can find the [full list of hash commands in the documentation](/commands?group=hash).
 
 It is worth noting that small hashes (i.e., a few elements with small values) are
 encoded in special way in memory that make them very memory efficient.

--- a/content/develop/data-types/hashes.md
+++ b/content/develop/data-types/hashes.md
@@ -49,8 +49,8 @@ While hashes are handy to represent *objects*, actually the number of fields you
 put inside a hash has no practical limits (other than available memory), so you can use
 hashes in many different ways inside your application.
 
-The command [`HSET`]({{< relref "/commands/hset" >}}) sets multiple fields of the hash, while [`HGET`]({{< relref "/commands/hget" >}}) retrieves
-a single field. [`HMGET`]({{< relref "/commands/hmget" >}}) is similar to [`HGET`]({{< relref "/commands/hget" >}}) but returns an array of values:
+The command [`HSET`](/content/commands/hset.md) sets multiple fields of the hash, while [`HGET`](/content/commands/hget.md) retrieves
+a single field. [`HMGET`](/content/commands/hmget.md) is similar to [`HGET`](/content/commands/hget.md) but returns an array of values:
 
 {{< clients-example set="hash_tutorial" step="hmget" description="Retrieve multiple field values from a hash using HMGET when you need to reduce round trips to the server" buildsUpon="set_get_all" >}}
 # Recreate the bike:1 hash so this example runs on its own.
@@ -65,7 +65,7 @@ a single field. [`HMGET`]({{< relref "/commands/hmget" >}}) is similar to [`HGET
 {{< /clients-example >}}
 
 There are commands that are able to perform operations on individual fields
-as well, like [`HINCRBY`]({{< relref "/commands/hincrby" >}}):
+as well, like [`HINCRBY`](/content/commands/hincrby.md):
 
 {{< clients-example set="hash_tutorial" step="hincrby" description="Increment hash field values for counters using HINCRBY (creates field if missing, initializes to 0)" buildsUpon="set_get_all" >}}
 # Recreate the bike:1 hash so this example runs on its own.
@@ -79,7 +79,7 @@ as well, like [`HINCRBY`]({{< relref "/commands/hincrby" >}}):
 (integer) 4972
 {{< /clients-example >}}
 
-You can find the [full list of hash commands in the documentation]({{< relref "/commands#hash" >}}).
+You can find the [full list of hash commands in the documentation](/commands#hash).
 
 It is worth noting that small hashes (i.e., a few elements with small values) are
 encoded in special way in memory that make them very memory efficient.
@@ -108,32 +108,32 @@ encoded in special way in memory that make them very memory efficient.
 ## Field expiration
 
 Redis 7.4 introduced the ability to specify an expiration time or a time-to-live (TTL) value for individual hash fields.
-This capability is comparable to [key expiration]({{< relref "/develop/using-commands/keyspace#key-expiration" >}}) and includes a number of similar commands.
+This capability is comparable to [key expiration](/content/develop/using-commands/keyspace.md#key-expiration) and includes a number of similar commands.
 
 Use the following commands to set either an exact expiration time or a TTL value for specific fields:
 
-* [`HEXPIRE`]({{< relref "/commands/hexpire" >}}): set the remaining TTL in seconds.
-* [`HPEXPIRE`]({{< relref "/commands/hpexpire" >}}): set the remaining TTL in milliseconds.
-* [`HEXPIREAT`]({{< relref "/commands/hexpireat" >}}): set the expiration time to a timestamp[^1] specified in seconds.
-* [`HPEXPIREAT`]({{< relref "/commands/hpexpireat" >}}): set the expiration time to a timestamp specified in milliseconds.
+* [`HEXPIRE`](/content/commands/hexpire.md): set the remaining TTL in seconds.
+* [`HPEXPIRE`](/content/commands/hpexpire.md): set the remaining TTL in milliseconds.
+* [`HEXPIREAT`](/content/commands/hexpireat.md): set the expiration time to a timestamp[^1] specified in seconds.
+* [`HPEXPIREAT`](/content/commands/hpexpireat.md): set the expiration time to a timestamp specified in milliseconds.
 
 [^1]: all timestamps are specified in seconds or milliseconds since the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time).
 
 Use the following commands to retrieve either the exact time when or the remaining TTL until specific fields will expire:
 
-* [`HEXPIRETIME`]({{< relref "/commands/hexpiretime" >}}): get the expiration time as a timestamp in seconds.
-* [`HPEXPIRETIME`]({{< relref "/commands/hpexpiretime" >}}): get the expiration time as a timestamp in milliseconds.
-* [`HTTL`]({{< relref "/commands/httl" >}}): get the remaining TTL in seconds.
-* [`HPTTL`]({{< relref "/commands/hpttl" >}}): get the remaining TTL in milliseconds.
+* [`HEXPIRETIME`](/content/commands/hexpiretime.md): get the expiration time as a timestamp in seconds.
+* [`HPEXPIRETIME`](/content/commands/hpexpiretime.md): get the expiration time as a timestamp in milliseconds.
+* [`HTTL`](/content/commands/httl.md): get the remaining TTL in seconds.
+* [`HPTTL`](/content/commands/hpttl.md): get the remaining TTL in milliseconds.
 
 Use the following command to remove the expiration of specific fields:
 
-* [`HPERSIST`]({{< relref "/commands/hpersist" >}}): remove the expiration.
+* [`HPERSIST`](/content/commands/hpersist.md): remove the expiration.
 
 Redis 8.0 introduced the following commands:
 
-* [`HGETEX`]({{< relref "/commands/HGETEX" >}}): Get the value of one or more fields of a given hash key and optionally set their expiration time or time-to-live (TTL).
-* [`HSETEX`]({{< relref "/commands/HSETEX" >}}): Set the value of one or more fields of a given hash key and optionally set their expiration time or time-to-live (TTL).
+* [`HGETEX`](/content/commands/hgetex.md): Get the value of one or more fields of a given hash key and optionally set their expiration time or time-to-live (TTL).
+* [`HSETEX`](/content/commands/hsetex.md): Set the value of one or more fields of a given hash key and optionally set their expiration time or time-to-live (TTL).
 
 ### Common field expiration use cases
 
@@ -211,11 +211,11 @@ Redis 8.10 introduced *compact hashes*, a way to reduce the memory used by hashe
 **Compact hashes work well when:**
 
 - Many keys share the same, mostly stable set of field names — classic object mapping, such as one hash per user, order, or session. The more keys that share a field set, the greater the memory saving.
-- Reads and value updates stay as fast as on a regular hash. Reading any field (for example, [`HGET`]({{< relref "/commands/hget" >}}), [`HGETALL`]({{< relref "/commands/hgetall" >}}), or [`HRANDFIELD`]({{< relref "/commands/hrandfield" >}})) and overwriting an existing field's value (`HSET key field value` where `field` already exists) are unaffected.
+- Reads and value updates stay as fast as on a regular hash. Reading any field (for example, [`HGET`](/content/commands/hget.md), [`HGETALL`](/content/commands/hgetall.md), or [`HRANDFIELD`](/content/commands/hrandfield.md)) and overwriting an existing field's value (`HSET key field value` where `field` already exists) are unaffected.
 
 **Compact hashes are not a good fit when:**
 
-- **Field names change often.** Adding a new field with [`HSET`]({{< relref "/commands/hset" >}}) or removing one with [`HDEL`]({{< relref "/commands/hdel" >}}) detaches the key from its shared field-name set and re-resolves it against the new set, creating a new one if that layout hasn't been seen before. A workload that constantly adds or removes field names erodes the benefit. Note also that once a hash becomes a compact hash, it stays one for the life of the key: it moves between field-name sets as its fields change, but never reverts to a plain hash.
+- **Field names change often.** Adding a new field with [`HSET`](/content/commands/hset.md) or removing one with [`HDEL`](/content/commands/hdel.md) detaches the key from its shared field-name set and re-resolves it against the new set, creating a new one if that layout hasn't been seen before. A workload that constantly adds or removes field names erodes the benefit. Note also that once a hash becomes a compact hash, it stays one for the life of the key: it moves between field-name sets as its fields change, but never reverts to a plain hash.
 - **Field names are unique or highly dynamic per key.** With little sharing, a key ends up with its own field-name set, which carries some metadata overhead. A set used by only a few keys can therefore consume more memory than a plain hash. Compact hashes pay off when hundreds or thousands of keys share a set.
 - **Hashes are very large.** Because a compact hash is transferred as a single blob during replication and slot migration, very large hash keys may reduce or negate the benefit.
 
@@ -223,15 +223,15 @@ There are two ways to opt in.
 
 ### Bulk import with HIMPORT
 
-The [`HIMPORT`]({{< relref "/commands/himport" >}}) command family lets a client import many hashes that share the same field names efficiently. You declare the shared field names once with [`HIMPORT PREPARE`]({{< relref "/commands/himport-prepare" >}}), then create each key with [`HIMPORT SET`]({{< relref "/commands/himport-set" >}}) by sending only its values. This reduces network traffic and per-command work compared with running [`HSET`]({{< relref "/commands/hset" >}}) once per key, and hints Redis to store the new keys as compact hashes. See [`HIMPORT`]({{< relref "/commands/himport" >}}) for the full workflow and its subcommands.
+The [`HIMPORT`](/content/commands/himport.md) command family lets a client import many hashes that share the same field names efficiently. You declare the shared field names once with [`HIMPORT PREPARE`](/content/commands/himport-prepare.md), then create each key with [`HIMPORT SET`](/content/commands/himport-set.md) by sending only its values. This reduces network traffic and per-command work compared with running [`HSET`](/content/commands/hset.md) once per key, and hints Redis to store the new keys as compact hashes. See [`HIMPORT`](/content/commands/himport.md) for the full workflow and its subcommands.
 
 ### Automatic conversion
 
-For workloads that can't adopt a new command, Redis can convert eligible hashes to compact hashes on its own, with no code change. All the following settings default to `0` (off) and can be changed at runtime with [`CONFIG SET`]({{< relref "/commands/config-set" >}}).
+For workloads that can't adopt a new command, Redis can convert eligible hashes to compact hashes on its own, with no code change. All the following settings default to `0` (off) and can be changed at runtime with [`CONFIG SET`](/content/commands/config-set.md).
 
 #### On the write path
 
-These convert hashes created or modified by normal commands (such as [`HSET`]({{< relref "/commands/hset" >}})), so an existing application gains the memory saving with no code change. They take effect lazily, like `hash-max-listpack-entries`: a change applies to a given hash only on its next write, not the moment you run [`CONFIG SET`]({{< relref "/commands/config-set" >}}).
+These convert hashes created or modified by normal commands (such as [`HSET`](/content/commands/hset.md)), so an existing application gains the memory saving with no code change. They take effect lazily, like `hash-max-listpack-entries`: a change applies to a given hash only on its next write, not the moment you run [`CONFIG SET`](/content/commands/config-set.md).
 
 | Config | Meaning |
 |---|---|
@@ -256,7 +256,7 @@ The disassembly threshold avoids wasting memory on field-name sets shared by onl
 
 Most Redis hash commands are O(1).
 
-A few commands, such as [`HKEYS`]({{< relref "/commands/hkeys" >}}), [`HVALS`]({{< relref "/commands/hvals" >}}), [`HGETALL`]({{< relref "/commands/hgetall" >}}), and most of the expiration-related commands, are O(n), where _n_ is the number of field-value pairs.
+A few commands, such as [`HKEYS`](/content/commands/hkeys.md), [`HVALS`](/content/commands/hvals.md), [`HGETALL`](/content/commands/hgetall.md), and most of the expiration-related commands, are O(n), where _n_ is the number of field-value pairs.
 
 ## Limits
 

--- a/content/develop/data-types/lists.md
+++ b/content/develop/data-types/lists.md
@@ -75,7 +75,7 @@ Redis lists are frequently used to:
 1) "bike:2"
 {{< /clients-example >}}
 
-* To limit the length of a list you can call [`LTRIM`]({{< relref "/commands/ltrim" >}}):
+* To limit the length of a list you can call [`LTRIM`](/content/commands/ltrim.md):
 {{< clients-example set="list_tutorial" step="ltrim.1" description="Capped lists: Use LTRIM to keep only a specific range of elements when you need to maintain a fixed-size list" difficulty="intermediate" buildsUpon="lpush_rpush" >}}
 > DEL bikes:repairs
 (integer) 1
@@ -105,7 +105,7 @@ an Array are very different from the properties of a List implemented using a
 Redis lists are implemented via Linked Lists. This means that even if you have
 millions of elements inside a list, the operation of adding a new element in
 the head or in the tail of the list is performed *in constant time*. The speed of adding a
-new element with the [`LPUSH`]({{< relref "/commands/lpush" >}}) command to the head of a list with ten
+new element with the [`LPUSH`](/content/commands/lpush.md) command to the head of a list with ten
 elements is the same as adding an element to the head of list with 10
 million elements.
 
@@ -121,14 +121,14 @@ taken at constant length in constant time.
 
 When fast access to the middle of a large collection of elements is important,
 there is a different data structure that can be used, called sorted sets.
-Sorted sets are covered in the [Sorted sets]({{< relref "/develop/data-types/sorted-sets" >}}) tutorial page.
+Sorted sets are covered in the [Sorted sets](/content/develop/data-types/sorted-sets.md) tutorial page.
 
 ### First steps with Redis Lists
 
-The [`LPUSH`]({{< relref "/commands/lpush" >}}) command adds a new element into a list, on the
-left (at the head), while the [`RPUSH`]({{< relref "/commands/rpush" >}}) command adds a new
+The [`LPUSH`](/content/commands/lpush.md) command adds a new element into a list, on the
+left (at the head), while the [`RPUSH`](/content/commands/rpush.md) command adds a new
 element into a list, on the right (at the tail). Finally the
-[`LRANGE`]({{< relref "/commands/lrange" >}}) command extracts ranges of elements from lists:
+[`LRANGE`](/content/commands/lrange.md) command extracts ranges of elements from lists:
 
 {{< clients-example set="list_tutorial" step="lpush_rpush" description="Foundational: Add elements to both ends of a list using LPUSH (left/head) and RPUSH (right/tail) to build ordered sequences" >}}
 > DEL bikes:repairs
@@ -145,13 +145,13 @@ element into a list, on the right (at the tail). Finally the
 3) "bike:2"
 {{< /clients-example >}}
 
-Note that [`LRANGE`]({{< relref "/commands/lrange" >}}) takes two indexes, the first and the last
+Note that [`LRANGE`](/content/commands/lrange.md) takes two indexes, the first and the last
 element of the range to return. Both the indexes can be negative, telling Redis
 to start counting from the end: so -1 is the last element, -2 is the
 penultimate element of the list, and so forth.
 
-As you can see [`RPUSH`]({{< relref "/commands/rpush" >}}) appended the elements on the right of the list, while
-the final [`LPUSH`]({{< relref "/commands/lpush" >}}) appended the element on the left.
+As you can see [`RPUSH`](/content/commands/rpush.md) appended the elements on the right of the list, while
+the final [`LPUSH`](/content/commands/lpush.md) appended the element on the left.
 
 Both commands are *variadic commands*, meaning that you are free to push
 multiple elements into a list in a single call:
@@ -214,7 +214,7 @@ posted by users into Redis lists.
 To describe a common use case step by step, imagine your home page shows the latest
 photos published in a photo sharing social network and you want to speedup access.
 
-* Every time a user posts a new photo, we add its ID into a list with [`LPUSH`]({{< relref "/commands/lpush" >}}).
+* Every time a user posts a new photo, we add its ID into a list with [`LPUSH`](/content/commands/lpush.md).
 * When users visit the home page, we use `LRANGE 0 9` in order to get the latest 10 posted items.
 
 ### Capped lists
@@ -223,9 +223,9 @@ In many use cases we just want to use lists to store the *latest items*,
 whatever they are: social network updates, logs, or anything else.
 
 Redis allows us to use lists as a capped collection, only remembering the latest
-N items and discarding all the oldest items using the [`LTRIM`]({{< relref "/commands/ltrim" >}}) command.
+N items and discarding all the oldest items using the [`LTRIM`](/content/commands/ltrim.md) command.
 
-The [`LTRIM`]({{< relref "/commands/ltrim" >}}) command is similar to [`LRANGE`]({{< relref "/commands/lrange" >}}), but **instead of displaying the
+The [`LTRIM`](/content/commands/ltrim.md) command is similar to [`LRANGE`](/content/commands/lrange.md), but **instead of displaying the
 specified range of elements** it sets this range as the new list value. All
 the elements outside the given range are removed.
 
@@ -245,11 +245,11 @@ OK
 3) "bike:3"
 {{< /clients-example >}}
 
-The above [`LTRIM`]({{< relref "/commands/ltrim" >}}) command tells Redis to keep just list elements from index
+The above [`LTRIM`](/content/commands/ltrim.md) command tells Redis to keep just list elements from index
 0 to 2, everything else will be discarded. This allows for a very simple but
 useful pattern: doing a List push operation + a List trim operation together 
 to add a new element and discard elements exceeding a limit. Using 
-[`LTRIM`]({{< relref "/commands/ltrim" >}}) with negative indexes can then be used to keep only the 3 most recently added:
+[`LTRIM`](/content/commands/ltrim.md) with negative indexes can then be used to keep only the 3 most recently added:
 
 {{< clients-example set="list_tutorial" step="ltrim_end_of_list" description="Capped lists with negative indexes: Use LTRIM with negative indexes to keep the most recent elements when you need to maintain a fixed-size list of latest items" difficulty="intermediate" buildsUpon="lpush_rpush" >}}
 > DEL bikes:repairs
@@ -265,10 +265,10 @@ OK
 {{< /clients-example >}}
 
 The above combination adds new elements and keeps only the 3
-newest elements into the list. With [`LRANGE`]({{< relref "/commands/lrange" >}}) you can access the top items
+newest elements into the list. With [`LRANGE`](/content/commands/lrange.md) you can access the top items
 without any need to remember very old data.
 
-Note: while [`LRANGE`]({{< relref "/commands/lrange" >}}) is technically an O(N) command, accessing small ranges
+Note: while [`LRANGE`](/content/commands/lrange.md) is technically an O(N) command, accessing small ranges
 towards the head or the tail of the list is a constant time operation.
 
 ## Blocking operations on lists
@@ -282,23 +282,23 @@ a different process in order to actually do some kind of work with those
 items. This is the usual producer / consumer setup, and can be implemented
 in the following simple way:
 
-* To push items into the list, producers call [`LPUSH`]({{< relref "/commands/lpush" >}}).
-* To extract / process items from the list, consumers call [`RPOP`]({{< relref "/commands/rpop" >}}).
+* To push items into the list, producers call [`LPUSH`](/content/commands/lpush.md).
+* To extract / process items from the list, consumers call [`RPOP`](/content/commands/rpop.md).
 
 However it is possible that sometimes the list is empty and there is nothing
-to process, so [`RPOP`]({{< relref "/commands/rpop" >}}) just returns NULL. In this case a consumer is forced to wait
-some time and retry again with [`RPOP`]({{< relref "/commands/rpop" >}}). This is called *polling*, and is not
+to process, so [`RPOP`](/content/commands/rpop.md) just returns NULL. In this case a consumer is forced to wait
+some time and retry again with [`RPOP`](/content/commands/rpop.md). This is called *polling*, and is not
 a good idea in this context because it has several drawbacks:
 
 1. Forces Redis and clients to process useless commands (all the requests when the list is empty will get no actual work done, they'll just return NULL).
-2. Adds a delay to the processing of items, since after a worker receives a NULL, it waits some time. To make the delay smaller, we could wait less between calls to [`RPOP`]({{< relref "/commands/rpop" >}}), with the effect of amplifying problem number 1, i.e. more useless calls to Redis.
+2. Adds a delay to the processing of items, since after a worker receives a NULL, it waits some time. To make the delay smaller, we could wait less between calls to [`RPOP`](/content/commands/rpop.md), with the effect of amplifying problem number 1, i.e. more useless calls to Redis.
 
-So Redis implements commands called [`BRPOP`]({{< relref "/commands/brpop" >}}) and [`BLPOP`]({{< relref "/commands/blpop" >}}) which are versions
-of [`RPOP`]({{< relref "/commands/rpop" >}}) and [`LPOP`]({{< relref "/commands/lpop" >}}) able to block if the list is empty: they'll return to
+So Redis implements commands called [`BRPOP`](/content/commands/brpop.md) and [`BLPOP`](/content/commands/blpop.md) which are versions
+of [`RPOP`](/content/commands/rpop.md) and [`LPOP`](/content/commands/lpop.md) able to block if the list is empty: they'll return to
 the caller only when a new element is added to the list, or when a user-specified
 timeout is reached.
 
-This is an example of a [`BRPOP`]({{< relref "/commands/brpop" >}}) call we could use in the worker:
+This is an example of a [`BRPOP`](/content/commands/brpop.md) call we could use in the worker:
 
 {{< clients-example set="list_tutorial" step="brpop" description="Blocking operations: Use BRPOP to wait for elements with a timeout when you need to implement producer-consumer patterns without polling" difficulty="intermediate" buildsUpon="lpush_rpush, lpop_rpop" runnable="false" >}}
 > DEL bikes:repairs
@@ -324,17 +324,17 @@ also specify multiple lists and not just one, in order to wait on multiple
 lists at the same time, and get notified when the first list receives an
 element.
 
-A few things to note about [`BRPOP`]({{< relref "/commands/brpop" >}}):
+A few things to note about [`BRPOP`](/content/commands/brpop.md):
 
 1. Clients are served in an ordered way: the first client that blocked waiting for a list, is served first when an element is pushed by some other client, and so forth.
-2. The return value is different compared to [`RPOP`]({{< relref "/commands/rpop" >}}): it is a two-element array since it also includes the name of the key, because [`BRPOP`]({{< relref "/commands/brpop" >}}) and [`BLPOP`]({{< relref "/commands/blpop" >}}) are able to block waiting for elements from multiple lists.
+2. The return value is different compared to [`RPOP`](/content/commands/rpop.md): it is a two-element array since it also includes the name of the key, because [`BRPOP`](/content/commands/brpop.md) and [`BLPOP`](/content/commands/blpop.md) are able to block waiting for elements from multiple lists.
 3. If the timeout is reached, NULL is returned.
 
 There are more things you should know about lists and blocking ops. We
 suggest that you read more on the following:
 
-* It is possible to build safer queues or rotating queues using [`LMOVE`]({{< relref "/commands/lmove" >}}).
-* There is also a blocking variant of the command, called [`BLMOVE`]({{< relref "/commands/blmove" >}}).
+* It is possible to build safer queues or rotating queues using [`LMOVE`](/content/commands/lmove.md).
+* There is also a blocking variant of the command, called [`BLMOVE`](/content/commands/blmove.md).
 
 ## Automatic creation and removal of keys
 
@@ -342,7 +342,7 @@ So far in our examples we never had to create empty lists before pushing
 elements, or removing empty lists when they no longer have elements inside.
 It is Redis' responsibility to delete keys when lists are left empty, or to create
 an empty list if the key does not exist and we are trying to add elements
-to it, for example, with [`LPUSH`]({{< relref "/commands/lpush" >}}).
+to it, for example, with [`LPUSH`](/content/commands/lpush.md).
 
 This is not specific to lists, it applies to all the Redis data types
 composed of multiple elements -- Streams, Sets, Sorted Sets and Hashes.
@@ -351,7 +351,7 @@ Basically we can summarize the behavior with three rules:
 
 1. When we add an element to an aggregate data type, if the target key does not exist, an empty aggregate data type is created before adding the element.
 2. When we remove elements from an aggregate data type, if the value remains empty, the key is automatically destroyed. The Stream data type is the only exception to this rule.
-3. Calling a read-only command such as [`LLEN`]({{< relref "/commands/llen" >}}) (which returns the length of the list), or a write command removing elements, with an empty key, always produces the same result as if the key is holding an empty aggregate type of the type the command expects to find.
+3. Calling a read-only command such as [`LLEN`](/content/commands/llen.md) (which returns the length of the list), or a write command removing elements, with an empty key, always produces the same result as if the key is holding an empty aggregate type of the type the command expects to find.
 
 Examples of rule 1:
 
@@ -416,12 +416,12 @@ The maximum length of a Redis list is 2^32 - 1 (4,294,967,295) elements.
 
 List operations that access its head or tail are O(1), which means they're highly efficient.
 However, commands that manipulate elements within a list are usually O(n).
-Examples of these include [`LINDEX`]({{< relref "/commands/lindex" >}}), [`LINSERT`]({{< relref "/commands/linsert" >}}), and [`LSET`]({{< relref "/commands/lset" >}}).
+Examples of these include [`LINDEX`](/content/commands/lindex.md), [`LINSERT`](/content/commands/linsert.md), and [`LSET`](/content/commands/lset.md).
 Exercise caution when running these commands, mainly when operating on large lists.
 
 ## Alternatives
 
-Consider [Redis streams]({{< relref "/develop/data-types/streams" >}}) as an alternative to lists when you need to store and process an indeterminate series of events.
+Consider [Redis streams](/content/develop/data-types/streams/_index.md) as an alternative to lists when you need to store and process an indeterminate series of events.
 
 ## Learn more
 

--- a/content/develop/data-types/sets.md
+++ b/content/develop/data-types/sets.md
@@ -67,7 +67,7 @@ if you add a member that already exists, it will be ignored.
 
 ## Tutorial
 
-The [`SADD`]({{< relref "/commands/sadd" >}}) command adds new elements to a set. It's also possible
+The [`SADD`](/content/commands/sadd.md) command adds new elements to a set. It's also possible
 to do a number of other operations against sets like testing if a given element
 already exists, performing the intersection, union or difference between
 multiple sets, and so forth.
@@ -119,7 +119,7 @@ to know which bikes are racing in France but not in the USA:
 There are other non trivial operations that are still easy to implement
 using the right Redis commands. For instance we may want a list of all the
 bikes racing in France, the USA, and some other races. We can do this using
-the [`SINTER`]({{< relref "/commands/sinter" >}}) command, which performs the intersection between different
+the [`SINTER`](/content/commands/sinter.md) command, which performs the intersection between different
 sets. In addition to intersection you can also perform
 unions, difference, and more. For example 
 if we add a third race we can see some of these commands in action:
@@ -149,14 +149,14 @@ if we add a third race we can see some of these commands in action:
 1) "bike:4"
 {{< /clients-example >}}
 
-You'll note that the [`SDIFF`]({{< relref "/commands/sdiff" >}}) command returns an empty array when the
+You'll note that the [`SDIFF`](/content/commands/sdiff.md) command returns an empty array when the
 difference between all sets is empty. You'll also note that the order of sets
-passed to [`SDIFF`]({{< relref "/commands/sdiff" >}}) matters, since the difference is not commutative.
+passed to [`SDIFF`](/content/commands/sdiff.md) matters, since the difference is not commutative.
 
-When you want to remove items from a set, you can use the [`SREM`]({{< relref "/commands/srem" >}}) command to
-remove one or more items from a set, or you can use the [`SPOP`]({{< relref "/commands/spop" >}}) command to
+When you want to remove items from a set, you can use the [`SREM`](/content/commands/srem.md) command to
+remove one or more items from a set, or you can use the [`SPOP`](/content/commands/spop.md) command to
 remove a random item from a set. You can also _return_ a random item from a
-set without removing it using the [`SRANDMEMBER`]({{< relref "/commands/srandmember" >}}) command:
+set without removing it using the [`SRANDMEMBER`](/content/commands/srandmember.md) command:
 
 {{< clients-example set="sets_tutorial" step="srem" description="Removal strategies: Use SREM for targeted removal, SPOP for random removal, or SRANDMEMBER to inspect without modifying when you need flexible deletion patterns" difficulty="intermediate" buildsUpon="sadd" >}}
 > DEL bikes:racing:france
@@ -183,17 +183,17 @@ The max size of a Redis set is 2^32 - 1 (4,294,967,295) members.
 
 Most set operations, including adding, removing, and checking whether an item is a set member, are O(1).
 This means that they're highly efficient.
-However, for large sets with hundreds of thousands of members or more, you should exercise caution when running the [`SMEMBERS`]({{< relref "/commands/smembers" >}}) command.
+However, for large sets with hundreds of thousands of members or more, you should exercise caution when running the [`SMEMBERS`](/content/commands/smembers.md) command.
 This command is O(n) and returns the entire set in a single response. 
-As an alternative, consider the [`SSCAN`]({{< relref "/commands/sscan" >}}), which lets you retrieve all members of a set iteratively.
+As an alternative, consider the [`SSCAN`](/content/commands/sscan.md), which lets you retrieve all members of a set iteratively.
 
 ## Alternatives
 
 Sets membership checks on large datasets (or on streaming data) can use a lot of memory.
-If you're concerned about memory usage and don't need perfect precision, consider a [Bloom filter or Cuckoo filter]({{< relref "/develop/data-types/probabilistic/bloom-filter" >}}) as an alternative to a set.
+If you're concerned about memory usage and don't need perfect precision, consider a [Bloom filter or Cuckoo filter](/content/develop/data-types/probabilistic/bloom-filter.md) as an alternative to a set.
 
 Redis sets are frequently used as a kind of index.
-If you need to index and query your data, consider the [JSON]({{< relref "/develop/data-types/json/" >}}) data type and the [Redis Search]({{< relref "/develop/ai/search-and-query/" >}}) features.
+If you need to index and query your data, consider the [JSON](/content/develop/data-types/json/_index.md) data type and the [Redis Search](/content/develop/ai/search-and-query/_index.md) features.
 
 ## Learn more
 

--- a/content/develop/data-types/sorted-sets.md
+++ b/content/develop/data-types/sorted-sets.md
@@ -58,9 +58,9 @@ Let's start with a simple example, we'll add all our racers and the score they g
 {{< /clients-example >}}
 
 
-As you can see [`ZADD`]({{< relref "/commands/zadd" >}}) is similar to [`SADD`]({{< relref "/commands/sadd" >}}), but takes one additional argument
+As you can see [`ZADD`](/content/commands/zadd.md) is similar to [`SADD`](/content/commands/sadd.md), but takes one additional argument
 (placed before the element to be added) which is the score.
-[`ZADD`]({{< relref "/commands/zadd" >}}) is also variadic, so you are free to specify multiple score-value
+[`ZADD`](/content/commands/zadd.md) is also variadic, so you are free to specify multiple score-value
 pairs, as shown in the example above.
 
 With sorted sets it is trivial to return a list of racers sorted by their
@@ -70,7 +70,7 @@ Implementation note: Sorted sets are implemented via a
 dual-ported data structure containing both a skip list and a hash table, so
 every time we add an element Redis performs an O(log(N)) operation. That's
 good, so when we ask for sorted elements, Redis does not have to do any work at
-all, it's already sorted. Note that the [`ZRANGE`]({{< relref "/commands/zrange" >}}) order is low to high, while the [`ZREVRANGE`]({{< relref "/commands/zrevrange" >}}) order is high to low:
+all, it's already sorted. Note that the [`ZRANGE`](/content/commands/zrange.md) order is low to high, while the [`ZREVRANGE`](/content/commands/zrevrange.md) order is high to low:
 
 {{< clients-example set="ss_tutorial" step="zrange" description="Retrieve members in ascending or descending order using ZRANGE and ZREVRANGE (no sorting needed, already ordered)" buildsUpon="zadd" needs_prereq="true" >}}
 > ZRANGE racer_scores 0 -1
@@ -90,7 +90,7 @@ all, it's already sorted. Note that the [`ZRANGE`]({{< relref "/commands/zrange"
 {{< /clients-example >}}
 
 Note: 0 and -1 means from element index 0 to the last element (-1 works
-here just as it does in the case of the [`LRANGE`]({{< relref "/commands/lrange" >}}) command).
+here just as it does in the case of the [`LRANGE`](/content/commands/lrange.md) command).
 
 It is possible to return scores as well, using the `WITHSCORES` argument:
 
@@ -114,7 +114,7 @@ It is possible to return scores as well, using the `WITHSCORES` argument:
 
 Sorted sets are more powerful than this. They can operate on ranges.
 Let's get all the racers with 10 or fewer points. We
-use the [`ZRANGEBYSCORE`]({{< relref "/commands/zrangebyscore" >}}) command to do it:
+use the [`ZRANGEBYSCORE`](/content/commands/zrangebyscore.md) command to do it:
 
 {{< clients-example set="ss_tutorial" step="zrangebyscore" description="Query by score range: Retrieve members within a score range using ZRANGEBYSCORE when you need to filter by numeric values" difficulty="intermediate" buildsUpon="zadd" needs_prereq="true" >}}
 > ZRANGEBYSCORE racer_scores -inf 10
@@ -127,7 +127,7 @@ use the [`ZRANGEBYSCORE`]({{< relref "/commands/zrangebyscore" >}}) command to d
 We asked Redis to return all the elements with a score between negative
 infinity and 10 (both extremes are included).
 
-To remove an element we'd simply call [`ZREM`]({{< relref "/commands/zrem" >}}) with the racer's name.
+To remove an element we'd simply call [`ZREM`](/content/commands/zrem.md) with the racer's name.
 It's also possible to remove ranges of elements. Let's remove racer Castilla along with all
 the racers with strictly fewer than 10 points:
 
@@ -142,13 +142,13 @@ the racers with strictly fewer than 10 points:
 3) "Prickett"
 {{< /clients-example >}}
 
-[`ZREMRANGEBYSCORE`]({{< relref "/commands/zremrangebyscore" >}}) is perhaps not the best command name,
+[`ZREMRANGEBYSCORE`](/content/commands/zremrangebyscore.md) is perhaps not the best command name,
 but it can be very useful, and returns the number of removed elements.
 
 Another extremely useful operation defined for sorted set elements
 is the get-rank operation. It is possible to ask what is the
 position of an element in the set of ordered elements.
-The [`ZREVRANK`]({{< relref "/commands/zrevrank" >}}) command is also available in order to get the rank, considering
+The [`ZREVRANK`](/content/commands/zrevrank.md) command is also available in order to get the rank, considering
 the elements sorted in a descending way.
 
 {{< clients-example set="ss_tutorial" step="zrank" description="Get member position: Use ZRANK and ZREVRANK to find a member's position in the sorted set (useful for leaderboards)" difficulty="intermediate" buildsUpon="zadd" >}}
@@ -171,11 +171,11 @@ inserted with the same identical score (elements are compared with the C
 `memcmp` function, so it is guaranteed that there is no collation, and every
 Redis instance will reply with the same output).
 
-The main commands to operate with lexicographical ranges are [`ZRANGEBYLEX`]({{< relref "/commands/zrangebylex" >}}),
-[`ZREVRANGEBYLEX`]({{< relref "/commands/zrevrangebylex" >}}), [`ZREMRANGEBYLEX`]({{< relref "/commands/zremrangebylex" >}}) and [`ZLEXCOUNT`]({{< relref "/commands/zlexcount" >}}).
+The main commands to operate with lexicographical ranges are [`ZRANGEBYLEX`](/content/commands/zrangebylex.md),
+[`ZREVRANGEBYLEX`](/content/commands/zrevrangebylex.md), [`ZREMRANGEBYLEX`](/content/commands/zremrangebylex.md) and [`ZLEXCOUNT`](/content/commands/zlexcount.md).
 
 For example, let's add again our list of famous racers, but this time
-using a score of zero for all the elements. We'll see that because of the sorted sets ordering rules, they are already sorted lexicographically. Using [`ZRANGEBYLEX`]({{< relref "/commands/zrangebylex" >}}) we can ask for lexicographical ranges:
+using a score of zero for all the elements. We'll see that because of the sorted sets ordering rules, they are already sorted lexicographically. Using [`ZRANGEBYLEX`](/content/commands/zrangebylex.md) we can ask for lexicographical ranges:
 
 {{< clients-example set="ss_tutorial" step="zadd_lex" description="Lexicographical queries: Add members with identical scores and use ZRANGEBYLEX to query by string range (enables generic indexing)" difficulty="intermediate" buildsUpon="zadd" >}}
 > ZADD racer_scores 0 "Norem" 0 "Sam-Bodden" 0 "Royce" 0 "Castilla" 0 "Prickett" 0 "Ford"
@@ -209,7 +209,7 @@ Updating the score: leaderboards
 ---
 
 Just a final note about sorted sets before switching to the next topic.
-Sorted sets' scores can be updated at any time. Just calling [`ZADD`]({{< relref "/commands/zadd" >}}) against
+Sorted sets' scores can be updated at any time. Just calling [`ZADD`](/content/commands/zadd.md) against
 an element already included in the sorted set will update its score
 (and position) with O(log(N)) time complexity.  As such, sorted sets are suitable
 when there are tons of updates.
@@ -222,7 +222,7 @@ the #4932 best score here").
 
 ## Examples
 
-* There are two ways we can use a sorted set to represent a leaderboard. If we know a racer's new score, we can update it directly via the [`ZADD`]({{< relref "/commands/zadd" >}}) command. However, if we want to add points to an existing score, we can use the [`ZINCRBY`]({{< relref "/commands/zincrby" >}}) command.
+* There are two ways we can use a sorted set to represent a leaderboard. If we know a racer's new score, we can update it directly via the [`ZADD`](/content/commands/zadd.md) command. However, if we want to add points to an existing score, we can use the [`ZINCRBY`](/content/commands/zincrby.md) command.
 {{< clients-example set="ss_tutorial" step="leaderboard" description="Practical pattern: Use ZADD to set scores and ZINCRBY to increment them when you need to update leaderboards with atomic operations" difficulty="intermediate" buildsUpon="zadd" >}}
 > ZADD racer_scores 100 "Wood"
 (integer) 1
@@ -236,19 +236,19 @@ the #4932 best score here").
 "200"
 {{< /clients-example >}}
 
-You'll see that [`ZADD`]({{< relref "/commands/zadd" >}}) returns 0 when the member already exists (the score is updated), while [`ZINCRBY`]({{< relref "/commands/zincrby" >}}) returns the new score. The score for racer Henshaw went from 100, was changed to 150 with no regard for what score was there before, and then was incremented by 50 to 200.
+You'll see that [`ZADD`](/content/commands/zadd.md) returns 0 when the member already exists (the score is updated), while [`ZINCRBY`](/content/commands/zincrby.md) returns the new score. The score for racer Henshaw went from 100, was changed to 150 with no regard for what score was there before, and then was incremented by 50 to 200.
 
 ## Performance
 
 Most sorted set operations are O(log(n)), where _n_ is the number of members.
 
-Exercise some caution when running the [`ZRANGE`]({{< relref "/commands/zrange" >}}) command with large returns values (e.g., in the tens of thousands or more).
+Exercise some caution when running the [`ZRANGE`](/content/commands/zrange.md) command with large returns values (e.g., in the tens of thousands or more).
 This command's time complexity is O(log(n) + m), where _m_ is the number of results returned. 
 
 ## Alternatives
 
 Redis sorted sets are sometimes used for indexing other Redis data structures.
-If you need to index and query your data, consider the [JSON]({{< relref "/develop/data-types/json/" >}}) data type and the [Redis Search]({{< relref "/develop/ai/search-and-query/" >}}) features.
+If you need to index and query your data, consider the [JSON](/content/develop/data-types/json/_index.md) data type and the [Redis Search](/content/develop/ai/search-and-query/_index.md) features.
 
 ## Learn more
 


### PR DESCRIPTION
## Summary
- Converts the 8 top-level pages under `content/develop/data-types/` (unit E of DOC-7055; subdirectories are separate units) from Hugo shortcode links/callouts to native-Markdown render hooks, per DOC-6909/DOC-7047: `]({{< relref "X" >}})` → `](X)`, and `{{< note >}}...{{< /note >}}` → `> [!NOTE]`.
- Ran `build/migrate_shortcode_links.py all` (relref-to-plain → callouts-to-blockquote → linkify) against exactly: `_index.md`, `geospatial.md`, `sorted-sets.md`, `hashes.md`, `sets.md`, `lists.md`, `compare-data-types.md`, `arrays.md`.
- No manual edits beyond the automated conversion.

## Notes
- `_index.md`'s ~18 command-reference links carry a `?group=X` query string outside the relref shortcode (house style, ~105 files site-wide); all survived the rewrite intact, e.g. `/commands/?group=string`.
- `geospatial.md`'s one `{{< note >}}` sits before an `## Examples` heading, not directly against the `clients-example` widget, so the DOC-6909 `&nbsp;`-spacer workaround wasn't needed.
- **Base branch**: this stacks on #3965 (percent-form/attributed callout support in `migrate_shortcode_links.py`), which hasn't merged yet. GitHub will auto-retarget this PR to `main` once #3965 merges and its branch is deleted.

## Test plan
- [x] Confirmed no `relref`/shortcode-callout syntax remains in any of the 8 files.
- [x] Full-site `hugo --minify` build, before vs. after, run from two isolated git worktrees pinned at the same base commit (to avoid a shared-`.git` stash race hit by sibling DOC-7055 units running in parallel this session).
- [x] `build/diff_rendered_hrefs.py` on `develop/data-types`: **0 href differences** across all 55 rendered pages.
- [x] Full build WARN/ERROR output byte-identical before vs. after, aside from one pre-existing, content-unrelated PostCSS/npm environment error (wording differs run to run; unrelated to this change).

Ticket: DOC-7055

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout syntax changes with verified zero rendered href diffs; migration script broadens callout matching without touching runtime services.
> 
> **Overview**
> **DOC-7055** migrates the eight top-level `content/develop/data-types/` pages (`_index.md`, `arrays.md`, `compare-data-types.md`, `geospatial.md`, `hashes.md`, `lists.md`, `sets.md`, `sorted-sets.md`) from Hugo `relref` / callout shortcodes to native Markdown handled by render hooks.
> 
> Content changes are produced by `build/migrate_shortcode_links.py all`: `]({{< relref "…" >}})` becomes plain targets then **linkify** to canonical `/content/…/*.md` paths (command index links stay as `/commands/?group=…` with query strings preserved). The lone `{{< note >}}` in `geospatial.md` becomes a `> [!NOTE]` blockquote.
> 
> The same PR extends **`callouts_to_blockquote`** in the migration script: it now matches `{{% … %}}` delimiters and optional `title="…"` on opening tags, maps `alert` to the NOTE type, and drops titles that only repeat the default label.
> 
> Shortcodes such as `command-group` and `clients-example` are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0fce5a8a8569605951b41afcec93dbbca823b29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->