### PR TITLE
K8s: make OLM distinction in limitation

### DIFF
--- a/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
+++ b/content/operate/kubernetes/release-notes/7-22-2-releases/7-22-2-43-august2026.md
@@ -34,6 +34,6 @@ This is a maintenance release of Redis for Kubernetes to support Redis Software 
 
 ### New limitations
 
-- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Remain on 7.22.2-43 until a later 8.0.20 maintenance release is available.
+- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported in OLM-based deployments** due to an upgrade path limitation between these builds. Remain on 7.22.2-43 until a later 8.0.20 maintenance release is available.
 
 See [7.22.2 releases]({{<relref "/operate/kubernetes/release-notes/7-22-2-releases/">}}) for information on other known limitations.

--- a/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
+++ b/content/operate/kubernetes/release-notes/8-0-20-releases/8-0-20-26-august2026.md
@@ -42,6 +42,6 @@ This is a maintenance release to support [Redis Software 8.0.20]({{<relref "/ope
 
 ### New limitations
 
-- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported** due to an upgrade path limitation between these builds. Remain on 7.22.2-43 until a later 8.0.20 maintenance release is available.
+- **Upgrading directly from Redis for Kubernetes 7.22.2-43 to 8.0.20-26 is not supported in OLM-based deployments** due to an upgrade path limitation between these builds. Remain on 7.22.2-43 until a later 8.0.20 maintenance release is available.
 
 See [8.0.20 releases]({{<relref "/operate/kubernetes/release-notes/8-0-20-releases/">}}) for information on other known limitations.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only edits to release notes with no product or deployment logic changes.
> 
> **Overview**
> Updates the **Known limitations** note on the **7.22.2-43** and **8.0.20-26** August 2026 release pages so the blocked upgrade path applies specifically to **OLM-based deployments**, not all install methods.
> 
> The guidance no longer tells customers to stay on 7.22.2-43 until a newer 8.0.20 build; it now directs them to **upgrade to 8.0.20-27 or later** instead of stopping at 8.0.20-26.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6f17e47c910022a98d59df11a60ced1ff5bd556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->