### PR TITLE
DOC-7059: Migrate develop/reference+setup to render hooks

### DIFF
--- a/content/develop/_index.md
+++ b/content/develop/_index.md
@@ -8,26 +8,26 @@ hideListLinks: true
 
 
 Get a Redis server running in minutes with a free trial of
-[Redis Cloud]({{< relref "/operate/rc" >}}), or install
-[Redis Open Source]({{< relref "/operate/oss_and_stack" >}}) locally
+[Redis Cloud](/content/operate/rc/_index.md), or install
+[Redis Open Source](/content/operate/oss_and_stack/_index.md) locally
 on your machine. Check out the <a href="https://hub.docker.com/_/redis">Redis Docker Hub</a> for the latest release. Then, explore Redis with your favorite
-[programming language]({{< relref "/develop/clients" >}})
+[programming language](/content/develop/clients/_index.md)
 or analyze and manage your database with our
-[UI tools]({{< relref "/develop/tools" >}}):
+[UI tools](/content/develop/tools/_index.md):
 
 | | Get started | Document search | Vector search |
 |:----- | :-----: | :-----: | :-----:|
-| [Python]({{< relref "/develop/clients/redis-py" >}}) | [See Python examples]({{< relref "/develop/clients/redis-py/connect" >}}) | [See Python examples]({{< relref "/develop/clients/redis-py/queryjson" >}}) | [See Python examples]({{< relref "/develop/clients/redis-py/vecsearch" >}}) |
-| [C#/.NET]({{< relref "/develop/clients/dotnet" >}}) | [See C# examples]({{< relref "/develop/clients/dotnet/connect" >}}) | [See C# examples]({{< relref "/develop/clients/dotnet/nredisstack/queryjson" >}}) | [See C# examples]({{< relref "/develop/clients/dotnet/nredisstack/vecsearch" >}}) |
-| [Node.js]({{< relref "/develop/clients/nodejs" >}}) | [See JS examples]({{< relref "/develop/clients/nodejs/connect" >}}) | [See JS examples]({{< relref "/develop/clients/nodejs/queryjson" >}}) | [See JS examples]({{< relref "/develop/clients/nodejs/vecsearch" >}}) |
-| [Java (Jedis)]({{< relref "/develop/clients/jedis" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/connect" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/queryjson" >}}) | [See Java examples]({{< relref "/develop/clients/jedis/vecsearch" >}}) |
-| [Java (Lettuce)]({{< relref "/develop/clients/lettuce" >}}) | [See Java examples]({{< relref "/develop/clients/lettuce/connect" >}}) | [See Java examples]({{< relref "/develop/clients/lettuce/queryjson" >}}) | [See Java examples]({{< relref "/develop/clients/lettuce/vecsearch" >}}) |
-| [Go]({{< relref "/develop/clients/go" >}}) | [See Go examples]({{< relref "/develop/clients/go/connect" >}}) | [See Go examples]({{< relref "/develop/clients/go/queryjson" >}}) | [See Go examples]({{< relref "/develop/clients/go/vecsearch" >}}) |
-| [PHP]({{< relref "/develop/clients/php" >}}) | [See PHP examples]({{< relref "/develop/clients/php/connect" >}}) | [See PHP examples]({{< relref "/develop/clients/php/queryjson" >}}) | [See PHP examples]({{< relref "/develop/clients/php/vecsearch" >}}) |
-| [JavaScript (ioredis)]({{< relref "/develop/clients/ioredis" >}}) | [See JS examples]({{< relref "/develop/clients/ioredis/connect" >}}) | - | - |
-| [Rust]({{< relref "/develop/clients/rust" >}}) | - | - | - |
-| [C]({{< relref "/develop/clients/hiredis" >}}) | - | - | - |
-| [Ruby]({{< relref "/develop/clients/ruby" >}}) | - | - | - |
+| [Python](/content/develop/clients/redis-py/_index.md) | [See Python examples](/content/develop/clients/redis-py/connect.md) | [See Python examples](/content/develop/clients/redis-py/queryjson.md) | [See Python examples](/content/develop/clients/redis-py/vecsearch.md) |
+| [C#/.NET](/content/develop/clients/dotnet/_index.md) | [See C# examples](/content/develop/clients/dotnet/connect.md) | [See C# examples](/content/develop/clients/dotnet/nredisstack/queryjson.md) | [See C# examples](/content/develop/clients/dotnet/nredisstack/vecsearch.md) |
+| [Node.js](/content/develop/clients/nodejs/_index.md) | [See JS examples](/content/develop/clients/nodejs/connect.md) | [See JS examples](/content/develop/clients/nodejs/queryjson.md) | [See JS examples](/content/develop/clients/nodejs/vecsearch.md) |
+| [Java (Jedis)](/content/develop/clients/jedis/_index.md) | [See Java examples](/content/develop/clients/jedis/connect.md) | [See Java examples](/content/develop/clients/jedis/queryjson.md) | [See Java examples](/content/develop/clients/jedis/vecsearch.md) |
+| [Java (Lettuce)](/content/develop/clients/lettuce/_index.md) | [See Java examples](/content/develop/clients/lettuce/connect.md) | [See Java examples](/content/develop/clients/lettuce/queryjson.md) | [See Java examples](/content/develop/clients/lettuce/vecsearch.md) |
+| [Go](/content/develop/clients/go/_index.md) | [See Go examples](/content/develop/clients/go/connect.md) | [See Go examples](/content/develop/clients/go/queryjson.md) | [See Go examples](/content/develop/clients/go/vecsearch.md) |
+| [PHP](/content/develop/clients/php/_index.md) | [See PHP examples](/content/develop/clients/php/connect.md) | [See PHP examples](/content/develop/clients/php/queryjson.md) | [See PHP examples](/content/develop/clients/php/vecsearch.md) |
+| [JavaScript (ioredis)](/content/develop/clients/ioredis/_index.md) | [See JS examples](/content/develop/clients/ioredis/connect.md) | - | - |
+| [Rust](/content/develop/clients/rust/_index.md) | - | - | - |
+| [C](/content/develop/clients/hiredis/_index.md) | - | - | - |
+| [Ruby](/content/develop/clients/ruby/_index.md) | - | - | - |
 
 | | |
 | - | - |
@@ -36,4 +36,4 @@ or analyze and manage your database with our
 
 | {{< image-card image="images/icon_logo/icon-developers-64-midnight.png" alt="Quick start icon" title="Quick start" url="/develop/get-started" >}} | {{< image-card image="images/icon_logo/icon-data-structures-64-midnight.png" alt="Data types icon" title="Data types" url="/develop/data-types" >}} | {{< image-card image="images/icon_logo/icon-text-search-64-midnight.png" alt="Redis Search icon" title="Redis Search" url="/develop/ai/search-and-query" >}} |
 |:---:| :---: | :---: |
-| [Vector database]({{< relref "/develop/get-started/search-tutorial/vector-search" >}})</br>[Document store]({{< relref "/develop/get-started/search-tutorial" >}})</br>[Data structure store]({{< relref "/develop/get-started/data-store" >}})</br>[RAG with Redis]({{< relref "/develop/get-started/rag" >}})</br>[GenAI]({{< relref "/develop/get-started/redis-in-ai" >}}) | [String]({{< relref "/develop/data-types/strings" >}})</br>[JSON]({{< relref "/develop/data-types/json" >}})</br>[Hash]({{< relref "/develop/data-types/hashes" >}})</br>[Vector set]({{< relref "/develop/data-types/vector-sets" >}})</br>[Probabilistic types]({{< relref "/develop/data-types/probabilistic" >}}) | [Get started]({{< relref "/develop/ai/search-and-query" >}})</br>[Schema field types]({{< relref "/develop/ai/search-and-query/indexing/field-and-type-options" >}})</br>[Indexing]({{< relref "/develop/ai/search-and-query/indexing" >}})</br>[Querying]({{< relref "/develop/ai/search-and-query/query" >}})
+| [Vector database](/content/develop/get-started/search-tutorial/vector-search.md)</br>[Document store](/content/develop/get-started/search-tutorial/_index.md)</br>[Data structure store](/content/develop/get-started/data-store.md)</br>[RAG with Redis](/content/develop/get-started/rag.md)</br>[GenAI](/content/develop/get-started/redis-in-ai.md) | [String](/content/develop/data-types/strings/_index.md)</br>[JSON](/content/develop/data-types/json/_index.md)</br>[Hash](/content/develop/data-types/hashes.md)</br>[Vector set](/content/develop/data-types/vector-sets/_index.md)</br>[Probabilistic types](/content/develop/data-types/probabilistic/_index.md) | [Get started](/content/develop/ai/search-and-query/_index.md)</br>[Schema field types](/content/develop/ai/search-and-query/indexing/field-and-type-options.md)</br>[Indexing](/content/develop/ai/search-and-query/indexing/_index.md)</br>[Querying](/content/develop/ai/search-and-query/query/_index.md)

--- a/content/develop/reference/client-side-caching.md
+++ b/content/develop/reference/client-side-caching.md
@@ -18,11 +18,11 @@ aliases: /develop/use/client-side-caching/
 weight: 2
 ---
 
-{{<note>}}This document is intended as an in-depth reference for
-client-side caching. See
-[Client-side caching introduction]({{< relref "/develop/clients/client-side-caching" >}})
-for general usage guidelines.
-{{</note>}}
+> [!NOTE]
+> This document is intended as an in-depth reference for
+> client-side caching. See
+> [Client-side caching introduction](/content/develop/clients/client-side-caching.md)
+> for general usage guidelines.
 
 Client-side caching is a technique used to create high performance services.
 It exploits the memory available on application servers, servers that are
@@ -91,7 +91,7 @@ listening clients. This can be made to work but is tricky and costly from
 the point of view of the bandwidth used, because often such patterns involve
 sending the invalidation messages to every client in the application, even
 if certain clients may not have any copy of the invalidated data. Moreover
-every application query altering the data requires to use the [`PUBLISH`]({{< relref "/commands/publish" >}})
+every application query altering the data requires to use the [`PUBLISH`](/content/commands/publish.md)
 command, costing the database more CPU time to process this command.
 
 Regardless of what schema is used, there is a simple fact: many very large
@@ -141,7 +141,7 @@ Using the new version of the Redis protocol, RESP3, supported by Redis 6, it is 
 
 Here's an example of a complete session using the Redis protocol in the old RESP2 mode involving the following steps: enabling tracking redirecting to another connection, asking for a key, and getting an invalidation message once the key gets modified.
 
-To start, the client opens a first connection that will be used for invalidations, requests the connection ID, and subscribes via Pub/Sub to the special channel that is used to get invalidation messages when in RESP2 modes (remember that RESP2 is the usual Redis protocol, and not the more advanced protocol that you can use, optionally, with Redis 6 using the [`HELLO`]({{< relref "/commands/hello" >}}) command):
+To start, the client opens a first connection that will be used for invalidations, requests the connection ID, and subscribes via Pub/Sub to the special channel that is used to get invalidation messages when in RESP2 modes (remember that RESP2 is the usual Redis protocol, and not the more advanced protocol that you can use, optionally, with Redis 6 using the [`HELLO`](/content/commands/hello.md) command):
 
 ```
 (Connection 1 -- used for invalidations)
@@ -196,14 +196,14 @@ The client will check if there are cached keys in this caching slot, and will ev
 Note that the third element of the Pub/Sub message is not a single key but
 is a Redis array with just a single element. Since we send an array, if there
 are groups of keys to invalidate, we can do that in a single message.
-In case of a flush ([`FLUSHALL`]({{< relref "/commands/flushall" >}}) or [`FLUSHDB`]({{< relref "/commands/flushdb" >}})), a `null` message will be sent.
+In case of a flush ([`FLUSHALL`](/content/commands/flushall.md) or [`FLUSHDB`](/content/commands/flushdb.md)), a `null` message will be sent.
 
 A very important thing to understand about client-side caching used with
 RESP2 and a Pub/Sub connection in order to read the invalidation messages,
 is that using Pub/Sub is entirely a trick **in order to reuse old client
 implementations**, but actually the message is not really sent to a channel
 and received by all the clients subscribed to it. Only the connection we
-specified in the `REDIRECT` argument of the [`CLIENT`]({{< relref "/commands/client" >}}) command will actually
+specified in the `REDIRECT` argument of the [`CLIENT`](/content/commands/client.md) command will actually
 receive the Pub/Sub message, making the feature a lot more scalable.
 
 When RESP3 is used instead, invalidation messages are sent (either in the
@@ -256,7 +256,7 @@ In this mode, by default, keys mentioned in read queries *are not supposed to be
     "bar"
 
 The `CACHING` command affects the command executed immediately after it.
-However, in case the next command is [`MULTI`]({{< relref "/commands/multi" >}}), all the commands in the
+However, in case the next command is [`MULTI`](/content/commands/multi.md), all the commands in the
 transaction will be tracked. Similarly, in case of Lua scripts, all the
 commands executed by the script will be tracked.
 
@@ -356,7 +356,7 @@ future what is good to cache. In general:
 
 * We don't want to cache many keys that change continuously.
 * We don't want to cache many keys that are requested very rarely.
-* We want to cache keys that are requested often and change at a reasonable rate. For an example of key not changing at a reasonable rate, think of a global counter that is continuously [`INCR`]({{< relref "/commands/incr" >}})emented.
+* We want to cache keys that are requested often and change at a reasonable rate. For an example of key not changing at a reasonable rate, think of a global counter that is continuously [`INCR`](/content/commands/incr.md)emented.
 
 However simpler clients may just evict data using some random sampling just
 remembering the last time a given cached value was served, trying to evict

--- a/content/develop/reference/clients.md
+++ b/content/develop/reference/clients.md
@@ -112,7 +112,7 @@ Different kind of clients have different default limits:
 * **Pub/Sub clients** have a default hard limit of 32 megabytes and a soft limit of 8 megabytes per 60 seconds.
 * **Replicas** have a default hard limit of 256 megabytes and a soft limit of 64 megabyte per 60 seconds.
 
-It is possible to change the limit at runtime using the [`CONFIG SET`]({{< relref "/commands/config-set" >}}) command or in a permanent way using the Redis configuration file `redis.conf`. See the example `redis.conf` in the Redis distribution for more information about how to set the limit.
+It is possible to change the limit at runtime using the [`CONFIG SET`](/content/commands/config-set.md) command or in a permanent way using the Redis configuration file `redis.conf`. See the example `redis.conf` in the Redis distribution for more information about how to set the limit.
 
 ## Query Buffer Hard Limit
 
@@ -134,7 +134,7 @@ The aggregation takes into account all the memory used by the client connections
 
 Note that replica and master connections aren't affected by the client eviction mechanism. Therefore, such connections are never evicted.
 
-`maxmemory-clients` can be set permanently in the configuration file (`redis.conf`) or via the [`CONFIG SET`]({{< relref "/commands/config-set" >}}) command.
+`maxmemory-clients` can be set permanently in the configuration file (`redis.conf`) or via the [`CONFIG SET`](/content/commands/config-set.md) command.
 This setting can either be 0 (meaning no limit), a size in bytes (possibly with `mb`/`gb` suffix),
 or a percentage of `maxmemory` by using the `%` suffix (e.g. setting it to `10%` would mean 10% of the `maxmemory` configuration).
 
@@ -144,14 +144,14 @@ A value `5%`, for example, can be a good place to start.
 
 It is possible to flag a specific client connection to be excluded from the client eviction mechanism.
 This is useful for control path connections.
-If, for example, you have an application that monitors the server via the [`INFO`]({{< relref "/commands/info" >}}) command and alerts you in case of a problem, you might want to make sure this connection isn't evicted.
+If, for example, you have an application that monitors the server via the [`INFO`](/content/commands/info.md) command and alerts you in case of a problem, you might want to make sure this connection isn't evicted.
 You can do so using the following command (from the relevant client's connection):
 
-[`CLIENT NO-EVICT`]({{< relref "/commands/client-no-evict" >}}) `on`
+[`CLIENT NO-EVICT`](/content/commands/client-no-evict.md) `on`
 
 And you can revert that with:
 
-[`CLIENT NO-EVICT`]({{< relref "/commands/client-no-evict" >}}) `off`
+[`CLIENT NO-EVICT`](/content/commands/client-no-evict.md) `off`
 
 For more information and an example refer to the `maxmemory-clients` section in the default `redis.conf` file.
 
@@ -178,9 +178,9 @@ Timeouts are not to be considered very precise: Redis avoids setting timer event
 
 ## The CLIENT Command
 
-The Redis [`CLIENT`]({{< relref "/commands/client" >}}) command allows you to inspect the state of every connected client, to kill a specific client, and to name connections. It is a very powerful debugging tool if you use Redis at scale.
+The Redis [`CLIENT`](/content/commands/client.md) command allows you to inspect the state of every connected client, to kill a specific client, and to name connections. It is a very powerful debugging tool if you use Redis at scale.
 
-[`CLIENT LIST`]({{< relref "/commands/client-list" >}}) is used in order to obtain a list of connected clients and their state:
+[`CLIENT LIST`](/content/commands/client-list.md) is used in order to obtain a list of connected clients and their state:
 
 ```
 redis 127.0.0.1:6379> client list
@@ -192,19 +192,19 @@ In the above example two clients are connected to the Redis server. Let's look a
 
 * **addr**: The client address, that is, the client IP and the remote port number it used to connect with the Redis server.
 * **fd**: The client socket file descriptor number.
-* **name**: The client name as set by [`CLIENT SETNAME`]({{< relref "/commands/client-setname" >}}).
+* **name**: The client name as set by [`CLIENT SETNAME`](/content/commands/client-setname.md).
 * **age**: The number of seconds the connection existed for.
 * **idle**: The number of seconds the connection is idle.
-* **flags**: The kind of client (N means normal client, check the [full list of flags]({{< relref "/commands/client-list" >}})).
+* **flags**: The kind of client (N means normal client, check the [full list of flags](/content/commands/client-list.md)).
 * **omem**: The amount of memory used by the client for the output buffer.
 * **cmd**: The last executed command.
 
-See the [`CLIENT LIST`]({{< relref "/commands/client-list" >}}) documentation for the full listing of fields and their purpose.
+See the [`CLIENT LIST`](/content/commands/client-list.md) documentation for the full listing of fields and their purpose.
 
-Once you have the list of clients, you can close a client's connection using the [`CLIENT KILL`]({{< relref "/commands/client-kill" >}}) command, specifying the client address as its argument.
+Once you have the list of clients, you can close a client's connection using the [`CLIENT KILL`](/content/commands/client-kill.md) command, specifying the client address as its argument.
 
-The commands [`CLIENT SETNAME`]({{< relref "/commands/client-setname" >}}) and [`CLIENT GETNAME`]({{< relref "/commands/client-getname" >}}) can be used to set and get the connection name. Starting with Redis 4.0, the client name is shown in the
-[`SLOWLOG`]({{< relref "/commands/slowlog" >}}) output, to help identify clients that create latency issues.
+The commands [`CLIENT SETNAME`](/content/commands/client-setname.md) and [`CLIENT GETNAME`](/content/commands/client-getname.md) can be used to set and get the connection name. Starting with Redis 4.0, the client name is shown in the
+[`SLOWLOG`](/content/commands/slowlog.md) output, to help identify clients that create latency issues.
 
 ## TCP keepalive
 

--- a/content/develop/reference/command-arguments.md
+++ b/content/develop/reference/command-arguments.md
@@ -15,7 +15,7 @@ title: Redis command arguments
 weight: 7
 ---
 
-The [`COMMAND DOCS`]({{< relref "/commands/command-docs" >}}) command returns documentation-focused information about available Redis commands.
+The [`COMMAND DOCS`](/content/commands/command-docs.md) command returns documentation-focused information about available Redis commands.
 The map reply that the command returns includes the _arguments_ key.
 This key stores an array that describes the command's arguments.
 
@@ -39,27 +39,27 @@ Every element in the _arguments_ array is a map with the following fields:
   - **pure-token:** an argument is a token, meaning a reserved keyword, which may or may not be provided. 
     Not to be confused with free-text user input.
   - **oneof**: the argument is a container for nested arguments.
-    This type enables choice among several nested arguments (see the [`XADD`]({{< relref "/commands/xadd" >}}) example below).
+    This type enables choice among several nested arguments (see the [`XADD`](/content/commands/xadd.md) example below).
   - **block:** the argument is a container for nested arguments.
-    This type enables grouping arguments and applying a property (such as _optional_) to all (see the [`XADD`]({{< relref "/commands/xadd" >}}) example below).
+    This type enables grouping arguments and applying a property (such as _optional_) to all (see the [`XADD`](/content/commands/xadd.md) example below).
 * **key_spec_index:** this value is available for every argument of the _key_ type.
-  It is a 0-based index of the specification in the command's [key specifications]({{< relref "/develop/reference/key-specs.md" >}}) that corresponds to the argument.
+  It is a 0-based index of the specification in the command's [key specifications](/content/develop/reference/key-specs.md) that corresponds to the argument.
 * **token**: a constant literal that precedes the argument (user input) itself.
 * **summary:** a short description of the argument.
 * **since:** the debut Redis version of the argument (or for module commands, the module version).
 * **deprecated_since:** the Redis version that deprecated the command (or for module commands, the module version).
 * **flags:** an array of argument flags.
   Possible flags are:
-  - **optional**: denotes that the argument is optional (for example, the _GET_ clause of the  [`SET`]({{< relref "/commands/set" >}}) command).
-  - **multiple**: denotes that the argument may be repeated (such as the _key_ argument of [`DEL`]({{< relref "/commands/del" >}})).
-  - **multiple-token:** denotes the possible repetition of the argument with its preceding token (see [`SORT`]({{< relref "/commands/sort" >}})'s `GET pattern` clause).
+  - **optional**: denotes that the argument is optional (for example, the _GET_ clause of the  [`SET`](/content/commands/set.md) command).
+  - **multiple**: denotes that the argument may be repeated (such as the _key_ argument of [`DEL`](/content/commands/del.md)).
+  - **multiple-token:** denotes the possible repetition of the argument with its preceding token (see [`SORT`](/content/commands/sort.md)'s `GET pattern` clause).
 * **value:** the argument's value.
   For arguments types other than _oneof_ and _block_, this is a string that describes the value in the command's syntax.
   For the _oneof_ and _block_ types, this is an array of nested arguments, each being a map as described in this section.
 
 ## Example
 
-The trimming clause of [`XADD`]({{< relref "/commands/xadd" >}}), i.e., `[MAXLEN|MINID [=|~] threshold [LIMIT count]]`, is represented at the top-level as _block_-typed argument.
+The trimming clause of [`XADD`](/content/commands/xadd.md), i.e., `[MAXLEN|MINID [=|~] threshold [LIMIT count]]`, is represented at the top-level as _block_-typed argument.
 
 It consists of four nested arguments:
 
@@ -70,7 +70,7 @@ It consists of four nested arguments:
 3. **threshold:** this nested argument is a _string_.
 4. **count:** this nested argument is an optional _integer_ with a _token_ (_LIMIT_).
 
-Here's [`XADD`]({{< relref "/commands/xadd" >}})'s arguments array:
+Here's [`XADD`](/content/commands/xadd.md)'s arguments array:
 
 ```
 1) 1) "name"

--- a/content/develop/reference/command-tips.md
+++ b/content/develop/reference/command-tips.md
@@ -19,7 +19,7 @@ Command tips are an array of strings.
 These provide Redis clients with additional information about the command.
 The information can instruct Redis Cluster clients as to how the command should be executed and its output processed in a clustered deployment.
 
-Unlike the command's flags (see the 3rd element of [`COMMAND`]({{< relref "/commands/command" >}})'s reply), which are strictly internal to the server's operation, tips don't serve any purpose other than being reported to clients.
+Unlike the command's flags (see the 3rd element of [`COMMAND`](/content/commands/command.md)'s reply), which are strictly internal to the server's operation, tips don't serve any purpose other than being reported to clients.
 
 Command tips are arbitrary strings.
 However, the following sections describe proposed tips and demonstrate the conventions they are likely to adhere to.
@@ -28,14 +28,14 @@ However, the following sections describe proposed tips and demonstrate the conve
 
 This tip indicates that the command's output isn't deterministic.
 That means that calls to the command may yield different results with the same arguments and data.
-That difference could be the result of the command's random nature (e.g., [`RANDOMKEY`]({{< relref "/commands/randomkey" >}}) and [`SPOP`]({{< relref "/commands/spop" >}})); the call's timing (e.g., [`TTL`]({{< relref "/commands/ttl" >}})); or generic differences that relate to the server's state (e.g., [`INFO`]({{< relref "/commands/info" >}}) and [`CLIENT LIST`]({{< relref "/commands/client-list" >}})).
+That difference could be the result of the command's random nature (e.g., [`RANDOMKEY`](/content/commands/randomkey.md) and [`SPOP`](/content/commands/spop.md)); the call's timing (e.g., [`TTL`](/content/commands/ttl.md)); or generic differences that relate to the server's state (e.g., [`INFO`](/content/commands/info.md) and [`CLIENT LIST`](/content/commands/client-list.md)).
 
 **Note:**
 Prior to Redis 7.0, this tip was the _random_ command flag.
 
 ## nondeterministic_output_order
 
-The existence of this tip indicates that the command's output is deterministic, but its ordering is random (e.g., [`HGETALL`]({{< relref "/commands/hgetall" >}}) and [`SMEMBERS`]({{< relref "/commands/smembers" >}})).
+The existence of this tip indicates that the command's output is deterministic, but its ordering is random (e.g., [`HGETALL`](/content/commands/hgetall.md) and [`SMEMBERS`](/content/commands/smembers.md)).
 
 **Note:**
 Prior to Redis 7.0, this tip was the _sort_\__for_\__script_ flag.
@@ -51,19 +51,19 @@ The default behavior a client should implement for commands without the _request
 In cases where the client should adopt a behavior different than the default, the _request_policy_ tip can be one of:
 
 - **all_nodes:** the client should execute the command on all nodes - masters and replicas alike.
-  An example is the [`CONFIG SET`]({{< relref "/commands/config-set" >}}) command. 
+  An example is the [`CONFIG SET`](/content/commands/config-set.md) command. 
   This tip is in-use by commands that don't accept key name arguments.
   The command operates atomically per shard.
-* **all_shards:** the client should execute the command on all master shards (e.g., the [`DBSIZE`]({{< relref "/commands/dbsize" >}}) command).
+* **all_shards:** the client should execute the command on all master shards (e.g., the [`DBSIZE`](/content/commands/dbsize.md) command).
   This tip is in-use by commands that don't accept key name arguments.
   The command operates atomically per shard.
 - **multi_shard:** the client should execute the command on several shards.
   The client should split the inputs according to the hash slots of its input key name arguments.
   For example, the command `DEL {foo} {foo}1 bar` should be split to `DEL {foo} {foo}1` and `DEL bar`.
   If the keys are hashed to more than a single slot, the command must be split even if all the slots are managed by the same shard.
-  Examples for such commands include [`MSET`]({{< relref "/commands/mset" >}}), [`MGET`]({{< relref "/commands/mget" >}}) and [`DEL`]({{< relref "/commands/del" >}}).
-  However, note that [`SUNIONSTORE`]({{< relref "/commands/sunionstore" >}}) isn't considered as _multi_shard_ because all of its keys must belong to the same hash slot.
-- **special:** indicates a non-trivial form of the client's request policy, such as the [`SCAN`]({{< relref "/commands/scan" >}}) command.
+  Examples for such commands include [`MSET`](/content/commands/mset.md), [`MGET`](/content/commands/mget.md) and [`DEL`](/content/commands/del.md).
+  However, note that [`SUNIONSTORE`](/content/commands/sunionstore.md) isn't considered as _multi_shard_ because all of its keys must belong to the same hash slot.
+- **special:** indicates a non-trivial form of the client's request policy, such as the [`SCAN`](/content/commands/scan.md) command.
 
 ## response_policy
 
@@ -72,10 +72,10 @@ The default behavior for commands without a _request_policy_ tip only applies to
 The client's implementation for the default behavior should be as follows:
 
 1. The command doesn't accept key name arguments: the client can aggregate all replies within a single nested data structure.
-For example, the array replies we get from calling [`KEYS`]({{< relref "/commands/keys" >}}) against all shards.
+For example, the array replies we get from calling [`KEYS`](/content/commands/keys.md) against all shards.
 These should be packed in a single in no particular order.
 1. For commands that accept one or more key name arguments: the client needs to retain the same order of replies as the input key names.
-For example, [`MGET`]({{< relref "/commands/mget" >}})'s aggregated reply.
+For example, [`MGET`](/content/commands/mget.md)'s aggregated reply.
 
 The _response_policy_ tip is set for commands that reply with scalar data types, or when it's expected that clients implement a non-default aggregate.
 This tip can be one of:
@@ -83,24 +83,24 @@ This tip can be one of:
 * **one_succeeded:** the clients should return success if at least one shard didn't reply with an error.
   The client should reply with the first non-error reply it obtains.
   If all shards return an error, the client can reply with any one of these.
-  For example, consider a [`SCRIPT KILL`]({{< relref "/commands/script-kill" >}}) command that's sent to all shards.
-  Although the script should be loaded in all of the cluster's shards, the [`SCRIPT KILL`]({{< relref "/commands/script-kill" >}}) will typically run only on one at a given time.
+  For example, consider a [`SCRIPT KILL`](/content/commands/script-kill.md) command that's sent to all shards.
+  Although the script should be loaded in all of the cluster's shards, the [`SCRIPT KILL`](/content/commands/script-kill.md) will typically run only on one at a given time.
 * **all_succeeded:** the client should return successfully only if there are no error replies.
   Even a single error reply should disqualify the aggregate and be returned.
   Otherwise, the client should return one of the non-error replies.
-  As an example, consider the [`CONFIG SET`]({{< relref "/commands/config-set" >}}), [`SCRIPT FLUSH`]({{< relref "/commands/script-flush" >}}) and [`SCRIPT LOAD`]({{< relref "/commands/script-load" >}}) commands.
+  As an example, consider the [`CONFIG SET`](/content/commands/config-set.md), [`SCRIPT FLUSH`](/content/commands/script-flush.md) and [`SCRIPT LOAD`](/content/commands/script-load.md) commands.
 * **agg_logical_and:** the client should return the result of a logical _AND_ operation on all replies (only applies to integer replies, usually from commands that return either _0_ or _1_).
-  Consider the [`SCRIPT EXISTS`]({{< relref "/commands/script-exists" >}}) command as an example.
+  Consider the [`SCRIPT EXISTS`](/content/commands/script-exists.md) command as an example.
   It returns an array of _0_'s and _1_'s that denote the existence of its given SHA1 sums in the script cache.
   The aggregated response should be _1_ only when all shards had reported that a given script SHA1 sum is in their respective cache.
 * **agg_logical_or:** the client should return the result of a logical _OR_ operation on all replies (only applies to integer replies, usually from commands that return either _0_ or _1_).
 * **agg_min:** the client should return the minimal value from the replies (only applies to numerical replies).
-  The aggregate reply from a cluster-wide [`WAIT`]({{< relref "/commands/wait" >}}) command, for example, should be the minimal value (number of synchronized replicas) from all shards.
+  The aggregate reply from a cluster-wide [`WAIT`](/content/commands/wait.md) command, for example, should be the minimal value (number of synchronized replicas) from all shards.
 * **agg_max:** the client should return the maximal value from the replies (only applies to numerical replies).
 * **agg_sum:** the client should return the sum of replies (only applies to numerical replies).
-  Example: [`DBSIZE`]({{< relref "/commands/dbsize" >}}).
+  Example: [`DBSIZE`](/content/commands/dbsize.md).
 * **special:** this type of tip indicates a non-trivial form of reply policy.
-  [`INFO`]({{< relref "/commands/info" >}}) is an excellent example of that.
+  [`INFO`](/content/commands/info.md) is an excellent example of that.
 
 ## Example
 

--- a/content/develop/reference/eviction/index.md
+++ b/content/develop/reference/eviction/index.md
@@ -50,8 +50,8 @@ you can use the following directive inside `redis.conf`:
 maxmemory 100mb
 ```
 
-You can also use [`CONFIG SET`]({{< relref "/commands/config-set" >}}) to
-set `maxmemory` at runtime using [`redis-cli`]({{< relref "/develop/tools/cli" >}}):
+You can also use [`CONFIG SET`](/content/commands/config-set.md) to
+set `maxmemory` at runtime using [`redis-cli`](/content/develop/tools/cli.md):
 
 ```bash
 > CONFIG SET maxmemory 100mb
@@ -68,8 +68,8 @@ further growth of the cache.
 ### Setting `maxmemory` for a replicated or persisted instance
 
 If you are using
-[replication]({{< relref "/operate/rs/databases/durability-ha/replication" >}})
-or [persistence]({{< relref "/operate/rs/databases/configure/database-persistence" >}})
+[replication](/content/operate/rs/databases/durability-ha/replication.md)
+or [persistence](/content/operate/rs/databases/configure/database-persistence.md)
 for a server, Redis will use some RAM as a buffer to store the set of updates waiting
 to be written to the replicas or AOF files.
 The memory used by this buffer is not included in the total that
@@ -87,7 +87,7 @@ If you are using replication or persistence, we recommend that you set
 necessary for the `noeviction` policy (see [the section below](#eviction-policies)
 for more information about eviction policies).
 
-The [`INFO`]({{< relref "/commands/info" >}}) command returns a
+The [`INFO`](/content/commands/info.md) command returns a
 `mem_not_counted_for_evict` value in the `memory` section (you can use
 the `INFO memory` option to see just this section). This is the amount of
 memory currently used by the buffers. Although the exact amount will vary,
@@ -150,7 +150,7 @@ policy like `allkeys-lru` is more memory efficient since it doesn't need an
 
 ### Using the `INFO` command
 
-The [`INFO`]({{< relref "/commands/info" >}}) command provides several pieces
+The [`INFO`](/content/commands/info.md) command provides several pieces
 of data that are useful for checking the performance of your cache. In particular,
 the `INFO stats` section includes two important entries, `keyspace_hits` (the number of
 times keys were successfully found in the cache) and `keyspace_misses` (the number
@@ -164,9 +164,9 @@ keyspace_hits / (keyspace_hits + keyspace_misses) * 100
 Check that this is roughly equal to what you would expect for your app
 (naturally, a higher percentage indicates better cache performance).
 
-{{< note >}} When the [`EXISTS`]({{< relref "/commands/exists" >}})
-command reports that a key is absent then this is counted as a keyspace miss.
-{{< /note >}}
+> [!NOTE]
+>  When the [`EXISTS`](/content/commands/exists.md)
+> command reports that a key is absent then this is counted as a keyspace miss.
 
 If the percentage of hits is lower than expected, then this might
 mean you are not using the best eviction policy. For example, if
@@ -213,7 +213,7 @@ before every eviction with the `maxmemory-samples` configuration directive:
 maxmemory-samples 5
 ```
 
-See these pages for information on eviction policies in: (1) [Redis Software]({{< relref "/operate/rs/databases/memory-performance/eviction-policy" >}}) and (2) [Redis Cloud]({{< relref "/operate/rc/databases/configuration/data-eviction-policies" >}}).
+See these pages for information on eviction policies in: (1) [Redis Software](/content/operate/rs/databases/memory-performance/eviction-policy.md) and (2) [Redis Cloud](/content/operate/rc/databases/configuration/data-eviction-policies.md).
 
 The reason Redis does not use a true LRU implementation is because it
 costs more memory. However, the approximation is virtually equivalent for an

--- a/content/develop/reference/key-specs.md
+++ b/content/develop/reference/key-specs.md
@@ -16,20 +16,20 @@ weight: 3
 ---
 
 Many of the commands in Redis accept key names as input arguments.
-The 9th element in the reply of [`COMMAND`]({{< relref "/commands/command" >}}) (and [`COMMAND INFO`]({{< relref "/commands/command-info" >}})) is an array that consists of the command's key specifications.
+The 9th element in the reply of [`COMMAND`](/content/commands/command.md) (and [`COMMAND INFO`](/content/commands/command-info.md)) is an array that consists of the command's key specifications.
 
 A _key specification_ describes a rule for extracting the names of one or more keys from the arguments of a given command.
 Key specifications provide a robust and flexible mechanism, compared to the _first key_, _last key_ and _step_ scheme employed until Redis 7.0.
 Before introducing these specifications, Redis clients had no trivial programmatic means to extract key names for all commands.
 
-Cluster-aware Redis clients had to have the keys' extraction logic hard-coded in the cases of commands such as [`EVAL`]({{< relref "/commands/eval" >}}) and [`ZUNIONSTORE`]({{< relref "/commands/zunionstore" >}}) that rely on a _numkeys_ argument or [`SORT`]({{< relref "/commands/sort" >}}) and its many clauses.
-Alternatively, the [`COMMAND GETKEYS`]({{< relref "/commands/command-getkeys" >}}) can be used to achieve a similar extraction effect but at a higher latency.
+Cluster-aware Redis clients had to have the keys' extraction logic hard-coded in the cases of commands such as [`EVAL`](/content/commands/eval.md) and [`ZUNIONSTORE`](/content/commands/zunionstore.md) that rely on a _numkeys_ argument or [`SORT`](/content/commands/sort.md) and its many clauses.
+Alternatively, the [`COMMAND GETKEYS`](/content/commands/command-getkeys.md) can be used to achieve a similar extraction effect but at a higher latency.
 
 A Redis client isn't obligated to support key specifications.
-It can continue using the legacy _first key_, _last key_ and _step_ scheme along with the [_movablekeys_ flag]({{< relref "/commands/command#flags" >}}) that remain unchanged.
+It can continue using the legacy _first key_, _last key_ and _step_ scheme along with the [_movablekeys_ flag](/content/commands/command.md#flags) that remain unchanged.
 
 However, a Redis client that implements key specifications support can consolidate most of its keys' extraction logic.
-Even if the client encounters an unfamiliar type of key specification, it can always revert to the [`COMMAND GETKEYS`]({{< relref "/commands/command-getkeys" >}}) command.
+Even if the client encounters an unfamiliar type of key specification, it can always revert to the [`COMMAND GETKEYS`](/content/commands/command-getkeys.md) command.
 
 That said, most cluster-aware clients only require a single key name to perform correct command routing, so it is possible that although a command features one unfamiliar specification, its other specification may still be usable by the client.
 
@@ -69,9 +69,9 @@ It is a map under the _spec_ with two keys:
 
 More examples of the _keyword_ search type include:
 
-* [`SET`]({{< relref "/commands/set" >}}) has a `begin_search` specification of type _index_ with a value of _1_.
-* [`XREAD`]({{< relref "/commands/xread" >}}) has a `begin_search` specification of type _keyword_ with the values _"STREAMS"_ and _1_ as _keyword_ and _startfrom_, respectively.
-* [`MIGRATE`]({{< relref "/commands/migrate" >}}) has a _start_search_ specification of type _keyword_ with the values of _"KEYS"_ and _-2_.
+* [`SET`](/content/commands/set.md) has a `begin_search` specification of type _index_ with a value of _1_.
+* [`XREAD`](/content/commands/xread.md) has a `begin_search` specification of type _keyword_ with the values _"STREAMS"_ and _1_ as _keyword_ and _startfrom_, respectively.
+* [`MIGRATE`](/content/commands/migrate.md) has a _start_search_ specification of type _keyword_ with the values of _"KEYS"_ and _-2_.
 
 ## find_keys
 
@@ -105,10 +105,10 @@ The _keynum_ type of `find_keys` is a map under the _spec_ key with three keys:
 
 Examples:
 
-* The [`SET`]({{< relref "/commands/set" >}}) command has a _range_ of _0_, _1_ and _0_.
-* The [`MSET`]({{< relref "/commands/mset" >}}) command has a _range_ of _-1_, _2_ and _0_.
-* The [`XREAD`]({{< relref "/commands/xread" >}}) command has a _range_ of _-1_, _1_ and _2_.
-* The [`ZUNION`]({{< relref "/commands/zunion" >}}) command has a _start_search_ type _index_ with the value _1_, and `find_keys` of type _keynum_ with values of _0_, _1_ and _1_.
+* The [`SET`](/content/commands/set.md) command has a _range_ of _0_, _1_ and _0_.
+* The [`MSET`](/content/commands/mset.md) command has a _range_ of _-1_, _2_ and _0_.
+* The [`XREAD`](/content/commands/xread.md) command has a _range_ of _-1_, _1_ and _2_.
+* The [`ZUNION`](/content/commands/zunion.md) command has a _start_search_ type _index_ with the value _1_, and `find_keys` of type _keynum_ with values of _0_, _1_ and _1_.
 
 **Note:**
 this isn't a perfect solution as the module writers can come up with anything.
@@ -176,30 +176,30 @@ Key specifications may have the following flags:
 ### incomplete
 
 Some commands feature exotic approaches when it comes to specifying their keys, which makes extraction difficult.
-Consider, for example, what would happen with a call to [`MIGRATE`]({{< relref "/commands/migrate" >}}) that includes the literal string _"KEYS"_ as an argument to its _AUTH_ clause.
+Consider, for example, what would happen with a call to [`MIGRATE`](/content/commands/migrate.md) that includes the literal string _"KEYS"_ as an argument to its _AUTH_ clause.
 Our key specifications would miss the mark, and extraction would begin at the wrong index.
 
 Thus, we recognize that key specifications are incomplete and may fail to extract all keys.
 However, we assure that even incomplete specifications never yield the wrong names of keys, providing that the command is syntactically correct.
 
-In the case of [`MIGRATE`]({{< relref "/commands/migrate" >}}), the search begins at the end (_startfrom_ has the value of _-1_).
+In the case of [`MIGRATE`](/content/commands/migrate.md), the search begins at the end (_startfrom_ has the value of _-1_).
 If and when we encounter a key named _"KEYS"_, we'll only extract the subset of the key name arguments after it.
-That's why [`MIGRATE`]({{< relref "/commands/migrate" >}}) has the _incomplete_ flag in its key specification.
+That's why [`MIGRATE`](/content/commands/migrate.md) has the _incomplete_ flag in its key specification.
 
-Another case of incompleteness is the [`SORT`]({{< relref "/commands/sort" >}}) command.
+Another case of incompleteness is the [`SORT`](/content/commands/sort.md) command.
 Here, the `begin_search` and `find_keys` are of type _unknown_.
-The client should revert to calling the [`COMMAND GETKEYS`]({{< relref "/commands/command-getkeys" >}}) command to extract key names from the arguments, short of implementing it natively.
-The difficulty arises, for example, because the string _"STORE"_ is both a keyword (token) and a valid literal argument for [`SORT`]({{< relref "/commands/sort" >}}).
+The client should revert to calling the [`COMMAND GETKEYS`](/content/commands/command-getkeys.md) command to extract key names from the arguments, short of implementing it natively.
+The difficulty arises, for example, because the string _"STORE"_ is both a keyword (token) and a valid literal argument for [`SORT`](/content/commands/sort.md).
 
 **Note:**
-the only commands with _incomplete_ key specifications are [`SORT`]({{< relref "/commands/sort" >}}) and [`MIGRATE`]({{< relref "/commands/migrate" >}}).
+the only commands with _incomplete_ key specifications are [`SORT`](/content/commands/sort.md) and [`MIGRATE`](/content/commands/migrate.md).
 We don't expect the addition of such commands in the future.
 
 ### variable_flags
 
 In some commands, the flags for the same key name argument can depend on other arguments.
-For example, consider the [`SET`]({{< relref "/commands/set" >}}) command and its optional  _GET_ argument.
-Without the _GET_ argument, [`SET`]({{< relref "/commands/set" >}}) is write-only, but it becomes a read and write command with it.
+For example, consider the [`SET`](/content/commands/set.md) command and its optional  _GET_ argument.
+Without the _GET_ argument, [`SET`](/content/commands/set.md) is write-only, but it becomes a read and write command with it.
 When this flag is present, it means that the key specification flags cover all possible options, but the effective flags depend on other arguments.
 
 ## Examples

--- a/content/develop/reference/modules/_index.md
+++ b/content/develop/reference/modules/_index.md
@@ -20,16 +20,16 @@ weight: 2
 The modules documentation is composed of the following pages:
 
 * Introduction to Redis modules (this file). An overview about Redis Modules system and API. It's a good idea to start your reading here.
-* [Implementing native data types]({{< relref "/develop/reference/modules/modules-native-types" >}}) covers the implementation of native data types into modules.
-* [Blocking operations]({{< relref "/develop/reference/modules/modules-blocking-ops" >}}) shows how to write blocking commands that will not reply immediately, but will block the client, without blocking the Redis server, and will provide a reply whenever will be possible.
-* [Redis modules API reference]({{< relref "/develop/reference/modules/modules-api-ref" >}}) is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
+* [Implementing native data types](/content/develop/reference/modules/modules-native-types.md) covers the implementation of native data types into modules.
+* [Blocking operations](/content/develop/reference/modules/modules-blocking-ops.md) shows how to write blocking commands that will not reply immediately, but will block the client, without blocking the Redis server, and will provide a reply whenever will be possible.
+* [Redis modules API reference](/content/develop/reference/modules/modules-api-ref.md) is generated from module.c top comments of RedisModule functions. It is a good reference in order to understand how each function works.
 
 Redis modules make it possible to extend Redis functionality using external
 modules, rapidly implementing new Redis commands with features
 similar to what can be done inside the core itself.
 
 Redis modules are dynamic libraries that can be loaded into Redis at
-startup, or using the [`MODULE LOAD`]({{< relref "/commands/module-load" >}}) command. Redis exports a C API, in the
+startup, or using the [`MODULE LOAD`](/content/commands/module-load.md) command. Redis exports a C API, in the
 form of a single C header file called `redismodule.h`. Modules are meant
 to be written in C, however it will be possible to use C++ or other languages
 that have C binding functionalities.
@@ -65,7 +65,7 @@ following command:
 
 Note that `mymodule` above is not the filename without the `.so` suffix, but
 instead, the name the module used to register itself into the Redis core.
-The name can be obtained using [`MODULE LIST`]({{< relref "/commands/module-list" >}}). However it is good practice
+The name can be obtained using [`MODULE LIST`](/content/commands/module-list.md). However it is good practice
 that the filename of the dynamic library is the same as the name the module
 uses to register itself into the Redis core.
 
@@ -121,7 +121,7 @@ The following is the function prototype:
                          int module_version, int api_version);
 
 The `Init` function announces the Redis core that the module has a given
-name, its version (that is reported by [`MODULE LIST`]({{< relref "/commands/module-list" >}})), and that is willing
+name, its version (that is reported by [`MODULE LIST`](/content/commands/module-list.md)), and that is willing
 to use a specific version of the API.
 
 If the API version is wrong, the name is already taken, or there are other
@@ -163,7 +163,7 @@ Zooming into the example command implementation, we can find another call:
     int RedisModule_ReplyWithLongLong(RedisModuleCtx *ctx, long long integer);
 
 This function returns an integer to the client that invoked the command,
-exactly like other Redis commands do, like for example [`INCR`]({{< relref "/commands/incr" >}}) or [`SCARD`]({{< relref "/commands/scard" >}}).
+exactly like other Redis commands do, like for example [`INCR`](/content/commands/incr.md) or [`SCARD`](/content/commands/scard.md).
 
 ## Module cleanup
 
@@ -207,7 +207,7 @@ Using the macro or just comparing with NULL is a matter of personal preference.
 
 ## Passing configuration parameters to Redis modules
 
-When the module is loaded with the [`MODULE LOAD`]({{< relref "/commands/module-load" >}}) command, or using the
+When the module is loaded with the [`MODULE LOAD`](/content/commands/module-load.md) command, or using the
 `loadmodule` directive in the `redis.conf` file, the user is able to pass
 configuration parameters to the module by adding arguments after the module
 file name:
@@ -311,7 +311,7 @@ kind of strings: null-terminated C strings, RedisModuleString objects as
 received from the `argv` parameter in the command implementation, binary
 safe C buffers with a pointer and a length, and so forth.
 
-For example if I want to call [`INCRBY`]({{< relref "/commands/incrby" >}}) using a first argument (the key)
+For example if I want to call [`INCRBY`](/content/commands/incrby.md) using a first argument (the key)
 a string received in the argument vector `argv`, which is an array
 of RedisModuleString object pointers, and a C string representing the
 number "10" as second argument (the increment), I'll use the following
@@ -669,7 +669,7 @@ replaced with the new value.
 
 If the key has an expire, and the special value `REDISMODULE_NO_EXPIRE` is
 used as a new expire, the expire is removed, similarly to the Redis
-[`PERSIST`]({{< relref "/commands/persist" >}}) command. In case the key was already persistent, no operation is
+[`PERSIST`](/content/commands/persist.md) command. In case the key was already persistent, no operation is
 performed.
 
 ## Obtaining the length of values
@@ -685,12 +685,12 @@ If the key does not exist, 0 is returned by the function:
 
 ## String type API
 
-Setting a new string value, like the Redis [`SET`]({{< relref "/commands/set" >}}) command does, is performed
+Setting a new string value, like the Redis [`SET`](/content/commands/set.md) command does, is performed
 using:
 
     int RedisModule_StringSet(RedisModuleKey *key, RedisModuleString *str);
 
-The function works exactly like the Redis [`SET`]({{< relref "/commands/set" >}}) command itself, that is, if
+The function works exactly like the Redis [`SET`](/content/commands/set.md) command itself, that is, if
 there is a prior value (of any type) it will be deleted.
 
 Accessing existing string values is performed using DMA (direct memory
@@ -868,7 +868,7 @@ specific functions, that are exact replacements for `malloc`, `free`,
 
 They work exactly like their `libc` equivalent calls, however they use
 the same allocator Redis uses, and the memory allocated using these
-functions is reported by the [`INFO`]({{< relref "/commands/info" >}}) command in the memory section, is
+functions is reported by the [`INFO`](/content/commands/info.md) command in the memory section, is
 accounted when enforcing the `maxmemory` policy, and in general is
 a first citizen of the Redis executable. On the contrary, the method
 allocated inside modules with libc `malloc()` is transparent to Redis.

--- a/content/develop/reference/modules/modules-blocking-ops.md
+++ b/content/develop/reference/modules/modules-blocking-ops.md
@@ -18,13 +18,13 @@ weight: 1
 ---
 
 Redis has a few blocking commands among the built-in set of commands.
-One of the most used is [`BLPOP`]({{< relref "/commands/blpop" >}}) (or the symmetric [`BRPOP`]({{< relref "/commands/brpop" >}})) which blocks
+One of the most used is [`BLPOP`](/content/commands/blpop.md) (or the symmetric [`BRPOP`](/content/commands/brpop.md)) which blocks
 waiting for elements arriving in a list.
 
 The interesting fact about blocking commands is that they do not block
 the whole server, but just the client calling them. Usually the reason to
 block is that we expect some external event to happen: this can be
-some change in the Redis data structures like in the [`BLPOP`]({{< relref "/commands/blpop" >}}) case, a
+some change in the Redis data structures like in the [`BLPOP`](/content/commands/blpop.md) case, a
 long computation happening in a thread, to receive some data from the
 network, and so forth.
 

--- a/content/develop/reference/modules/modules-native-types.md
+++ b/content/develop/reference/modules/modules-native-types.md
@@ -30,7 +30,7 @@ We call the ability of Redis modules to implement new data structures that
 feel like native Redis ones **native types support**. This document describes
 the API exported by the Redis modules system in order to create new data
 structures and handle the serialization in RDB files, the rewriting process
-in AOF, the type reporting via the [`TYPE`]({{< relref "/commands/type" >}}) command, and so forth.
+in AOF, the type reporting via the [`TYPE`](/content/commands/type.md) command, and so forth.
 
 ## Overview of native types
 
@@ -99,7 +99,7 @@ finds no matching module, the integer is converted back to a name in order to
 provide some clue to the user about what module is missing in order to load
 the data.
 
-The type name is also used as a reply for the [`TYPE`]({{< relref "/commands/type" >}}) command when called
+The type name is also used as a reply for the [`TYPE`](/content/commands/type.md) command when called
 with a key holding the registered type.
 
 The `encver` argument is the encoding version used by the module to store data
@@ -127,8 +127,8 @@ registration function: `rdb_load`, `rdb_save`, `aof_rewrite`, `digest` and
 * `rdb_save` is called when saving data to the RDB file.
 * `aof_rewrite` is called when the AOF is being rewritten, and the module needs to tell Redis what is the sequence of commands to recreate the content of a given key.
 * `digest` is called when `DEBUG DIGEST` is executed and a key holding this module type is found. Currently this is not yet implemented so the function ca be left empty.
-* `mem_usage` is called when the [`MEMORY`]({{< relref "/commands/memory" >}}) command asks for the total memory consumed by a specific key, and is used in order to get the amount of bytes used by the module value.
-* `free` is called when a key with the module native type is deleted via [`DEL`]({{< relref "/commands/del" >}}) or in any other mean, in order to let the module reclaim the memory associated with such a value.
+* `mem_usage` is called when the [`MEMORY`](/content/commands/memory.md) command asks for the total memory consumed by a specific key, and is used in order to get the amount of bytes used by the module value.
+* `free` is called when a key with the module native type is deleted via [`DEL`](/content/commands/del.md) or in any other mean, in order to let the module reclaim the memory associated with such a value.
 
 ### Why module types require nine character names
 

--- a/content/develop/reference/protocol-spec.md
+++ b/content/develop/reference/protocol-spec.md
@@ -37,10 +37,9 @@ RESP is binary-safe and uses prefixed length to transfer bulk data so it does no
 
 RESP is the protocol you should implement in your Redis client.
 
-{{% alert title="Note" color="info" %}}
-The protocol outlined here is used only for client-server communication.
-[Redis Cluster]({{< relref "/operate/oss_and_stack/reference/cluster-spec" >}}) uses a different binary protocol for exchanging messages between nodes.
-{{% /alert %}}
+> [!NOTE]
+> The protocol outlined here is used only for client-server communication.
+> [Redis Cluster](/content/operate/oss_and_stack/reference/cluster-spec.md) uses a different binary protocol for exchanging messages between nodes.
 
 ## RESP versions
 Support for the first version of the RESP protocol was introduced in Redis 1.2.
@@ -50,7 +49,7 @@ In Redis 2.0, the protocol's next version, a.k.a RESP2, became the standard comm
 
 [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) is mostly a superset of RESP2 that mainly aims to make a client author's life a little bit easier.
 Redis 6.0 introduced experimental opt-in support of RESP3's features (excluding streaming strings and streaming aggregates).
-In addition, the introduction of the [`HELLO`]({{< relref "/commands/hello" >}}) command allows clients to handshake and upgrade the connection's protocol version (see [Client handshake](#client-handshake)).
+In addition, the introduction of the [`HELLO`](/content/commands/hello.md) command allows clients to handshake and upgrade the connection's protocol version (see [Client handshake](#client-handshake)).
 
 From Redis version 7 and forward, both RESP2 and RESP3 clients can invoke all core commands.
 However, commands may return differently typed replies for different protocol versions.
@@ -72,12 +71,12 @@ This is the simplest model possible; however, there are some exceptions:
 
 * Redis requests can be [pipelined](#multiple-commands-and-pipelining).
   Pipelining enables clients to send multiple commands at once and wait for replies later.
-* When a RESP2 connection subscribes to a [Pub/Sub]({{< relref "/develop/pubsub" >}}) channel, the protocol changes semantics and becomes a *push* protocol.
+* When a RESP2 connection subscribes to a [Pub/Sub](/content/develop/pubsub/_index.md) channel, the protocol changes semantics and becomes a *push* protocol.
   The client no longer requires sending commands because the server will automatically send new messages to the client (for the channels the client is subscribed to) as soon as they are received.
-* The [`MONITOR`]({{< relref "/commands/monitor" >}}) command.
-  Invoking the [`MONITOR`]({{< relref "/commands/monitor" >}}) command switches the connection to an ad-hoc push mode.
+* The [`MONITOR`](/content/commands/monitor.md) command.
+  Invoking the [`MONITOR`](/content/commands/monitor.md) command switches the connection to an ad-hoc push mode.
   The protocol of this mode is not specified but is obvious to parse.
-* [Protected mode]({{< relref "operate/oss_and_stack/management/security/#protected-mode" >}}).
+* [Protected mode](/content/operate/oss_and_stack/management/security/_index.md#protected-mode).
   Connections opened from a non-loopback address to a Redis while in protected mode are denied and terminated by the server.
   Before terminating the connection, Redis unconditionally sends a `-DENIED` reply, regardless of whether the client writes to the socket.
 * The [RESP3 Push type](#resp3-pushes).
@@ -205,15 +204,15 @@ RESP encodes integers in the following way:
 
 For example, `:0\r\n` and `:1000\r\n` are integer replies (of zero and one thousand, respectively).
 
-Many Redis commands return RESP integers, including [`INCR`]({{< relref "/commands/incr" >}}), [`LLEN`]({{< relref "/commands/llen" >}}), and [`LASTSAVE`]({{< relref "/commands/lastsave" >}}).
+Many Redis commands return RESP integers, including [`INCR`](/content/commands/incr.md), [`LLEN`](/content/commands/llen.md), and [`LASTSAVE`](/content/commands/lastsave.md).
 An integer, by itself, has no special meaning other than in the context of the command that returned it.
-For example, it is an incremental number for [`INCR`]({{< relref "/commands/incr" >}}), a UNIX timestamp for [`LASTSAVE`]({{< relref "/commands/lastsave" >}}), and so forth.
+For example, it is an incremental number for [`INCR`](/content/commands/incr.md), a UNIX timestamp for [`LASTSAVE`](/content/commands/lastsave.md), and so forth.
 However, the returned integer is guaranteed to be in the range of a signed 64-bit integer.
 
 In some cases, integers can represent true and false Boolean values.
-For instance, [`SISMEMBER`]({{< relref "/commands/sismember" >}}) returns 1 for true and 0 for false.
+For instance, [`SISMEMBER`](/content/commands/sismember.md) returns 1 for true and 0 for false.
 
-Other commands, including [`SADD`]({{< relref "/commands/sadd" >}}), [`SREM`]({{< relref "/commands/srem" >}}), and [`SETNX`]({{< relref "/commands/setnx" >}}), return 1 when the data changes and 0 otherwise.
+Other commands, including [`SADD`](/content/commands/sadd.md), [`SREM`](/content/commands/srem.md), and [`SETNX`](/content/commands/setnx.md), return 1 when the data changes and 0 otherwise.
 
 <a name="bulk-string-reply"></a>
 
@@ -246,7 +245,7 @@ Whereas RESP3 has a dedicated data type for [null values](#nulls), RESP2 has no 
 Instead, due to historical reasons, the representation of null values in RESP2 is via predetermined forms of the [bulk strings](#bulk-strings) and [arrays](#arrays) types.
 
 The null bulk string represents a non-existing value.
-The [`GET`]({{< relref "/commands/get" >}}) command returns the Null Bulk String when the target key doesn't exist.
+The [`GET`](/content/commands/get.md) command returns the Null Bulk String when the target key doesn't exist.
 
 It is encoded as a bulk string with the length of negative one (-1), like so:
 
@@ -260,7 +259,7 @@ For example, a Ruby library should return `nil` while a C library should return 
 ### Arrays
 Clients send commands to the Redis server as RESP arrays.
 Similarly, some Redis commands that return collections of elements use arrays as their replies. 
-An example is the [`LRANGE`]({{< relref "/commands/lrange" >}}) command that returns elements of a list.
+An example is the [`LRANGE`](/content/commands/lrange.md) command that returns elements of a list.
 
 RESP Arrays' encoding uses the following format:
 
@@ -319,10 +318,9 @@ The above encodes a two-element array.
 The first element is an array that, in turn, contains three integers (1, 2, 3).
 The second element is another array containing a simple string and an error.
 
-{{% alert title="Multi bulk reply" color="info" %}}
-In some places, the RESP Array type may be referred to as _multi bulk_.
-The two are the same.
-{{% /alert %}}
+> [!NOTE] Multi bulk reply
+> In some places, the RESP Array type may be referred to as _multi bulk_.
+> The two are the same.
 
 <a name="nil-array-reply"></a>
 
@@ -330,18 +328,18 @@ The two are the same.
 Whereas RESP3 has a dedicated data type for [null values](#nulls), RESP2 has no such type. Instead, due to historical reasons, the representation of null values in RESP2 is via predetermined forms of the [Bulk Strings](#bulk-strings) and [arrays](#arrays) types.
 
 Null arrays exist as an alternative way of representing a null value.
-For instance, when the [`BLPOP`]({{< relref "/commands/blpop" >}}) command times out, it returns a null array.
+For instance, when the [`BLPOP`](/content/commands/blpop.md) command times out, it returns a null array.
 
 The encoding of a null array is that of an array with the length of -1, i.e.:
 
     *-1\r\n
 
 When Redis replies with a null array, the client should return a null object rather than an empty array.
-This is necessary to distinguish between an empty list and a different condition (for instance, the timeout condition of the [`BLPOP`]({{< relref "/commands/blpop" >}}) command).
+This is necessary to distinguish between an empty list and a different condition (for instance, the timeout condition of the [`BLPOP`](/content/commands/blpop.md) command).
 
 #### Null elements in arrays
 Single elements of an array may be [null bulk string](#null-bulk-strings).
-This is used in Redis replies to signal that these elements are missing and not empty strings. This can happen, for example, with the [`SORT`]({{< relref "/commands/sort" >}}) command when used with the `GET pattern` option
+This is used in Redis replies to signal that these elements are missing and not empty strings. This can happen, for example, with the [`SORT`](/content/commands/sort.md) command when used with the `GET pattern` option
 if the specified key is missing.
 
 Here's an example of an array reply containing a null element:
@@ -368,12 +366,11 @@ Here's Null's raw RESP encoding:
 
     _\r\n
 
-{{% alert title="Null Bulk String, Null Arrays and Nulls" color="info" %}}
-Due to historical reasons, RESP2 features two specially crafted values for representing null values of bulk strings and arrays.
-This duality has always been a redundancy that added zero semantical value to the protocol itself.
-
-The null type, introduced in RESP3, aims to fix this wrong.
-{{% /alert %}}
+> [!NOTE] Null Bulk String, Null Arrays and Nulls
+> Due to historical reasons, RESP2 features two specially crafted values for representing null values of bulk strings and arrays.
+> This duality has always been a redundancy that added zero semantical value to the protocol itself.
+>
+> The null type, introduced in RESP3, aims to fix this wrong.
 
 <a name="boolean-reply">
 
@@ -489,11 +486,11 @@ Example:
 (The raw RESP encoding is split into multiple lines for readability).
 
 Some client libraries may ignore the difference between this type and the string type and return a native string in both cases.
-However, interactive clients, such as command line interfaces (e.g., [`redis-cli`]({{< relref "/develop/tools/cli" >}})), can use this type and know that their output should be presented to the human user as is and without quoting the string.
+However, interactive clients, such as command line interfaces (e.g., [`redis-cli`](/content/develop/tools/cli.md)), can use this type and know that their output should be presented to the human user as is and without quoting the string.
 
-For example, the Redis command [`INFO`]({{< relref "/commands/info" >}}) outputs a report that includes newlines.
+For example, the Redis command [`INFO`](/content/commands/info.md) outputs a report that includes newlines.
 When using RESP3, `redis-cli` displays it correctly because it is sent as a Verbatim String reply (with its three bytes being "txt").
-When using RESP2, however, the `redis-cli` is hard-coded to look for the [`INFO`]({{< relref "/commands/info" >}}) command to ensure its correct display to the user.
+When using RESP2, however, the `redis-cli` is hard-coded to look for the [`INFO`](/content/commands/info.md) command to ensure its correct display to the user.
 
 <a name="map-reply"></a>
 
@@ -531,12 +528,11 @@ Both map keys and values can be any of RESP's types.
 Redis clients should return the idiomatic dictionary type that their language provides.
 However, low-level programming languages (such as C, for example) will likely return an array along with type information that indicates to the caller that it is a dictionary.
 
-{{% alert title="Map pattern in RESP2" color="info" %}}
-RESP2 doesn't have a map type.
-A map in RESP2 is represented by a flat array containing the keys and the values.
-The first element is a key, followed by the corresponding value, then the next key and so on, like this:
-`key1, value1, key2, value2, ...`.
-{{% /alert %}}
+> [!NOTE] Map pattern in RESP2
+> RESP2 doesn't have a map type.
+> A map in RESP2 is represented by a flat array containing the keys and the values.
+> The first element is a key, followed by the corresponding value, then the next key and so on, like this:
+> `key1, value1, key2, value2, ...`.
 
 <a name="attribute-reply"></a>
 
@@ -684,14 +680,14 @@ A streamed map's elements are field-value pairs, as in a regular [map](#maps), s
 As with [streamed strings](#streamed-strings), Redis doesn't emit streamed aggregates.
 
 ## Client handshake
-New RESP connections should begin the session by calling the [`HELLO`]({{< relref "/commands/hello" >}}) command.
+New RESP connections should begin the session by calling the [`HELLO`](/content/commands/hello.md) command.
 This practice accomplishes two things:
 
 1. It allows servers to be backward compatible with RESP2 versions.
   This is needed in Redis to make the transition to version 3 of the protocol gentler.
-2. The [`HELLO`]({{< relref "/commands/hello" >}}) command returns information about the server and the protocol that the client can use for different goals.
+2. The [`HELLO`](/content/commands/hello.md) command returns information about the server and the protocol that the client can use for different goals.
 
-The [`HELLO`]({{< relref "/commands/hello" >}}) command has the following high-level syntax:
+The [`HELLO`](/content/commands/hello.md) command has the following high-level syntax:
 
     HELLO <protocol-version> [optional-arguments]
 
@@ -711,14 +707,14 @@ Similarly, the client can easily detect a server that is only able to speak RESP
 
 The client can then proceed and use RESP2 to communicate with the server.
 
-Note that even if the protocol's version is supported, the [`HELLO`]({{< relref "/commands/hello" >}}) command may return an error, perform no action and remain in RESP2 mode. 
+Note that even if the protocol's version is supported, the [`HELLO`](/content/commands/hello.md) command may return an error, perform no action and remain in RESP2 mode. 
 For example, when used with invalid authentication credentials in the command's optional `AUTH` clause:
 
     Client: HELLO 3 AUTH default mypassword
     Server: -ERR invalid password
     (the connection remains in RESP2 mode)
 
-A successful reply to the [`HELLO`]({{< relref "/commands/hello" >}}) command is a map reply.
+A successful reply to the [`HELLO`](/content/commands/hello.md) command is a map reply.
 The information in the reply is partly server-dependent, but certain fields are mandatory for all the RESP3 implementations:
 * **server**: "redis" (or other software name).
 * **version**: the server's version.
@@ -759,7 +755,7 @@ Pipelining is supported, so multiple commands can be sent with a single write op
 The client can skip reading replies and continue to send the commands one after the other.
 All the replies can be read at the end.
 
-For more information, see [Pipelining]({{< relref "/develop/using-commands/pipelining" >}}).
+For more information, see [Pipelining](/content/develop/using-commands/pipelining.md).
 
 ## Inline commands
 Sometimes you may need to send a command to the Redis server but only have `telnet` available.
@@ -818,7 +814,7 @@ While comparable in performance to a binary protocol, the Redis protocol is sign
 
 ## Tips for Redis client authors
 
-* For testing purposes, use [Lua's type conversions]({{< relref "develop/programmability/lua-api#lua-to-resp3-type-conversion" >}}) to have Redis reply with any RESP2/RESP3 needed.
+* For testing purposes, use [Lua's type conversions](/content/develop/programmability/lua-api.md#lua-to-resp3-type-conversion) to have Redis reply with any RESP2/RESP3 needed.
   As an example, a RESP3 double can be generated like so:
   ```
   EVAL "return { double = tonumber(ARGV[1]) }" 0 1e0

--- a/content/develop/reference/sentinel-clients.md
+++ b/content/develop/reference/sentinel-clients.md
@@ -27,7 +27,7 @@ This document is targeted at Redis clients developers that want to support Senti
 * Automatic configuration of clients via Sentinel.
 * Improved safety of Redis Sentinel automatic failover.
 
-For details about how Redis Sentinel works, please check the [Redis Documentation]({{< relref "/operate/oss_and_stack/management/sentinel" >}}), as this document only contains information needed for Redis client developers, and it is expected that readers are familiar with the way Redis Sentinel works.
+For details about how Redis Sentinel works, please check the [Redis Documentation](/content/operate/oss_and_stack/management/sentinel.md), as this document only contains information needed for Redis client developers, and it is expected that readers are familiar with the way Redis Sentinel works.
 
 ## Redis service discovery via Sentinel
 
@@ -72,10 +72,10 @@ If an ip:port pair is received, this address should be used to connect to the Re
 ### Step 3: call the ROLE command in the target instance
 
 Once the client discovered the address of the master instance, it should
-attempt a connection with the master, and call the [`ROLE`]({{< relref "/commands/role" >}}) command in order
+attempt a connection with the master, and call the [`ROLE`](/content/commands/role.md) command in order
 to verify the role of the instance is actually a master.
 
-If the [`ROLE`]({{< relref "/commands/role" >}}) commands is not available (it was introduced in Redis 2.8.12), a client may resort to the `INFO replication` command parsing the `role:` field of the output.
+If the [`ROLE`](/content/commands/role.md) commands is not available (it was introduced in Redis 2.8.12), a client may resort to the `INFO replication` command parsing the `role:` field of the output.
 
 If the instance is not a master as expected, the client should wait a short amount of time (a few hundreds of milliseconds) and should try again starting from Step 1.
 
@@ -98,7 +98,7 @@ command to the instance in order to make sure all the clients are disconnected
 from the reconfigured instance. This will force clients to resolve the master
 address again.
 
-If the client will contact a Sentinel with yet not updated information, the verification of the Redis instance role via the [`ROLE`]({{< relref "/commands/role" >}}) command will fail, allowing the client to detect that the contacted Sentinel provided stale information, and will try again.
+If the client will contact a Sentinel with yet not updated information, the verification of the Redis instance role via the [`ROLE`](/content/commands/role.md) command will fail, allowing the client to detect that the contacted Sentinel provided stale information, and will try again.
 
 Note: it is possible that a stale master returns online at the same time a client contacts a stale Sentinel instance, so the client may connect with a stale master, and yet the ROLE output will match. However when the master is back again Sentinel will try to demote it to replica, triggering a new disconnection. The same reasoning applies to connecting to stale replicas that will get reconfigured to replicate with a different master.
 
@@ -114,7 +114,7 @@ The clients should call instead:
 
 In order to retrieve a list of replica instances.
 
-Symmetrically the client should verify with the [`ROLE`]({{< relref "/commands/role" >}}) command that the
+Symmetrically the client should verify with the [`ROLE`](/content/commands/role.md) command that the
 instance is actually a replica, in order to avoid scaling read queries with
 the master.
 
@@ -140,7 +140,7 @@ It is not needed for a client to be able to make the list persistent updating it
 
 ## Subscribe to Sentinel events to improve responsiveness
 
-The [Sentinel documentation]({{< relref "/operate/oss_and_stack/management/sentinel" >}}) shows how clients can connect to
+The [Sentinel documentation](/content/operate/oss_and_stack/management/sentinel.md) shows how clients can connect to
 Sentinel instances using Pub/Sub in order to subscribe to changes in the
 Redis instances configurations.
 

--- a/content/develop/setup/_index.md
+++ b/content/develop/setup/_index.md
@@ -16,7 +16,7 @@ This section shows how to set up a Redis deployment and connect to it with `redi
 
    Before you begin, install the following dependencies in your development environment:
 
-   - **[`redis-cli`]({{< relref "/develop/tools/cli" >}})**: command-line tool that connects to a deployment and runs Redis commands
+   - **[`redis-cli`](/content/develop/tools/cli.md)**: command-line tool that connects to a deployment and runs Redis commands
    - **[Docker](https://docs.docker.com/get-docker/)**: platform that runs software in containers, including local Redis deployments
 
    Select the tab corresponding to your deployment method to see which of these you need.
@@ -33,16 +33,16 @@ This section shows how to set up a Redis deployment and connect to it with `redi
      curl -fsSL https://packages.redis.io/redis-cli/install.sh | sh
      ```
 
-     See [Install redis-cli]({{< relref "/operate/oss_and_stack/install/install-stack/install-redis-cli" >}}) for more information.
+     See [Install redis-cli](/content/operate/oss_and_stack/install/install-stack/install-redis-cli.md) for more information.
 
    -tab-sep-
 
-   - [Docker](https://docs.docker.com/get-docker/) installed, to run the Docker quick start in step 2. To install without Docker, see the [Redis Software on Linux quick start]({{< relref "/operate/rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart" >}}) for its own system requirements.
+   - [Docker](https://docs.docker.com/get-docker/) installed, to run the Docker quick start in step 2. To install without Docker, see the [Redis Software on Linux quick start](/content/operate/rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart.md) for its own system requirements.
    - A command-line HTTP client such as `curl`, if you want to create a database with the REST API in step 2.
 
    -tab-sep-
 
-   - [Docker](https://docs.docker.com/get-docker/) installed, to run the Docker quick start in step 2. To install without Docker, see [Install Redis on Linux, macOS, or from source]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) for its own system requirements.
+   - [Docker](https://docs.docker.com/get-docker/) installed, to run the Docker quick start in step 2. To install without Docker, see [Install Redis on Linux, macOS, or from source](/content/operate/oss_and_stack/install/install-stack/_index.md) for its own system requirements.
 
    {{< /multitabs >}}
 
@@ -59,18 +59,18 @@ This section shows how to set up a Redis deployment and connect to it with `redi
 
    To create additional or different types of databases from the console, see:
 
-   - [Create an Essentials database]({{< relref "/operate/rc/databases/create-database/create-essentials-database" >}}) — a cost-efficient, fully managed database for low-throughput workloads, training, and prototyping.
-   - [Create a Pro database]({{< relref "/operate/rc/databases/create-database/create-pro-database-new" >}}) — a dedicated, "pay as you go" database for production workloads that need higher throughput, larger datasets, and advanced features like Active-Active and clustering.
+   - [Create an Essentials database](/content/operate/rc/databases/create-database/create-essentials-database.md) — a cost-efficient, fully managed database for low-throughput workloads, training, and prototyping.
+   - [Create a Pro database](/content/operate/rc/databases/create-database/create-pro-database-new.md) — a dedicated, "pay as you go" database for production workloads that need higher throughput, larger datasets, and advanced features like Active-Active and clustering.
 
    -tab-sep-
 
-   [Redis Software]({{< relref "/operate/rs/" >}}) is a self-managed Redis cluster you install and run on your own infrastructure. The fastest way to try it is with Docker:
+   [Redis Software](/content/operate/rs/_index.md) is a self-managed Redis cluster you install and run on your own infrastructure. The fastest way to try it is with Docker:
 
    ```sh
    docker run -d --cap-add sys_resource --name RE -p 8443:8443 -p 9443:9443 -p 12000:12000 redislabs/redis
    ```
 
-   See the [Redis Software on Docker quick start]({{< relref "/operate/rs/installing-upgrading/quickstarts/docker-quickstart" >}}) for the full procedure, or the [Redis Software on Linux quick start]({{< relref "/operate/rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart" >}}) to install without Docker.
+   See the [Redis Software on Docker quick start](/content/operate/rs/installing-upgrading/quickstarts/docker-quickstart.md) for the full procedure, or the [Redis Software on Linux quick start](/content/operate/rs/installing-upgrading/quickstarts/redis-enterprise-software-quickstart.md) to install without Docker.
 
    You can create databases with Redis Software using the console or the REST API. To create a database with the REST API:
 
@@ -84,17 +84,17 @@ This section shows how to set up a Redis deployment and connect to it with `redi
    }
    ```
 
-   See [Create a database]({{< relref "/operate/rs/databases/create" >}}) for the full procedure, including the console method and additional configuration fields.
+   See [Create a database](/content/operate/rs/databases/create.md) for the full procedure, including the console method and additional configuration fields.
 
    -tab-sep-
 
-   [Redis Open Source]({{< relref "/operate/oss_and_stack/" >}}) is the free, self-managed core Redis server. The fastest way to run it is with Docker:
+   [Redis Open Source](/content/operate/oss_and_stack/_index.md) is the free, self-managed core Redis server. The fastest way to run it is with Docker:
 
    ```sh
    docker run -d --name redis -p 6379:6379 redis:latest
    ```
 
-   Starting the server creates your database — there's no separate create step. See [Run Redis on Docker]({{< relref "/operate/oss_and_stack/install/install-stack/docker" >}}) for the full procedure, or [Install Redis on Linux, macOS, or from source]({{< relref "/operate/oss_and_stack/install/install-stack" >}}) to install without Docker.
+   Starting the server creates your database — there's no separate create step. See [Run Redis on Docker](/content/operate/oss_and_stack/install/install-stack/docker.md) for the full procedure, or [Install Redis on Linux, macOS, or from source](/content/operate/oss_and_stack/install/install-stack/_index.md) to install without Docker.
 
    {{< /multitabs >}}
 
@@ -113,7 +113,7 @@ This section shows how to set up a Redis deployment and connect to it with `redi
    redis-cli -h <hostname> -p <portnumber> -a <password>
    ```
 
-   See [Connect to a Redis Cloud database]({{< relref "/operate/rc/databases/connect" >}}) for the full procedure, including Redis Insight and client library options.
+   See [Connect to a Redis Cloud database](/content/operate/rc/databases/connect/_index.md) for the full procedure, including Redis Insight and client library options.
 
    -tab-sep-
 
@@ -123,7 +123,7 @@ This section shows how to set up a Redis deployment and connect to it with `redi
    docker exec -it <container_name_or_ID> redis-cli -h <host_or_IP> -p <port>
    ```
 
-   See [Connect to a Redis Software database]({{< relref "/operate/rs/databases/connect" >}}) for the full procedure and for further options, including Redis Insight and client library connections.
+   See [Connect to a Redis Software database](/content/operate/rs/databases/connect/_index.md) for the full procedure and for further options, including Redis Insight and client library connections.
 
    -tab-sep-
 
@@ -133,7 +133,7 @@ This section shows how to set up a Redis deployment and connect to it with `redi
    docker exec -it redis redis-cli
    ```
 
-   See [Redis CLI]({{< relref "/develop/tools/cli" >}}) for the full procedure, including non-Docker installs and [Redis Insight]({{< relref "/develop/tools/insight" >}}) as a GUI alternative to the CLI.
+   See [Redis CLI](/content/develop/tools/cli.md) for the full procedure, including non-Docker installs and [Redis Insight](/content/develop/tools/insight/_index.md) as a GUI alternative to the CLI.
 
    {{< /multitabs >}}
 
@@ -143,7 +143,7 @@ In the next section, you'll learn how to create an application that connects to 
 
 ## Create your first Redis application
 
-To connect to your Redis deployment in an application, you can use one of the official [Redis client libraries]({{< relref "/develop/clients" >}}).
+To connect to your Redis deployment in an application, you can use one of the official [Redis client libraries](/content/develop/clients/_index.md).
 
 Select your preferred programming language from the tabs in each step below.
 
@@ -165,7 +165,7 @@ Select your preferred programming language from the tabs in each step below.
        tab9="PHP"
        tab10="RedisVL" >}}
 
-   Create a project directory and [install redis-py]({{< relref "/develop/clients/redis-py/_index.md#install" >}}):
+   Create a project directory and [install redis-py](/content/develop/clients/redis-py/_index.md#install):
 
    ```sh
    mkdir python-quickstart
@@ -175,7 +175,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Create a project directory and [install node-redis]({{< relref "/develop/clients/nodejs/_index.md#install" >}}):
+   Create a project directory and [install node-redis](/content/develop/clients/nodejs/_index.md#install):
 
    ```sh
    mkdir node-quickstart
@@ -186,7 +186,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Add [Jedis]({{< relref "/develop/clients/jedis/_index.md" >}}) as a dependency in your Maven project's `pom.xml`:
+   Add [Jedis](/content/develop/clients/jedis/_index.md) as a dependency in your Maven project's `pom.xml`:
 
    ```xml
    <dependency>
@@ -198,7 +198,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Create a project directory and [install go-redis]({{< relref "/develop/clients/go/_index.md" >}}):
+   Create a project directory and [install go-redis](/content/develop/clients/go/_index.md):
 
    ```sh
    mkdir go-quickstart
@@ -209,7 +209,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Create a project directory and [install StackExchange.Redis]({{< relref "/develop/clients/dotnet/_index.md" >}}):
+   Create a project directory and [install StackExchange.Redis](/content/develop/clients/dotnet/_index.md):
 
    ```sh
    mkdir csharp-quickstart
@@ -220,7 +220,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Create a project directory and [install redis-rb]({{< relref "/develop/clients/ruby/_index.md#install" >}}):
+   Create a project directory and [install redis-rb](/content/develop/clients/ruby/_index.md#install):
 
    ```sh
    mkdir ruby-quickstart
@@ -230,7 +230,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   [Build and install hiredis]({{< relref "/develop/clients/hiredis/_index.md#build-and-install" >}}) from source:
+   [Build and install hiredis](/content/develop/clients/hiredis/_index.md#build-and-install) from source:
 
    ```sh
    git clone https://github.com/redis/hiredis.git
@@ -241,7 +241,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Create a project directory and [add the `redis` crate]({{< relref "/develop/clients/rust/_index.md#install" >}}) as a dependency in `Cargo.toml`:
+   Create a project directory and [add the `redis` crate](/content/develop/clients/rust/_index.md#install) as a dependency in `Cargo.toml`:
 
    ```toml
    [dependencies]
@@ -250,7 +250,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Use [Composer]({{< relref "/develop/clients/php/_index.md#install" >}}) to install Predis:
+   Use [Composer](/content/develop/clients/php/_index.md#install) to install Predis:
 
    ```sh
    composer require predis/predis
@@ -258,7 +258,7 @@ Select your preferred programming language from the tabs in each step below.
 
    -tab-sep-
 
-   Create a project directory and [install RedisVL]({{< relref "/develop/ai/redisvl/install" >}}):
+   Create a project directory and [install RedisVL](/content/develop/ai/redisvl/install.md):
 
    ```sh
    mkdir redisvl-quickstart
@@ -477,13 +477,13 @@ Select your preferred programming language from the tabs in each step below.
    index.create(overwrite=True)
    ```
 
-   See the [RedisVL getting started guide]({{< relref "/develop/ai/redisvl/user_guide/getting_started" >}}) for the full procedure, including loading data and running vector searches.
+   See the [RedisVL getting started guide](/content/develop/ai/redisvl/user_guide/getting_started.md) for the full procedure, including loading data and running vector searches.
 
    {{< /multitabs >}}
 
 4. Add your connection string
 
-   The examples in step 3 connect to `localhost:6379`. Replace that with your actual deployment's host, port, and password — from the [Redis Cloud connection wizard](https://cloud.redis.io), the [Redis Software connection details]({{< relref "/operate/rs/databases/connect" >}}), or `localhost:6379` if you're already running Redis Open Source locally.
+   The examples in step 3 connect to `localhost:6379`. Replace that with your actual deployment's host, port, and password — from the [Redis Cloud connection wizard](https://cloud.redis.io), the [Redis Software connection details](/content/operate/rs/databases/connect/_index.md), or `localhost:6379` if you're already running Redis Open Source locally.
 
    {{< multitabs id="getting-started-connstring"
        tab1="Python"
@@ -658,16 +658,16 @@ Select your preferred programming language from the tabs in each step below.
 
    Each of the following quick starts shows a complete example application for a specific use case:
 
-   - [Data structure store]({{< relref "/develop/get-started/data-store" >}})
-   - [Document database]({{< relref "/develop/get-started/search-tutorial" >}})
-   - [Vector database]({{< relref "/develop/get-started/search-tutorial/vector-search" >}})
+   - [Data structure store](/content/develop/get-started/data-store.md)
+   - [Document database](/content/develop/get-started/search-tutorial/_index.md)
+   - [Vector database](/content/develop/get-started/search-tutorial/vector-search.md)
 
-   Refer to the [Redis use cases]({{< relref "/develop/use-cases" >}}) page for a complete set of use cases with code examples in your programming language.
+   Refer to the [Redis use cases](/content/develop/use-cases/_index.md) page for a complete set of use cases with code examples in your programming language.
 
 ### Next steps
 
 To learn more about developing with Redis, see the following resources:
 
-- [Explore all client libraries]({{< relref "/develop/clients" >}})
-- [Redis products overview]({{< relref "/operate/" >}})
-- [Develop with Redis]({{< relref "/develop/" >}})
+- [Explore all client libraries](/content/develop/clients/_index.md)
+- [Redis products overview](/content/operate/_index.md)
+- [Develop with Redis](/content/develop/_index.md)

--- a/content/develop/setup/build-with-an-agent.md
+++ b/content/develop/setup/build-with-an-agent.md
@@ -18,9 +18,8 @@ Redis publishes two agent-facing tools that work alongside the client libraries 
 
 [`redis.io/mcp`](https://redis.io/mcp) is a public, read-only [Model Context Protocol](https://modelcontextprotocol.io/introduction) server that serves the Redis documentation to any MCP client. It requires no API key or sign-up.
 
-{{< note >}}
-This is a different server from the [Redis MCP server]({{< relref "/integrate/redis-mcp" >}}) (`mcp-redis`). `mcp-redis` is a self-hosted server that connects an agent to *your own* Redis database, so it can run commands against your data. The Redis Docs MCP server has no access to any Redis instance except Redis's own documentation index.
-{{< /note >}}
+> [!NOTE]
+> This is a different server from the [Redis MCP server](/content/integrate/redis-mcp/_index.md) (`mcp-redis`). `mcp-redis` is a self-hosted server that connects an agent to *your own* Redis database, so it can run commands against your data. The Redis Docs MCP server has no access to any Redis instance except Redis's own documentation index.
 
 
 ### Connect a client
@@ -69,6 +68,6 @@ Or install it as a plugin in your agent tool of choice:
 
 ## See also
 
-- [Redis MCP server]({{< relref "/integrate/redis-mcp" >}}) — connect an agent to your own Redis database
-- [Redis client libraries]({{< relref "/develop/clients" >}})
-- [Redis for AI agents]({{< relref "/develop/get-started/redis-in-ai" >}})
+- [Redis MCP server](/content/integrate/redis-mcp/_index.md) — connect an agent to your own Redis database
+- [Redis client libraries](/content/develop/clients/_index.md)
+- [Redis for AI agents](/content/develop/get-started/redis-in-ai.md)


### PR DESCRIPTION
## Summary

Part of DOC-7059 (continuing DOC-6909/DOC-7047): replaces two Hugo shortcode kinds with native-Markdown render-hook equivalents in this unit's scope:

- `]({{< relref "X" >}})` links → plain `](X)`, canonicalized to repo-root-relative `/content/<path>.md[#anchor]` form.
- `{{< note >}}`/`{{% note %}}` (and warning/tip/info/alert) callouts → native `> [!NOTE]` etc. blockquotes.

**Scope**: `content/develop/reference/` (recursive, including nested `eviction/` and `modules/`), `content/develop/setup/`, and the top-level `content/develop/_index.md`. File-disjoint from the sibling units already merged/opened (`ai/search-and-query` #3982, `programmability+pubsub+using-commands` #3983, `get-started+whats-new` #3984, `ai/context-engine+featureform+agent-builder` #3985).

**File count**: 14 of 17 candidate files converted (relref and/or callout shortcodes found and converted). The other 3 (`reference/_index.md`, `reference/gopher.md`, `reference/modules/modules-api-ref.md`) had no relref or callout shortcodes to begin with, so the script correctly no-op'd them.

Ran `build/migrate_shortcode_links.py all <file>` per file (relref-to-plain → callouts-to-blockquote → linkify), then verified with a leftover-shortcode grep (clean) and a manual pass for blockquote-adjacency spacing issues (none found — every converted callout already had blank lines on both sides).

`reference/protocol-spec.md` carried the DOC-7055-flagged percent-form `{{% alert title="..." %}}` custom-title callouts; all four converted correctly, with the two titled "Note" dropping the redundant title as expected.

**Still pending** (not done in this PR): the central href-diff and Hugo build-warning verification against `main`, and human review — both handled batched across DOC-7059's units, not per-unit.

## Test plan

- [ ] Central href-diff check (batched, separate from this PR)
- [ ] Hugo build-warning check against main (batched, separate from this PR)
- [ ] Human review of converted prose/links

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only markup and link format changes with no runtime code; residual risk is broken internal links if render-hook resolution differs from Hugo relref until batched verification completes.
> 
> **Overview**
> **DOC-7059** continues the Hugo → native Markdown migration in `content/develop/reference/` (including `eviction/` and `modules/`), `content/develop/setup/`, and `content/develop/_index.md`.
> 
> **Internal links** no longer use `{{< relref ... >}}`; they are plain Markdown targets canonicalized as repo-root paths like `/content/develop/clients/_index.md` (and `/content/commands/...` for command docs).
> 
> **Callouts** (`{{< note >}}`, `{{% alert %}}`, etc.) are replaced with GitHub-style blockquotes (`> [!NOTE]`, including titled alerts in `protocol-spec.md` where redundant titles were dropped).
> 
> Hugo shortcodes such as `image-card` and `multitabs` are unchanged. Three files in scope had no relref/callout work. Central href-diff and Hugo build checks are still planned batch-wise for DOC-7059.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ef7a13eb481dfd12f6b2897d15bc740334cdcf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->