### PR TITLE
OP: fix broken link in RC/Radar docs

### DIFF
--- a/content/operate/rc/radar.md
+++ b/content/operate/rc/radar.md
@@ -15,7 +15,7 @@ Redis Radar gives you one place to view the status of every Redis cluster in you
 
 Redis Cloud's hosted Radar needs no setup. There's no subscription toggle to turn on and nothing to request from your account team.
 
-1. Go to [`redis-radar.redis.io`](https://redis-radar.redis.io).
+1. Go to [`radar.redis.io`](http://radar.redis.io).
 2. Sign in with your Redis Cloud credentials. If you don't have a Redis Cloud account, create one first.
 
 Radar uses the same sign-in as the rest of Redis Cloud, so any Redis Cloud account can sign in.


### PR DESCRIPTION
Link fix per Matthew Schaeffer (Slack):

https://redis.slack.com/archives/CBPBES9RB/p1789049321037119

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation link change with no application or security impact.
> 
> **Overview**
> Updates the **Redis Cloud Radar** getting-started step so the documented URL matches the live product: **`redis-radar.redis.io`** (HTTPS) is replaced with **`radar.redis.io`** (HTTP).
> 
> No other doc pages in this repo reference the old hostname.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5631bfeb4fc182233e7706db9c29b5fdc517ce6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->