### PR TITLE
Point last/ bottom Beekeeper Studio download link to Redis client page

### DIFF
--- a/content/develop/tools/_index.md
+++ b/content/develop/tools/_index.md
@@ -76,4 +76,4 @@ Redis support includes
 
 It connects to a Redis server directly or over an SSH tunnel, with TLS/SSL supported, and authenticates with either a password or a username and password against Redis 6+ ACLs.
 
-[Download for free on their website](https://beekeeperstudio.io/get)
+[Download for free on their website](https://www.beekeeperstudio.io/db/redis-client/)


### PR DESCRIPTION
I thought I updated both links at the same time, but I didn't. Sorry.

Updates the "Download for free on their website" link in the Beekeeper Studio section of content/develop/tools/_index.md so it points to the Redis-specific client page (/db/redis-client/) instead of the generic download page, matching the intro link updated in #3952.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL change with no runtime or security impact.
> 
> **Overview**
> Updates the Beekeeper Studio **“Download for free on their website”** CTA in `content/develop/tools/_index.md` so it uses `https://www.beekeeperstudio.io/db/redis-client/` instead of the generic `https://beekeeperstudio.io/get` page.
> 
> This aligns the bottom link with the intro **Beekeeper Studio** link (already pointed at the Redis client page in #3952).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46852091ae790235fbfe834c61fbcd7fc0c01fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->