### PR TITLE
docs: remove duplicate 'the' in Redis Cloud SAML SSO guides

### DIFF
--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-auth0.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-auth0.md
@@ -205,7 +205,7 @@ Replace `ID` so it matches the `AssertionConsumerService` Location URL ID (the c
 
     {{<image filename="images/rc/saml/auth0_saml_12.png" >}}
 
-If everything is configured correctly, you will see the the Redis Cloud console screen. Your local account is now considered a SAML account. 
+If everything is configured correctly, you will see the Redis Cloud console screen. Your local account is now considered a SAML account. 
 
 To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 

--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-aws-identity-center.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-aws-identity-center.md
@@ -145,7 +145,7 @@ The final step in our SAML integration with AWS IAM identity Center is to activa
 
    {{<image filename="images/rc/saml/aws_iam_identity_center_saml_18.png" >}}
 
-If everything is configured correctly, you will see the the Redis Cloud console screen. Your local account is now considered a SAML account. 
+If everything is configured correctly, you will see the Redis Cloud console screen. Your local account is now considered a SAML account. 
 
 To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 

--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-azure-ad.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-azure-ad.md
@@ -175,7 +175,7 @@ Make sure the **Namespace** field is empty when modifying these claims.
 
     {{<image filename="images/rc/saml/ad_saml_19.png" >}}
 
-If everything is configured correctly, you will see the the Redis Cloud console screen. Your local account is now considered a SAML account. 
+If everything is configured correctly, you will see the Redis Cloud console screen. Your local account is now considered a SAML account. 
 
 To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 

--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-google.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-google.md
@@ -164,7 +164,7 @@ A logout notification screen displays, letting you know that you are redirected 
 
    {{<image filename="images/rc/saml/google_workspace_saml_18.png" >}}
 
-If everything is configured correctly, you will see the the Redis Cloud console screen. Your local account is now considered a SAML account. 
+If everything is configured correctly, you will see the Redis Cloud console screen. Your local account is now considered a SAML account. 
 
 To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 

--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-okta-generic.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-okta-generic.md
@@ -282,7 +282,7 @@ Paste the X.509 certificate exactly as Okta provides it. Don't add `-----BEGIN C
 
     {{<image filename="images/rc/saml/okta_saml_app_int_14.png" >}}
 
-If everything is configured correctly, you will see the the Redis Cloud console screen. Your local account is now considered a SAML account. 
+If everything is configured correctly, you will see the Redis Cloud console screen. Your local account is now considered a SAML account. 
 
 To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 

--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-okta-org2org.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-okta-org2org.md
@@ -248,7 +248,7 @@ Replace `<ID>` so it matches the AssertionConsumerService Location URL ID (the c
 
     {{<image filename="images/rc/saml/sm_saml_10.png" >}}
 
-If everything is configured correctly, you will see the the Redis Cloud console screen. Your local account is now considered a SAML account. 
+If everything is configured correctly, you will see the Redis Cloud console screen. Your local account is now considered a SAML account. 
 
 To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 

--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-ping-identity.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-ping-identity.md
@@ -171,7 +171,7 @@ To activate SAML, you must have a local user (or social sign-on user) with the *
 
     {{<image filename="images/rc/saml/ping_identity_saml_20.png" >}}
 
-If everything is configured correctly, you will see the the Redis Cloud console screen. Your local account is now considered a SAML account. 
+If everything is configured correctly, you will see the Redis Cloud console screen. Your local account is now considered a SAML account. 
 
 To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 


### PR DESCRIPTION
## Summary
Remove duplicated word in the Redis Cloud SAML SSO success text: "see the the Redis Cloud console" → "see the Redis Cloud console".

Applied across the Azure AD, Okta, Google, AWS Identity Center, Auth0, and Ping Identity integration guides, which share the same sentence.

## Test plan
- [x] Confirmed each updated line reads correctly
- [x] No other wording changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only typo fix with no impact on product code, configuration, or security behavior.
> 
> **Overview**
> Fixes a duplicated **the** in the post-activation success sentence shared across seven Redis Cloud SAML SSO integration guides (Auth0, AWS IAM Identity Center, Microsoft Entra, Google Workspace, Okta Generic, Okta Org2Org, and Ping Identity).
> 
> The wording changes from “you will see **the the** Redis Cloud console screen” to “you will see **the** Redis Cloud console screen.” No other content or behavior is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ce61f24aaf5e5367965979818f4c6f91b7d81f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->