### PR TITLE
docs: fix 'enviroment' typo in Ping Identity SAML URL

### DIFF
--- a/content/operate/rc/security/access-control/saml-sso/saml-integration-ping-identity.md
+++ b/content/operate/rc/security/access-control/saml-sso/saml-integration-ping-identity.md
@@ -183,7 +183,7 @@ To log in to the Redis Cloud console from now on, click on **Sign in with SSO**.
 
 1. In Ping Identity, go to **Administrators > Connections > Applications** and select your application name. Select the **Configuration** tab and select **Edit**.
 
-1. Go to **Target Application URL** and enter: **https://{enviroment}/#/login/?idpId={idpId}**, where idpId is the ID found in the Location field, after the last '/'
+1. Go to **Target Application URL** and enter: **https://{environment}/#/login/?idpId={idpId}**, where idpId is the ID found in the Location field, after the last '/'
 
 1. Select **Save**.
 


### PR DESCRIPTION
## Summary
Correct placeholder spelling in the Ping Identity SAML Target Application URL example: `{enviroment}` → `{environment}`.

## Test plan
- [x] Confirmed the surrounding URL template is otherwise unchanged
- [x] Single typo fix only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only spelling fix with no runtime or security impact.
> 
> **Overview**
> Fixes a typo in the **IdP-initiated SSO** section of the Ping Identity SAML guide: the **Target Application URL** placeholder is corrected from `{enviroment}` to `{environment}` so it matches the spelling used elsewhere in the same section (e.g. the `apps.pingone.com` URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979f2286df0221d82dd133880e92a4fbe9ccadc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->