### PR TITLE
DOC-7055: Migrate develop/data-types/streams+strings+timeseries to render hooks

### DIFF
--- a/build/migrate_shortcode_links.py
+++ b/build/migrate_shortcode_links.py
@@ -10,6 +10,9 @@ Formalizes the three ad hoc converters used to migrate develop/clients/redis-py
 Stages, and why this order is load-bearing:
   1. relref-to-plain   -- unwrap `]({{< relref "X" >}})` to `](X)`.
   2. callouts-to-blockquote -- `{{< note >}}...{{< /note >}}` to `> [!NOTE]...`.
+     Also handles the `{{% note %}}` percent form and a `title=` attribute
+     (`alert` maps onto the `note` alert type; a title matching the type's
+     default label is dropped as redundant).
      MUST run before stage 3: shortcode callouts pipe their inner content
      through markdownify with no page context, so a link inside one resolves
      against site root, not the page -- only a native blockquote resolves
@@ -35,10 +38,24 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".claude", "hoo
 import check_shortcode_paths as csp  # noqa: E402  (reuse mount-aware path resolution)
 
 RELREF_RX = re.compile(r'\]\(\{\{<\s*relref\s+"([^"]*)"\s*>\}\}([^)]*)\)')
+# Matches both delimiter forms (`{{< note >}}` and `{{% note %}}`) and an
+# optional run of attributes on the opening tag (e.g. `title="..."`),
+# without requiring the open/close delimiter to match each other -- real
+# Hugo content always pairs them correctly, so being lenient here only
+# widens what converts, never what breaks.
 CALLOUT_RX = re.compile(
-    r'\{\{<\s*(note|warning|tip|info|alert)\s*>\}\}(.*?)\{\{<\s*/\1\s*>\}\}',
+    r'\{\{[<%]\s*(note|warning|tip|info|alert)((?:\s+\w+="[^"]*")*)\s*[%>]\}\}'
+    r'(.*?)\{\{[<%]\s*/\1\s*[%>]\}\}',
     re.DOTALL,
 )
+# The `alert` shortcode has no fixed type of its own (it's `note`/`warning`/
+# etc. with a custom title bolted on) -- render hooks have no such shortcode,
+# so it maps onto the plain `note` alert type. A `title=` attribute that just
+# restates the type's default label (e.g. `alert title="Note"`) is dropped
+# rather than carried over as a redundant `> [!NOTE] Note`.
+CALLOUT_DEFAULT_LABEL = {
+    "note": "Note", "warning": "Warning", "tip": "Tip", "info": "Info", "alert": "Note",
+}
 LINK_RX = re.compile(r'\]\(([^)\s]+)\)')
 SKIP_HREF_PREFIXES = ("http://", "https://", "mailto:", "#", "/content/")
 
@@ -54,10 +71,16 @@ def relref_to_plain(text):
 
 def callouts_to_blockquote(text):
     def repl(m):
-        kind, body = m.group(1), m.group(2).strip("\n")
+        kind, attrs, body = m.group(1), m.group(2), m.group(3).strip("\n")
+        out_type = "note" if kind == "alert" else kind
+        title_m = re.search(r'\btitle="([^"]*)"', attrs)
+        title = title_m.group(1) if title_m else ""
+        if title.strip().lower() == CALLOUT_DEFAULT_LABEL[kind].lower():
+            title = ""
+        header = f"> [!{out_type.upper()}]" + (f" {title}" if title else "")
         lines = body.split("\n")
         quoted = "\n".join(f"> {line}" if line else ">" for line in lines)
-        return f"> [!{kind.upper()}]\n{quoted}"
+        return f"{header}\n{quoted}"
 
     return CALLOUT_RX.sub(repl, text)
 

--- a/content/develop/data-types/streams/_index.md
+++ b/content/develop/data-types/streams/_index.md
@@ -34,9 +34,9 @@ Examples of Redis stream use cases include:
 Redis generates a unique ID for each stream entry.
 You can use these IDs to retrieve their associated entries later or to read and process all subsequent entries in the stream. Note that because these IDs are related to time, the ones shown here may vary and will be different from the IDs you see in your own Redis instance.
 
-Redis streams support several trimming strategies (to prevent streams from growing unbounded) and more than one consumption strategy (see [`XREAD`]({{< relref "/commands/xread" >}}), [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}), and [`XRANGE`]({{< relref "/commands/xrange" >}})). Starting with Redis 8.2, the `XACKDEL`, `XDELEX`, `XADD`, and `XTRIM` commands provide fine-grained control over how stream operations interact with multiple consumer groups, simplifying the coordination of message processing across different applications.
+Redis streams support several trimming strategies (to prevent streams from growing unbounded) and more than one consumption strategy (see [`XREAD`](/content/commands/xread.md), [`XREADGROUP`](/content/commands/xreadgroup.md), and [`XRANGE`](/content/commands/xrange.md)). Starting with Redis 8.2, the `XACKDEL`, `XDELEX`, `XADD`, and `XTRIM` commands provide fine-grained control over how stream operations interact with multiple consumer groups, simplifying the coordination of message processing across different applications.
 
-Beginning with Redis 8.6, Redis streams support idempotent message processing (at-most-once production) to prevent duplicate entries when using at-least-once delivery patterns. This feature enables reliable message submission with automatic deduplication. See [Idempotent Message Processing]({{< relref "/develop/data-types/streams/idempotency" >}}) for more information.
+Beginning with Redis 8.6, Redis streams support idempotent message processing (at-most-once production) to prevent duplicate entries when using at-least-once delivery patterns. This feature enables reliable message submission with automatic deduplication. See [Idempotent Message Processing](/content/develop/data-types/streams/idempotency.md) for more information.
 
 ## Examples
 
@@ -91,7 +91,7 @@ See each command's time complexity for the details.
 
 ## Streams basics
 
-Streams are an append-only data structure. The fundamental write command, called [`XADD`]({{< relref "/commands/xadd" >}}), appends a new entry to the specified stream.
+Streams are an append-only data structure. The fundamental write command, called [`XADD`](/content/commands/xadd.md), appends a new entry to the specified stream.
 
 Each stream entry consists of one or more field-value pairs, somewhat like a dictionary or a Redis hash:
 
@@ -100,9 +100,9 @@ Each stream entry consists of one or more field-value pairs, somewhat like a dic
 "1692632147973-0"
 {{< /clients-example >}}
 
-The above call to the [`XADD`]({{< relref "/commands/xadd" >}}) command adds an entry `rider: Castilla, speed: 29.9, position: 1, location_id: 2` to the stream at key `race:france`, using an auto-generated entry ID, which is the one returned by the command, specifically `1692632147973-0`. It gets as its first argument the key name `race:france`, the second argument is the entry ID that identifies every entry inside a stream. However, in this case, we passed `*` because we want the server to generate a new ID for us. Every new ID will be monotonically increasing, so in more simple terms, every new entry added will have a higher ID compared to all the past entries. Auto-generation of IDs by the server is almost always what you want, and the reasons for specifying an ID explicitly are very rare. We'll talk more about this later. The fact that each Stream entry has an ID is another similarity with log files, where line numbers, or the byte offset inside the file, can be used in order to identify a given entry. Returning back at our [`XADD`]({{< relref "/commands/xadd" >}}) example, after the key name and ID, the next arguments are the field-value pairs composing our stream entry.
+The above call to the [`XADD`](/content/commands/xadd.md) command adds an entry `rider: Castilla, speed: 29.9, position: 1, location_id: 2` to the stream at key `race:france`, using an auto-generated entry ID, which is the one returned by the command, specifically `1692632147973-0`. It gets as its first argument the key name `race:france`, the second argument is the entry ID that identifies every entry inside a stream. However, in this case, we passed `*` because we want the server to generate a new ID for us. Every new ID will be monotonically increasing, so in more simple terms, every new entry added will have a higher ID compared to all the past entries. Auto-generation of IDs by the server is almost always what you want, and the reasons for specifying an ID explicitly are very rare. We'll talk more about this later. The fact that each Stream entry has an ID is another similarity with log files, where line numbers, or the byte offset inside the file, can be used in order to identify a given entry. Returning back at our [`XADD`](/content/commands/xadd.md) example, after the key name and ID, the next arguments are the field-value pairs composing our stream entry.
 
-It is possible to get the number of items inside a Stream just using the [`XLEN`]({{< relref "/commands/xlen" >}}) command:
+It is possible to get the number of items inside a Stream just using the [`XLEN`](/content/commands/xlen.md) command:
 
 {{< clients-example set="stream_tutorial" step="xlen" description="Foundational: Get the total number of entries in a stream using XLEN" try_it="false" runnable="false" >}}
 > XLEN race:france
