### PR TITLE
docs: remove duplicate 'of' in REC certificates docs

### DIFF
--- a/content/operate/kubernetes/7.22/security/manage-rec-certificates.md
+++ b/content/operate/kubernetes/7.22/security/manage-rec-certificates.md
@@ -12,7 +12,7 @@ weight: 94
 url: '/operate/kubernetes/7.22/security/manage-rec-certificates/'
 ---
 
-By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
+By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
 
 To install and use your own certificates with Kubernetes on your Redis Enterprise cluster, they need to be stored in [secrets](https://kubernetes.io/docs/concepts/configuration/secret/). The REC custom resource also needs to be configured with those secret names to read and use the certificates.
 

--- a/content/operate/kubernetes/7.4.6/security/manage-rec-certificates.md
+++ b/content/operate/kubernetes/7.4.6/security/manage-rec-certificates.md
@@ -12,7 +12,7 @@ weight: 94
 url: '/operate/kubernetes/7.4.6/security/manage-rec-certificates/'
 ---
 
-By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
+By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
 
 To install and use your own certificates with Kubernetes on your Redis Enterprise cluster, they need to be stored in [secrets](https://kubernetes.io/docs/concepts/configuration/secret/). The REC custom resource also needs to be configured with those secret names to read and use the certificates.
 

--- a/content/operate/kubernetes/7.8.4/security/manage-rec-certificates.md
+++ b/content/operate/kubernetes/7.8.4/security/manage-rec-certificates.md
@@ -12,7 +12,7 @@ weight: 94
 url: '/operate/kubernetes/7.8.4/security/manage-rec-certificates/'
 ---
 
-By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
+By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
 
 To install and use your own certificates with Kubernetes on your Redis Enterprise cluster, they need to be stored in [secrets](https://kubernetes.io/docs/concepts/configuration/secret/). The REC custom resource also needs to be configured with those secret names to read and use the certificates.
 

--- a/content/operate/kubernetes/7.8.6/security/manage-rec-certificates.md
+++ b/content/operate/kubernetes/7.8.6/security/manage-rec-certificates.md
@@ -12,7 +12,7 @@ weight: 94
 url: '/operate/kubernetes/7.8.6/security/manage-rec-certificates/'
 ---
 
-By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
+By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
 
 To install and use your own certificates with Kubernetes on your Redis Enterprise cluster, they need to be stored in [secrets](https://kubernetes.io/docs/concepts/configuration/secret/). The REC custom resource also needs to be configured with those secret names to read and use the certificates.
 

--- a/content/operate/kubernetes/8.0/security/manage-rec-certificates.md
+++ b/content/operate/kubernetes/8.0/security/manage-rec-certificates.md
@@ -12,7 +12,7 @@ weight: 94
 url: '/operate/kubernetes/8.0/security/manage-rec-certificates/'
 ---
 
-By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
+By default, Redis Enterprise Software for Kubernetes generates TLS certificates for the cluster during creation. These self-signed certificates are generated on the first node of each Redis Enterprise cluster (REC) and are copied to all other nodes added to the cluster. For the list of certificates used by Redis Enterprise Software and the traffic they encrypt, see the [certificates table]({{< relref "/operate/rs/security/certificates" >}}).
 
 To install and use your own certificates with Kubernetes on your Redis Enterprise cluster, they need to be stored in [secrets](https://kubernetes.io/docs/concepts/configuration/secret/). The REC custom resource also needs to be configured with those secret names to read and use the certificates.
 


### PR DESCRIPTION
## Summary
Fix duplicated preposition in Redis Enterprise on Kubernetes certificate docs: "list of of certificates" → "list of certificates".

## Test plan
- [x] Confirmed the sentence reads correctly in each versioned copy updated
- [x] No other wording changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only copy edit with no impact on product code, configuration, or security behavior.
> 
> **Overview**
> Fixes a wording typo in the **Manage REC certificates** intro across five Kubernetes doc versions (`7.4.6`, `7.8.4`, `7.8.6`, `7.22`, and `8.0`): **"list of of certificates"** is corrected to **"list of certificates"** in the sentence that links to the certificates table. No other content or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793fe16dea8ff649af169065b988e96cf06e5ad9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->