### PR TITLE
DOC-7059: Migrate develop/tools to render hooks

### DIFF
--- a/content/develop/tools/_index.md
+++ b/content/develop/tools/_index.md
@@ -27,20 +27,20 @@ manage it and interact with the data:
 
 ## Redis command line interface (CLI)
 
-The [Redis command line interface]({{< relref "/develop/tools/cli" >}}) (also known as `redis-cli`) is a terminal program that sends commands to and reads replies from the Redis server. It has the following two main modes:
+The [Redis command line interface](/content/develop/tools/cli.md) (also known as `redis-cli`) is a terminal program that sends commands to and reads replies from the Redis server. It has the following two main modes:
 
 1. An interactive Read Eval Print Loop (REPL) mode where the user types Redis commands and receives replies.
 2. A command mode where `redis-cli` is executed with additional arguments, and the reply is printed to the standard output.
 
 ## Redis Insight
 
-[Redis Insight]({{< relref "/develop/tools/insight" >}}) combines a graphical user interface with Redis CLI to let you work with any Redis deployment. You can visually browse and interact with data, take advantage of diagnostic tools, learn by example, and much more. Best of all, Redis Insight is free.
+[Redis Insight](/content/develop/tools/insight/_index.md) combines a graphical user interface with Redis CLI to let you work with any Redis deployment. You can visually browse and interact with data, take advantage of diagnostic tools, learn by example, and much more. Best of all, Redis Insight is free.
 
 [Download Redis Insight](https://redis.io/downloads/#insight).
 
 ## Redis VSCode extension
 
-[Redis for VS Code]({{< relref "/develop/tools/redis-for-vscode" >}})
+[Redis for VS Code](/content/develop/tools/redis-for-vscode/_index.md)
 is an extension that allows you to connect to your Redis databases from within Microsoft Visual Studio Code. After connecting to a database, you can view, add, modify, and delete keys, and interact with your Redis databases using a Redis Insight like UI and also a built-in CLI interface.
 
 ## redisctl

--- a/content/develop/tools/cli.md
+++ b/content/develop/tools/cli.md
@@ -31,18 +31,18 @@ This topic covers the different aspects of `redis-cli`, starting from the simple
 
 ## Install `redis-cli`
 
-You have several options for installing or using `redis-cli`. The easiest method is to install the standalone `redis-cli` binary for Linux or macOS. See the [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) page for more information.
+You have several options for installing or using `redis-cli`. The easiest method is to install the standalone `redis-cli` binary for Linux or macOS. See the [Install redis-cli](/content/operate/oss_and_stack/install/install-stack/install-redis-cli.md) page for more information.
 
 Other methods include:
 
-- [Install Redis Open Source]({{< relref "/operate/oss_and_stack/install/install-stack/" >}}). The `redis-cli` utility is installed as part of each installation method.
-- [Build Redis from source]({{< relref "/operate/oss_and_stack/install/build-stack" >}}). Instead of building everything, you can just run the following command:
+- [Install Redis Open Source](/content/operate/oss_and_stack/install/install-stack/_index.md). The `redis-cli` utility is installed as part of each installation method.
+- [Build Redis from source](/content/operate/oss_and_stack/install/build-stack/_index.md). Instead of building everything, you can just run the following command:
 
     `$ make redis-cli`.
     
     The `redis-cli` utility will be built in the `/path/to/redis-source/src` directory as `/path/to/redis-source/src/redis-cli`.
 
-If you prefer not to install Redis, you can also run `redis-cli` in Docker. See the [Run `redis-cli` using Docker]({{< relref "/operate/oss_and_stack/install/install-stack/docker/#connect-with-redis-cli" >}}) page for instructions.
+If you prefer not to install Redis, you can also run `redis-cli` in Docker. See the [Run `redis-cli` using Docker](/content/operate/oss_and_stack/install/install-stack/docker.md#connect-with-redis-cli) page for instructions.
 
 ## Command line usage
 
@@ -122,7 +122,7 @@ You can change the port using several command line options. To specify a differe
     PONG
 
 If your instance is password protected, the `-a <password>` option will
-perform authentication saving the need of explicitly using the [`AUTH`]({{< relref "/commands/auth" >}}) command:
+perform authentication saving the need of explicitly using the [`AUTH`](/content/commands/auth.md) command:
 
     $ redis-cli -a myUnguessablePazzzzzword123 PING
     PONG
@@ -212,7 +212,7 @@ arguments with spaces, newlines, or other special characters:
 It is possible to execute a single command a specified number of times
 with a user-selected pause between executions. This is useful in
 different contexts - for example when we want to continuously monitor some
-key content or [`INFO`]({{< relref "/commands/info" >}}) field output, or when we want to simulate some
+key content or [`INFO`](/content/commands/info.md) field output, or when we want to simulate some
 recurring write event, such as pushing a new item into a list every 5 seconds.
 
 This feature is controlled by two options: `-r <count>` and `-i <delay>`.
@@ -243,7 +243,7 @@ To monitor over time the RSS memory size it's possible to use the following comm
 ## Mass insertion of data using `redis-cli`
 
 Mass insertion using `redis-cli` is covered in a separate page as it is a
-worthwhile topic itself. Please refer to our [mass insertion guide]({{< relref "/develop/clients/patterns/bulk-loading" >}}).
+worthwhile topic itself. Please refer to our [mass insertion guide](/content/develop/clients/patterns/bulk-loading.md).
 
 ## CSV output
 
@@ -259,7 +259,7 @@ Note that the `--csv` flag will only work on a single command, not the entirety 
 ## Run Lua scripts
 
 The `redis-cli` has extensive support for using the debugging facility
-of Lua scripting, available with Redis 3.2 onwards. For this feature, refer to the [Redis Lua debugger documentation]({{< relref "/develop/programmability/lua-debugging" >}}).
+of Lua scripting, available with Redis 3.2 onwards. For this feature, refer to the [Redis Lua debugger documentation](/content/develop/programmability/lua-debugging.md).
 
 Even without using the debugger, `redis-cli` can be used to
 run scripts from a file as an argument:
@@ -269,15 +269,15 @@ run scripts from a file as an argument:
     $ redis-cli --eval /tmp/script.lua location:hastings:temp , 23
     OK
 
-The Redis [`EVAL`]({{< relref "/commands/eval" >}}) command takes the list of keys the script uses, and the
-other non key arguments, as different arrays. When calling [`EVAL`]({{< relref "/commands/eval" >}}) you
+The Redis [`EVAL`](/content/commands/eval.md) command takes the list of keys the script uses, and the
+other non key arguments, as different arrays. When calling [`EVAL`](/content/commands/eval.md) you
 provide the number of keys as a number. 
 
 When calling `redis-cli` with the `--eval` option above, there is no need to specify the number of keys
 explicitly. Instead it uses the convention of separating keys and arguments
 with a comma. This is why in the above call you see `location:hastings:temp , 23` as arguments.
 
-So `location:hastings:temp` will populate the [`KEYS`]({{< relref "/commands/keys" >}}) array, and `23` the `ARGV` array.
+So `location:hastings:temp` will populate the [`KEYS`](/content/commands/keys.md) array, and `23` the `ARGV` array.
 
 The `--eval` option is useful when writing simple scripts. For more
 complex work, the Lua debugger is recommended. It is possible to mix the two approaches, since the debugger can also execute scripts from an external file.
@@ -424,7 +424,7 @@ name by a number:
 
 ### Show online help for Redis commands
 
-`redis-cli` provides online help for most Redis [commands]({{< relref "/commands" >}}), using the `HELP` command. The command can be used
+`redis-cli` provides online help for most Redis [commands](/commands), using the `HELP` command. The command can be used
 in two forms:
 
 * `HELP @<category>` shows all the commands about a given category. The
@@ -446,7 +446,7 @@ categories are:
     - `@stream`
 * `HELP <commandname>` shows specific help for the command given as argument.
 
-For example in order to show help for the [`PFADD`]({{< relref "/commands/pfadd" >}}) command, use:
+For example in order to show help for the [`PFADD`](/content/commands/pfadd.md) command, use:
 
     127.0.0.1:6379> HELP PFADD
 
@@ -473,13 +473,13 @@ are explained in the next sections:
 * Monitoring tool to show continuous stats about a Redis server.
 * Scanning a Redis database for very large keys.
 * Key space scanner with pattern matching.
-* Acting as a [Pub/Sub]({{< relref "/develop/pubsub" >}}) client to subscribe to channels.
+* Acting as a [Pub/Sub](/content/develop/pubsub/_index.md) client to subscribe to channels.
 * Monitoring the commands executed into a Redis instance.
-* Checking the [latency]({{< relref "/operate/oss_and_stack/management/optimization/latency" >}}) of a Redis server in different ways.
+* Checking the [latency](/content/operate/oss_and_stack/management/optimization/latency.md) of a Redis server in different ways.
 * Checking the scheduler latency of the local computer.
 * Transferring RDB backups from a remote Redis server locally.
 * Acting as a Redis replica for showing what a replica receives.
-* Simulating [LRU]({{< relref "/develop/reference/eviction" >}}) workloads for showing stats about keys hits.
+* Simulating [LRU](/content/develop/reference/eviction/index.md) workloads for showing stats about keys hits.
 * A client for the Lua debugger.
 
 ### Continuous stats mode
@@ -554,10 +554,10 @@ In the first part of the output, each new key larger than the previous larger
 key (of the same type) encountered is reported. The summary section
 provides general stats about the data inside the Redis instance.
 
-The program uses the [`SCAN`]({{< relref "/commands/scan" >}}) command, so it can be executed against a busy
+The program uses the [`SCAN`](/content/commands/scan.md) command, so it can be executed against a busy
 server without impacting the operations, however the `-i` option can be
 used in order to throttle the scanning process of the specified fraction
-of second for each [`SCAN`]({{< relref "/commands/scan" >}}) command. 
+of second for each [`SCAN`](/content/commands/scan.md) command. 
 
 For example, `-i 0.01` will slow down the program execution considerably, but will also reduce the load on the server
 to a negligible amount.
@@ -704,7 +704,7 @@ ReJSON-RL           25  45.45%   15.38K     629B                 -           -
 It is also possible to scan the key space, again in a way that does not
 block the Redis server (which does happen when you use a command
 like `KEYS *`), and print all the key names, or filter them for specific
-patterns. This mode, like the `--bigkeys` option, uses the [`SCAN`]({{< relref "/commands/scan" >}}) command,
+patterns. This mode, like the `--bigkeys` option, uses the [`SCAN`](/content/commands/scan.md) command,
 so keys may be reported multiple times if the dataset is changing, but no
 key would ever be missing, if that key was present since the start of the
 iteration. Because of the command that it uses this option is called `--scan`.
@@ -725,7 +725,7 @@ Note that `head -10` is used in order to print only the first ten lines of the
 output.
 
 Scanning is able to use the underlying pattern matching capability of
-the [`SCAN`]({{< relref "/commands/scan" >}}) command with the `--pattern` option.
+the [`SCAN`](/content/commands/scan.md) command with the `--pattern` option.
 
     $ redis-cli --scan --pattern '*-11*'
     key-114
@@ -746,17 +746,17 @@ kind of objects, by key name:
     $ redis-cli --scan --pattern 'user:*' | wc -l
     3829433
 
-You can use `-i 0.01` to add a delay between calls to the [`SCAN`]({{< relref "/commands/scan" >}}) command.
+You can use `-i 0.01` to add a delay between calls to the [`SCAN`](/content/commands/scan.md) command.
 This will make the command slower but will significantly reduce load on the server.
 
 ## Pub/sub mode
 
 The CLI is able to publish messages in Redis Pub/Sub channels using
-the [`PUBLISH`]({{< relref "/commands/publish" >}}) command. Subscribing to channels in order to receive
+the [`PUBLISH`](/content/commands/publish.md) command. Subscribing to channels in order to receive
 messages is different - the terminal is blocked and waits for
 messages, so this is implemented as a special mode in `redis-cli`. Unlike
 other special modes this mode is not enabled by using a special option,
-but simply by using the [`SUBSCRIBE`]({{< relref "/commands/subscribe" >}}) or [`PSUBSCRIBE`]({{< relref "/commands/psubscribe" >}}) command, which are available in
+but simply by using the [`SUBSCRIBE`](/content/commands/subscribe.md) or [`PSUBSCRIBE`](/content/commands/psubscribe.md) command, which are available in
 interactive or command mode:
 
     $ redis-cli PSUBSCRIBE '*'
@@ -779,7 +779,7 @@ To exit the Pub/Sub mode just process `CTRL-C`.
 ## Monitor commands executed in Redis
 
 Similarly to the Pub/Sub mode, the monitoring mode is entered automatically
-once you use the [`MONITOR`]({{< relref "/commands/monitor" >}}) command. All commands received by the active Redis instance will be printed to the standard output:
+once you use the [`MONITOR`](/content/commands/monitor.md) command. All commands received by the active Redis instance will be printed to the standard output:
 
     $ redis-cli MONITOR
     OK
@@ -799,7 +799,7 @@ The `redis-cli` has multiple facilities for studying the latency of a Redis
 instance and understanding the latency's maximum, average and distribution.
 
 The basic latency-checking tool is the `--latency` option. Using this
-option the CLI runs a loop where the [`PING`]({{< relref "/commands/ping" >}}) command is sent to the Redis
+option the CLI runs a loop where the [`PING`](/content/commands/ping.md) command is sent to the Redis
 instance and the time to receive a reply is measured. This happens 100
 times per second, and stats are updated in a real time in the console:
 
@@ -919,7 +919,7 @@ in order to improve the bug report.
 
 ## Perform an LRU simulation
 
-Redis is often used as a cache with [LRU eviction]({{< relref "/develop/reference/eviction" >}}).
+Redis is often used as a cache with [LRU eviction](/content/develop/reference/eviction/index.md).
 Depending on the number of keys and the amount of memory allocated for the
 cache (specified via the `maxmemory` directive), the amount of cache hits
 and misses will change. Sometimes, simulating the rate of hits is very

--- a/content/develop/tools/insight/_index.md
+++ b/content/develop/tools/insight/_index.md
@@ -45,9 +45,8 @@ Redis Insight is a powerful tool for visualizing and optimizing data in Redis, m
 
 {{< image filename="images/ri/ri-databases.png" alt="The databases screen" >}}
 
-{{< note >}}
-When you add a Redis database for a particular user using the `username` and `password` fields, that user must be able to run the `INFO` command. See the [access control list (ACL) documentation]({{< relref "/operate/oss_and_stack/management/security/acl" >}}) for more information.
-{{< /note >}}
+> [!NOTE]
+> When you add a Redis database for a particular user using the `username` and `password` fields, that user must be able to run the `INFO` command. See the [access control list (ACL) documentation](/content/operate/oss_and_stack/management/security/acl.md) for more information.
 
 ### Connect to Azure Managed Redis with ease
 
@@ -58,9 +57,8 @@ Automatically discover databases across subscriptions and connect using Microsof
 - Multi-account support for switching between Azure accounts
 - Improved, user-friendly error handling
 
-{{< note >}}
-This feature requires Azure-side configuration. Please coordinate with your Azure administrator and follow [the setup guide](https://github.com/redis/RedisInsight/blob/main/docs/azure-setup.md) to configure the necessary permissions.
-{{< /note>}}
+> [!NOTE]
+> This feature requires Azure-side configuration. Please coordinate with your Azure administrator and follow [the setup guide](https://github.com/redis/RedisInsight/blob/main/docs/azure-setup.md) to configure the necessary permissions.
 
 ### Redis Copilot
 
@@ -82,17 +80,17 @@ Here's an example of using Redis Copilot to search data using a simple, natural 
 
 {{< image filename="images/ri/ri-redis-copilot-query.png" alt="An example of using Redis Copilot to search data" >}}
 
-See the [Redis Insight Copilot FAQ]({{< relref "/develop/tools/insight/copilot-faq" >}}) for more information.
+See the [Redis Insight Copilot FAQ](/content/develop/tools/insight/copilot-faq.md) for more information.
 
 ### RDI in Redis Insight
 
-Redis Insight includes Redis Data Integration (RDI) connectivity, which allows you to connect to an RDI management plane, and create, test, and deploy RDI pipelines. Read more about this feature [here]({{< relref "/develop/tools/insight/rdi-connector" >}}).
+Redis Insight includes Redis Data Integration (RDI) connectivity, which allows you to connect to an RDI management plane, and create, test, and deploy RDI pipelines. Read more about this feature [here](/content/develop/tools/insight/rdi-connector.md).
 
 ### Browser
 
 Browse, filter and visualize your key-value Redis data structures.
 * [CRUD](https://en.wikipedia.org/wiki/Create,_read,_update_and_delete) support for lists, hashes, strings, sets, sorted sets, streams, arrays, and vector sets.
-* CRUD support for [JSON]({{< relref "/develop/data-types/json/" >}}).
+* CRUD support for [JSON](/content/develop/data-types/json/_index.md).
 * Group keys according to their namespaces.
 
 * View, validate, and manage your key values in a human-readable format using formatters that prettify and highlight data in different formats (for example, Unicode, JSON, MessagePack, HEX, and ASCII) in the Browser tool.
@@ -107,7 +105,7 @@ Analyze every command sent to Redis in real time. To use the profiler, click  **
 
 ### CLI
 
-The CLI is accessible at any time within the application. To use the CLI, click  **>_ CLI** at the bottom left of the screen. It should reveal the CLI window, and there you can start typing Redis [commands]({{< relref "/commands" >}}).
+The CLI is accessible at any time within the application. To use the CLI, click  **>_ CLI** at the bottom left of the screen. It should reveal the CLI window, and there you can start typing Redis [commands](/commands).
 
 The CLI includes the following features:
 
@@ -129,7 +127,7 @@ Workbench is an advanced command line interface with intelligent command auto-co
 Workbench also includes:
 
 * Visualizations of your indexes, queries, and aggregations.
-* Visualizations of your [time series]({{< relref "/develop/data-types/timeseries/" >}}) data.
+* Visualizations of your [time series](/content/develop/data-types/timeseries/_index.md) data.
 
 {{< image filename="images/ri/ri-workbench-timeseries.png" alt="Visualizations of time series data" >}}
 
@@ -139,9 +137,8 @@ Workbench also includes:
 
 Use the database analysis tool to optimize the performance and memory usage of your Redis database. Check data type distribution and memory allocation and review the summary of key expiration time and memory to be freed over time. Inspect the top keys and namespaces sorted by consumed memory or key length and count of keys, respectively. Capture and track the changes in your database by viewing historical analysis reports. Next figure shows a sample database analysis report.
 
-{{< note >}}
-The database analysis tool will only analyze up to 10,000 keys. If more than 10,000 keys are present, the tool will attempt to use extrapolation in its analysis.
-{{< /note >}}
+> [!NOTE]
+> The database analysis tool will only analyze up to 10,000 keys. If more than 10,000 keys are present, the tool will attempt to use extrapolation in its analysis.
 
 {{< image filename="images/ri/ri-analysis.png" alt="The database analysis tool" >}}
 
@@ -155,9 +152,9 @@ View and manage the list of consumer groups. See existing consumers in a given c
 
 ### Search workspace
 
-The dedicated **Search** workspace lets you work with [Redis Search]({{< relref "/develop/ai/search-and-query" >}}) from a single page: browse the search indexes in your database, create indexes from sample or existing data, build and run queries with a schema-aware editor that includes Profile and Explain actions, and save queries to a reusable Query Library. You can also move between the Browser and Search workspaces to make data searchable and view the indexes associated with a key.
+The dedicated **Search** workspace lets you work with [Redis Search](/content/develop/ai/search-and-query/_index.md) from a single page: browse the search indexes in your database, create indexes from sample or existing data, build and run queries with a schema-aware editor that includes Profile and Explain actions, and save queries to a reusable Query Library. You can also move between the Browser and Search workspaces to make data searchable and view the indexes associated with a key.
 
-Read more about this feature [here]({{< relref "/develop/tools/insight/search-workspace" >}}).
+Read more about this feature [here](/content/develop/tools/insight/search-workspace.md).
 
 {{< image filename="images/ri/ri-search-indexes-list.png" alt="The Search workspace" >}}
 
@@ -194,13 +191,12 @@ These are the locations on supported platforms:
 - **Windows**: In the `C:\Users\<your-username>\.redis-insight` directory.
 - **Linux**: In the `/home/<your-username>/.redis-insight` directory.
 
-{{< note >}}
-You can install Redis Insight on operating systems that are not officially supported, but it may not behave as expected.
-{{< /note >}}
+> [!NOTE]
+> You can install Redis Insight on operating systems that are not officially supported, but it may not behave as expected.
 
 ## Redis Insight API (only for Docker)
 
-If you are running Redis Insight from [Docker]({{< relref "/operate/redisinsight/install/install-on-docker" >}}),
+If you are running Redis Insight from [Docker](/content/operate/redisinsight/install/install-on-docker.md),
 you can access the API from `http://localhost:5540/api/docs`.
 
 ## Feedback

--- a/content/develop/tools/insight/insight-stream-consumer.md
+++ b/content/develop/tools/insight/insight-stream-consumer.md
@@ -22,7 +22,7 @@ A _stream_ is an append-only log file.
 When you add data to it, you cannot change it. 
 That may seem like a disadvantage; however, a stream serves as a log or single source of truth. 
 It can also be used as a buffer between processes that work at different speeds and do not need to know about each other. 
-For more conceptual information about streams, see [Redis Streams]({{< relref "/develop/data-types/streams" >}}). 
+For more conceptual information about streams, see [Redis Streams](/content/develop/data-types/streams/_index.md). 
 
 In this topic, you will learn how to add and work with streams as well as consumer groups in Redis Insight.
 
@@ -38,13 +38,13 @@ For example, if the temperature is above a certain threshold, it puts a message 
 It is possible to have multiple consumers doing different jobs, one measuring humidity, and another taking temperature measurements over periods of time. 
 Redis stores a copy of the entire dataset in memory, which is a finite resource.
 To avoid runaway data, streams can be trimmed when you add something to them. 
-When adding to a stream with [`XADD`]({{< relref "/commands/xadd" >}}), you can optionally specify that the stream should be trimmed to a specific or approximate number of the newest entries, or to only include entries whose ID is higher than the ID specified.
+When adding to a stream with [`XADD`](/content/commands/xadd.md), you can optionally specify that the stream should be trimmed to a specific or approximate number of the newest entries, or to only include entries whose ID is higher than the ID specified.
 You can also manage the storage required for streaming data using key expiry.  For example, by writing each day's data to its own stream in Redis and expiring each stream's key after a period of time, say a week.
 An ID can be any number, but each new entry in the stream must have an ID whose value is higher than the last ID added to the stream.
 
 ## Adding new entries 
 
-Use [`XADD`]({{< relref "/commands/xadd" >}}) with `*` for the ID to have Redis automatically generate a new ID for you consisting of a millisecond precision timestamp, a dash and a sequence number.  For example `1656416957625-0`.  Then supply the field names and values to store in the new stream entry.
+Use [`XADD`](/content/commands/xadd.md) with `*` for the ID to have Redis automatically generate a new ID for you consisting of a millisecond precision timestamp, a dash and a sequence number.  For example `1656416957625-0`.  Then supply the field names and values to store in the new stream entry.
 
 There are a couple of ways of retrieving things. You can retrieve entries by time range or you could ask for everything that's happened since a timestamp or ID that you specify. Using a single command you can ask for anything from 10:30 until 11:15 am on a given day.
 
@@ -76,7 +76,7 @@ Then, enter fields and values using + to add more than one (for example, name an
 Now you have a stream that appears in the **Streams** view and you can continue adding fields and values to it.
 
 Redis Insight runs read commands for you so you can see the stream entries in the **Streams** view. 
-And the **Consumer Groups** view shows each consumers in a given consumer group and the last time Redis allocated a message, what the ID of it was and how many times that process has happened, and whether a consumer has you have told Redis that you are finished working with that task using the [`XACK`]({{< relref "/commands/xack" >}}) command.
+And the **Consumer Groups** view shows each consumers in a given consumer group and the last time Redis allocated a message, what the ID of it was and how many times that process has happened, and whether a consumer has you have told Redis that you are finished working with that task using the [`XACK`](/content/commands/xack.md) command.
 
 ## Monitor temperature and humidity from sensors in Redis Insight
 
@@ -86,7 +86,7 @@ This example shows how to bring an existing stream into Redis Insight and work w
 
 1. Install [Redis Insight](https://redis.com/redis-enterprise/redis-insight/?_ga=2.48624486.1318387955.1655817244-1963545967.1655260674#insight-form).
 2. Download and install [Node.js](https://nodejs.org/en/download/) (LTS version).
-3. Install [Redis]({{< relref "/operate/oss_and_stack/install" >}}). In Docker, check that Redis is running locally on the default port 6379 (with no password set). 
+3. Install [Redis](/content/operate/oss_and_stack/install/_index.md). In Docker, check that Redis is running locally on the default port 6379 (with no password set). 
 4. Clone the [code repository](https://github.com/redis-developer/introducing-redis-talk) for this example. 
 See the [README](https://github.com/redis-developer/introducing-redis-talk/tree/main/streams) for more information about this example and installation tips.
 5. On your command-line, navigate to the folder containing the code repository and install the Node.js package manager (npm). 
@@ -198,9 +198,9 @@ Note that in this model, each consumer instance does not receive all of the entr
 
 You can now toggle between **Stream** and **Consumer Groups** views to see your data. 
 As mentioned earlier in this topic, a stream is an append-only log so you can't modify the contents of an entry, but you can delete an entire entry. 
-A case when that's useful is in the event of a so-called _poison-pill message_ that can cause consumers to crash. You can physically remove such messages in the **Streams** view or use the [`XDEL`]({{< relref "/commands/xdel" >}}) command at the command-line interface (CLI).
+A case when that's useful is in the event of a so-called _poison-pill message_ that can cause consumers to crash. You can physically remove such messages in the **Streams** view or use the [`XDEL`](/content/commands/xdel.md) command at the command-line interface (CLI).
 
-You can continue interacting with your stream at the CLI. For example, to get the current length of a stream, use the [`XLEN`]({{< relref "/commands/xlen" >}}) command:
+You can continue interacting with your stream at the CLI. For example, to get the current length of a stream, use the [`XLEN`](/content/commands/xlen.md) command:
 
 {{< highlight bash >}}
 XLEN ingest:temphumidity
@@ -210,5 +210,5 @@ Use streams for auditing and processing events in banking, gaming, supply chain,
 
 ## Related topics
 
-- [Redis Streams]({{< relref "/develop/data-types/streams" >}})
+- [Redis Streams](/content/develop/data-types/streams/_index.md)
 - [Introducing Redis Streams with Redis Insight, node.js, and Python](https://www.youtube.com/watch?v=q2UOkQmIo9Q) (video)

--- a/content/develop/tools/insight/rdi-connector.md
+++ b/content/develop/tools/insight/rdi-connector.md
@@ -17,10 +17,10 @@ title: RDI in Redis Insight
 weight: 4
 ---
 
-Redis Data Integration (RDI) and its [ingest pipeline capability]({{< relref "/integrate/redis-data-integration" >}}) is an end-to-end solution for mirroring your application's primary database in Redis. RDI employs a capture data change mechanism and a stream processor to map and transform source data such as relational tables into fast Redis data structures that match your use cases.
-You can read more about RDI's ingest architecture [on these pages]({{< relref "/integrate/redis-data-integration/architecture" >}}).
+Redis Data Integration (RDI) and its [ingest pipeline capability](/content/integrate/redis-data-integration/_index.md) is an end-to-end solution for mirroring your application's primary database in Redis. RDI employs a capture data change mechanism and a stream processor to map and transform source data such as relational tables into fast Redis data structures that match your use cases.
+You can read more about RDI's ingest architecture [on these pages](/content/integrate/redis-data-integration/architecture/_index.md).
 
-As of version `2.54.0`, Redis Insight includes RDI connectivity, which allows you to connect to [RDI management planes]({{< relref "/integrate/redis-data-integration/architecture" >}}#how-rdi-is-deployed), create, test, and deploy [RDI pipelines]({{< relref "/integrate/redis-data-integration/data-pipelines" >}}), and view RDI statistics.
+As of version `2.54.0`, Redis Insight includes RDI connectivity, which allows you to connect to [RDI management planes](/content/integrate/redis-data-integration/architecture/_index.md#how-rdi-is-deployed), create, test, and deploy [RDI pipelines](/content/integrate/redis-data-integration/data-pipelines/_index.md), and view RDI statistics.
 
 ## Connect
 
@@ -81,7 +81,7 @@ After you make your selections and click **Apply**, Redis Insight will populate 
 
 The **Insert template** menu is only available when the editor panel is empty.
 
-See the [RDI documentation]({{< relref "/integrate/redis-data-integration/reference/config-yaml-reference" >}}) for information about required fields.
+See the [RDI documentation](/content/integrate/redis-data-integration/reference/config-yaml-reference.md) for information about required fields.
 
 ### Test your target database connection
 
@@ -97,7 +97,7 @@ In the **Pipeline Management** pane, click the `+` next to the **Transform and V
 
 Next, click the job name you just created. You can either begin manually editing your transformation job or you can select **Insert template**, which will populate a sample, non-functional job template in the editor.
 
-The [RDI documentation]({{< relref "/integrate/redis-data-integration/data-pipelines/transform-examples" >}}) has several examples of transformation jobs that can help get you started. Note: RDI uses a very specific YAML format for job files. See [here]({{< relref "/integrate/redis-data-integration/data-pipelines" >}}#job-files) for more information.
+The [RDI documentation](/content/integrate/redis-data-integration/data-pipelines/transform-examples/_index.md) has several examples of transformation jobs that can help get you started. Note: RDI uses a very specific YAML format for job files. See [here](/content/integrate/redis-data-integration/data-pipelines/_index.md#job-files) for more information.
 
 ## Use the built-in editors
 
@@ -108,11 +108,10 @@ The Redis Insight pipeline file editors are context-aware. They provide auto-com
 
 {{< image filename="images/ri/ri-rdi-pl-addl-editors.png" alt="SQL and JMESPath editors" >}}
 
-Here's a [reference]({{< relref "/integrate/redis-data-integration/reference/jmespath-custom-functions" >}}) to the supported JMESPath extension functions and expressions that you can use in your job files.
+Here's a [reference](/content/integrate/redis-data-integration/reference/jmespath-custom-functions.md) to the supported JMESPath extension functions and expressions that you can use in your job files.
 
-{{< warning >}}
-Any changes you make in the editors will be lost if you exit Redis Insight without saving your work. To save any changes you made to your pipeline files, deploy them to your RDI server (see below) or download the modified files as a ZIP file to your local computer. Redis Insight will prepend a green circle on unsaved/undeployed files. Redis Insight will also show errors (if present) using an exclamation point icon.
-{{< /warning >}}
+> [!WARNING]
+> Any changes you make in the editors will be lost if you exit Redis Insight without saving your work. To save any changes you made to your pipeline files, deploy them to your RDI server (see below) or download the modified files as a ZIP file to your local computer. Redis Insight will prepend a green circle on unsaved/undeployed files. Redis Insight will also show errors (if present) using an exclamation point icon.
 
 {{< image filename="images/ri/ri-rdi-pl-unsaved.png" alt="Unsaved pipeline" >}}
 

--- a/content/develop/tools/insight/release-notes/v2.0.md
+++ b/content/develop/tools/insight/release-notes/v2.0.md
@@ -178,7 +178,7 @@ RedisInsight-preview 2.0 can be installed along with the current GA (1.11) versi
 - Workbench:
   - Advanced command-line interface that lets you run commands against your Redis server 
   - Workbench editor allows comments, multi-line formatting and multi-command execution
-  - Intelligent Redis command auto-complete and syntax highlighting with support for [RediSearch](https://oss.redis.com/redisearch/), [RedisJSON](https://oss.redis.com/redisjson/), [RedisGraph](https://oss.redis.com/redisgraph/), [RedisTimeSeries](https://oss.redis.com/redistimeseries/), [RedisGears]({{< relref "/operate/oss_and_stack/stack-with-enterprise/deprecated-features/triggers-and-functions" >}}), [RedisAI](https://oss.redis.com/redisai/), [RedisBloom](https://oss.redis.com/redisbloom/)
+  - Intelligent Redis command auto-complete and syntax highlighting with support for [RediSearch](https://oss.redis.com/redisearch/), [RedisJSON](https://oss.redis.com/redisjson/), [RedisGraph](https://oss.redis.com/redisgraph/), [RedisTimeSeries](https://oss.redis.com/redistimeseries/), [RedisGears](/content/operate/oss_and_stack/stack-with-enterprise/deprecated-features/triggers-and-functions/_index.md), [RedisAI](https://oss.redis.com/redisai/), [RedisBloom](https://oss.redis.com/redisbloom/)
   - Allows rendering custom data visualization per Redis command using externally developed plugins
 - Browser:
   - Browse, filter and visualize key-value Redis data structures

--- a/content/develop/tools/insight/search-workspace.md
+++ b/content/develop/tools/insight/search-workspace.md
@@ -17,7 +17,7 @@ title: Search workspace
 weight: 5
 ---
 
-The **Search** workspace in Redis Insight is a dedicated space for working with [Redis Search]({{< relref "/develop/ai/search-and-query" >}}). From a single page you can browse the search indexes in your database, create new indexes from sample or existing data, build and run queries with a schema-aware editor, and save queries to a reusable library.
+The **Search** workspace in Redis Insight is a dedicated space for working with [Redis Search](/content/develop/ai/search-and-query/_index.md). From a single page you can browse the search indexes in your database, create new indexes from sample or existing data, build and run queries with a schema-aware editor, and save queries to a reusable library.
 
 To open the workspace, select **Search** in the menu at the top of the screen.
 
@@ -43,7 +43,7 @@ If your database contains at least one search index, the Search workspace opens 
 
 ## Search indexes list
 
-The Search workspace lists the [search indexes]({{< relref "/develop/ai/search-and-query/indexing" >}}) defined in the connected database.
+The Search workspace lists the [search indexes](/content/develop/ai/search-and-query/indexing/_index.md) defined in the connected database.
 
 The list shows the following information for each index. Several columns include an info button that explains the column when selected.
 
@@ -105,13 +105,13 @@ The schema is shown in a table with the following columns:
 
 {{< image filename="images/ri/ri-search-create-existing.png" alt="Creating an index from existing data with automatic field detection" >}}
 
-{{< note >}}
-The first time you create an index from existing data, Redis Insight shows a short guided tour of the page. Select **Skip tour** to dismiss it, or **Next** to step through it.
-{{< /note >}}
+> [!NOTE]
+> The first time you create an index from existing data, Redis Insight shows a short guided tour of the page. Select **Skip tour** to dismiss it, or **Next** to step through it.
+
 &nbsp;
-{{< note >}}
-Nested JSON objects and arrays cannot be indexed directly. If Redis Insight detects one, it removes the field and shows a warning that explains why.
-{{< /note >}}
+
+> [!NOTE]
+> Nested JSON objects and arrays cannot be indexed directly. If Redis Insight detects one, it removes the field and shows a warning that explains why.
 
 #### Configure field types
 
@@ -130,7 +130,7 @@ To add a field, select **+ Add field**; to change a detected field, select its *
 The create-index page provides two views of your index definition:
 
 - **Table view** &mdash; the visual schema editor described above.
-- **Command view** &mdash; the equivalent [`FT.CREATE`]({{< relref "/commands/ft.create" >}}) command that Redis Insight will run.
+- **Command view** &mdash; the equivalent [`FT.CREATE`](/content/commands/ft.create.md) command that Redis Insight will run.
 
 {{< image filename="images/ri/ri-search-command-view.png" alt="The generated FT.CREATE command in command view" >}}
 
@@ -148,12 +148,12 @@ The rest of the page is split into two resizable panes: the query editor on top 
 
 ### Query editor
 
-The **Query editor** tab lets you write and run [Redis Query Engine commands]({{< relref "/develop/ai/search-and-query/query" >}}) (such as `FT.SEARCH` and `FT.AGGREGATE`) against the selected index, with syntax highlighting and schema-aware autocomplete. Start typing `FT.` to see available search commands, index names, and fields based on your current query.
+The **Query editor** tab lets you write and run [Redis Query Engine commands](/content/develop/ai/search-and-query/query/_index.md) (such as `FT.SEARCH` and `FT.AGGREGATE`) against the selected index, with syntax highlighting and schema-aware autocomplete. Start typing `FT.` to see available search commands, index names, and fields based on your current query.
 
 The action bar at the bottom of the editor pane provides the following actions:
 
-- **Explain** &mdash; show the execution plan for the query (using [`FT.EXPLAIN`]({{< relref "/commands/ft.explain" >}})) so you can understand how it will run. Available for `FT.SEARCH` and `FT.AGGREGATE` queries.
-- **Profile** &mdash; profile the query (using [`FT.PROFILE`]({{< relref "/commands/ft.profile" >}})) to see where time is spent and identify bottlenecks. Available for `FT.SEARCH` and `FT.AGGREGATE` queries.
+- **Explain** &mdash; show the execution plan for the query (using [`FT.EXPLAIN`](/content/commands/ft.explain.md)) so you can understand how it will run. Available for `FT.SEARCH` and `FT.AGGREGATE` queries.
+- **Profile** &mdash; profile the query (using [`FT.PROFILE`](/content/commands/ft.profile.md)) to see where time is spent and identify bottlenecks. Available for `FT.SEARCH` and `FT.AGGREGATE` queries.
 - **Save** &mdash; save the current query to the Query library for reuse.
 - **Run** &mdash; run the query and view the results in the lower pane.
 
@@ -189,7 +189,7 @@ To save your own query, write it in the **Query editor** tab, select **Save**, a
 
 ## Navigate between the Browse and Search workspaces
 
-The [Browse]({{< relref "/develop/tools/insight#browser" >}}) and Search workspaces are connected so you can move between your raw data and your indexes.
+The [Browse](/content/develop/tools/insight/_index.md#browser) and Search workspaces are connected so you can move between your raw data and your indexes.
 
 ### Make data searchable from the Browse workspace
 

--- a/content/develop/tools/redis-for-vscode/_index.md
+++ b/content/develop/tools/redis-for-vscode/_index.md
@@ -22,12 +22,12 @@ Redis for VS Code is an extension that allows you to connect to your Redis datab
 After connecting to a database, you can view, add, modify, and delete keys, and interact with your Redis databases using a Redis Insight like UI and also a built-in CLI interface.
 The following data types are supported:
 
-- [Hash]({{< relref "/develop/data-types/hashes" >}})
-- [List]({{< relref "/develop/data-types/lists" >}})
-- [Set]({{< relref "/develop/data-types/sets" >}})
-- [Sorted Set]({{< relref "/develop/data-types/sorted-sets" >}})
-- [String]({{< relref "/develop/data-types/strings" >}})
-- [JSON]({{< relref "/develop/data-types/json" >}})
+- [Hash](/content/develop/data-types/hashes.md)
+- [List](/content/develop/data-types/lists.md)
+- [Set](/content/develop/data-types/sets.md)
+- [Sorted Set](/content/develop/data-types/sorted-sets.md)
+- [String](/content/develop/data-types/strings/_index.md)
+- [JSON](/content/develop/data-types/json/_index.md)
 
 ## Install the Redis for VS Code extension
 
@@ -49,11 +49,10 @@ Click on the Redis mark (the cursive **R**) in the VS Code menu to begin connect
 
 {{< image filename="images/dev/connect/vscode/vscode-initial.png" >}}
 
-Click on the **+ Connect database** button. A dialog will display in the main pane. In the image shown below, all the options have been checked to show the available details for each connection. These connection details are similar to those accessible from [`redis-cli`]({{< relref "/develop/tools/cli" >}}).
+Click on the **+ Connect database** button. A dialog will display in the main pane. In the image shown below, all the options have been checked to show the available details for each connection. These connection details are similar to those accessible from [`redis-cli`](/content/develop/tools/cli.md).
 
-{{< note >}}
-In the first release of Redis for VS Code, there is no way to change the logical database after you have selected it. If you need to connect to a different logical database, you need to add a separate database connection.
-{{< /note >}}
+> [!NOTE]
+> In the first release of Redis for VS Code, there is no way to change the logical database after you have selected it. If you need to connect to a different logical database, you need to add a separate database connection.
 
 {{< image filename="images/dev/connect/vscode/vscode-add-menu.png" >}}
 
@@ -61,9 +60,8 @@ After filling out the necessary fields, click on the **Add Redis database** butt
 
 {{< image filename="images/dev/connect/vscode/vscode-cnx-view.png" >}}
 
-{{< note >}}
-Local databases, excluding OSS cluster databases, with default usernames and no passwords will automatically be added to your list of database connections.
-{{< /note >}}
+> [!NOTE]
+> Local databases, excluding OSS cluster databases, with default usernames and no passwords will automatically be added to your list of database connections.
 
 ### Connection tools
 
@@ -144,4 +142,4 @@ The connection tool with the boxed `>_` icon opens a Redis CLI window in the **R
 
 {{< image filename="images/dev/connect/vscode/vscode-cli.png" >}}
 
-The CLI interface works just like the [`redis-cli`]({{< relref "/develop/tools/cli" >}}) command.
+The CLI interface works just like the [`redis-cli`](/content/develop/tools/cli.md) command.


### PR DESCRIPTION
## Summary
- Migrates `content/develop/tools/` (cli, insight, insight/release-notes, redis-for-vscode, redis-for-vscode/release-notes) from `relref` link shortcodes and `note`/`warning` callout shortcodes to native-Markdown render-hook equivalents, per DOC-7059 (continuing DOC-6909/DOC-7047).
- Ran `build/migrate_shortcode_links.py all <file>` (all 3 stages) sequentially over all 75 `.md` files in scope. 8 files actually contained relref/callout shortcodes and were converted; the other 67 (mostly versioned release-notes pages) had nothing to convert.
- Fixed one blockquote-adjacency issue by hand in `content/develop/tools/insight/search-workspace.md`: two `{{< note >}}` blocks separated only by a bare `&nbsp;` line collapsed into one blockquote after conversion (CommonMark lazy-continuation), so a blank line was added on both sides of the `&nbsp;`.
- Left `content/develop/tools/_index.md`'s Beekeeper Studio external-URL line untouched, for open PR #3976 to handle.

## Scope confirmation
- `git status --short` shows only the 8 converted files, all under `content/develop/tools/`.
- No leftover `relref`/`note`/`warning`/`tip`/`info`/`alert` shortcodes remain in `content/develop/tools/` (verified by grep).
- `content/develop/tools/_index.md`'s diff does not touch the Beekeeper Studio URL line.

## Test plan
- [ ] Central href-diff + build-warning verification against `main`, batched across this ticket's units (not done here per instructions)
- [ ] Human review of rendered pages, especially `insight/search-workspace.md`'s adjacent-note fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and callout markup changes under content/develop/tools with no runtime or security impact.
> 
> **Overview**
> Migrates **develop/tools** docs (CLI, Insight, Redis for VS Code, and related pages) from Hugo **`relref`** links and **`note`/`warning`** shortcodes to **native Markdown** targets the site’s render hooks understand.
> 
> Internal links now use explicit **`/content/...`** paths (including command refs like `/content/commands/auth.md` and section indexes with `_index.md`). Callouts become GitHub-style alerts (`> [!NOTE]`, `> [!WARNING]`). In **`search-workspace.md`**, blank lines were added around a lone `&nbsp;` so two adjacent notes don’t merge into one blockquote after conversion.
> 
> No product or API behavior changes—only link/callout markup for the docs build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de00d293c6ac8271b914a833257d5429be04c978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->