@@ -111,7 +111,7 @@ It is possible to get the number of items inside a Stream just using the [`XLEN`
 
 ### Entry IDs
 
-The entry ID returned by the [`XADD`]({{< relref "/commands/xadd" >}}) command, and identifying univocally each entry inside a given stream, is composed of two parts:
+The entry ID returned by the [`XADD`](/content/commands/xadd.md) command, and identifying univocally each entry inside a given stream, is composed of two parts:
 
 ```
 <millisecondsTime>-<sequenceNumber>
@@ -119,9 +119,9 @@ The entry ID returned by the [`XADD`]({{< relref "/commands/xadd" >}}) command, 
 
 The milliseconds time part is actually the local time in the local Redis node generating the stream ID, however if the current milliseconds time happens to be smaller than the previous entry time, then the previous entry time is used instead, so if a clock jumps backward the monotonically incrementing ID property still holds. The sequence number is used for entries created in the same millisecond. Since the sequence number is 64 bit wide, in practical terms there is no limit to the number of entries that can be generated within the same millisecond.
 
-The format of such IDs may look strange at first, and the gentle reader may wonder why the time is part of the ID. The reason is that Redis streams support range queries by ID. Because the ID is related to the time the entry is generated, this gives the ability to query for time ranges basically for free. We will see this soon while covering the [`XRANGE`]({{< relref "/commands/xrange" >}}) command.
+The format of such IDs may look strange at first, and the gentle reader may wonder why the time is part of the ID. The reason is that Redis streams support range queries by ID. Because the ID is related to the time the entry is generated, this gives the ability to query for time ranges basically for free. We will see this soon while covering the [`XRANGE`](/content/commands/xrange.md) command.
 
-If for some reason the user needs incremental IDs that are not related to time but are actually associated to another external system ID, as previously mentioned, the [`XADD`]({{< relref "/commands/xadd" >}}) command can take an explicit ID instead of the `*` wildcard ID that triggers auto-generation, like in the following examples:
+If for some reason the user needs incremental IDs that are not related to time but are actually associated to another external system ID, as previously mentioned, the [`XADD`](/content/commands/xadd.md) command can take an explicit ID instead of the `*` wildcard ID that triggers auto-generation, like in the following examples:
 
 {{< clients-example set="stream_tutorial" step="xadd_id" description="Specify explicit stream entry IDs instead of auto-generated ones when you need to use external system IDs" difficulty="advanced" try_it="false" runnable="false" >}}
 > XADD race:usa 0-1 racer Castilla
@@ -146,7 +146,7 @@ If you're running Redis 7 or later, you can also provide an explicit ID consisti
 
 ## Getting data from Streams
 
-Now we are finally able to append entries in our stream via [`XADD`]({{< relref "/commands/xadd" >}}). However, while appending data to a stream is quite obvious, the way streams can be queried in order to extract data is not so obvious. If we continue with the analogy of the log file, one obvious way is to mimic what we normally do with the Unix command `tail -f`, that is, we may start to listen in order to get the new messages that are appended to the stream. Note that unlike the blocking list operations of Redis, where a given element will reach a single client which is blocking in a *pop style* operation like [`BLPOP`]({{< relref "/commands/blpop" >}}), with streams we want multiple consumers to see the new messages appended to the stream (the same way many `tail -f` processes can see what is added to a log). Using the traditional terminology we want the streams to be able to *fan out* messages to multiple clients.
+Now we are finally able to append entries in our stream via [`XADD`](/content/commands/xadd.md). However, while appending data to a stream is quite obvious, the way streams can be queried in order to extract data is not so obvious. If we continue with the analogy of the log file, one obvious way is to mimic what we normally do with the Unix command `tail -f`, that is, we may start to listen in order to get the new messages that are appended to the stream. Note that unlike the blocking list operations of Redis, where a given element will reach a single client which is blocking in a *pop style* operation like [`BLPOP`](/content/commands/blpop.md), with streams we want multiple consumers to see the new messages appended to the stream (the same way many `tail -f` processes can see what is added to a log). Using the traditional terminology we want the streams to be able to *fan out* messages to multiple clients.
 
 However, this is just one potential access mode. We could also see a stream in quite a different way: not as a messaging system, but as a *time series store*. In this case, maybe it's also useful to get the new messages appended, but another natural query mode is to get messages by ranges of time, or alternatively to iterate the messages using a cursor to incrementally check all the history. This is definitely another useful access mode.
 
@@ -198,7 +198,7 @@ To query the stream by range we are only required to specify two IDs, *start* an
       8) "2"
 {{< /clients-example >}}
 
-Each entry returned is an array of two items: the ID and the list of field-value pairs. We already said that the entry IDs have a relation with the time, because the part at the left of the `-` character is the Unix time in milliseconds of the local node that created the stream entry, at the moment the entry was created (however note that streams are replicated with fully specified [`XADD`]({{< relref "/commands/xadd" >}}) commands, so the replicas will have identical IDs to the master). This means that I could query a range of time using [`XRANGE`]({{< relref "/commands/xrange" >}}). In order to do so, however, I may want to omit the sequence part of the ID: if omitted, in the start of the range it will be assumed to be 0, while in the end part it will be assumed to be the maximum sequence number available. This way, querying using just two milliseconds Unix times, we get all the entries that were generated in that range of time, in an inclusive way. For instance, if I want to query a two milliseconds period I could use:
+Each entry returned is an array of two items: the ID and the list of field-value pairs. We already said that the entry IDs have a relation with the time, because the part at the left of the `-` character is the Unix time in milliseconds of the local node that created the stream entry, at the moment the entry was created (however note that streams are replicated with fully specified [`XADD`](/content/commands/xadd.md) commands, so the replicas will have identical IDs to the master). This means that I could query a range of time using [`XRANGE`](/content/commands/xrange.md). In order to do so, however, I may want to omit the sequence part of the ID: if omitted, in the start of the range it will be assumed to be 0, while in the end part it will be assumed to be the maximum sequence number available. This way, querying using just two milliseconds Unix times, we get all the entries that were generated in that range of time, in an inclusive way. For instance, if I want to query a two milliseconds period I could use:
 
 {{< clients-example set="stream_tutorial" step="xrange_time" description="Query stream entries by time range using millisecond timestamps instead of full IDs" difficulty="intermediate" try_it="false" runnable="false" >}}
 > XRANGE race:france 1692632086369 1692632086371
@@ -213,7 +213,7 @@ Each entry returned is an array of two items: the ID and the list of field-value
       8) "1"
 {{< /clients-example >}}
 
-I have only a single entry in this range. However in real data sets, I could query for ranges of hours, or there could be many items in just two milliseconds, and the result returned could be huge. For this reason, [`XRANGE`]({{< relref "/commands/xrange" >}}) supports an optional **COUNT** option at the end. By specifying a count, I can just get the first *N* items. If I want more, I can get the last ID returned, increment the sequence part by one, and query again. Let's see this in the following example. Let's assume that the stream `race:france` was populated with 4 items. To start my iteration, getting 2 items per command, I start with the full range, but with a count of 2.
+I have only a single entry in this range. However in real data sets, I could query for ranges of hours, or there could be many items in just two milliseconds, and the result returned could be huge. For this reason, [`XRANGE`](/content/commands/xrange.md) supports an optional **COUNT** option at the end. By specifying a count, I can just get the first *N* items. If I want more, I can get the last ID returned, increment the sequence part by one, and query again. Let's see this in the following example. Let's assume that the stream `race:france` was populated with 4 items. To start my iteration, getting 2 items per command, I start with the full range, but with a count of 2.
 
 {{< clients-example set="stream_tutorial" step="xrange_step_1" description="Practical pattern: Paginate stream entries using XRANGE with COUNT to retrieve results in batches" difficulty="intermediate" max_lines="10" try_it="false" runnable="false" >}}
 > XRANGE race:france - + COUNT 2
@@ -237,7 +237,7 @@ I have only a single entry in this range. However in real data sets, I could que
       8) "1"
 {{< /clients-example >}}
 
-To continue the iteration with the next two items, I have to pick the last ID returned, that is `1692632094485-0`, and add the prefix `(` to it. The resulting exclusive range interval, that is `(1692632094485-0` in this case, can now be used as the new *start* argument for the next [`XRANGE`]({{< relref "/commands/xrange" >}}) call:
+To continue the iteration with the next two items, I have to pick the last ID returned, that is `1692632094485-0`, and add the prefix `(` to it. The resulting exclusive range interval, that is `(1692632094485-0` in this case, can now be used as the new *start* argument for the next [`XRANGE`](/content/commands/xrange.md) call:
 
 {{< clients-example set="stream_tutorial" step="xrange_step_2" description="Practical pattern: Continue pagination using exclusive range syntax with ( prefix to skip the last retrieved entry" difficulty="intermediate" max_lines="10" try_it="false" runnable="false" >}}
 > XRANGE race:france (1692632094485-0 + COUNT 2
@@ -268,9 +268,9 @@ Now that we've retrieved 4 items out of a stream that only had 4 entries in it, 
 (empty array)
 {{< /clients-example >}}
 
-Since [`XRANGE`]({{< relref "/commands/xrange" >}}) complexity is *O(log(N))* to seek, and then *O(M)* to return M elements, with a small count the command has a logarithmic time complexity, which means that each step of the iteration is fast. So [`XRANGE`]({{< relref "/commands/xrange" >}}) is also the de facto *streams iterator* and does not require an **XSCAN** command.
+Since [`XRANGE`](/content/commands/xrange.md) complexity is *O(log(N))* to seek, and then *O(M)* to return M elements, with a small count the command has a logarithmic time complexity, which means that each step of the iteration is fast. So [`XRANGE`](/content/commands/xrange.md) is also the de facto *streams iterator* and does not require an **XSCAN** command.
 
-The command [`XREVRANGE`]({{< relref "/commands/xrevrange" >}}) is the equivalent of [`XRANGE`]({{< relref "/commands/xrange" >}}) but returning the elements in inverted order, so a practical use for [`XREVRANGE`]({{< relref "/commands/xrevrange" >}}) is to check what is the last item in a Stream:
+The command [`XREVRANGE`](/content/commands/xrevrange.md) is the equivalent of [`XRANGE`](/content/commands/xrange.md) but returning the elements in inverted order, so a practical use for [`XREVRANGE`](/content/commands/xrevrange.md) is to check what is the last item in a Stream:
 
 {{< clients-example set="stream_tutorial" step="xrevrange" description="Foundational: Retrieve stream entries in reverse order using XREVRANGE when you need the most recent entries first" try_it="false" runnable="false" >}}
 > XREVRANGE race:france + - COUNT 1
@@ -285,7 +285,7 @@ The command [`XREVRANGE`]({{< relref "/commands/xrevrange" >}}) is the equivalen
       8) "2"
 {{< /clients-example >}}
 
-Note that the [`XREVRANGE`]({{< relref "/commands/xrevrange" >}}) command takes the *start* and *stop* arguments in reverse order.
+Note that the [`XREVRANGE`](/content/commands/xrevrange.md) command takes the *start* and *stop* arguments in reverse order.
 
 ## Listening for new items with XREAD
 
@@ -295,7 +295,7 @@ When we do not want to access items by a range in a stream, usually what we want
 2. While in Pub/Sub messages are *fire and forget* and are never stored anyway, and while when using blocking lists, when a message is received by the client it is *popped* (effectively removed) from the list, streams work in a fundamentally different way. All the messages are appended in the stream indefinitely (unless the user explicitly asks to delete entries): different consumers will know what is a new message from its point of view by remembering the ID of the last message received.
 3. Streams Consumer Groups provide a level of control that Pub/Sub or blocking lists cannot achieve, with different groups for the same stream, explicit acknowledgment of processed items, ability to inspect the pending items, claiming of unprocessed messages, and coherent history visibility for each single client, that is only able to see its private past history of messages.
 
-The command that provides the ability to listen for new messages arriving into a stream is called [`XREAD`]({{< relref "/commands/xread" >}}). It's a bit more complex than [`XRANGE`]({{< relref "/commands/xrange" >}}), so we'll start showing simple forms, and later the whole command layout will be provided.
+The command that provides the ability to listen for new messages arriving into a stream is called [`XREAD`](/content/commands/xread.md). It's a bit more complex than [`XRANGE`](/content/commands/xrange.md), so we'll start showing simple forms, and later the whole command layout will be provided.
 
 {{< clients-example set="stream_tutorial" step="xread" description="Foundational: Read entries from a stream starting from a specific ID using XREAD (non-blocking form)" max_lines="10" try_it="false" runnable="false" >}}
 > XREAD COUNT 2 STREAMS race:france 0
@@ -320,30 +320,30 @@ The command that provides the ability to listen for new messages arriving into a
             8) "1"
 {{< /clients-example >}}
 
-The above is the non-blocking form of [`XREAD`]({{< relref "/commands/xread" >}}). Note that the **COUNT** option is not mandatory, in fact the only mandatory option of the command is the **STREAMS** option, that specifies a list of keys together with the corresponding maximum ID already seen for each stream by the calling consumer, so that the command will provide the client only with messages with an ID greater than the one we specified.
+The above is the non-blocking form of [`XREAD`](/content/commands/xread.md). Note that the **COUNT** option is not mandatory, in fact the only mandatory option of the command is the **STREAMS** option, that specifies a list of keys together with the corresponding maximum ID already seen for each stream by the calling consumer, so that the command will provide the client only with messages with an ID greater than the one we specified.
 
 In the above command we wrote `STREAMS race:france 0` so we want all the messages in the Stream `race:france` having an ID greater than `0-0`. As you can see in the example above, the command returns the key name, because actually it is possible to call this command with more than one key to read from different streams at the same time. I could write, for instance: `STREAMS race:france race:italy 0 0`. Note how after the **STREAMS** option we need to provide the key names, and later the IDs. For this reason, the **STREAMS** option must always be the last option.
 Any other options must come before the **STREAMS** option.
 
-Apart from the fact that [`XREAD`]({{< relref "/commands/xread" >}}) can access multiple streams at once, and that we are able to specify the last ID we own to just get newer messages, in this simple form the command is not doing something so different compared to [`XRANGE`]({{< relref "/commands/xrange" >}}). However, the interesting part is that we can turn [`XREAD`]({{< relref "/commands/xread" >}}) into a *blocking command* easily, by specifying the **BLOCK** argument:
+Apart from the fact that [`XREAD`](/content/commands/xread.md) can access multiple streams at once, and that we are able to specify the last ID we own to just get newer messages, in this simple form the command is not doing something so different compared to [`XRANGE`](/content/commands/xrange.md). However, the interesting part is that we can turn [`XREAD`](/content/commands/xread.md) into a *blocking command* easily, by specifying the **BLOCK** argument:
 
 ```
 > XREAD BLOCK 0 STREAMS race:france $
 ```
 
-Note that in the example above, other than removing **COUNT**, I specified the new **BLOCK** option with a timeout of 0 milliseconds (that means to never timeout). Moreover, instead of passing a normal ID for the stream `race:france` I passed the special ID `$`. This special ID means that [`XREAD`]({{< relref "/commands/xread" >}}) should use as last ID the maximum ID already stored in the stream `race:france`, so that we will receive only *new* messages, starting from the time we started listening. This is similar to the `tail -f` Unix command in some way.
+Note that in the example above, other than removing **COUNT**, I specified the new **BLOCK** option with a timeout of 0 milliseconds (that means to never timeout). Moreover, instead of passing a normal ID for the stream `race:france` I passed the special ID `$`. This special ID means that [`XREAD`](/content/commands/xread.md) should use as last ID the maximum ID already stored in the stream `race:france`, so that we will receive only *new* messages, starting from the time we started listening. This is similar to the `tail -f` Unix command in some way.
 
 Note that when the **BLOCK** option is used, we do not have to use the special ID `$`. We can use any valid ID. If the command is able to serve our request immediately without blocking, it will do so, otherwise it will block. Normally if we want to consume the stream starting from new entries, we start with the ID `$`, and after that we continue using the ID of the last message received to make the next call, and so forth.
 
-The blocking form of [`XREAD`]({{< relref "/commands/xread" >}}) is also able to listen to multiple Streams, just by specifying multiple key names. If the request can be served synchronously because there is at least one stream with elements greater than the corresponding ID we specified, it returns with the results. Otherwise, the command will block and will return the items of the first stream which gets new data (according to the specified ID).
+The blocking form of [`XREAD`](/content/commands/xread.md) is also able to listen to multiple Streams, just by specifying multiple key names. If the request can be served synchronously because there is at least one stream with elements greater than the corresponding ID we specified, it returns with the results. Otherwise, the command will block and will return the items of the first stream which gets new data (according to the specified ID).
 
 Similarly to blocking list operations, blocking stream reads are *fair* from the point of view of clients waiting for data, since the semantics is FIFO style. The first client that blocked for a given stream will be the first to be unblocked when new items are available.
 
-[`XREAD`]({{< relref "/commands/xread" >}}) has no other options than **COUNT** and **BLOCK**, so it's a pretty basic command with a specific purpose to attach consumers to one or multiple streams. More powerful features to consume streams are available using the consumer groups API, however reading via consumer groups is implemented by a different command called [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}), covered in the next section of this guide.
+[`XREAD`](/content/commands/xread.md) has no other options than **COUNT** and **BLOCK**, so it's a pretty basic command with a specific purpose to attach consumers to one or multiple streams. More powerful features to consume streams are available using the consumer groups API, however reading via consumer groups is implemented by a different command called [`XREADGROUP`](/content/commands/xreadgroup.md), covered in the next section of this guide.
 
 ## Consumer groups
 
-When the task at hand is to consume the same stream from different clients, then [`XREAD`]({{< relref "/commands/xread" >}}) already offers a way to *fan-out* to N clients, potentially also using replicas in order to provide more read scalability. However in certain problems what we want to do is not to provide the same stream of messages to many clients, but to provide a *different subset* of messages from the same stream to many clients. An obvious case where this is useful is that of messages which are slow to process: the ability to have N different workers that will receive different parts of the stream allows us to scale message processing, by routing different messages to different workers that are ready to do more work.
+When the task at hand is to consume the same stream from different clients, then [`XREAD`](/content/commands/xread.md) already offers a way to *fan-out* to N clients, potentially also using replicas in order to provide more read scalability. However in certain problems what we want to do is not to provide the same stream of messages to many clients, but to provide a *different subset* of messages from the same stream to many clients. An obvious case where this is useful is that of messages which are slow to process: the ability to have N different workers that will receive different parts of the stream allows us to scale message processing, by routing different messages to different workers that are ready to do more work.
 
 In practical terms, if we imagine having three consumers C1, C2, C3, and a stream that contains the messages 1, 2, 3, 4, 5, 6, 7 then what we want is to serve the messages according to the following diagram:
 
@@ -384,15 +384,15 @@ In a way, a consumer group can be imagined as some *amount of state* about a str
 +----------------------------------------+
 ```
 
-If you see this from this point of view, it is very simple to understand what a consumer group can do, how it is able to just provide consumers with their history of pending messages, and how consumers asking for new messages will just be served with message IDs greater than `last_delivered_id`. At the same time, if you look at the consumer group as an auxiliary data structure for Redis streams, it is obvious that a single stream can have multiple consumer groups, that have a different set of consumers. Actually, it is even possible for the same stream to have clients reading without consumer groups via [`XREAD`]({{< relref "/commands/xread" >}}), and clients reading via [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) in different consumer groups.
+If you see this from this point of view, it is very simple to understand what a consumer group can do, how it is able to just provide consumers with their history of pending messages, and how consumers asking for new messages will just be served with message IDs greater than `last_delivered_id`. At the same time, if you look at the consumer group as an auxiliary data structure for Redis streams, it is obvious that a single stream can have multiple consumer groups, that have a different set of consumers. Actually, it is even possible for the same stream to have clients reading without consumer groups via [`XREAD`](/content/commands/xread.md), and clients reading via [`XREADGROUP`](/content/commands/xreadgroup.md) in different consumer groups.
 
 Now it's time to zoom in to see the fundamental consumer group commands. They are the following:
 
-* [`XGROUP`]({{< relref "/commands/xgroup" >}}) is used in order to create, destroy and manage consumer groups.
-* [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) is used to read from a stream via a consumer group.
-* [`XACK`]({{< relref "/commands/xack" >}}) is the command that allows a consumer to mark a pending message as correctly processed.
-* [`XNACK`]({{< relref "/commands/xnack" >}}) is the command that allows a consumer to release pending messages back to the group without acknowledging them, making them immediately available for re-delivery to other consumers.
-* [`XACKDEL`]({{< relref "/commands/xackdel" >}}) combines acknowledgment and deletion in a single atomic operation with enhanced control over consumer group references.
+* [`XGROUP`](/content/commands/xgroup.md) is used in order to create, destroy and manage consumer groups.
+* [`XREADGROUP`](/content/commands/xreadgroup.md) is used to read from a stream via a consumer group.
+* [`XACK`](/content/commands/xack.md) is the command that allows a consumer to mark a pending message as correctly processed.
+* [`XNACK`](/content/commands/xnack.md) is the command that allows a consumer to release pending messages back to the group without acknowledging them, making them immediately available for re-delivery to other consumers.
+* [`XACKDEL`](/content/commands/xackdel.md) combines acknowledgment and deletion in a single atomic operation with enhanced control over consumer group references.
 
 ## Creating a consumer group
 
@@ -405,16 +405,16 @@ OK
 
 As you can see in the command above when creating the consumer group we have to specify an ID, which in the example is just `$`. This is needed because the consumer group, among the other states, must have an idea about what message to serve next at the first consumer connecting, that is, what was the *last message ID* when the group was just created. If we provide `$` as we did, then only new messages arriving in the stream from now on will be provided to the consumers in the group. If we specify `0` instead the consumer group will consume *all* the messages in the stream history to start with. Of course, you can specify any other valid ID. What you know is that the consumer group will start delivering messages that are greater than the ID you specify. Because `$` means the current greatest ID in the stream, specifying `$` will have the effect of consuming only new messages.
 
-[`XGROUP CREATE`]({{< relref "/commands/xgroup-create" >}}) also supports creating the stream automatically, if it doesn't exist, using the optional `MKSTREAM` subcommand as the last argument:
+[`XGROUP CREATE`](/content/commands/xgroup-create.md) also supports creating the stream automatically, if it doesn't exist, using the optional `MKSTREAM` subcommand as the last argument:
 
 {{< clients-example set="stream_tutorial" step="xgroup_create_mkstream" description="Create a consumer group and stream atomically using XGROUP CREATE with MKSTREAM option" difficulty="intermediate" try_it="false" runnable="false" >}}
 > XGROUP CREATE race:italy italy_riders $ MKSTREAM
 OK
 {{< /clients-example >}}
 
-Now that the consumer group is created we can immediately try to read messages via the consumer group using the [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) command. We'll read from consumers, that we will call Alice and Bob, to see how the system will return different messages to Alice or Bob.
+Now that the consumer group is created we can immediately try to read messages via the consumer group using the [`XREADGROUP`](/content/commands/xreadgroup.md) command. We'll read from consumers, that we will call Alice and Bob, to see how the system will return different messages to Alice or Bob.
 
-[`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) is very similar to [`XREAD`]({{< relref "/commands/xread" >}}) and provides the same **BLOCK** option, otherwise it is a synchronous command. However there is a *mandatory* option that must be always specified, which is **GROUP** and has two arguments: the name of the consumer group, and the name of the consumer that is attempting to read. The option **COUNT** is also supported and is identical to the one in [`XREAD`]({{< relref "/commands/xread" >}}).
+[`XREADGROUP`](/content/commands/xreadgroup.md) is very similar to [`XREAD`](/content/commands/xread.md) and provides the same **BLOCK** option, otherwise it is a synchronous command. However there is a *mandatory* option that must be always specified, which is **GROUP** and has two arguments: the name of the consumer group, and the name of the consumer that is attempting to read. The option **COUNT** is also supported and is identical to the one in [`XREAD`](/content/commands/xread.md).
 
 We'll add riders to the race:italy stream and try reading something using the consumer group:
 Note: *here rider is the field name, and the name is the associated value. Remember that stream items are small dictionaries.*
@@ -437,14 +437,14 @@ Note: *here rider is the field name, and the name is the associated value. Remem
             2) "Castilla"
 {{< /clients-example >}}
 
-[`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) replies are just like [`XREAD`]({{< relref "/commands/xread" >}}) replies. Note however the `GROUP <group-name> <consumer-name>` provided above. It states that I want to read from the stream using the consumer group `mygroup` and I'm the consumer `Alice`. Every time a consumer performs an operation with a consumer group, it must specify its name, uniquely identifying this consumer inside the group.
+[`XREADGROUP`](/content/commands/xreadgroup.md) replies are just like [`XREAD`](/content/commands/xread.md) replies. Note however the `GROUP <group-name> <consumer-name>` provided above. It states that I want to read from the stream using the consumer group `mygroup` and I'm the consumer `Alice`. Every time a consumer performs an operation with a consumer group, it must specify its name, uniquely identifying this consumer inside the group.
 
 There is another very important detail in the command line above, after the mandatory **STREAMS** option the ID requested for the key `race:italy` is the special ID `>`. This special ID is only valid in the context of consumer groups, and it means: **messages never delivered to other consumers so far**.
 
-This is almost always what you want, however it is also possible to specify a real ID, such as `0` or any other valid ID, in this case, however, what happens is that we request from [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) to just provide us with the **history of pending messages**, and in such case, will never see new messages in the group. So basically [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) has the following behavior based on the ID we specify:
+This is almost always what you want, however it is also possible to specify a real ID, such as `0` or any other valid ID, in this case, however, what happens is that we request from [`XREADGROUP`](/content/commands/xreadgroup.md) to just provide us with the **history of pending messages**, and in such case, will never see new messages in the group. So basically [`XREADGROUP`](/content/commands/xreadgroup.md) has the following behavior based on the ID we specify:
 
 * If the ID is the special ID `>` then the command will return only new messages never delivered to other consumers so far, and as a side effect, will update the consumer group's *last ID*.
-* If the ID is any other valid numerical ID, then the command will let us access our *history of pending messages*. That is, the set of messages that were delivered to this specified consumer (identified by the provided name), and never acknowledged so far with [`XACK`]({{< relref "/commands/xack" >}}).
+* If the ID is any other valid numerical ID, then the command will let us access our *history of pending messages*. That is, the set of messages that were delivered to this specified consumer (identified by the provided name), and never acknowledged so far with [`XACK`](/content/commands/xack.md).
 
 We can test this behavior immediately specifying an ID of 0, without any **COUNT** option: we'll just see the only pending message, that is, the one about Castilla:
 
@@ -466,7 +466,7 @@ However, if we acknowledge the message as processed, it will no longer be part o
    2) (empty array)
 {{< /clients-example >}}
 
-Don't worry if you yet don't know how [`XACK`]({{< relref "/commands/xack" >}}) works, the idea is just that processed messages are no longer part of the history that we can access.
+Don't worry if you yet don't know how [`XACK`](/content/commands/xack.md) works, the idea is just that processed messages are no longer part of the history that we can access.
 
 Now it's Bob's turn to read something:
 
@@ -488,8 +488,8 @@ This way Alice, Bob, and any other consumer in the group, are able to read diffe
 There are a few things to keep in mind:
 
 * Consumers are auto-created the first time they are mentioned, no need for explicit creation.
-* Even with [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) you can read from multiple keys at the same time, however for this to work, you need to create a consumer group with the same name in every stream. This is not a common need, but it is worth mentioning that the feature is technically available.
-* [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) is a *write command* because even if it reads from the stream, the consumer group is modified as a side effect of reading, so it can only be called on master instances.
+* Even with [`XREADGROUP`](/content/commands/xreadgroup.md) you can read from multiple keys at the same time, however for this to work, you need to create a consumer group with the same name in every stream. This is not a common need, but it is worth mentioning that the feature is technically available.
+* [`XREADGROUP`](/content/commands/xreadgroup.md) is a *write command* because even if it reads from the stream, the consumer group is modified as a side effect of reading, so it can only be called on master instances.
 
 An example of a consumer implementation, using consumer groups, written in the Ruby language could be the following. The Ruby code is aimed to be readable by virtually any experienced programmer, even if they do not know Ruby:
 
@@ -558,7 +558,7 @@ The example above allows us to write consumers that participate in the same cons
 
 Redis consumer groups offer a feature that is used in these situations in order to *claim* the pending messages of a given consumer so that such messages will change ownership and will be re-assigned to a different consumer. The feature is very explicit. A consumer has to inspect the list of pending messages, and will have to claim specific messages using a special command, otherwise the server will leave the messages pending forever and assigned to the old consumer. In this way different applications can choose if to use such a feature or not, and exactly how to use it.
 
-The first step of this process is just a command that provides observability of pending entries in the consumer group and is called [`XPENDING`]({{< relref "/commands/xpending" >}}).
+The first step of this process is just a command that provides observability of pending entries in the consumer group and is called [`XPENDING`](/content/commands/xpending.md).
 This is a read-only command which is always safe to call and will not change ownership of any message.
 In its simplest form, the command is called with two arguments, which are the name of the stream and the name of the consumer group.
 
@@ -572,15 +572,15 @@ In its simplest form, the command is called with two arguments, which are the na
 {{< /clients-example >}}
 
 When called in this way, the command outputs the total number of pending messages in the consumer group (two in this case), the lower and higher message ID among the pending messages, and finally a list of consumers and the number of pending messages they have.
-We have only Bob with two pending messages because the single message that Alice requested was acknowledged using [`XACK`]({{< relref "/commands/xack" >}}).
+We have only Bob with two pending messages because the single message that Alice requested was acknowledged using [`XACK`](/content/commands/xack.md).
 
-We can ask for more information by giving more arguments to [`XPENDING`]({{< relref "/commands/xpending" >}}), because the full command signature is the following:
+We can ask for more information by giving more arguments to [`XPENDING`](/content/commands/xpending.md), because the full command signature is the following:
 
 ```
 XPENDING <key> <groupname> [[IDLE <min-idle-time>] <start-id> <end-id> <count> [<consumer-name>]]
 ```
 
-By providing a start and end ID (that can be just `-` and `+` as in [`XRANGE`]({{< relref "/commands/xrange" >}})) and a count to control the amount of information returned by the command, we are able to know more about the pending messages. The optional final argument, the consumer name, is used if we want to limit the output to just messages pending for a given consumer, but won't use this feature in the following example.
+By providing a start and end ID (that can be just `-` and `+` as in [`XRANGE`](/content/commands/xrange.md)) and a count to control the amount of information returned by the command, we are able to know more about the pending messages. The optional final argument, the consumer name, is used if we want to limit the output to just messages pending for a given consumer, but won't use this feature in the following example.
 
 {{< clients-example set="stream_tutorial" step="xpending_plus_minus" description="Get detailed pending message information including idle time and delivery count using XPENDING with range" difficulty="advanced" try_it="false" runnable="false" >}}
 > XPENDING race:italy italy_riders - + 10
@@ -597,7 +597,7 @@ By providing a start and end ID (that can be just `-` and `+` as in [`XRANGE`]({
 Now we have the details for each message: the ID, the consumer name, the *idle time* in milliseconds, which is how many milliseconds have passed since the last time the message was delivered to some consumer, and finally the number of times that a given message was delivered.
 We have two messages from Bob, and they are idle for 60000+ milliseconds, about a minute.
 
-Note that nobody prevents us from checking what the first message content was by just using [`XRANGE`]({{< relref "/commands/xrange" >}}).
+Note that nobody prevents us from checking what the first message content was by just using [`XRANGE`](/content/commands/xrange.md).
 
 {{< clients-example set="stream_tutorial" step="xrange_pending" description="Retrieve the content of pending messages using XRANGE to inspect what needs to be processed" difficulty="intermediate" try_it="false" runnable="false" >}}
 > XRANGE race:italy 1692632647899-0 1692632647899-0
@@ -606,7 +606,7 @@ Note that nobody prevents us from checking what the first message content was by
       2) "Royce"
 {{< /clients-example >}}
 
-We have just to repeat the same ID twice in the arguments. Now that we have some ideas, Alice may decide that after 1 minute of not processing messages, Bob will probably not recover quickly, and it's time to *claim* such messages and resume the processing in place of Bob. To do so, we use the [`XCLAIM`]({{< relref "/commands/xclaim" >}}) command.
+We have just to repeat the same ID twice in the arguments. Now that we have some ideas, Alice may decide that after 1 minute of not processing messages, Bob will probably not recover quickly, and it's time to *claim* such messages and resume the processing in place of Bob. To do so, we use the [`XCLAIM`](/content/commands/xclaim.md) command.
 
 This command is very complex and full of options in its full form, since it is used for replication of consumer groups changes, but we'll use just the arguments that we need normally. In this case it is as simple as:
 
@@ -634,17 +634,17 @@ This is the result of the command execution:
 
 The message was successfully claimed by Alice, who can now process the message and acknowledge it, and move things forward even if the original consumer is not recovering.
 
-It is clear from the example above that as a side effect of successfully claiming a given message, the [`XCLAIM`]({{< relref "/commands/xclaim" >}}) command also returns it. However this is not mandatory. The **JUSTID** option can be used in order to return just the IDs of the message successfully claimed. This is useful if you want to reduce the bandwidth used between the client and the server (and also the performance of the command) and you are not interested in the message because your consumer is implemented in a way that it will rescan the history of pending messages from time to time.
+It is clear from the example above that as a side effect of successfully claiming a given message, the [`XCLAIM`](/content/commands/xclaim.md) command also returns it. However this is not mandatory. The **JUSTID** option can be used in order to return just the IDs of the message successfully claimed. This is useful if you want to reduce the bandwidth used between the client and the server (and also the performance of the command) and you are not interested in the message because your consumer is implemented in a way that it will rescan the history of pending messages from time to time.
 
 Claiming may also be implemented by a separate process: one that just checks the list of pending messages, and assigns idle messages to consumers that appear to be active. Active consumers can be obtained using one of the observability features of Redis streams. This is the topic of the next section.
 
 ## Automatic claiming
 
-The [`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}}) command, added in Redis 6.2, implements the claiming process that we've described above.
-[`XPENDING`]({{< relref "/commands/xpending" >}}) and [`XCLAIM`]({{< relref "/commands/xclaim" >}}) provide the basic building blocks for different types of recovery mechanisms.
+The [`XAUTOCLAIM`](/content/commands/xautoclaim.md) command, added in Redis 6.2, implements the claiming process that we've described above.
+[`XPENDING`](/content/commands/xpending.md) and [`XCLAIM`](/content/commands/xclaim.md) provide the basic building blocks for different types of recovery mechanisms.
 This command optimizes the generic process by having Redis manage it and offers a simple solution for most recovery needs.
 
-[`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}}) identifies idle pending messages and transfers ownership of them to a consumer.
+[`XAUTOCLAIM`](/content/commands/xautoclaim.md) identifies idle pending messages and transfers ownership of them to a consumer.
 The command's signature looks like this:
 
 ```
@@ -661,7 +661,7 @@ So, in the example above, I could have used automatic claiming to claim a single
          2) "Sam-Bodden"
 {{< /clients-example >}}
 
-Like [`XCLAIM`]({{< relref "/commands/xclaim" >}}), the command replies with an array of the claimed messages, but it also returns a stream ID that allows iterating the pending entries.
+Like [`XCLAIM`](/content/commands/xclaim.md), the command replies with an array of the claimed messages, but it also returns a stream ID that allows iterating the pending entries.
 The stream ID is a cursor, and I can use it in my next call to continue in claiming idle pending messages:
 
 {{< clients-example set="stream_tutorial" step="xautoclaim_cursor" description="Continue automatic claiming using the cursor returned by XAUTOCLAIM to iterate through pending messages" difficulty="advanced" try_it="false" runnable="false" >}}
@@ -672,18 +672,18 @@ The stream ID is a cursor, and I can use it in my next call to continue in claim
          2) "Royce"
 {{< /clients-example >}}
 
-When [`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}}) returns the "0-0" stream ID as a cursor, that means that it reached the end of the consumer group pending entries list.
-That doesn't mean that there are no new idle pending messages, so the process continues by calling [`XAUTOCLAIM`]({{< relref "/commands/xautoclaim" >}}) from the beginning of the stream.
+When [`XAUTOCLAIM`](/content/commands/xautoclaim.md) returns the "0-0" stream ID as a cursor, that means that it reached the end of the consumer group pending entries list.
+That doesn't mean that there are no new idle pending messages, so the process continues by calling [`XAUTOCLAIM`](/content/commands/xautoclaim.md) from the beginning of the stream.
 
 ## Claiming and the delivery counter
 
-The counter that you observe in the [`XPENDING`]({{< relref "/commands/xpending" >}}) output is the number of deliveries of each message. The counter is incremented in two ways: when a message is successfully claimed via [`XCLAIM`]({{< relref "/commands/xclaim" >}}) or when an [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) call is used in order to access the history of pending messages.
+The counter that you observe in the [`XPENDING`](/content/commands/xpending.md) output is the number of deliveries of each message. The counter is incremented in two ways: when a message is successfully claimed via [`XCLAIM`](/content/commands/xclaim.md) or when an [`XREADGROUP`](/content/commands/xreadgroup.md) call is used in order to access the history of pending messages.
 
 When there are failures, it is normal that messages will be delivered multiple times, but eventually they usually get processed and acknowledged. However there might be a problem processing some specific message, because it is corrupted or crafted in a way that triggers a bug in the processing code. In such a case what happens is that consumers will continuously fail to process this particular message. Because we have the counter of the delivery attempts, we can use that counter to detect messages that for some reason are not processable. So once the deliveries counter reaches a given large number that you chose, it is probably wiser to put such messages in another stream and send a notification to the system administrator. This is basically the way that Redis Streams implements the *dead letter* concept.
 
 ## Releasing messages back to the group: XNACK
 
-Starting with Redis 8.8, the [`XNACK`]({{< relref "/commands/xnack" >}}) command provides a way for consumers to explicitly release pending messages back to the group without acknowledging them. This is the opposite of claiming - instead of taking ownership of messages from other consumers, a consumer can release its own messages back to the group for immediate re-delivery.
+Starting with Redis 8.8, the [`XNACK`](/content/commands/xnack.md) command provides a way for consumers to explicitly release pending messages back to the group without acknowledging them. This is the opposite of claiming - instead of taking ownership of messages from other consumers, a consumer can release its own messages back to the group for immediate re-delivery.
 
 This capability addresses several common scenarios:
 
@@ -708,22 +708,22 @@ Released messages are placed in a special "NACK zone" at the head of the consume
 (integer) 1
 ```
 
-After NACKing, the message appears with an empty consumer in [`XPENDING`]({{< relref "/commands/xpending" >}}) output and becomes immediately available for claiming or consumption via [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) with the CLAIM option.
+After NACKing, the message appears with an empty consumer in [`XPENDING`](/content/commands/xpending.md) output and becomes immediately available for claiming or consumption via [`XREADGROUP`](/content/commands/xreadgroup.md) with the CLAIM option.
 
 ## Working with multiple consumer groups
 
 Redis Streams can be associated with multiple consumer groups, where each entry is delivered to all the stream's consumer groups. Within each consumer group, consumers handle a portion of the entries collaboratively. This design enables different applications or services to process the same stream data independently.
 
-Traditionally, when a consumer processesed a message, it acknowledged it using the [`XACK`]({{< relref "/commands/xack" >}}) command, which removed the entry reference from the Pending Entries List (PEL) of that specific consumer group. However, the entry remained in the stream and in the PELs of other consumer groups until they also acknowledge it. Applications needed to implement complex logic to delete entries from the stream only after all consumer groups had acknowledged them. This coordination was challenging to implement correctly and efficiently.
+Traditionally, when a consumer processesed a message, it acknowledged it using the [`XACK`](/content/commands/xack.md) command, which removed the entry reference from the Pending Entries List (PEL) of that specific consumer group. However, the entry remained in the stream and in the PELs of other consumer groups until they also acknowledge it. Applications needed to implement complex logic to delete entries from the stream only after all consumer groups had acknowledged them. This coordination was challenging to implement correctly and efficiently.
 
 ### Enhanced deletion control in Redis 8.2
 
 Starting with Redis 8.2, several commands provide enhanced control over how entries are handled with respect to multiple consumer groups:
 
-* [`XADD`]({{< relref "/commands/xadd" >}}) with trimming options now supports `KEEPREF`, `DELREF`, and `ACKED` modes
-* [`XTRIM`]({{< relref "/commands/xtrim" >}}) supports the same reference handling options
-* [`XDELEX`]({{< relref "/commands/xdelex" >}}) provides fine-grained deletion control
-* [`XACKDEL`]({{< relref "/commands/xackdel" >}}) combines acknowledgment and deletion atomically
+* [`XADD`](/content/commands/xadd.md) with trimming options now supports `KEEPREF`, `DELREF`, and `ACKED` modes
+* [`XTRIM`](/content/commands/xtrim.md) supports the same reference handling options
+* [`XDELEX`](/content/commands/xdelex.md) provides fine-grained deletion control
+* [`XACKDEL`](/content/commands/xackdel.md) combines acknowledgment and deletion atomically
 
 These options control how consumer group references are handled:
 
@@ -735,9 +735,9 @@ The `ACKED` option is particularly useful as it automates the complex logic of c
 
 ## Streams observability
 
-Messaging systems that lack observability are very hard to work with. Not knowing who is consuming messages, what messages are pending, the set of consumer groups active in a given stream, makes everything opaque. For this reason, Redis Streams and consumer groups have different ways to observe what is happening. We already covered [`XPENDING`]({{< relref "/commands/xpending" >}}), which allows us to inspect the list of messages that are under processing at a given moment, together with their idle time and number of deliveries.
+Messaging systems that lack observability are very hard to work with. Not knowing who is consuming messages, what messages are pending, the set of consumer groups active in a given stream, makes everything opaque. For this reason, Redis Streams and consumer groups have different ways to observe what is happening. We already covered [`XPENDING`](/content/commands/xpending.md), which allows us to inspect the list of messages that are under processing at a given moment, together with their idle time and number of deliveries.
 
-However we may want to do more than that, and the [`XINFO`]({{< relref "/commands/xinfo" >}}) command is an observability interface that can be used with sub-commands in order to get information about streams or consumer groups.
+However we may want to do more than that, and the [`XINFO`](/content/commands/xinfo.md) command is an observability interface that can be used with sub-commands in order to get information about streams or consumer groups.
 
 This command uses subcommands in order to show different information about the status of the stream and its consumer groups. For instance **XINFO STREAM <key>** reports information about the stream itself.
 
@@ -777,7 +777,7 @@ The output shows information about how the stream is encoded internally, and als
    8) "1692632662819-0"
 {{< /clients-example >}}
 
-As you can see in this and in the previous output, the [`XINFO`]({{< relref "/commands/xinfo" >}}) command outputs a sequence of field-value items. Because it is an observability command this allows the human user to immediately understand what information is reported, and allows the command to report more information in the future by adding more fields without breaking compatibility with older clients. Other commands that must be more bandwidth efficient, like [`XPENDING`]({{< relref "/commands/xpending" >}}), just report the information without the field names.
+As you can see in this and in the previous output, the [`XINFO`](/content/commands/xinfo.md) command outputs a sequence of field-value items. Because it is an observability command this allows the human user to immediately understand what information is reported, and allows the command to report more information in the future by adding more fields without breaking compatibility with older clients. Other commands that must be more bandwidth efficient, like [`XPENDING`](/content/commands/xpending.md), just report the information without the field names.
 
 The output of the example above, where the **GROUPS** subcommand is used, should be clear observing the field names. We can check in more detail the state of a specific consumer group by checking the consumers that are registered in the group.
 
@@ -836,7 +836,7 @@ So basically Kafka partitions are more similar to using N different Redis keys, 
 
 ## Capped Streams
 
-Many applications do not want to collect data into a stream forever. Sometimes it is useful to have at maximum a given number of items inside a stream, other times once a given size is reached, it is useful to move data from Redis to a storage which is not in memory and not as fast but suited to store the history for, potentially, decades to come. Redis streams have some support for this. One is the **MAXLEN** option of the [`XADD`]({{< relref "/commands/xadd" >}}) command. This option is very simple to use:
+Many applications do not want to collect data into a stream forever. Sometimes it is useful to have at maximum a given number of items inside a stream, other times once a given size is reached, it is useful to move data from Redis to a storage which is not in memory and not as fast but suited to store the history for, potentially, decades to come. Redis streams have some support for this. One is the **MAXLEN** option of the [`XADD`](/content/commands/xadd.md) command. This option is very simple to use:
 
 {{< clients-example set="stream_tutorial" step="maxlen" description="Limit stream size using MAXLEN option with XADD to automatically evict old entries and maintain constant memory usage" difficulty="intermediate" try_it="false" runnable="false" >}}
 > XADD race:italy MAXLEN 2 * rider Jones
@@ -866,27 +866,27 @@ XADD race:italy MAXLEN ~ 1000 * ... entry fields here ...
 
 The `~` argument between the **MAXLEN** option and the actual count means, I don't really need this to be exactly 1000 items. It can be 1000 or 1010 or 1030, just make sure to save at least 1000 items. With this argument, the trimming is performed only when we can remove a whole node. This makes it much more efficient, and it is usually what you want. You'll note here that the client libraries have various implementations of this. For example, the Python client defaults to approximate and has to be explicitly set to a true length.
 
-There is also the [`XTRIM`]({{< relref "/commands/xtrim" >}}) command, which performs something very similar to what the **MAXLEN** option does above, except that it can be run by itself:
+There is also the [`XTRIM`](/content/commands/xtrim.md) command, which performs something very similar to what the **MAXLEN** option does above, except that it can be run by itself:
 
 {{< clients-example set="stream_tutorial" step="xtrim" description="Trim a stream to a maximum length using XTRIM MAXLEN to remove old entries" difficulty="intermediate" try_it="false" runnable="false" >}}
 > XTRIM race:italy MAXLEN 10
 (integer) 0
 {{< /clients-example >}}
 
-Or, as for the [`XADD`]({{< relref "/commands/xadd" >}}) option:
+Or, as for the [`XADD`](/content/commands/xadd.md) option:
 
 {{< clients-example set="stream_tutorial" step="xtrim2" description="Use approximate trimming with XTRIM MAXLEN ~ for more efficient memory management" difficulty="intermediate" try_it="false" runnable="false" >}}
 > XTRIM mystream MAXLEN ~ 10
 (integer) 0
 {{< /clients-example >}}
 
-However, [`XTRIM`]({{< relref "/commands/xtrim" >}}) is designed to accept different trimming strategies. Another trimming strategy is **MINID**, that evicts entries with IDs lower than the one specified.
+However, [`XTRIM`](/content/commands/xtrim.md) is designed to accept different trimming strategies. Another trimming strategy is **MINID**, that evicts entries with IDs lower than the one specified.
 
-As [`XTRIM`]({{< relref "/commands/xtrim" >}}) is an explicit command, the user is expected to know about the possible shortcomings of different trimming strategies.
+As [`XTRIM`](/content/commands/xtrim.md) is an explicit command, the user is expected to know about the possible shortcomings of different trimming strategies.
 
 ### Trimming with consumer group awareness
 
-Starting with Redis 8.2, both [`XADD`]({{< relref "/commands/xadd" >}}) with trimming options and [`XTRIM`]({{< relref "/commands/xtrim" >}}) support enhanced control over how trimming interacts with consumer groups through the `KEEPREF`, `DELREF`, and `ACKED` options:
+Starting with Redis 8.2, both [`XADD`](/content/commands/xadd.md) with trimming options and [`XTRIM`](/content/commands/xtrim.md) support enhanced control over how trimming interacts with consumer groups through the `KEEPREF`, `DELREF`, and `ACKED` options:
 
 ```
 XADD mystream KEEPREF MAXLEN 1000 * field value
@@ -899,21 +899,21 @@ XTRIM mystream ACKED MAXLEN 1000
 
 The `ACKED` option is particularly useful for maintaining data integrity across multiple consumer groups, ensuring that entries are only removed when all groups have finished processing them.
 
-Another useful eviction strategy that may be added to [`XTRIM`]({{< relref "/commands/xtrim" >}}) in the future, is to remove by a range of IDs to ease use of [`XRANGE`]({{< relref "/commands/xrange" >}}) and [`XTRIM`]({{< relref "/commands/xtrim" >}}) to move data from Redis to other storage systems if needed.
+Another useful eviction strategy that may be added to [`XTRIM`](/content/commands/xtrim.md) in the future, is to remove by a range of IDs to ease use of [`XRANGE`](/content/commands/xrange.md) and [`XTRIM`](/content/commands/xtrim.md) to move data from Redis to other storage systems if needed.
 
 ## Special IDs in the streams API
 
 You may have noticed that there are several special IDs that can be used in the Redis API. Here is a short recap, so that they can make more sense in the future.
 
-The first two special IDs are `-` and `+`, and are used in range queries with the [`XRANGE`]({{< relref "/commands/xrange" >}}) command. Those two IDs respectively mean the smallest ID possible (that is basically `0-1`) and the greatest ID possible (that is `18446744073709551615-18446744073709551615`). As you can see it is a lot cleaner to write `-` and `+` instead of those numbers.
+The first two special IDs are `-` and `+`, and are used in range queries with the [`XRANGE`](/content/commands/xrange.md) command. Those two IDs respectively mean the smallest ID possible (that is basically `0-1`) and the greatest ID possible (that is `18446744073709551615-18446744073709551615`). As you can see it is a lot cleaner to write `-` and `+` instead of those numbers.
 
-Then there are APIs where we want to say, the ID of the item with the greatest ID inside the stream. This is what `$` means. So for instance if I want only new entries with [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) I use this ID to signify I already have all the existing entries, but not the new ones that will be inserted in the future. Similarly when I create or set the ID of a consumer group, I can set the last delivered item to `$` in order to just deliver new entries to the consumers in the group.
+Then there are APIs where we want to say, the ID of the item with the greatest ID inside the stream. This is what `$` means. So for instance if I want only new entries with [`XREADGROUP`](/content/commands/xreadgroup.md) I use this ID to signify I already have all the existing entries, but not the new ones that will be inserted in the future. Similarly when I create or set the ID of a consumer group, I can set the last delivered item to `$` in order to just deliver new entries to the consumers in the group.
 
 As you can see `$` does not mean `+`, they are two different things, as `+` is the greatest ID possible in every possible stream, while `$` is the greatest ID in a given stream containing given entries. Moreover APIs will usually only understand `+` or `$`, yet it was useful to avoid loading a given symbol with multiple meanings.
 
-Another special ID is `>`, that is a special meaning only related to consumer groups and only when the [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) command is used. This special ID means that we want only entries that were never delivered to other consumers so far. So basically the `>` ID is the *last delivered ID* of a consumer group.
+Another special ID is `>`, that is a special meaning only related to consumer groups and only when the [`XREADGROUP`](/content/commands/xreadgroup.md) command is used. This special ID means that we want only entries that were never delivered to other consumers so far. So basically the `>` ID is the *last delivered ID* of a consumer group.
 
-Finally the special ID `*`, that can be used only with the [`XADD`]({{< relref "/commands/xadd" >}}) command, means to auto select an ID for us for the new entry.
+Finally the special ID `*`, that can be used only with the [`XADD`](/content/commands/xadd.md) command, means to auto select an ID for us for the new entry.
 
 So we have `-`, `+`, `$`, `>` and `*`, and all have a different meaning, and most of the time, can be used in different contexts.
 
@@ -924,14 +924,14 @@ A Stream, like any other Redis data structure, is asynchronously replicated to r
 However note that Redis streams and consumer groups are persisted and replicated using the Redis default replication, so:
 
 * AOF must be used with a strong fsync policy if persistence of messages is important in your application.
-* By default the asynchronous replication will not guarantee that [`XADD`]({{< relref "/commands/xadd" >}}) commands or consumer groups state changes are replicated: after a failover something can be missing depending on the ability of replicas to receive the data from the master.
-* The [`WAIT`]({{< relref "/commands/wait" >}}) command may be used in order to force the propagation of the changes to a set of replicas. However note that while this makes it very unlikely that data is lost, the Redis failover process as operated by Sentinel or Redis Cluster performs only a *best effort* check to failover to the replica which is the most updated, and under certain specific failure conditions may promote a replica that lacks some data.
+* By default the asynchronous replication will not guarantee that [`XADD`](/content/commands/xadd.md) commands or consumer groups state changes are replicated: after a failover something can be missing depending on the ability of replicas to receive the data from the master.
+* The [`WAIT`](/content/commands/wait.md) command may be used in order to force the propagation of the changes to a set of replicas. However note that while this makes it very unlikely that data is lost, the Redis failover process as operated by Sentinel or Redis Cluster performs only a *best effort* check to failover to the replica which is the most updated, and under certain specific failure conditions may promote a replica that lacks some data.
 
 So when designing an application using Redis streams and consumer groups, make sure to understand the semantical properties your application should have during failures, and configure things accordingly, evaluating whether it is safe enough for your use case.
 
 ## Removing single items from a stream
 
-Streams also have a special command for removing items from the middle of a stream, just by ID. Normally for an append only data structure this may look like an odd feature, but it is actually useful for applications involving, for instance, privacy regulations. The command is called [`XDEL`]({{< relref "/commands/xdel" >}}) and receives the name of the stream followed by the IDs to delete:
+Streams also have a special command for removing items from the middle of a stream, just by ID. Normally for an append only data structure this may look like an odd feature, but it is actually useful for applications involving, for instance, privacy regulations. The command is called [`XDEL`](/content/commands/xdel.md) and receives the name of the stream followed by the IDs to delete:
 
 {{< clients-example set="stream_tutorial" step="xdel" description="Delete specific entries from a stream by ID using XDEL for privacy or data cleanup purposes" difficulty="advanced" try_it="false" runnable="false" >}}
 > XRANGE race:italy - + COUNT 2
@@ -951,7 +951,7 @@ Streams also have a special command for removing items from the middle of a stre
 
 ### Enhanced deletion with XDELEX
 
-Starting with Redis 8.2, the [`XDELEX`]({{< relref "/commands/xdelex" >}}) command provides enhanced control over entry deletion, particularly when working with consumer groups. Like other enhanced commands, it supports `KEEPREF`, `DELREF`, and `ACKED` options:
+Starting with Redis 8.2, the [`XDELEX`](/content/commands/xdelex.md) command provides enhanced control over entry deletion, particularly when working with consumer groups. Like other enhanced commands, it supports `KEEPREF`, `DELREF`, and `ACKED` options:
 
 ```
 XDELEX mystream ACKED IDS 2 1692633198206-0 1692633208557-0
@@ -961,27 +961,27 @@ This allows you to delete entries only when they have been acknowledged by all c
 
 ## Zero length streams
 
-A difference between streams and other Redis data structures is that when the other data structures no longer have any elements, as a side effect of calling commands that remove elements, the key itself will be removed. So for instance, a sorted set will be completely removed when a call to [`ZREM`]({{< relref "/commands/zrem" >}}) will remove the last element in the sorted set. Streams, on the other hand, are allowed to stay at zero elements, both as a result of using a **MAXLEN** option with a count of zero ([`XADD`]({{< relref "/commands/xadd" >}}) and [`XTRIM`]({{< relref "/commands/xtrim" >}}) commands), or because [`XDEL`]({{< relref "/commands/xdel" >}}) was called.
+A difference between streams and other Redis data structures is that when the other data structures no longer have any elements, as a side effect of calling commands that remove elements, the key itself will be removed. So for instance, a sorted set will be completely removed when a call to [`ZREM`](/content/commands/zrem.md) will remove the last element in the sorted set. Streams, on the other hand, are allowed to stay at zero elements, both as a result of using a **MAXLEN** option with a count of zero ([`XADD`](/content/commands/xadd.md) and [`XTRIM`](/content/commands/xtrim.md) commands), or because [`XDEL`](/content/commands/xdel.md) was called.
 
 The reason why such an asymmetry exists is because Streams may have associated consumer groups, and we do not want to lose the state that the consumer groups defined just because there are no longer any items in the stream. Currently the stream is not deleted even when it has no associated consumer groups.
 
 ## Total latency of consuming a message
 
-Non blocking stream commands like [`XRANGE`]({{< relref "/commands/xrange" >}}) and [`XREAD`]({{< relref "/commands/xread" >}}) or [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) without the BLOCK option are served synchronously like any other Redis command, so to discuss latency of such commands is meaningless: it is more interesting to check the time complexity of the commands in the Redis documentation. It should be enough to say that stream commands are at least as fast as sorted set commands when extracting ranges, and that [`XADD`]({{< relref "/commands/xadd" >}}) is very fast and can easily insert from half a million to one million items per second in an average machine if pipelining is used.
+Non blocking stream commands like [`XRANGE`](/content/commands/xrange.md) and [`XREAD`](/content/commands/xread.md) or [`XREADGROUP`](/content/commands/xreadgroup.md) without the BLOCK option are served synchronously like any other Redis command, so to discuss latency of such commands is meaningless: it is more interesting to check the time complexity of the commands in the Redis documentation. It should be enough to say that stream commands are at least as fast as sorted set commands when extracting ranges, and that [`XADD`](/content/commands/xadd.md) is very fast and can easily insert from half a million to one million items per second in an average machine if pipelining is used.
 
-However latency becomes an interesting parameter if we want to understand the delay of processing a message, in the context of blocking consumers in a consumer group, from the moment the message is produced via [`XADD`]({{< relref "/commands/xadd" >}}), to the moment the message is obtained by the consumer because [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) returned with the message.
+However latency becomes an interesting parameter if we want to understand the delay of processing a message, in the context of blocking consumers in a consumer group, from the moment the message is produced via [`XADD`](/content/commands/xadd.md), to the moment the message is obtained by the consumer because [`XREADGROUP`](/content/commands/xreadgroup.md) returned with the message.
 
 ## How serving blocked consumers works
 
 Before providing the results of performed tests, it is interesting to understand what model Redis uses in order to route stream messages (and in general actually how any blocking operation waiting for data is managed).
 
 * The blocked client is referenced in a hash table that maps keys for which there is at least one blocking consumer, to a list of consumers that are waiting for such key. This way, given a key that received data, we can resolve all the clients that are waiting for such data.
-* When a write happens, in this case when the [`XADD`]({{< relref "/commands/xadd" >}}) command is called, it calls the `signalKeyAsReady()` function. This function will put the key into a list of keys that need to be processed, because such keys may have new data for blocked consumers. Note that such *ready keys* will be processed later, so in the course of the same event loop cycle, it is possible that the key will receive other writes.
+* When a write happens, in this case when the [`XADD`](/content/commands/xadd.md) command is called, it calls the `signalKeyAsReady()` function. This function will put the key into a list of keys that need to be processed, because such keys may have new data for blocked consumers. Note that such *ready keys* will be processed later, so in the course of the same event loop cycle, it is possible that the key will receive other writes.
 * Finally, before returning into the event loop, the *ready keys* are finally processed. For each key the list of clients waiting for data is scanned, and if applicable, such clients will receive the new data that arrived. In the case of streams the data is the messages in the applicable range requested by the consumer.
 
-As you can see, basically, before returning to the event loop both the client calling [`XADD`]({{< relref "/commands/xadd" >}}) and the clients blocked to consume messages, will have their reply in the output buffers, so the caller of [`XADD`]({{< relref "/commands/xadd" >}}) should receive the reply from Redis at about the same time the consumers will receive the new messages.
+As you can see, basically, before returning to the event loop both the client calling [`XADD`](/content/commands/xadd.md) and the clients blocked to consume messages, will have their reply in the output buffers, so the caller of [`XADD`](/content/commands/xadd.md) should receive the reply from Redis at about the same time the consumers will receive the new messages.
 
-This model is *push-based*, since adding data to the consumers buffers will be performed directly by the action of calling [`XADD`]({{< relref "/commands/xadd" >}}), so the latency tends to be quite predictable.
+This model is *push-based*, since adding data to the consumers buffers will be performed directly by the action of calling [`XADD`](/content/commands/xadd.md), so the latency tends to be quite predictable.
 
 ## Latency tests results
 
@@ -1003,7 +1003,7 @@ Adding a few million unacknowledged messages to the stream does not change the g
 
 A few remarks:
 
-* Here we processed up to 10k messages per iteration, this means that the `COUNT` parameter of [`XREADGROUP`]({{< relref "/commands/xreadgroup" >}}) was set to 10000. This adds a lot of latency but is needed in order to allow the slow consumers to be able to keep with the message flow. So you can expect a real world latency that is a lot smaller.
+* Here we processed up to 10k messages per iteration, this means that the `COUNT` parameter of [`XREADGROUP`](/content/commands/xreadgroup.md) was set to 10000. This adds a lot of latency but is needed in order to allow the slow consumers to be able to keep with the message flow. So you can expect a real world latency that is a lot smaller.
 * The system used for this benchmark is very slow compared to today's standards.
 
 ## Learn more

--- a/content/develop/data-types/streams/idempotency.md
+++ b/content/develop/data-types/streams/idempotency.md
@@ -44,7 +44,7 @@ For (1), this is the producer’s responsibility, and for (2), Redis will calcul
 
 ## Idempotency modes
 
-Use the [`XADD`]({{< relref "/commands/xadd" >}}) command with idempotency parameters, `IDMP` or `IDMPAUTO`:
+Use the [`XADD`](/content/commands/xadd.md) command with idempotency parameters, `IDMP` or `IDMPAUTO`:
 
 ```
 XADD mystream IDMP producer-1 iid-1 * field value      # producer-1 (pid) and iid-1 (iid) are provided manually
@@ -90,7 +90,7 @@ Here's an illustration of how message processing in Redis Streams works with and
 
 ## Stream configuration
 
-Configure idempotency settings for a stream using [`XCFGSET`]({{< relref "/commands/xcfgset" >}}):
+Configure idempotency settings for a stream using [`XCFGSET`](/content/commands/xcfgset.md):
 
 ```
 XCFGSET mystream IDMP-DURATION 300 IDMP-MAXSIZE 1000
@@ -143,7 +143,7 @@ Producers can use the same iid without conflicts, as long as long as the pids ar
 
 ## Monitoring
 
-Use [`XINFO STREAM`]({{< relref "/commands/xinfo-stream" >}}) to monitor idempotency metrics:
+Use [`XINFO STREAM`](/content/commands/xinfo-stream.md) to monitor idempotency metrics:
 
 ```
 XINFO STREAM mystream

--- a/content/develop/data-types/strings/_index.md
+++ b/content/develop/data-types/strings/_index.md
@@ -35,16 +35,16 @@ OK
 "Deimos"
 {{< /clients-example >}}
 
-As you can see using the [`SET`]({{< relref "/commands/set" >}}) and the [`GET`]({{< relref "/commands/get" >}}) commands are the way we set
-and retrieve a string value. Note that [`SET`]({{< relref "/commands/set" >}}) will replace any existing value
+As you can see using the [`SET`](/content/commands/set.md) and the [`GET`](/content/commands/get.md) commands are the way we set
+and retrieve a string value. Note that [`SET`](/content/commands/set.md) will replace any existing value
 already stored into the key, in the case that the key already exists, even if
-the key is associated with a non-string value. So [`SET`]({{< relref "/commands/set" >}}) performs an assignment.
+the key is associated with a non-string value. So [`SET`](/content/commands/set.md) performs an assignment.
 
 Values can be strings (including binary data) of every kind, for instance you
 can store a jpeg image inside a value. A value can't be bigger than 512 MB.
 
-The [`SET`]({{< relref "/commands/set" >}}) command has interesting options that are provided as additional
-arguments. For example, I may ask [`SET`]({{< relref "/commands/set" >}}) to fail if the key already exists,
+The [`SET`](/content/commands/set.md) command has interesting options that are provided as additional
+arguments. For example, I may ask [`SET`](/content/commands/set.md) to fail if the key already exists,
 or the opposite, that it only succeed if the key already exists:
 
 {{< clients-example set="set_tutorial" step="setnx_xx" description="Conditional SET operations: Use NX and XX options to control key existence when you need atomic compare-and-set behavior" difficulty="intermediate" buildsUpon="set_get" >}}
@@ -58,17 +58,17 @@ OK
 {{< /clients-example >}}
 
 There are a number of other commands for operating on strings. For example
-the [`GETSET`]({{< relref "/commands/getset" >}}) command sets a key to a new value, returning the old value as the
+the [`GETSET`](/content/commands/getset.md) command sets a key to a new value, returning the old value as the
 result. You can use this command, for example, if you have a
-system that increments a Redis key using [`INCR`]({{< relref "/commands/incr" >}})
+system that increments a Redis key using [`INCR`](/content/commands/incr.md)
 every time your web site receives a new visitor. You may want to collect this
 information once every hour, without losing a single increment.
-You can [`GETSET`]({{< relref "/commands/getset" >}}) the key, assigning it the new value of "0" and reading the
+You can [`GETSET`](/content/commands/getset.md) the key, assigning it the new value of "0" and reading the
 old value back.
 
 The ability to set or retrieve the value of multiple keys in a single
 command is also useful for reduced latency. For this reason there are
-the [`MSET`]({{< relref "/commands/mset" >}}) and [`MGET`]({{< relref "/commands/mget" >}}) commands:
+the [`MSET`](/content/commands/mset.md) and [`MGET`](/content/commands/mget.md) commands:
 
 {{< clients-example set="set_tutorial" step="mset" description="Set and retrieve multiple values using MSET and MGET when you need to reduce round trips to the server" buildsUpon="set_get" >}}
 > MSET bike:1 "Deimos" bike:2 "Ares" bike:3 "Vanth"
@@ -79,7 +79,7 @@ OK
 3) "Vanth"
 {{< /clients-example >}}
 
