### PR TITLE
Fix Beekeeper Studio link in tools documentation

### DIFF
--- a/content/develop/tools/_index.md
+++ b/content/develop/tools/_index.md
@@ -65,7 +65,7 @@ It connects to a single standalone node over an unencrypted connection: Cluster,
 
 ### Beekeeper Studio
 
-[Beekeeper Studio](https://www.beekeeperstudio.io) Beekeeper Studio is a free, open-source database manager that supports a range of databases like Redis, MongoDB, PostgreSQL, MySQL and more.
+[Beekeeper Studio](https://www.beekeeperstudio.io/db/redis-client) is a free, open-source database manager that supports a range of databases like Redis, MongoDB, PostgreSQL, MySQL and more.
 Beekeeper Studio is a desktop app, and is available for Linux, macOS, and Windows with full feature parity across all operating systems. 
 
 Redis support includes


### PR DESCRIPTION
Fix double wording on the beekeeper page, and point to correct page on the site

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only text and URL change with no runtime or security impact.
> 
> **Overview**
> Updates the **Beekeeper Studio** entry in the third-party client tools docs so the link targets the Redis-specific page (`/db/redis-client`) instead of the generic homepage.
> 
> Also fixes a copy glitch where the product name appeared twice in the opening sentence (link text plus repeated “Beekeeper Studio” before “is a free…”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4e520360f0a40faf75d31f6488e3395e06e8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->