### PR TITLE
Let scrollbar clicks pass through the Qualified widget strip

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1863,3 +1863,19 @@ a[href*="#no-click"], img[src*="#no-click"] {
   white-space: nowrap;
   border: 0;
 }
+
+/* Qualified chat widget (production only, injected via GTM): while the chat
+   is closed, its #q-messenger-frame iframe is an invisible ~20px-wide strip
+   fixed to the right edge of the viewport, with pointer-events enabled. The
+   widget also restyles <html> to overflow:hidden, so <body> is the page's
+   scroll container and body's scrollbar sits exactly under that strip.
+   Firefox hit-tests page content before non-root scrollbars, so the strip
+   swallows every click and hover on the scrollbar — it never reacts and, with
+   overlay scrollbars, never fades in (Chrome hit-tests its scrollbars first,
+   which is why only Firefox users reported it). Let clicks pass through the
+   strip while the chat is closed. The widget sets the q-docked attribute on
+   <html> when the chat panel is open, which restores normal pointer events
+   for the panel. */
+html:not([q-docked]) iframe#q-messenger-frame {
+  pointer-events: none !important;
+}

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1864,18 +1864,48 @@ a[href*="#no-click"], img[src*="#no-click"] {
   border: 0;
 }
 
-/* Qualified chat widget (production only, injected via GTM): while the chat
-   is closed, its #q-messenger-frame iframe is an invisible ~20px-wide strip
-   fixed to the right edge of the viewport, with pointer-events enabled. The
-   widget also restyles <html> to overflow:hidden, so <body> is the page's
-   scroll container and body's scrollbar sits exactly under that strip.
-   Firefox hit-tests page content before non-root scrollbars, so the strip
-   swallows every click and hover on the scrollbar — it never reacts and, with
-   overlay scrollbars, never fades in (Chrome hit-tests its scrollbars first,
-   which is why only Firefox users reported it). Let clicks pass through the
-   strip while the chat is closed. The widget sets the q-docked attribute on
-   <html> when the chat panel is open, which restores normal pointer events
-   for the panel. */
-html:not([q-docked]) iframe#q-messenger-frame {
+/* Qualified chat widget accommodations. The widget (production only,
+   injected via GTM, owned by web/marketing) replaces root scrolling with a
+   <body> scroller: it measures the root scrollbar width N, then applies
+   html { width: calc(100dvw - N); margin-right: N; overflow: hidden } and
+   body { width: calc(100% + N) }, expecting body's scrollbar to land where
+   the root scrollbar was. When N > 0 (classic, always-visible scrollbars:
+   Windows, or macOS with a mouse), body overshoots html's box by N and
+   html's own overflow: hidden clips body's scrollbar out of view — the page
+   scrollbar disappears the moment the widget loads. The widget marks <html>
+   with q-docked-target while it is active and q-docked while the chat panel
+   is open. */
+
+/* While the chat is closed, neutralize the width/margin compensation on
+   both elements so body fills the window exactly and its scrollbar sits at
+   the window edge, unclipped. While the panel is docked open (q-docked) the
+   widget's own geometry must win, so none of this applies then. */
+html[q-docked-target]:not([q-docked]) {
+  width: 100dvw !important;
+  min-width: 100dvw !important;
+  max-width: 100dvw !important;
+  margin-right: 0 !important;
+}
+
+html[q-docked-target]:not([q-docked]) body {
+  width: 100% !important;
+  max-width: 100% !important;
+}
+
+/* The html { scrollbar-gutter: stable } rule set earlier in this file would
+   re-reserve a gutter inside the widget's overflow-hidden html box and push
+   body's scrollbar inboard by another scrollbar-width. Scoped to the widget
+   being active so normal pages keep the stable gutter. */
+html[q-docked-target] {
+  scrollbar-gutter: auto !important;
+}
+
+/* While the chat is closed, the widget's invisible #q-messenger-frame
+   iframe overlays page content near the right edge with pointer events
+   enabled, stealing clicks and hovers from whatever is underneath —
+   including the page scrollbar, since Firefox hit-tests page content before
+   non-root scrollbars. Let events pass through; q-docked restores normal
+   pointer events for the open panel. */
+html:not([q-docked]) #q-messenger-frame {
   pointer-events: none !important;
 }


### PR DESCRIPTION
On production the Qualified chat widget (injected via GTM, not part of this repo) restyles <html> to overflow:hidden so <body> becomes the page's scroll container, and parks an invisible ~20px-wide, full-height, max-z-index iframe (#q-messenger-frame) against the right edge of the viewport — exactly where body's scrollbar sits. Chrome hit-tests its scrollbars before page content, but Firefox hit-tests content first, so the invisible strip swallowed every click and hover on the scrollbar: it never reacted and, with overlay scrollbars, never faded in. Reported as 'the scrollbar doesn't show up on Firefox'; never reproduces on hugo server because GTM only runs on production.

Disable pointer events on the strip while the chat is closed. The widget sets the q-docked attribute on <html> whenever the panel is open (on mobile too, where the docked width is 0), so scoping the override to html:not([q-docked]) hands pointer events back to the open panel.

Verified by hit-testing (elementFromPoint) a repro page built from the widget's captured stylesheet plus a simulated messenger iframe: without the fix the strip captures the point next to the scrollbar; with the fix clicks pass through; with q-docked set the frame captures again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only, production-widget-specific selectors with `!important`; no auth or data paths, though layout could shift slightly when the widget is active.
> 
> **Overview**
> Adds **Qualified chat widget** overrides in `index.css` for production (GTM-injected widget), scoped with `q-docked-target` / `q-docked` on `<html>`.
> 
> While the panel is **closed**, the widget’s width/margin compensation is neutralized so `<body>`’s scrollbar stays at the viewport edge and is not clipped by `html { overflow: hidden }`. When the widget is active, **`scrollbar-gutter: stable`** is turned off on `html` so it does not double-reserve gutter space inside the widget layout.
> 
> For **Firefox**, **`pointer-events: none`** is applied to `#q-messenger-frame` when the chat is not docked open, so the invisible edge iframe no longer steals clicks/hovers from the page scrollbar; open panel behavior is preserved when `q-docked` is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f5cb8ec1a8f622249b26f46c0bd75e114fc6bc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->