-When [`MGET`]({{< relref "/commands/mget" >}}) is used, Redis returns an array of values.
+When [`MGET`](/content/commands/mget.md) is used, Redis returns an array of values.
 
 ## Strings as counters
 Even if strings are the basic values of Redis, there are interesting operations
@@ -94,10 +94,10 @@ OK
 (integer) 11
 {{< /clients-example >}}
 
-The [`INCR`]({{< relref "/commands/incr" >}}) command parses the string value as an integer,
+The [`INCR`](/content/commands/incr.md) command parses the string value as an integer,
 increments it by one, and finally sets the obtained value as the new value.
-There are other similar commands like [`INCRBY`]({{< relref "/commands/incrby" >}}),
-[`DECR`]({{< relref "/commands/decr" >}}) and [`DECRBY`]({{< relref "/commands/decrby" >}}). Internally it's
+There are other similar commands like [`INCRBY`](/content/commands/incrby.md),
+[`DECR`](/content/commands/decr.md) and [`DECRBY`](/content/commands/decrby.md). Internally it's
 always the same command, acting in a slightly different way.
 
 What does it mean that INCR is atomic?
@@ -115,17 +115,17 @@ By default, a single Redis string can be a maximum of 512 MB.
 
 ## Bitwise and bitfield operations
 
