### PR TITLE
OP: edit pages that reference redis-full.conf

### DIFF
--- a/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-10.md
+++ b/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-10.md
@@ -125,8 +125,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]({{< relref "/commands/info" >}}) command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-8.md
+++ b/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-8.md
@@ -150,8 +150,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]({{< relref "/commands/info" >}}) command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-9.md
+++ b/content/operate/oss_and_stack/install/build-stack/almalinux-rocky-9.md
@@ -151,8 +151,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]({{< relref "/commands/info" >}}) command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/alpine.md
+++ b/content/operate/oss_and_stack/install/build-stack/alpine.md
@@ -101,8 +101,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]({{< relref "/commands/info" >}}) command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/debian-bookworm.md
+++ b/content/operate/oss_and_stack/install/build-stack/debian-bookworm.md
@@ -100,8 +100,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/debian-bullseye.md
+++ b/content/operate/oss_and_stack/install/build-stack/debian-bullseye.md
@@ -100,8 +100,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/macos-13-14.md
+++ b/content/operate/oss_and_stack/install/build-stack/macos-13-14.md
@@ -113,8 +113,11 @@ To start Redis, use the following command:
 cd ~/src/redis-<version>
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
-build_dir/bin/redis-server redis-full.conf
+build_dir/bin/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-focal.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-focal.md
@@ -122,8 +122,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-jammy.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-jammy.md
@@ -111,8 +111,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-noble.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-noble.md
@@ -97,8 +97,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]{{< relref "/commands/info" >}} command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/install/build-stack/ubuntu-resolute.md
+++ b/content/operate/oss_and_stack/install/build-stack/ubuntu-resolute.md
@@ -116,8 +116,11 @@ To start Redis, use the following command:
 
 ```bash
 cd /usr/src/redis-<version>
-./src/redis-server redis-full.conf
+./src/redis-server redis.conf
 ```
+
+> [!NOTE]
+> Before Redis 8.10, specify `redis-full.conf` instead of `redis.conf`.
 
 To validate that the available modules have been installed, run the [`INFO`]({{< relref "/commands/info" >}}) command and look for lines similar to the following:
 

--- a/content/operate/oss_and_stack/management/config.md
+++ b/content/operate/oss_and_stack/management/config.md
@@ -18,9 +18,11 @@ configuration, however this setup is only recommended for testing and
 development purposes.
 
 The proper way to configure Redis is by providing a Redis configuration file,
-usually called `redis.conf`. Beginning with Redis 8 in Redis Open Source, there are two configuration files:
+usually called `redis.conf`. For Redis releases 8.0 - 8.8.x in Redis Open Source, there are two configuration files:
 * `redis.conf` - contains the configuration settings for Redis server only.
 * `redis-full.conf` - contains configuration settings for Redis server and all available components: Redis Search, Redis time series, and Redis probabilistic data structures. This file has as its first line `include redis.conf`, which pulls in the Redis server configuration settings at startup. Use `redis-full.conf` when you want to enable all available components. The file contains four `loadmodule` directives, one for each component, and also loads Redis JSON (though JSON has no configuration parameters).
+
+Redis 8.10 and later use only one configuration file: `redis.conf`.
 
 If you are building Redis from source and choose to build Redis server without the available components, you can use `redis.conf` as your configuration file.
 
@@ -41,7 +43,7 @@ Single-quoted string can contain characters escaped by backslashes, and
 double-quoted strings can additionally include any ASCII symbols encoded using
 backslashed hexadecimal notation "\\xff".
 
-The list of configuration directives, along with comments describing their meaning and intended usage, is available in the self-documented sample files `redis.conf` and `redis-full.conf` files shipped with the Redis distributions.
+The list of configuration directives, along with comments describing their meaning and intended usage, is available in the self-documented sample files `redis.conf` and, for Redis releases 8.0 - 8.8.x, `redis-full.conf` files shipped with the Redis distributions.
 
 * Configuration files for Redis 8.10: [redis.conf](https://raw.githubusercontent.com/redis/redis/8.10/redis.conf).
 * Configuration files for Redis 8.8: [redis-full.conf](https://raw.githubusercontent.com/redis/redis/8.8/redis-full.conf) and [redis.conf](https://raw.githubusercontent.com/redis/redis/8.8/redis.conf).


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changes to install and configuration guidance; no runtime or application code is affected.
> 
> **Overview**
> Updates **build-from-source** guides across Linux, Alpine, macOS, and Ubuntu platforms so the **Start Redis** step runs `./src/redis-server redis.conf` (or the macOS equivalent) instead of **`redis-full.conf`**, matching Redis **8.10+** where modules are enabled through the single **`redis.conf`**.
> 
> Each guide adds a note that releases **before 8.10** should still use **`redis-full.conf`**.
> 
> The **Redis configuration** page now scopes the two-file layout (**`redis.conf`** vs **`redis-full.conf`**) to **8.0–8.8.x**, states that **8.10 and later** ship only **`redis.conf`**, and adjusts wording around sample config files accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d615e3d84d736ee7036493898baadd704172652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->