### PR TITLE
DOC-7056 Add note on temporary AWS me-central-1 unavailability

### DIFF
--- a/content/operate/rc/supported-regions.md
+++ b/content/operate/rc/supported-regions.md
@@ -25,6 +25,12 @@ Redis Cloud Pro databases on AWS support [VPC Peering]({{< relref "/operate/rc/s
 
 {{< rc-supported-regions provider="aws" >}}
 
+{{< note >}}
+The AWS `me-central-1` region is temporarily unavailable due to an ongoing AWS regional
+issue, even though it's listed as a supported region.
+{{< /note >}}
+<!--DOC-7056: remove once AWS resolves the regional issue-->
+
 ## Google Cloud
 
 Redis Cloud supports databases in the following Google Cloud regions.

--- a/content/operate/rc/supported-regions.md
+++ b/content/operate/rc/supported-regions.md
@@ -8,7 +8,9 @@ categories:
 description: null
 linktitle: Supported regions
 weight: 90
+bannerText: The AWS `me-central-1` region is temporarily unavailable due to an ongoing AWS regional issue, even though it's listed as a supported region.
 ---
+<!--DOC-7056: remove bannerText once AWS resolves the regional issue-->
 
 Your choice of cloud provider and region may affect latency between your application and your database, and may affect what connectivity options are available for your database.
 
@@ -24,12 +26,6 @@ Redis Cloud supports databases in the following Amazon Web Services (AWS) region
 Redis Cloud Pro databases on AWS support [VPC Peering]({{< relref "/operate/rc/security/vpc-peering#aws-vpc-peering" >}}), [Transit Gateway]({{< relref "/operate/rc/security/aws-transit-gateway" >}}), and [AWS PrivateLink]({{< relref "/operate/rc/security/aws-privatelink" >}}).
 
 {{< rc-supported-regions provider="aws" >}}
-
-{{< note >}}
-The AWS `me-central-1` region is temporarily unavailable due to an ongoing AWS regional
-issue, even though it's listed as a supported region.
-{{< /note >}}
-<!--DOC-7056: remove once AWS resolves the regional issue-->
 
 ## Google Cloud
 

--- a/content/operate/rc/supported-regions.md
+++ b/content/operate/rc/supported-regions.md
@@ -8,7 +8,7 @@ categories:
 description: null
 linktitle: Supported regions
 weight: 90
-bannerText: The AWS `me-central-1` region is temporarily unavailable due to an ongoing AWS regional issue, even though it's listed as a supported region.
+bannerText: Note - The AWS `me-central-1` region is temporarily unavailable due to an ongoing AWS regional issue, even though it's listed as a supported region in the Middle East and Africa tab.
 ---
 <!--DOC-7056: remove bannerText once AWS resolves the regional issue-->
 


### PR DESCRIPTION
## Summary
- Notes on the Supported regions page that AWS `me-central-1` is temporarily unprovisionable due to an ongoing AWS regional issue, even though it's listed as supported.
- Leaves `data/rc_supported_regions.json` untouched — the region is still supported, just not currently provisionable because of an external AWS incident, not a change to Redis Cloud's own support.

## Test plan
- [x] Verified the AWS `me-central-1` table entry is unchanged (still shows supported for Pro and Essentials).
- [x] Confirmed `rc-quickstart.md` and the `create-*-database.md` pages only link to this page rather than reproducing the region table, so no other page needs the note.
- [ ] Reviewer: preview the rendered page and confirm the note doesn't collide with the tabbed region table below it.

Jira: DOC-7056

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only notice; no product, API, or region data changes.
> 
> **Overview**
> Adds a **page-level banner** on the Supported regions doc (`supported-regions.md`) via new front matter `bannerText`, warning that AWS **`me-central-1` is temporarily unavailable** because of an ongoing AWS regional issue while it still appears in the Middle East and Africa region table.
> 
> Includes a **DOC-7056 HTML comment** to remove the banner once AWS resolves the incident. **No change** to region support data (e.g. `rc_supported_regions.json`)—only customer-facing notice on this page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5805a249d4ce3ecfbaf925f9c8ae2c858f7545d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->