-To perform bitwise operations on a string, see the [bitmaps data type]({{< relref "/develop/data-types/strings/bitmaps" >}}) docs. To store and manipulate integer values within a string, see the [bitfields data type]({{< relref "/develop/data-types/strings/bitfields" >}}) docs.
+To perform bitwise operations on a string, see the [bitmaps data type](/content/develop/data-types/strings/bitmaps.md) docs. To store and manipulate integer values within a string, see the [bitfields data type](/content/develop/data-types/strings/bitfields.md) docs.
 
 ## Performance
 
 Most string operations are O(1), which means they're highly efficient.
-However, be careful with the [`SUBSTR`]({{< relref "/commands/substr" >}}), [`GETRANGE`]({{< relref "/commands/getrange" >}}), and [`SETRANGE`]({{< relref "/commands/setrange" >}}) commands, which can be O(n).
+However, be careful with the [`SUBSTR`](/content/commands/substr.md), [`GETRANGE`](/content/commands/getrange.md), and [`SETRANGE`](/content/commands/setrange.md) commands, which can be O(n).
 These random-access string commands may cause performance issues when dealing with large strings.
 
 ## Alternatives
 
-If you're storing structured data as a serialized string, you may also want to consider Redis [hashes]({{< relref "/develop/data-types/hashes" >}}) or [JSON]({{< relref "/develop/data-types/json/" >}}).
+If you're storing structured data as a serialized string, you may also want to consider Redis [hashes](/content/develop/data-types/hashes.md) or [JSON](/content/develop/data-types/json/_index.md).
 
 ## Learn more
 

