### PR TITLE
docs: fix 'persistant'/'peristent' typos in Redis Insight K8s install

### DIFF
--- a/content/operate/redisinsight/install/install-on-k8s.md
+++ b/content/operate/redisinsight/install/install-on-k8s.md
@@ -99,10 +99,10 @@ $ minikube list
 |-------------|----------------------|--------------|---------------------------------------------|
 ```
 
-## Create the Redis Insight deployment with persistant storage
+## Create the Redis Insight deployment with persistent storage
 
 Below is an annotated YAML file that will create a Redis Insight
-deployment in a K8s cluster. It will assign a peristent volume created from a volume claim template.
+deployment in a K8s cluster. It will assign a persistent volume created from a volume claim template.
 Write access to the container is configured in an init container. When using deployments
 with persistent writeable volumes, it's best to set the strategy to `Recreate`. Otherwise you may find yourself
 with two pods trying to use the same volume.


### PR DESCRIPTION
## Summary
Correct spelling in the Redis Insight Kubernetes install guide:
- heading: "persistant storage" → "persistent storage"
- body: "peristent volume" → "persistent volume"

## Test plan
- [x] Confirmed both corrected words are the intended spelling
- [x] No other wording changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spelling corrections with no runtime or configuration impact.
> 
> **Overview**
> Fixes spelling in the Redis Insight Kubernetes install guide (`install-on-k8s.md`): the section heading now says **persistent storage** (was "persistant"), and the intro under that section says **persistent volume** (was "peristent"). No other wording or behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9632599bd27e1be47cedc50da28dafe31477926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->