--- a/content/develop/data-types/strings/bitfields.md
+++ b/content/develop/data-types/strings/bitfields.md
@@ -50,4 +50,4 @@ Suppose you want to maintain two metrics for various bicycles: the current price
 
 ## Performance
 
-[`BITFIELD`]({{< relref "/commands/bitfield" >}}) is O(n), where _n_ is the number of counters accessed.
+[`BITFIELD`](/content/commands/bitfield.md) is O(n), where _n_ is the number of counters accessed.

--- a/content/develop/data-types/strings/bitmaps.md
+++ b/content/develop/data-types/strings/bitmaps.md
@@ -64,22 +64,22 @@ where different users are represented by incremental user IDs, it is possible
 to remember a single bit information (for example, knowing whether
 a user wants to receive a newsletter) of 4 billion users using just 512 MB of memory.
 
-The [`SETBIT`]({{< relref "/commands/setbit" >}}) command takes as its first argument the bit number, and as its second
+The [`SETBIT`](/content/commands/setbit.md) command takes as its first argument the bit number, and as its second
 argument the value to set the bit to, which is 1 or 0. The command
 automatically enlarges the string if the addressed bit is outside the
 current string length.
 
-[`GETBIT`]({{< relref "/commands/getbit" >}}) just returns the value of the bit at the specified index.
+[`GETBIT`](/content/commands/getbit.md) just returns the value of the bit at the specified index.
 Out of range bits (addressing a bit that is outside the length of the string
 stored into the target key) are always considered to be zero.
 
 There are three commands operating on group of bits:
 
-1. [`BITOP`]({{< relref "/commands/bitop" >}}) performs bit-wise operations between different strings. The provided operators are `AND`, `OR`, `XOR`, `NOT`, `DIFF`, `DIFF1`, `ANDOR`, and `ONE`.
-2. [`BITCOUNT`]({{< relref "/commands/bitcount" >}}) performs population counting, reporting the number of bits set to 1.
-3. [`BITPOS`]({{< relref "/commands/bitpos" >}}) finds the first bit having the specified value of 0 or 1.
+1. [`BITOP`](/content/commands/bitop.md) performs bit-wise operations between different strings. The provided operators are `AND`, `OR`, `XOR`, `NOT`, `DIFF`, `DIFF1`, `ANDOR`, and `ONE`.
+2. [`BITCOUNT`](/content/commands/bitcount.md) performs population counting, reporting the number of bits set to 1.
+3. [`BITPOS`](/content/commands/bitpos.md) finds the first bit having the specified value of 0 or 1.
 
-Both [`BITPOS`]({{< relref "/commands/bitpos" >}}) and [`BITCOUNT`]({{< relref "/commands/bitcount" >}}) are able to operate with byte ranges of the
+Both [`BITPOS`](/content/commands/bitpos.md) and [`BITCOUNT`](/content/commands/bitcount.md) are able to operate with byte ranges of the
 string, instead of running for the whole length of the string. We can trivially see the number of bits that have been set in a bitmap.
 
 {{< clients-example set="bitmap_tutorial" step="bitcount" description="Bit counting: Use BITCOUNT to count the number of set bits in a bitmap when you need to get population counts" buildsUpon="ping" runnable="false" try_it="false" >}}
@@ -89,20 +89,20 @@ string, instead of running for the whole length of the string. We can trivially 
 
 For example imagine you want to know the longest streak of daily visits of
 your web site users. You start counting days starting from zero, that is the
-day you made your web site public, and set a bit with [`SETBIT`]({{< relref "/commands/setbit" >}}) every time
+day you made your web site public, and set a bit with [`SETBIT`](/content/commands/setbit.md) every time
 the user visits the web site. As a bit index you simply take the current unix
 time, subtract the initial offset, and divide by the number of seconds in a day
 (normally, 3600\*24).
 
 This way for each user you have a small string containing the visit
-information for each day. With [`BITCOUNT`]({{< relref "/commands/bitcount" >}}) it is possible to easily get
+information for each day. With [`BITCOUNT`](/content/commands/bitcount.md) it is possible to easily get
 the number of days a given user visited the web site, while with
-a few [`BITPOS`]({{< relref "/commands/bitpos" >}}) calls, or simply fetching and analyzing the bitmap client-side,
+a few [`BITPOS`](/content/commands/bitpos.md) calls, or simply fetching and analyzing the bitmap client-side,
 it is possible to easily compute the longest streak.
 
 ### Bitwise operations
 
-The [`BITOP`]({{< relref "/commands/bitop" >}}) command performs bitwise
+The [`BITOP`](/content/commands/bitop.md) command performs bitwise
 operations over two or more source keys, storing the result in a destination key.
 
 The examples below show the available operations using three keys: `A` (with bit pattern
@@ -276,8 +276,8 @@ the Nth bit to address inside the key with `bit-number MOD M`.
 
 ## Performance
 
-[`SETBIT`]({{< relref "/commands/setbit" >}}) and [`GETBIT`]({{< relref "/commands/getbit" >}}) are O(1).
-[`BITOP`]({{< relref "/commands/bitop" >}}) is O(n), where _n_ is the length of the longest string in the comparison.
+[`SETBIT`](/content/commands/setbit.md) and [`GETBIT`](/content/commands/getbit.md) are O(1).
+[`BITOP`](/content/commands/bitop.md) is O(n), where _n_ is the length of the longest string in the comparison.
 
 ## Learn more
 

--- a/content/develop/data-types/timeseries/_index.md
+++ b/content/develop/data-types/timeseries/_index.md
@@ -52,14 +52,14 @@ applications such as:
 
 Redis time series are available in Redis Open Source, Redis Software, and Redis Cloud.
 See
-[Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) or
-[Install Redis Software]({{< relref "/operate/rs/installing-upgrading/install" >}})
+[Install Redis Open Source](/content/operate/oss_and_stack/install/install-stack/_index.md) or
+[Install Redis Software](/content/operate/rs/installing-upgrading/install/_index.md)
 for full installation instructions.
 
 ## Create a time series
 
-You can create a new empty time series with the [`TS.CREATE`]({{< relref "commands/ts.create/" >}})
-command, specifying a key name. Alternatively, if you use [`TS.ADD`]({{< relref "commands/ts.add/" >}})
+You can create a new empty time series with the [`TS.CREATE`](/content/commands/ts.create.md)
+command, specifying a key name. Alternatively, if you use [`TS.ADD`](/content/commands/ts.add.md)
 to add data to a time series key that does not exist, it is automatically created (see
 [Adding data points](#adding-data-points) below for more information about `TS.ADD`).
 
@@ -185,8 +185,8 @@ for queries and aggregations.
 
 ## Add data points
 
-You can add individual data points with [`TS.ADD`]({{< relref "commands/ts.add/" >}}),
-but you can also use [`TS.MADD`]({{< relref "commands/ts.madd/" >}}) to add multiple data
+You can add individual data points with [`TS.ADD`](/content/commands/ts.add.md),
+but you can also use [`TS.MADD`](/content/commands/ts.madd.md) to add multiple data
 points to one or more time series in a single command. (Note that unlike `TS.ADD`, `TS.MADD`
 doesn't create any new time series if you specify keys that don't exist.) The return value
 is an array containing the number of samples in each time series after the operation.
@@ -209,7 +209,7 @@ OK
 
 ## Query data points
 
-Use [`TS.GET`]({{< relref "commands/ts.get/" >}}) to retrieve the data point
+Use [`TS.GET`](/content/commands/ts.get.md) to retrieve the data point
 with the highest timestamp in a time series. This returns both the timestamp and the value.
 
 {{< clients-example set="time_series_tutorial" step="get" description="Foundational: Use TS.GET to get the latest value and timestamp" difficulty="beginner" buildsUpon="madd" >}}
@@ -227,13 +227,13 @@ with the highest timestamp in a time series. This returns both the timestamp and
 2) 10.3
 {{< /clients-example >}}
 
-Use [`TS.RANGE`]({{< relref "commands/ts.range/" >}}) to retrieve data points
+Use [`TS.RANGE`](/content/commands/ts.range.md) to retrieve data points
 from a time series that fall within a given timestamp range. The range is inclusive,
 meaning that samples whose timestamp equals the start or end of the range are included.
 You can use `-` and `+` as the start and end of the range, respectively, to
 indicate the minimum and maximum timestamps in the series. The response is
 an array of timestamp-value pairs returned in ascending order by timestamp.
-If you want the results in descending order, use [`TS.REVRANGE`]({{< relref "commands/ts.revrange/" >}}) with the same parameters.
+If you want the results in descending order, use [`TS.REVRANGE`](/content/commands/ts.revrange.md) with the same parameters.
 
 {{< clients-example set="time_series_tutorial" step="range" description="Range queries: Retrieve data points within a timestamp range using TS.RANGE (ascending) or TS.REVRANGE (descending) when you need to analyze historical data" difficulty="intermediate" buildsUpon="madd" >}}
 # Add 5 data points to a time series named "rg:1".
@@ -335,9 +335,9 @@ OK
 
 The `TS.GET`, `TS.RANGE`, and `TS.REVRANGE` commands also have
 corresponding
-[`TS.MGET`]({{< relref "commands/ts.mget/" >}}),
-[`TS.MRANGE`]({{< relref "commands/ts.mrange/" >}}), and
-[`TS.MREVRANGE`]({{< relref "commands/ts.mrevrange/" >}}) versions that
+[`TS.MGET`](/content/commands/ts.mget.md),
+[`TS.MRANGE`](/content/commands/ts.mrange.md), and
+[`TS.MREVRANGE`](/content/commands/ts.mrevrange.md) versions that
 operate on multiple time series. `TS.MGET` returns the data point with the highest
 timestamp from each time series, while `TS.MRANGE` and `TS.MREVRANGE`
 return data points from a range of timestamps in each time series.
@@ -349,7 +349,7 @@ specific labels. (See [Creating a time series](#creating-a-time-series)
 above to learn how to add labels to a time series.) The filter expressions
 use a simple syntax that lets you include or exclude time series based on
 the presence or value of a label. See the description in the
-[`TS.MGET`]({{< relref "commands/ts.mget#required-arguments" >}}) command reference
+[`TS.MGET`](/content/commands/ts.mget.md#required-arguments) command reference
 for details of the filter syntax. You can also request that
 data points be returned with all their labels or with a selected subset of them.
 
@@ -594,8 +594,8 @@ Bucket(25ms):          |__________________________||_________________________||_
 ### Aggregation across timeseries
 
 By default, the results from
-[`TS.MRANGE`]({{< relref "commands/ts.mrange/" >}}) and
-[`TS.MREVRANGE`]({{< relref "commands/ts.mrevrange/" >}}) are grouped by time series. However, you can use the `GROUPBY` and `REDUCE` options to group them by label and apply an aggregation over elements
+[`TS.MRANGE`](/content/commands/ts.mrange.md) and
+[`TS.MREVRANGE`](/content/commands/ts.mrevrange.md) are grouped by time series. However, you can use the `GROUPBY` and `REDUCE` options to group them by label and apply an aggregation over elements
 that have the same timestamp and the same label value (this feature is available from RedisTimeSeries v1.6 onwards).
 
 For example, the following commands create four time series, two for the UK and two for the US, and add some data points. The first `TS.MRANGE` command groups the results by country and applies a `max` aggregation to find the maximum sample value in each country at each timestamp. The second `TS.MRANGE` command uses the same grouping, but applies an `avg` aggregation.
@@ -679,12 +679,12 @@ NaN values are useful in scenarios where you need to distinguish between:
 
 ### NaN Behavior
 
-- **Adding NaN values**: Use [`TS.ADD`]({{< relref "commands/ts.add/" >}}) and [`TS.MADD`]({{< relref "commands/ts.madd/" >}}) to insert NaN values
-- **Querying NaN values**: All raw measurement queries ([`TS.GET`]({{< relref "commands/ts.get/" >}}), [`TS.RANGE`]({{< relref "commands/ts.range/" >}}), etc.) include NaN values in results
+- **Adding NaN values**: Use [`TS.ADD`](/content/commands/ts.add.md) and [`TS.MADD`](/content/commands/ts.madd.md) to insert NaN values
+- **Querying NaN values**: All raw measurement queries ([`TS.GET`](/content/commands/ts.get.md), [`TS.RANGE`](/content/commands/ts.range.md), etc.) include NaN values in results
 - **Aggregation with NaN**: All existing aggregators except `countNaN` and `countAll` ignore NaN values. Use `countNaN` and `countAll` to count NaN and total values
-- **Increment/Decrement**: [`TS.INCRBY`]({{< relref "commands/ts.incrby/" >}}) and [`TS.DECRBY`]({{< relref "commands/ts.decrby/" >}}) return errors when the current value or operand is NaN
+- **Increment/Decrement**: [`TS.INCRBY`](/content/commands/ts.incrby.md) and [`TS.DECRBY`](/content/commands/ts.decrby.md) return errors when the current value or operand is NaN
 - **Duplicate policies**: Special handling for `MIN`, `MAX`, and `SUM` policies when mixing NaN and non-NaN values
-- **Filtering**: [`FILTER_BY_VALUE`]({{< relref "commands/ts.range#filter_by_value-min-max-since-redistimeseries-v16" >}}) parameters cannot be NaN values
+- **Filtering**: [`FILTER_BY_VALUE`](/content/commands/ts.range.md#filter_by_value-min-max-since-redistimeseries-v16) parameters cannot be NaN values
 - **Ignore duplicates**: NaN values are never considered duplicates when using `IGNORE` parameters
 
 ```bash
@@ -741,7 +741,7 @@ aggregation incrementally on data as it arrives. The values from the
 aggregation buckets are stored in a separate time series, leaving the original
 series unchanged.
 
-Use [`TS.CREATERULE`]({{< relref "commands/ts.createrule/" >}}) to create a
+Use [`TS.CREATERULE`](/content/commands/ts.createrule.md) to create a
 compaction rule, specifying the source and destination time series keys, an
 aggregator, and the bucket duration. Note that the destination time
 series must already exist when you create the rule and also that the compaction will
@@ -834,7 +834,7 @@ that bucket.
 
 ## Delete data points
 
-Use [`TS.DEL`]({{< relref "commands/ts.del/" >}}) to delete data points
+Use [`TS.DEL`](/content/commands/ts.del.md) to delete data points
 that fall within a given timestamp range. The range is inclusive, meaning that
 samples whose timestamp equals the start or end of the range are deleted.
 If you want to delete a single timestamp, use it as both the start and end of the range.
@@ -984,4 +984,4 @@ find projects that help you integrate RedisTimeSeries with other tools, includin
 ## More information
 
 The other pages in this section describe RedisTimeSeries concepts in more detail.
-See also the [time series command reference]({{< relref "/commands/" >}}?group=timeseries).
+See also the [time series command reference](/commands/?group=timeseries).

--- a/content/develop/data-types/timeseries/configuration.md
+++ b/content/develop/data-types/timeseries/configuration.md
@@ -57,7 +57,7 @@ In a cluster, you must run `CONFIG SET` and `CONFIG REWRITE` on each node separa
 In Redis 8.0, new names for the time series configuration parameters were introduced to align the naming with the Redis configuration parameters.
 You must use the new names when using the `CONFIG` command.
 
-See also [Redis configuration]({{< relref "/operate/oss_and_stack/management/config" >}}).
+See also [Redis configuration](/content/operate/oss_and_stack/management/config.md).
 
 ## Time series configuration parameters
 
@@ -88,7 +88,7 @@ Valid range: `[48 .. 1048576]`; must be a multiple of 8
 
 Because the chunk size can be provided at different levels, the actual precedence of the chunk size is:
 
-1. Key-level policy, as set with [`TS.CREATE`]({{< relref "/commands/ts.create/" >}})'s and [`TS.ALTER`]({{< relref "/commands/ts.alter/" >}})'s `CHUNK_SIZE` optional argument.
+1. Key-level policy, as set with [`TS.CREATE`](/content/commands/ts.create.md)'s and [`TS.ALTER`](/content/commands/ts.alter.md)'s `CHUNK_SIZE` optional argument.
 1. The `ts-chunk-size-bytes` configuration parameter.
 1. The hard-coded default: `4096`
 
@@ -110,11 +110,11 @@ redis> CONFIG SET ts-chunk-size-bytes 1024
 
 ### COMPACTION_POLICY / ts-compaction-policy
 
-Default compaction rules for newly created keys with [`TS.ADD`]({{< relref "/commands/ts.add/" >}}), [`TS.INCRBY`]({{< relref "/commands/ts.incrby/" >}}), and  [`TS.DECRBY`]({{< relref "/commands/ts.decrby/" >}}).
+Default compaction rules for newly created keys with [`TS.ADD`](/content/commands/ts.add.md), [`TS.INCRBY`](/content/commands/ts.incrby.md), and  [`TS.DECRBY`](/content/commands/ts.decrby.md).
 
 Type: string
 
-Note that this configuration parameter does not affect keys you create with [`TS.CREATE`]({{< relref "commands/ts.create/" >}}). To understand why, consider the following scenario: Suppose you define a default compaction policy but then want to manually create an additional compaction rule (using [`TS.CREATERULE`]({{< relref "commands/ts.createrule/" >}})), which requires you to first create an empty destination key (using `TS.CREATE`). This approach creates a problem: the default compaction policy would cause Redis to automatically create undesired compactions for the destination key.
+Note that this configuration parameter does not affect keys you create with [`TS.CREATE`](/content/commands/ts.create.md). To understand why, consider the following scenario: Suppose you define a default compaction policy but then want to manually create an additional compaction rule (using [`TS.CREATERULE`](/content/commands/ts.createrule.md)), which requires you to first create an empty destination key (using `TS.CREATE`). This approach creates a problem: the default compaction policy would cause Redis to automatically create undesired compactions for the destination key.
 
 Each rule is separated by a semicolon (`;`), the rule consists of multiple fields that are separated by a colon (`:`):
 
@@ -166,9 +166,8 @@ Each rule is separated by a semicolon (`;`), the rule consists of multiple field
 
   Ensure that there is a bucket that starts at exactly _alignTimestamp_ after the Epoch and align all other buckets accordingly. Default value: 0 (aligned with the Epoch). Example: if _bucketDuration_ is 24 hours, setting _alignTimestamp_ to `6h` (6 hours after the Epoch) will ensure that each bucket’s timeframe is [06:00 .. 06:00).
 
-{{% warning %}}
-In a clustered environment, if you set this configuration parameter, you must use [hash tags]({{< relref "/operate/oss_and_stack/reference/cluster-spec" >}}#hash-tags) for all time series key names. This ensures that Redis will create each compaction in the same hash slot as its source key. If you don't, the system may fail to compact the data without displaying any error messages.
-{{% /warning %}}
+> [!WARNING]
+> In a clustered environment, if you set this configuration parameter, you must use [hash tags](/content/operate/oss_and_stack/reference/cluster-spec.md#hash-tags) for all time series key names. This ensures that Redis will create each compaction in the same hash slot as its source key. If you don't, the system may fail to compact the data without displaying any error messages.
 
 When a compaction policy is defined, compaction rules are created automatically for newly created time series, and the compaction key name would be:
   
@@ -208,7 +207,7 @@ redis> CONFIG SET ts-compaction-policy max:1m:1h;min:10s:5d:10d;last:5M:10m;avg:
 
 ### DUPLICATE_POLICY / ts-duplicate-policy
 
-The default policy for handling insertion ([`TS.ADD`]({{< relref "/commands/ts.add/" >}}) and [`TS.MADD`]({{< relref "/commands/ts.madd/" >}})) of multiple samples with identical timestamps, with one of the following values:
+The default policy for handling insertion ([`TS.ADD`](/content/commands/ts.add.md) and [`TS.MADD`](/content/commands/ts.madd.md)) of multiple samples with identical timestamps, with one of the following values:
 
   | policy     | description                                                      |
   | ---------- | ---------------------------------------------------------------- |
@@ -227,8 +226,8 @@ Type: string
 
 Because the duplication policy can be provided at different levels, the actual precedence of the duplication policy is:
 
-1. [`TS.ADD`]({{< relref "/commands/ts.add/" >}})'s `ON_DUPLICATE_POLICY` optional argument.
-1. Key-level policy, as set with [`TS.CREATE`]({{< relref "/commands/ts.create/" >}})'s and [`TS.ALTER`]({{< relref "/commands/ts.alter/" >}})'s `DUPLICATE_POLICY` optional argument.
+1. [`TS.ADD`](/content/commands/ts.add.md)'s `ON_DUPLICATE_POLICY` optional argument.
+1. Key-level policy, as set with [`TS.CREATE`](/content/commands/ts.create.md)'s and [`TS.ALTER`](/content/commands/ts.alter.md)'s `DUPLICATE_POLICY` optional argument.
 1. The `ts-duplicate-policy` configuration parameter.
 1. The hard-coded default: `BLOCK`
 
@@ -236,7 +235,7 @@ Because the duplication policy can be provided at different levels, the actual p
 
 The default retention period, in milliseconds, for newly created keys.
 
-The retention period is the maximum age of samples compared to the highest reported timestamp, per key. Samples are expired based solely on the difference between their timestamps and the timestamps passed to subsequent [`TS.ADD`]({{< relref "commands/ts.add/" >}}), [`TS.MADD`]({{< relref "commands/ts.madd/" >}}), [`TS.INCRBY`]({{< relref "commands/ts.incrby/" >}}), and [`TS.DECRBY`]({{< relref "commands/ts.decrby/" >}}) calls.
+The retention period is the maximum age of samples compared to the highest reported timestamp, per key. Samples are expired based solely on the difference between their timestamps and the timestamps passed to subsequent [`TS.ADD`](/content/commands/ts.add.md), [`TS.MADD`](/content/commands/ts.madd.md), [`TS.INCRBY`](/content/commands/ts.incrby.md), and [`TS.DECRBY`](/content/commands/ts.decrby.md) calls.
 
 Type: integer
 
@@ -250,7 +249,7 @@ When both `COMPACTION_POLICY` / `ts-compaction-policy` and `RETENTION_POLICY` / 
 
 Because the retention can be provided at different levels, the actual precedence of the retention is:
 
-1. Key-level retention, as set with [`TS.CREATE`]({{< relref "/commands/ts.create/" >}})'s and [`TS.ALTER`]({{< relref "/commands/ts.alter/" >}})'s `RETENTION` optional argument.
+1. Key-level retention, as set with [`TS.CREATE`](/content/commands/ts.create.md)'s and [`TS.ALTER`](/content/commands/ts.alter.md)'s `RETENTION` optional argument.
 1. The `ts-retention-policy` configuration parameter.
 1. No retention.
 
@@ -346,7 +345,7 @@ redis> CONFIG SET ts-ignore-max-time-diff 10 ts-ignore-max-val-diff 0.1
 
 ### NUM_THREADS / ts-num-threads
 
-The maximum number of per-shard threads for cross-key queries when using cluster mode ([`TS.MRANGE`]({{< relref "/commands/ts.mrange/" >}}), [`TS.MREVRANGE`]({{< relref "/commands/ts.mrevrange/" >}}), [`TS.MGET`]({{< relref "/commands/ts.mget/" >}}), and [`TS.QUERYINDEX`]({{< relref "/commands/ts.queryindex/" >}})). The value must be equal to or greater than `1`. Note that increasing this value may either increase or decrease the performance!
+The maximum number of per-shard threads for cross-key queries when using cluster mode ([`TS.MRANGE`](/content/commands/ts.mrange.md), [`TS.MREVRANGE`](/content/commands/ts.mrevrange.md), [`TS.MGET`](/content/commands/ts.mget.md), and [`TS.QUERYINDEX`](/content/commands/ts.queryindex.md)). The value must be equal to or greater than `1`. Note that increasing this value may either increase or decrease the performance!
 
 Type: integer
 


### PR DESCRIPTION
## Summary
- Migrates `content/develop/data-types/streams/`, `strings/`, and `timeseries/` (unit D of DOC-7055) from `relref`/callout Hugo shortcodes to native-Markdown render hooks, using `build/migrate_shortcode_links.py`'s `all` stage.
- 7 of 9 files changed: `streams/_index.md`, `streams/idempotency.md`, `strings/_index.md`, `strings/bitfields.md`, `strings/bitmaps.md`, `timeseries/_index.md`, `timeseries/configuration.md`. The other two (`timeseries/out-of-order_performance_considerations.md`, `timeseries/use_cases.md`) contain no `relref`/callout shortcodes (only `image` shortcodes) and are correctly untouched.
- `timeseries/configuration.md` includes the one percent-delimited `{{% warning %}}...{{% /warning %}}` callout in this unit (inside a link whose anchor sits outside the `relref` shortcode) — both the callout-to-blockquote conversion and the anchored link conversion were verified.

## Test plan
- [x] Reviewed the full diff; confirmed no leftover `relref`/callout shortcodes remain in these files, and all converted links match the established `/content/<path>.md[#anchor]` convention already used elsewhere in the migrated corpus (including the bare `/commands/?group=...` precedent for query-string-only refs).
- [x] Built before/after with real Hugo builds — using a throwaway `git worktree add --detach` checkout for "before" rather than `git stash`, since `refs/stash` is shared across all worktrees in this repo and sibling DOC-7055 units running in parallel raced on it.
- [x] `build/diff_rendered_hrefs.py` reports **zero href differences** for `develop/data-types/streams`, `develop/data-types/strings`, and `develop/data-types/timeseries` (3 vs 3, 3 vs 3, 9 vs 9 pages compared).
- [x] Full build warning output is identical before/after (same 6 pre-existing warnings; only the absolute path prefix differs between the two checkouts).

Base is `DOC-7055-callout-percent-form-support` (PR #3965, not yet merged) since this stacks on its percent-delimited-callout support in `migrate_shortcode_links.py`. GitHub will auto-retarget to `main` once that PR merges and its branch is deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout syntax migration with verified zero rendered href diffs; no runtime or API impact.
> 
> **Overview**
> This PR **migrates unit D** of DOC-7055: develop docs for **streams**, **strings**, and **timeseries** from Hugo `relref` (and one callout) shortcodes to **native Markdown links** aimed at render hooks (`/content/.../*.md`, including anchors and query strings like `/commands/?group=timeseries`).
> 
> Across **seven markdown files**, internal references to commands and sibling pages are rewritten in bulk (the streams tutorial page alone updates a large set of `XREAD`/`XADD`/consumer-group links). **`timeseries/configuration.md`** also replaces a `{{% warning %}}` shortcode with a **`> [!WARNING]`** blockquote while preserving the hash-tags link inside it.
> 
> No tutorial prose or examples change—only link/callout syntax. Two timeseries pages with no `relref`/callouts are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 176b5e676a0e23648777f0ecbd67935834697051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->